### PR TITLE
WCPT: Trigger click on `Save Draft` when `Update` button is clicked i…

### DIFF
--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -148,6 +148,35 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 	});
 
 	/**
+	 * Bind Update button with Save Draft button in pages with block editor
+	 */
+	$( document ).ready(
+		function () {
+			if ( ! window.wcpt_admin || window.wcpt_admin[ 'gutenberg_enabled' ] !== "1" ) {
+				return;
+			}
+
+			function checkAndEnableUpdateButton() {
+				if ( $( ".editor-post-save-draft" ).length > 0 ) {
+					$( "#wcpt-update" ).removeAttr( 'disabled' );
+				} else {
+					setTimeout( checkAndEnableUpdateButton, 500 );
+				}
+			}
+
+			$( "#wcpt-update" ).click( function() {
+				$( ".editor-post-save-draft" ).click();
+			} );
+
+			$( "body" ).on( "click", ".editor-post-save-draft", function() {
+				$( "#wcpt-update" ).attr( 'disabled', 'disabled' );
+				setTimeout( checkAndEnableUpdateButton );
+			} );
+
+		}
+	);
+
+	/**
 	 * Kick things off
 	 */
 	$( document ).ready( function( $ ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -293,6 +293,16 @@ abstract class Event_Admin {
 			true
 		);
 
+		$gutenberg_enabled = false;
+		$current_screen = get_current_screen();
+		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+			$gutenberg_enabled = true;
+		}
+
+		wp_localize_script( 'wcpt-admin', 'wcpt_admin', array(
+			'gutenberg_enabled' => $gutenberg_enabled,
+		) );
+
 		wp_enqueue_script( 'wcpt-admin' );
 		wp_enqueue_script( 'select2' );
 


### PR DESCRIPTION
…n WCPT

With block editor, `Save Draft` looks like has same functionality as `Update` button used to have. We should  eventually remove the `Update` button in favor of already present `Save Draft`, but keeping it for now would make sense so as to give time to people to get used to the new editor. `Update` button is way more prominent then the `Save Draft` button, which is another reason to keep it for now.

Also linking Update to Save Draft may make it more clear that they have the same functionality.