### PR TITLE
Coming soon mode: Also support jetpack/contact-form block.

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -62,7 +62,7 @@ class WordCamp_Coming_Soon_Page {
 			'open-sans',
 			'https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,300,400,600',
 			array(),
-			null
+			2
 		);
 
 		wp_enqueue_style(
@@ -92,6 +92,7 @@ class WordCamp_Coming_Soon_Page {
 			return;
 		}
 
+		// phpcs:ignore WordPress.PHP.DontExtract.extract_extract -- Not sure whats the alternative to this could be.
 		extract( $GLOBALS['WordCamp_Coming_Soon_Page']->get_template_variables() );
 
 		require_once( dirname( __DIR__ ) . '/css/template-coming-soon-dynamic.php' );
@@ -178,17 +179,23 @@ class WordCamp_Coming_Soon_Page {
 			$color     = new Jetpack_Color( $background, 'hex' );
 			$color_hsl = $color->toHsl();
 
-			$lighter_color = new Jetpack_Color( array(
-				$color_hsl['h'],
-				$color_hsl['s'],
-				( $color_hsl['l'] >= 85 ) ? 100 : $color_hsl['l'] + 15,
-			), 'hsl' );
+			$lighter_color = new Jetpack_Color(
+				array(
+					$color_hsl['h'],
+					$color_hsl['s'],
+					( $color_hsl['l'] >= 85 ) ? 100 : $color_hsl['l'] + 15,
+				),
+				'hsl'
+			);
 
-			$darker_color = new Jetpack_Color( array(
-				$color_hsl['h'],
-				$color_hsl['s'],
-				( $color_hsl['l'] < 10 ) ? 0 : $color_hsl['l'] - 10,
-			), 'hsl' );
+			$darker_color = new Jetpack_Color(
+				array(
+					$color_hsl['h'],
+					$color_hsl['s'],
+					( $color_hsl['l'] < 10 ) ? 0 : $color_hsl['l'] - 10,
+				),
+				'hsl'
+			);
 
 			$background_lighter = '#' . $lighter_color->toHex();
 			$background_darker  = '#' . $darker_color->toHex();
@@ -292,6 +299,7 @@ class WordCamp_Coming_Soon_Page {
 			foreach ( $matches as $shortcode ) {
 				if ( 'contact-form' === $shortcode[2] ) {
 					global $post;
+					//phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- We need this because of jetpack bug #102
 					$post = $page;
 					setup_postdata( $post );
 
@@ -312,6 +320,7 @@ class WordCamp_Coming_Soon_Page {
 			foreach( $blocks as $block ) {
 				if ( 'jetpack/contact-form' === $block['blockName'] ) {
 					global $post;
+					//phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- We need this because of jetpack bug #102
 					$post = $page;
 					setup_postdata( $post );
 					$contact_form_content = render_block( $block );
@@ -457,7 +466,7 @@ class WordCamp_Coming_Soon_Page {
 	 * post, we will see a message that post has been cross posted in social media accounts. That message is incorrect,
 	 * but can only be fixed in JetPack, not here.
 	 *
-	 * @param bool $should_publicize Whether this post can be publicized or not
+	 * @param bool $should_publicize Whether this post can be publicized or not.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
We already support `contact-form` shortcode which is used to rendered contact us form when Coming Soon mode is enabled for a site.
This patch also adds support for jetpack/contact-form block which can also be used to create a contact-us form.