### PR TITLE
WordCamp Payment: Add status "Paid" and "Cancelled" to list of status…

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -421,6 +421,11 @@ abstract class Event_Admin {
 			return;
 		}
 
+		// Don't add/remove meta on trash, untrash, restore, etc.
+		if ( empty( $_POST['action'] ) || 'editpost' !== $_POST['action'] ) {
+			return;
+		}
+
 		// Make sure the request came from the edit post screen.
 		if ( $verify_nonce ) {
 			if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $post_id ) ) {
@@ -428,10 +433,6 @@ abstract class Event_Admin {
 			}
 		}
 
-		// Don't add/remove meta on trash, untrash, restore, etc.
-		if ( empty( $_POST['action'] ) || 'editpost' !== $_POST['action'] ) {
-			return;
-		}
 
 		$meta_keys = $this->meta_keys();
 		$orig_meta_values = get_post_meta( $post_id );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -435,6 +435,8 @@ class WCOR_Reminder {
 			return;
 		}
 
+		wp_die( 'Manually sending reminders is currently disabled while I track down a nasty bug. -Ian' );
+
 		$wordcamp = get_post( $form_values['wcor_manually_send_wordcamp'] );
 		$WCOR_Mailer->send_manual_email( $email, $wordcamp );
 	}

--- a/public_html/wp-content/plugins/wordcamp-payments/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/bootstrap.php
@@ -8,6 +8,8 @@ Author URI:  https://wordcamp.org
 Version:     0.1
 */
 
+define( 'WORDCAMP_PAYMENTS_PATH', plugin_dir_path( __FILE__ ) );
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Access denied.' );
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -170,7 +170,7 @@ class WordCamp_Budgets {
 			'wordcamp-budgets',
 			plugins_url( 'javascript/wordcamp-budgets.js', __DIR__ ),
 			array( 'jquery', 'jquery-ui-datepicker', 'media-upload', 'media-views' ),
-			3,
+			filemtime( WORDCAMP_PAYMENTS_PATH . '/javascript/wordcamp-budgets.js' ),
 			true
 		);
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
@@ -32,7 +32,7 @@ jQuery( document ).ready( function( $ ) {
 		maybeMakeFieldsOptional : function() {
 			var status = $( '#wcb_status' ).val();
 
-			if ( 'draft' === status || 'wcb-incomplete' === status ) {
+			if ( [ 'draft', 'wcb-incomplete', 'wcb-paid', 'wcb-cancelled' ].indexOf( status ) !== -1 ) {
 				app.makeFieldsOptional();
 
 				if ( 'wcb-incomplete' === status ) {


### PR DESCRIPTION
…es where we do not enforce required fields.

We periodically delete bank details data for privacy reasons. Because of this, it was not possible to update any other field in the Reimbursement request or Vendor Payment request without filling junk data into deleted fields. This patch allows updating these posts after the bank data is deleted.