### PR TITLE
Prevent submission of payment requests that have no documentation

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -464,6 +464,21 @@ class WCP_Payment_Request {
 	}
 
 	/**
+	 * Check if a post meets the requirements to be submitted for review.
+	 *
+	 * @param WP_Post $post
+	 */
+	protected function can_submit_request( $post ) {
+		$files = WordCamp_Budgets::get_attached_files( $post );
+
+		if ( empty( $files ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the value of a given field.
 	 *
 	 * @param string $name

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -249,10 +249,10 @@ class WCP_Payment_Request {
 			$current_user_can_edit_request = true;
 		} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
 			if ( WordCamp_Budgets::can_submit_request( $post ) ) {
-				$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
-				$submit_note = esc_html__( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
+				$submit_text = __( 'Submit for Review', 'wordcamporg' );
+				$submit_note = __( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
 			} else {
-				$submit_note = esc_html__( 'Please add an invoice or other supporting documentation in the Files section and save the draft.', 'wordcamporg' );
+				$submit_note = __( 'Please add an invoice or other supporting documentation in the Files section and save the draft.', 'wordcamporg' );
 				$submit_note_class = 'error';
 			}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -111,6 +111,15 @@ class WCP_Payment_Request {
 	}
 
 	/**
+	 * Get a list of statuses for which posts can be edited by non-admins.
+	 *
+	 * @return array
+	 */
+	protected static function get_editable_statuses() {
+		return [ 'auto-draft', 'draft', 'wcb-incomplete' ];
+	}
+
+	/**
 	 * Register meta boxes
 	 */
 	public function init_meta_boxes() {
@@ -230,7 +239,7 @@ class WCP_Payment_Request {
 			$post->post_status = $back_compat_statuses[ $post->post_status ];
 		}
 
-		$editable_statuses = array( 'auto-draft', 'draft', 'wcb-incomplete' );
+		$editable_statuses = self::get_editable_statuses();
 		$current_user_can_edit_request = false;
 		$submit_text = esc_html_x( 'Update', 'payment request', 'wordcamporg' );
 		$submit_note = '';
@@ -583,7 +592,7 @@ class WCP_Payment_Request {
 
 		// Submit for Review button was clicked.
 		if ( ! current_user_can( 'manage_network' ) ) {
-			$editable_statuses = array( 'auto-draft', 'draft', 'wcb-incomplete' );
+			$editable_statuses = self::get_editable_statuses();
 			if ( ! empty( $post_data_raw['wcb-update'] ) && in_array( $post_data['post_status'], $editable_statuses ) ) {
 				$post_data['post_status'] = 'wcb-pending-approval';
 			}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -243,15 +243,17 @@ class WCP_Payment_Request {
 		$current_user_can_edit_request = false;
 		$submit_text = esc_html_x( 'Update', 'payment request', 'wordcamporg' );
 		$submit_note = '';
+		$submit_note_class = 'warning';
 
 		if ( current_user_can( 'manage_network' ) ) {
 			$current_user_can_edit_request = true;
 		} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
 			if ( $this->can_submit_request( $post ) ) {
 				$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
-				$submit_note = esc_html__( 'Once submitted for review, this request can not be edited.', 'wordcamporg' );
+				$submit_note = esc_html__( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
 			} else {
-				$submit_note = esc_html__( 'Documentation must be attached and saved to the draft before this request can be submitted.', 'wordcamporg' );
+				$submit_note = esc_html__( 'Please add an invoice or other supporting documentation in the Files section and save the draft.', 'wordcamporg' );
+				$submit_note_class = 'error';
 			}
 
 			$current_user_can_edit_request = true;

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -247,8 +247,13 @@ class WCP_Payment_Request {
 		if ( current_user_can( 'manage_network' ) ) {
 			$current_user_can_edit_request = true;
 		} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
-			$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
-			$submit_note = esc_html__( 'Once submitted for review, this request can not be edited.', 'wordcamporg' );
+			if ( $this->can_submit_request( $post ) ) {
+				$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
+				$submit_note = esc_html__( 'Once submitted for review, this request can not be edited.', 'wordcamporg' );
+			} else {
+				$submit_note = esc_html__( 'Documentation must be attached and saved to the draft before this request can be submitted.', 'wordcamporg' );
+			}
+
 			$current_user_can_edit_request = true;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -248,7 +248,7 @@ class WCP_Payment_Request {
 		if ( current_user_can( 'manage_network' ) ) {
 			$current_user_can_edit_request = true;
 		} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
-			if ( $this->can_submit_request( $post ) ) {
+			if ( WordCamp_Budgets::can_submit_request( $post ) ) {
 				$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
 				$submit_note = esc_html__( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
 			} else {
@@ -468,21 +468,6 @@ class WCP_Payment_Request {
 		wp_localize_script( 'wcb-attached-files', 'wcbAttachedFiles', $files ); // todo merge into wordcampBudgets var
 
 		require( dirname( __DIR__ ) . '/views/payment-request/input-files.php' );
-	}
-
-	/**
-	 * Check if a post meets the requirements to be submitted for review.
-	 *
-	 * @param WP_Post $post
-	 */
-	protected function can_submit_request( $post ) {
-		$files = WordCamp_Budgets::get_attached_files( $post );
-
-		if ( empty( $files ) ) {
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -293,10 +293,10 @@ function render_status_metabox( $post ) {
 		$current_user_can_edit_request = true;
 	} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
 		if ( WordCamp_Budgets::can_submit_request( $post ) ) {
-			$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
-			$submit_note = esc_html__( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
+			$submit_text = __( 'Submit for Review', 'wordcamporg' );
+			$submit_note = __( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
 		} else {
-			$submit_note = esc_html__( 'Please add an invoice or other supporting documentation in the Files section and save the draft.', 'wordcamporg' );
+			$submit_note = __( 'Please add an invoice or other supporting documentation in the Files section and save the draft.', 'wordcamporg' );
 			$submit_note_class = 'error';
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -292,7 +292,7 @@ function render_status_metabox( $post ) {
 	if ( current_user_can( 'manage_network' ) ) {
 		$current_user_can_edit_request = true;
 	} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
-		if ( can_submit_request( $post ) ) {
+		if ( WordCamp_Budgets::can_submit_request( $post ) ) {
 			$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
 			$submit_note = esc_html__( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
 		} else {
@@ -410,21 +410,6 @@ function display_post_states( $states ) {
 	}
 
 	return $states;
-}
-
-/**
- * Check if a post meets the requirements to be submitted for review.
- *
- * @param WP_Post $post
- */
-function can_submit_request( $post ) {
-	$files = WordCamp_Budgets::get_attached_files( $post );
-
-	if ( empty( $files ) ) {
-		return false;
-	}
-
-	return true;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -287,15 +287,17 @@ function render_status_metabox( $post ) {
 	$current_user_can_edit_request = false;
 	$submit_text = esc_html_x( 'Update', 'payment request', 'wordcamporg' );
 	$submit_note = '';
+	$submit_note_class = 'warning';
 
 	if ( current_user_can( 'manage_network' ) ) {
 		$current_user_can_edit_request = true;
 	} elseif ( in_array( $post->post_status, $editable_statuses ) ) {
 		if ( can_submit_request( $post ) ) {
 			$submit_text = esc_html__( 'Submit for Review', 'wordcamporg' );
-			$submit_note = esc_html__( 'Once submitted for review, this request can not be edited.', 'wordcamporg' );
+			$submit_note = esc_html__( 'Once submitted for review, this request cannot be edited.', 'wordcamporg' );
 		} else {
-			$submit_note = esc_html__( 'Documentation must be attached and saved to the draft before this request can be submitted.', 'wordcamporg' );
+			$submit_note = esc_html__( 'Please add an invoice or other supporting documentation in the Files section and save the draft.', 'wordcamporg' );
+			$submit_note_class = 'error';
 		}
 
 		$current_user_can_edit_request = true;

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -2668,6 +2668,21 @@ class WordCamp_Budgets {
 	}
 
 	/**
+	 * Check if a request post meets the requirements to be submitted for review.
+	 *
+	 * @param WP_Post $post
+	 */
+	public static function can_submit_request( $post ) {
+		// A request must have documentation attached before it can be submitted.
+		$files = self::get_attached_files( $post );
+		if ( empty( $files ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the files attached to a post
 	 *
 	 * @param WP_Post $post

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
@@ -4,6 +4,7 @@
 /** @var bool $current_user_can_edit_request */
 /** @var string $submit_text */
 /** @var string $submit_note */
+/** @var string $submit_note_class */
 /** @var bool $date_vendor_paid_readonly */
 /** @var string $incomplete_notes */
 /** @var bool $incomplete_readonly */
@@ -97,7 +98,7 @@
 		<?php if ( $current_user_can_edit_request ) : ?>
 
 			<?php if ( ! empty( $submit_note ) ) : ?>
-				<div><?php echo $submit_note; ?></div>
+				<div class="notice notice-<?php echo esc_attr( $submit_note_class ); ?> inline"><?php echo wpautop( $submit_note ); ?></div>
 			<?php endif; ?>
 
 			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
@@ -95,36 +95,6 @@
 		<div class="clear"></div>
 	</div> <!-- #minor-publishing -->
 
-
-	<div id="major-publishing-actions">
-		<?php if ( $current_user_can_edit_request ) : ?>
-
-			<?php if ( ! empty( $submit_note ) ) : ?>
-				<div class="notice notice-<?php echo esc_attr( $submit_note_class ); ?> inline"><?php echo wpautop( $submit_note ); ?></div>
-			<?php endif; ?>
-
-			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
-				<div id="delete-action">
-					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post->ID ); ?>">
-						<?php _e( 'Delete', 'wordcamporg' ); ?>
-					</a>
-				</div>
-			<?php endif; ?>
-
-			<?php if ( $this->can_submit_request( $post ) ) : ?>
-				<div id="publishing-action">
-					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
-					<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
-				</div>
-			<?php endif; ?>
-
-			<div class="clear"></div>
-
-		<?php else : ?>
-
-			<?php _e( 'This request can not be edited.', 'wordcamporg' ); ?>
-
-		<?php endif; ?>
-	</div> <!-- #major-publishing-actions -->
+	<?php require dirname( __DIR__ ) . '/wordcamp-budgets/major-publishing-actions.php'; ?>
 
 </div> <!-- .submitbox -->

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
@@ -1,13 +1,15 @@
 <?php
-/** @var WP_Post $post */
-/** @var WCP_Payment_Request $this */
-/** @var bool $current_user_can_edit_request */
-/** @var string $submit_text */
-/** @var string $submit_note */
-/** @var string $submit_note_class */
-/** @var bool $date_vendor_paid_readonly */
-/** @var string $incomplete_notes */
-/** @var bool $incomplete_readonly */
+/**
+ * @var WP_Post             $post
+ * @var WCP_Payment_Request $this
+ * @var bool                $current_user_can_edit_request
+ * @var string              $submit_text
+ * @var string              $submit_note
+ * @var string              $submit_note_class
+ * @var bool                $date_vendor_paid_readonly
+ * @var string              $incomplete_notes
+ * @var bool                $incomplete_readonly
+ */
 ?>
 <div id="submitpost" class="wcb submitbox">
 	<div id="minor-publishing">

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-status.php
@@ -1,3 +1,13 @@
+<?php
+/** @var WP_Post $post */
+/** @var WCP_Payment_Request $this */
+/** @var bool $current_user_can_edit_request */
+/** @var string $submit_text */
+/** @var string $submit_note */
+/** @var bool $date_vendor_paid_readonly */
+/** @var string $incomplete_notes */
+/** @var bool $incomplete_readonly */
+?>
 <div id="submitpost" class="wcb submitbox">
 	<div id="minor-publishing">
 
@@ -39,7 +49,7 @@
 						<?php if ( current_user_can( 'manage_network' ) ) : ?>
 
 							<select id="wcb_status" name="post_status">
-								<?php foreach ( self::get_post_statuses() as $status ) : ?>
+								<?php foreach ( WCP_Payment_Request::get_post_statuses() as $status ) : ?>
 									<?php $status = get_post_status_object( $status ); ?>
 									<option value="<?php echo esc_attr( $status->name ); ?>" <?php selected( $post->post_status, $status->name ); ?> >
 										<?php echo esc_html( $status->label ); ?>
@@ -86,23 +96,24 @@
 	<div id="major-publishing-actions">
 		<?php if ( $current_user_can_edit_request ) : ?>
 
-			<?php if ( !empty( $submit_note ) ) : ?>
+			<?php if ( ! empty( $submit_note ) ) : ?>
 				<div><?php echo $submit_note; ?></div>
 			<?php endif; ?>
 
-
-			<div id="delete-action">
-				<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
+			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
+				<div id="delete-action">
 					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post->ID ); ?>">
 						<?php _e( 'Delete', 'wordcamporg' ); ?>
 					</a>
-				<?php endif; ?>
-			</div>
+				</div>
+			<?php endif; ?>
 
-			<div id="publishing-action">
-				<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
-				<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
-			</div>
+			<?php if ( $this->can_submit_request( $post ) ) : ?>
+				<div id="publishing-action">
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
+					<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
+				</div>
+			<?php endif; ?>
 
 			<div class="clear"></div>
 

--- a/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
@@ -95,35 +95,6 @@ defined( 'WPINC' ) or die();
 		<div class="clear"></div>
 	</div> <!-- #minor-publishing -->
 
-
-	<div id="major-publishing-actions">
-		<?php if ( $current_user_can_edit_request ) : ?>
-			<?php if ( !empty( $submit_note ) ) : ?>
-				<div class="notice notice-<?php echo esc_attr( $submit_note_class ); ?> inline"><?php echo wpautop( $submit_note ); ?></div>
-			<?php endif; ?>
-
-			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
-				<div id="delete-action">
-					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post->ID ); ?>">
-						<?php _e( 'Delete', 'wordcamporg' ); ?>
-					</a>
-				</div>
-			<?php endif; ?>
-
-			<?php if ( can_submit_request( $post ) ) : ?>
-				<div id="publishing-action">
-					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
-					<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
-				</div>
-			<?php endif; ?>
-
-			<div class="clear"></div>
-
-		<?php else : ?>
-
-			<?php _e( 'This request can not be edited.', 'wordcamporg' ); ?>
-
-		<?php endif; ?>
-	</div> <!-- #major-publishing-actions -->
+	<?php require dirname( __DIR__ ) . '/wordcamp-budgets/major-publishing-actions.php'; ?>
 
 </div> <!-- .submitbox -->

--- a/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
@@ -3,15 +3,17 @@
 namespace WordCamp\Budgets\Reimbursement_Requests;
 defined( 'WPINC' ) or die();
 
-/** @var \WP_Post $post */
-/** @var bool $current_user_can_edit_request */
-/** @var string $request_id */
-/** @var string $requested_by */
-/** @var string $incomplete_notes */
-/** @var bool $incomplete_readonly */
-/** @var string $submit_text */
-/** @var string $submit_note */
-/** @var string $submit_note_class */
+/**
+ * @var \WP_Post $post
+ * @var bool     $current_user_can_edit_request
+ * @var string   $request_id
+ * @var string   $requested_by
+ * @var string   $incomplete_notes
+ * @var bool     $incomplete_readonly
+ * @var string   $submit_text
+ * @var string   $submit_note
+ * @var string   $submit_note_class
+ */
 ?>
 
 <div id="submitpost" class="wcb submitbox">

--- a/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
@@ -11,7 +11,7 @@ defined( 'WPINC' ) or die();
 /** @var bool $incomplete_readonly */
 /** @var string $submit_text */
 /** @var string $submit_note */
-
+/** @var string $submit_note_class */
 ?>
 
 <div id="submitpost" class="wcb submitbox">
@@ -97,7 +97,7 @@ defined( 'WPINC' ) or die();
 	<div id="major-publishing-actions">
 		<?php if ( $current_user_can_edit_request ) : ?>
 			<?php if ( !empty( $submit_note ) ) : ?>
-				<div><?php echo $submit_note; ?></div>
+				<div class="notice notice-<?php echo esc_attr( $submit_note_class ); ?> inline"><?php echo wpautop( $submit_note ); ?></div>
 			<?php endif; ?>
 
 			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-status.php
@@ -3,6 +3,15 @@
 namespace WordCamp\Budgets\Reimbursement_Requests;
 defined( 'WPINC' ) or die();
 
+/** @var \WP_Post $post */
+/** @var bool $current_user_can_edit_request */
+/** @var string $request_id */
+/** @var string $requested_by */
+/** @var string $incomplete_notes */
+/** @var bool $incomplete_readonly */
+/** @var string $submit_text */
+/** @var string $submit_note */
+
 ?>
 
 <div id="submitpost" class="wcb submitbox">
@@ -91,18 +100,20 @@ defined( 'WPINC' ) or die();
 				<div><?php echo $submit_note; ?></div>
 			<?php endif; ?>
 
-			<div id="delete-action">
-				<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
+			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
+				<div id="delete-action">
 					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post->ID ); ?>">
 						<?php _e( 'Delete', 'wordcamporg' ); ?>
 					</a>
-				<?php endif; ?>
-			</div>
+				</div>
+			<?php endif; ?>
 
-			<div id="publishing-action">
-				<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
-				<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
-			</div>
+			<?php if ( can_submit_request( $post ) ) : ?>
+				<div id="publishing-action">
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
+					<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
+				</div>
+			<?php endif; ?>
 
 			<div class="clear"></div>
 

--- a/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/major-publishing-actions.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/major-publishing-actions.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @var WP_Post $post
+ * @var bool    $current_user_can_edit_request
+ * @var string  $submit_text
+ * @var string  $submit_note
+ * @var string  $submit_note_class
+ */
+?>
+
+<div id="major-publishing-actions">
+	<?php if ( $current_user_can_edit_request ) : ?>
+
+		<?php if ( ! empty( $submit_note ) ) : ?>
+			<div class="notice notice-<?php echo esc_attr( $submit_note_class ); ?> inline">
+				<?php echo wpautop( esc_html( $submit_note ) ); ?>
+			</div>
+		<?php endif; ?>
+
+		<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
+			<div id="delete-action">
+				<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post->ID ); ?>">
+					<?php _e( 'Delete', 'wordcamporg' ); ?>
+				</a>
+			</div>
+		<?php endif; ?>
+
+		<?php if ( \WordCamp_Budgets::can_submit_request( $post ) ) : ?>
+			<div id="publishing-action">
+				<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
+				<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
+			</div>
+		<?php endif; ?>
+
+		<div class="clear"></div>
+
+	<?php else : ?>
+
+		<?php _e( 'This request can not be edited.', 'wordcamporg' ); ?>
+
+	<?php endif; ?>
+</div> <!-- #major-publishing-actions -->


### PR DESCRIPTION
For both Payment Requests and Reimbursement Requests:

* Add a method to check and see if the request post can be submitted. Currently this just checks to see if the post has one or more files attached to it.
* When the post fails the check, show a note in the Status metabox that documentation must be attached first, and don't render the _Submit for Review_ button.

Screenshots:

Payment request with no attachments:
![payment-request_no-attachment](https://user-images.githubusercontent.com/916023/51541985-7af0c480-1e5a-11e9-8e91-a5ce8dd9c591.jpg)

Reimbursement request with no attachments:
![reimbursement-request_no-attachment](https://user-images.githubusercontent.com/916023/51542028-92c84880-1e5a-11e9-9c27-d3a038631868.jpg)
