### PR TITLE
WCPT: Move post type check to before nonce check.

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -412,17 +412,17 @@ abstract class Event_Admin {
 			return;
 		}
 
-		// Make sure the requset came from the edit post screen.
+		if ( $this->get_event_type() !== $post->post_status ) {
+			return;
+		}
+
+		// Make sure the request came from the edit post screen.
 		if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $post_id ) ) {
 			die( 'Unable to verify nonce' );
 		}
 
 		// Don't add/remove meta on trash, untrash, restore, etc.
 		if ( empty( $_POST['action'] ) || 'editpost' !== $_POST['action'] ) {
-			return;
-		}
-
-		if ( $this->get_event_type() !== get_post_type() ) {
 			return;
 		}
 


### PR DESCRIPTION
This was giving an error sometimes while submitting a post, looks like because `metabox_save` is getting enqueued some other place as well.