### PR TITLE
Make forms-to-drafts compatible w/ the block editor

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/attendees.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/attendees.php
@@ -1,0 +1,3 @@
+<!-- wp:shortcode -->
+[camptix_attendees columns="3"]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -1,0 +1,24 @@
+<?php /** @var WordCamp_New_Site $this */ ?>
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php printf(
+	// translators: %s: URL for code of conduct policy
+	__( '<em>Organizers note:</em> Below is a boilerplate code of conduct that you can customize; another great example is the Ada Initiative <a href="%s">anti-harassment policy.</a>', 'wordcamporg' ),
+	'http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy'
+); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php printf(
+	// translators: %s: URL for article about harassment reports
+	__( 'We also recommend the organizing team read this article on <a href="%s">how to take a harassment report</a>', 'wordcamporg' ),
+	'http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports'
+); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( 'Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>. You can use the "Remove Formatting" button on the toolbar (the eraser icon on the second line) to remove the color and underline.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list {"ordered":true} -->
+<?php echo $this->get_code_of_conduct(); ?>
+<!-- /wp:list -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/contact.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/contact.php
@@ -1,0 +1,7 @@
+<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Contact Request', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Name', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Message', 'wordcamporg' ); ?>","required":true} /-->
+<!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[organizers]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/schedule.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/schedule.php
@@ -1,0 +1,11 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2><?php _e( 'Saturday, January 1st', 'wordcamporg' ) ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:shortcode -->
+[schedule date="YYYY-MM-DD" tracks="example-track,another-example-track,yet-another-example-track"]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[sessions orderby="session_time" order="asc"]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/slideshow.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/slideshow.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( "<em>Organizers note:</em> Upload photos to this page and they'll automagically appear in a slideshow!", 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[slideshow]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/social-media-stream.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/social-media-stream.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> The [[tagregator]] shortcode will pull in a stream of social media posts and display them. In order to use it, you\'ll need to follow the setup instructions at http://wordpress.org/plugins/tagregator/installation, and then update "#wcxyz" below with your hashtag.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[tagregator hashtag="#wcxzy"]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[speakers]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
@@ -1,0 +1,27 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php printf(
+	/* translators: %s: Global Community Sponsorship page URL */
+	__( "<em>Organizers note:</em> Multi-event sponsors have been automatically created in the Sponsors menu, but you'll need to remove the ones that don't apply to your specific event. To find out which ones apply, please visit the <a href=\"%s\">Global Community Sponsorship</a> handbook page. After that, you should add the sponsors that are specific to your event. For non-English sites, make sure the URL below matches the Call for Sponsors page.", 'wordcamporg' ),
+	'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/fundraising/global-community-sponsorship-for-event-organizers/'
+); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2><?php _e( 'Our Sponsors', 'wordcamporg' ) ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Blurb thanking sponsors', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[sponsors]
+<!-- /wp:shortcode -->
+
+<!-- wp:heading -->
+<h2><?php _e( 'Interested in sponsoring WordCamp this year?', 'wordcamporg' ) ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'Check out our <a href="/call-for-sponsors">Call for Sponsors</a> post for details on how you can help make this year\'s WordCamp the best it can be!', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/tickets.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/tickets.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( "<em>Organizers note:</em> If you'd like to change the slug for this page, please make sure you do that before opening ticket sales. Changing the page slug after tickets have started selling will break the link that users receive in their receipt e-mail.", 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[camptix]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/videos.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/videos.php
@@ -1,0 +1,7 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> After your WordCamp is over and the sessions are published to WordPress.tv, you can embed them here. Just enter the event slug into the shortcode below, and hit the <em>Publish</em> button.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[wptv event="enter-event-slug-here"]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
@@ -1,0 +1,25 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> Submissions to this form will automatically create draft posts for the Speaker and Session post types. Feel free to customize the form, but deleting or renaming the following fields will break the automation: Name, Email, WordPress.org Username, Your Bio, Session Title, Session Description.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( "If you'd like to propose multiple topics, please submit the form multiple times, once for each topic. [Other speaker instructions/info goes here.]", 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Speaker Request', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Name', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email Address', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'WordPress.org Username', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Your Bio', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Topic Title', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Topic Description', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Intended Audience', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Past Speaking Experience (not necessary to apply)', 'wordcamporg' ); ?>"} /-->
+<!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
@@ -1,0 +1,21 @@
+<!-- wp:paragraph -->
+<p><?php _e( 'Blurb with information for potential sponsors.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Sponsor Request', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Contact Name', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Company Name', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-url {"label":"<?php esc_attr_e( 'Company Website', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-telephone {"label":"<?php esc_attr_e( 'Phone Number', 'wordcamporg' ); ?>"} /-->
+
+<!-- wp:jetpack/field-select {"label":"<?php esc_attr_e( 'Sponsorship Level', 'wordcamporg' ); ?>","options":["Bronze","Silver","Gold"]} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Why Would you Like to Sponsor WordCamp?', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Questions / Comments', 'wordcamporg' ); ?>"} /-->
+<!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
@@ -1,0 +1,15 @@
+<!-- wp:paragraph -->
+<p><?php _e( 'Blurb with information for potential volunteers.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Volunteer Application', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Name', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Skills / Interests / Experience (not necessary to volunteer)', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Number of Hours Available', 'wordcamporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Questions / Comments', 'wordcamporg' ); ?>"} /-->
+<!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/welcome.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/welcome.php
@@ -1,0 +1,15 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( 'We\'re happy to announce that <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> is officially on the calendar!', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( '<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> will be <span style="color: red; text-decoration: underline;">DATE(S)</span> at <span style="color: red; text-decoration: underline;">LOCATION</span>.', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php _e( '<span style="color: red; text-decoration: underline;">Subscribe using the form in the sidebar</span> to stay up to date on the most recent news. We’ll be keeping you posted on all the details over the coming months, including speaker submissions, ticket sales and more!', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -488,50 +488,31 @@ class WordCamp_New_Site {
 	 * @return array
 	 */
 	protected function get_stub_pages( $wordcamp, $meta ) {
-		// todo remove the to field from all contact forms and notes, just let it default to the admin email
-
 		$pages = array(
 			array(
 				'title'   => __( 'Schedule', 'wordcamporg' ),
-				'content' =>
-					'<p>'  . __( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ) . '</p> ' .
-					'<h1>' . __( 'Saturday, January 1st', 'wordcamporg' ) . '</h1> ' .
-					'<p>[schedule date="YYYY-MM-DD" tracks="example-track,another-example-track,yet-another-example-track"]</p>',
+				'content' => $this->get_stub_content( 'page', 'schedule' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Speakers', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.', 'wordcamporg' ) . '</p> ' .
-					'<p>[speakers]</p>',
+				'content' => $this->get_stub_content( 'page', 'speakers' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Sessions', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ) . '</p> ' .
-					'<p>[sessions orderby="session_time" order="asc"]</p>',
+				'content' => $this->get_stub_content( 'page', 'sessions' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Sponsors', 'wordcamporg' ),
-				'content' =>
-					'<p>' . sprintf(
-						/* translators: %s: Global Community Sponsorship page URL */
-						__( "<em>Organizers note:</em> Multi-event sponsors have been automatically created in the Sponsors menu, but you'll need to remove the ones that don't apply to your specific event. To find out which ones apply, please visit the <a href=\"%s\">Global Community Sponsorship</a> handbook page. After that, you should add the sponsors that are specific to your event. For non-English sites, make sure the URL below matches the Call for Sponsors page.", 'wordcamporg' ),
-						'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/fundraising/global-community-sponsorship-for-event-organizers/'
-					) . '</p> ' .
-					'<h3>' . __( 'Our Sponsors', 'wordcamporg' ) . '</h3> ' .
-					'<p>'  . __( 'Blurb thanking sponsors', 'wordcamporg' ) . '</p> ' .
-					'<p>[sponsors]</p> ' .
-					'<h3>' . __( 'Interested in sponsoring WordCamp this year?', 'wordcamporg' ) . '</h3> ' .
-					'<p>'  . __( 'Check out our <a href="/call-for-sponsors">Call for Sponsors</a> post for details on how you can help make this year\'s WordCamp the best it can be!</p>', 'wordcamporg' ),
+				'content' => $this->get_stub_content( 'page', 'sponsors' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
@@ -545,97 +526,57 @@ class WordCamp_New_Site {
 
 			array(
 				'title'   => __( 'Organizers', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.', 'wordcamporg' ) . '</p> ' .
-					'<p>[organizers]</p>',
+				'content' => $this->get_stub_content( 'page', 'organizers' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Tickets', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( "<em>Organizers note:</em> If you'd like to change the slug for this page, please make sure you do that before opening ticket sales. Changing the page slug after tickets have started selling will break the link that users receive in their receipt e-mail.", 'wordcamporg' ) . '</p> ' .
-					'<p>[camptix]</p>',
+				'content' => $this->get_stub_content( 'page', 'tickets' ),
 				'status'  => 'draft',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Attendees', 'wordcamporg' ),
-				'content' => '[camptix_attendees columns="3"]',
+				'content' => $this->get_stub_content( 'page', 'attendees' ),
 				'status'  => 'draft',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Videos', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> After your WordCamp is over and the sessions are published to WordPress.tv, you can embed them here. Just enter the event slug into the shortcode below, and hit the <em>Publish</em> button.', 'wordcamporg' ) . '</p> ' .
-					 '<p>[wptv event="enter-event-slug-here"]</p>',
+				'content' => $this->get_stub_content( 'page', 'videos' ),
 				'status'  => 'draft',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Slideshow', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( "<em>Organizers note:</em> Upload photos to this page and they'll automagically appear in a slideshow!", 'wordcamporg' ) . '</p> ' .
-					'<p>[slideshow]</p>',
+				// todo Update this one when Jetpack's Slideshow block becomes available.
+				'content' => $this->get_stub_content( 'page', 'slideshow' ),
 				'status'  => 'draft',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Contact', 'wordcamporg' ),
-				'content' => sprintf(
-					'<p>' .
-						'[contact-form to="%s" subject="%s"]' .
-							'[contact-field label="%s" type="name"     required="1" /]' .
-							'[contact-field label="%s" type="email"    required="1" /]' .
-							'[contact-field label="%s" type="textarea" required="1" /]' .
-						'[/contact-form]' .
-					'</p>',
-					get_option( 'admin_email' ),
-					__( 'WordCamp Contact Request', 'wordcamporg' ),
-					__( 'Name', 'wordcamporg' ),
-					__( 'Email', 'wordcamporg' ),
-					__( 'Message', 'wordcamporg' )
-				),
+				'content' => $this->get_stub_content( 'page', 'contact' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Social Media Stream', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> The [[tagregator]] shortcode will pull in a stream of social media posts and display them. In order to use it, you\'ll need to follow the setup instructions at http://wordpress.org/plugins/tagregator/installation, and then update "#wcxyz" below with your hashtag.', 'wordcamporg' ) . '</p> ' .
-					'<p>[tagregator hashtag="#wcxzy"]</p>',
+				'content' => $this->get_stub_content( 'page', 'social-media-stream' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
 
 			array(
 				'title'   => __( 'Code of Conduct', 'wordcamporg' ),
-				'content' =>
-					'<p>' .
-						sprintf(
-							// translators: %s: URL for code of conduct policy
-							__( '<em>Organizers note:</em> Below is a boilerplate code of conduct that you can customize; another great example is the Ada Initiative <a href="%s">anti-harassment policy.</a>', 'wordcamporg' ),
-							'http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy'
-						) .
-					'</p> ' .
-
-					'<p>' .
-						sprintf(
-							// translators: %s: URL for article about harassment reports
-							__( 'We also recommend the organizing team read this article on <a href="%s">how to take a harassment report</a>', 'wordcamporg' ),
-							'http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports'
-						) .
-					'</p> ' .
-
-					'<p>' . __( 'Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>. You can use the "Remove Formatting" button on the toolbar (the eraser icon on the second line) to remove the color and underline.', 'wordcamporg' ) .
-					$this->get_code_of_conduct(),
+				'content' => $this->get_stub_content( 'page', 'code-of-conduct' ),
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
@@ -657,74 +598,21 @@ class WordCamp_New_Site {
 			array(
 				// translators: %s: site title
 				'title'   => sprintf( __( 'Welcome to %s', 'wordcamporg' ), get_option( 'blogname' ) ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>.', 'wordcamporg' ) . '</p> ' .
-					'<p>' . __( 'We\'re happy to announce that <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> is officially on the calendar!', 'wordcamporg' ) . '</p> ' .
-					'<p>' . __( '<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> will be <span style="color: red; text-decoration: underline;">DATE(S)</span> at <span style="color: red; text-decoration: underline;">LOCATION</span>.', 'wordcamporg' ) . '</p> ' .
-					'<p>' . __( '<span style="color: red; text-decoration: underline;">Subscribe using the form in the sidebar</span> to stay up to date on the most recent news. We’ll be keeping you posted on all the details over the coming months, including speaker submissions, ticket sales and more!', 'wordcamporg' ) . '</p> ',
+				'content' => $this->get_stub_content( 'post', 'welcome' ),
 				'status'  => 'publish',
 				'type'    => 'post',
 			),
 
 			array(
 				'title'   => __( 'Call for Sponsors', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( 'Blurb with information for potential sponsors.', 'wordcamporg' ) . '</p> ' .
-					'<p>' .
-						sprintf( '
-							[contact-form to="%s" subject="%s"]
-							[contact-field label="%s" type="text"     required="1" /]
-							[contact-field label="%s" type="name"     required="1" /]
-							[contact-field label="%s" type="email"    required="1" /]
-							[contact-field label="%s" type="text"                  /]
-							[contact-field label="%s" type="text"                  /]
-							[contact-field label="%s" type="textarea" required="1" /]
-							[contact-field label="%s" type="textarea"              /]
-							[/contact-form]',
-							get_option( 'admin_email' ),
-							__( 'WordCamp Sponsor Request', 'wordcamporg' ),
-							__( 'Contact Name', 'wordcamporg' ),
-							__( 'Company Name', 'wordcamporg' ),
-							__( 'Email', 'wordcamporg' ),
-							__( 'Phone Number', 'wordcamporg' ),
-							__( 'Sponsorship Level', 'wordcamporg' ),
-							__( 'Why Would you Like to Sponsor WordCamp?', 'wordcamporg' ),
-							__( 'Questions / Comments', 'wordcamporg' )
-						) .
-					'</p>',
+				'content' => $this->get_stub_content( 'post', 'call-for-sponsors' ),
 				'status'  => 'draft',
 				'type'    => 'post',
 			),
 
 			array(
 				'title'   => __( 'Call for Speakers', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( '<em>Organizers note:</em> Submissions to this form will automatically create draft posts for the Speaker and Session post types. Feel free to customize the form, but deleting or renaming the following fields will break the automation: Name, Email, WordPress.org Username, Your Bio, Session Title, Session Description.', 'wordcamporg' ) . '</p>' .
-					'<p>' . __( "If you'd like to propose multiple topics, please submit the form multiple times, once for each topic. [Other speaker instructions/info goes here.]", 'wordcamporg' ) . '</p>' .
-					'<p>' .
-						sprintf( '
-							[contact-form to="%s" subject="%s"]
-								[contact-field label="%s" type="name"     required="1" /]
-								[contact-field label="%s" type="email"    required="1" /]
-								[contact-field label="%s" type="text"     required="1" /]
-								[contact-field label="%s" type="textarea" required="1" /]
-								[contact-field label="%s" type="text"     required="1" /]
-								[contact-field label="%s" type="textarea" required="1" /]
-								[contact-field label="%s" type="text"     required="1" /]
-								[contact-field label="%s" type="textarea"              /]
-							[/contact-form]',
-							get_option( 'admin_email' ),
-							__( 'WordCamp Speaker Request', 'wordcamporg' ),
-							__( 'Name', 'wordcamporg' ),
-							__( 'Email Address', 'wordcamporg' ),
-							__( 'WordPress.org Username', 'wordcamporg' ),
-							__( 'Your Bio', 'wordcamporg' ),
-							__( 'Topic Title', 'wordcamporg' ),
-							__( 'Topic Description', 'wordcamporg' ),
-							__( 'Intended Audience', 'wordcamporg' ),
-							__( 'Past Speaking Experience (not necessary to apply)', 'wordcamporg' )
-						) .
-					'</p>',
+				'content' => $this->get_stub_content( 'post', 'call-for-speakers' ),
 				'status'  => 'draft',
 				'type'    => 'post',
 				'meta'    => array(
@@ -734,32 +622,34 @@ class WordCamp_New_Site {
 
 			array(
 				'title'   => __( 'Call for Volunteers', 'wordcamporg' ),
-				'content' =>
-					'<p>' . __( 'Blurb with information for potential volunteers.', 'wordcamporg' ) . '</p> ' .
-					'<p>' .
-						sprintf( '
-							[contact-form to="%s" subject="%s"]
-								[contact-field label="%s" type="text"     required="1" /]
-								[contact-field label="%s" type="email"    required="1" /]
-								[contact-field label="%s" type="textarea" required="1" /]
-								[contact-field label="%s" type="text"     required="1" /]
-								[contact-field label="%s" type="textarea"              /]
-							[/contact-form]',
-							get_option( 'admin_email' ),
-							__( 'WordCamp Volunteer Application', 'wordcamporg' ),
-							__( 'Name', 'wordcamporg' ),
-							__( 'Email', 'wordcamporg' ),
-							__( 'Skills / Interests / Experience (not necessary to volunteer)', 'wordcamporg' ),
-							__( 'Number of Hours Available', 'wordcamporg' ),
-							__( 'Questions / Comments', 'wordcamporg' )
-						) .
-					'</p>',
+				'content' => $this->get_stub_content( 'post', 'call-for-volunteers' ),
 				'status'  => 'draft',
 				'type'    => 'post',
 			),
 		);
 
 		return $posts;
+	}
+
+	/**
+	 * Load the content for a stub from an include file.
+	 *
+	 * @param string $post_type
+	 * @param string $stub_name
+	 *
+	 * @return string
+	 */
+	protected function get_stub_content( $post_type, $stub_name ) {
+		$content   = '';
+		$stub_file = WCPT_DIR . "stubs/$post_type/$stub_name.php";
+
+		if ( is_readable( $stub_file ) ) {
+			ob_start();
+			require $stub_file;
+			$content = ob_get_clean();
+		}
+
+		return $content;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -269,6 +269,8 @@ class WordCamp_Forms_To_Drafts {
 	 *   taxonomy and the selected term is applied to the drafted post. Maybe need to send PR to add filter to
 	 *   insert custom fields programmatically.
 	 * - Sideload the logo from submitted URL and set it as the featured image.
+	 * - Add a Company Description field to the form stub, or populate content from something else?
+	 * - Also ensure content is formatted for the block editor.
 	 *
 	 * @param int   $submission_id
 	 * @param array $all_values
@@ -378,11 +380,19 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_speaker( $speaker ) {
+		$content = ( ! empty( $speaker['Your Bio'] ) ) ?: '';
+
+		if ( $content ) {
+			$content = wpautop( $content );
+			$content = str_replace( '<p>', "<!-- wp:paragraph -->\n<p>", $content );
+			$content = str_replace( '</p>', "</p>\n<!-- /wp:paragraph -->", $content );
+		}
+
 		$speaker_id = wp_insert_post(
 			array(
 				'post_type'    => 'wcb_speaker',
 				'post_title'   => $speaker['Name'],
-				'post_content' => $speaker['Your Bio'],
+				'post_content' => $content,
 				'post_status'  => 'draft',
 				'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
 			),
@@ -406,11 +416,19 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_session( $session, $speaker ) {
+		$content = ( ! empty( $session['Topic Description'] ) ) ?: '';
+
+		if ( $content ) {
+			$content = wpautop( $content );
+			$content = str_replace( '<p>', "<!-- wp:paragraph -->\n<p>", $content );
+			$content = str_replace( '</p>', "</p>\n<!-- /wp:paragraph -->", $content );
+		}
+
 		$session_id = wp_insert_post(
 			array(
 				'post_type'    => 'wcb_session',
 				'post_title'   => $session['Topic Title'],
-				'post_content' => $session['Topic Description'],
+				'post_content' => $content,
 				'post_status'  => 'draft',
 				'post_author'  => $this->get_user_id_from_username( $session['WordPress.org Username'] ),
 			),

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -380,7 +380,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_speaker( $speaker ) {
-		$content = ( ! empty( $speaker['Your Bio'] ) ) ?: '';
+		$content = ( ! empty( $speaker['Your Bio'] ) ) ? $speaker['Your Bio'] : '';
 
 		if ( $content ) {
 			$content = wpautop( $content );
@@ -416,7 +416,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_session( $session, $speaker ) {
-		$content = ( ! empty( $session['Topic Description'] ) ) ?: '';
+		$content = ( ! empty( $session['Topic Description'] ) ) ? $session['Topic Description'] : '';
 
 		if ( $content ) {
 			$content = wpautop( $content );

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -269,7 +269,7 @@ class WordCamp_Forms_To_Drafts {
 	 *   taxonomy and the selected term is applied to the drafted post. Maybe need to send PR to add filter to
 	 *   insert custom fields programmatically.
 	 * - Sideload the logo from submitted URL and set it as the featured image.
-	 * - Add a Company Description field to the form stub, or populate content from something else?
+	 * - Add a Company Description field to the Call For Sponsors form stub, or populate content from something else?
 	 * - Also ensure content is formatted for the block editor.
 	 *
 	 * @param int   $submission_id

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -380,7 +380,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_speaker( $speaker ) {
-		$content = ( ! empty( $speaker['Your Bio'] ) ) ? $speaker['Your Bio'] : '';
+		$content = $speaker['Your Bio'] ?? '';
 
 		if ( $content ) {
 			$content = wpautop( $content );
@@ -416,7 +416,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_session( $session, $speaker ) {
-		$content = ( ! empty( $session['Topic Description'] ) ) ? $session['Topic Description'] : '';
+		$content = $session['Topic Description'] ?? '';
 
 		if ( $content ) {
 			$content = wpautop( $content );


### PR DESCRIPTION
* Changes all the post and page stubs for new sites to use block editor grammar. This includes the stub with the Call For Speakers form, which is what is currently used by the Forms To Drafts plugin.
* This also moves all the post and page stub content to separate files so that they are easier to manage and modify.
* Modify the callbacks that create the speaker and session drafts to use block editor grammar for the post content.

Question:

* Does this fully address [this conversation](https://wordpress.slack.com/archives/C08M59V3P/p1546874499054900)?