### PR TITLE
Add an ignore list mechanism for errors we don't need to send to Slack

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -525,7 +525,7 @@ function send_error_to_slack( $err_no, $err_msg, $file, $line ) {
 
 	$domain    = get_site_url();
 	$page_slug = esc_html( trim( $_SERVER['REQUEST_URI'], '/' ) );
-	$text      = $text . "Message : \"$err_msg\" occured on \"$file:$line\" \n Domain: $domain \n Page: $page_slug \n Error type: $err_no";
+	$text      = $text . "Message : \"$err_msg\" occurred on \"$file:$line\" \n Domain: $domain \n Page: $page_slug \n Error type: $err_no";
 
 	$message = array(
 		'fallback'    => $text,

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -481,6 +481,16 @@ function send_error_to_slack( $err_no, $err_msg, $file, $line ) {
 		return false;
 	}
 
+	// Always use the ABSPATH constant in the keys here to avoid path disclosure.
+	$error_ignorelist = [
+		// See https://core.trac.wordpress.org/ticket/29204
+		ABSPATH . 'wp-includes/SimplePie/Registry.php:215' => 'Non-static method WP_Feed_Cache::create() should not be called statically',
+	];
+
+	if ( isset( $error_ignorelist[ "$file:$line" ] ) && false !== strpos( $err_msg, $error_ignorelist[ "$file:$line" ] ) ) {
+		return false;
+	}
+
 	// Max file length for ubuntu system is 255.
 	$err_key = substr( base64_encode("$file-$line-$err_no" ), -254 );
 

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -466,7 +466,7 @@ function send_error_to_slack( $err_no, $err_msg, $file, $line ) {
 		return false;
 	}
 
-	$error_whitelist = array(
+	$error_safelist = [
 		E_ERROR,
 		E_USER_ERROR,
 		E_CORE_ERROR,
@@ -475,9 +475,9 @@ function send_error_to_slack( $err_no, $err_msg, $file, $line ) {
 		E_NOTICE,
 		E_DEPRECATED,
 		E_WARNING,
-	);
+	];
 
-	if ( ! in_array( $err_no, $error_whitelist ) ) {
+	if ( ! in_array( $err_no, $error_safelist ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Two things to note here:

* This uses the `ABSPATH` constant to obscure the full file paths that come with the error messages, since this ignore list is in a public repo. This might be overkill though. Or we could just put the ignore list in a non-public file. Thoughts?
* This looks for substring matches in the error messages instead of exact matches. This way we can still catch and ignore error messages that contain unique parts, like `wp-content/temp-write-test-1543906354`