### PR TITLE
WIP: WordCamp: Add docker setup to ease development flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN cd ~ && openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout wordcamp
 RUN cp ~/wordcamp.crt /etc/ssl/certs/wordcamp.crt
 RUN cp ~/wordcamp.key /etc/ssl/private/wordcamp.key
 
+# Install wkhtmltopdf for camptix invoices. See https://stackoverflow.com/a/38336153/1845153
+RUN curl -L https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz > wkhtmltox.tar.xz
+RUN tar xvf wkhtmltox.tar.xz
+RUN mv wkhtmltox/bin/wkhtmlto* /usr/bin/
+
 # Install cli
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 RUN chmod +x wp-cli.phar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM wordpress:5.0.3-fpm
+
+RUN mv /usr/src/wordpress /usr/src/public_html
+WORKDIR /usr/src/public_html
+
+RUN apt-get update
+RUN apt-get install nginx -y
+
+COPY nginx.conf /etc/nginx/sites-enabled/wordcamp.conf
+COPY wordcamp.ssl.conf /var/wordcamp.ssl.conf
+
+RUN cd ~ && openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout wordcamp.key -out wordcamp.crt -config /var/wordcamp.ssl.conf
+RUN cp ~/wordcamp.crt /etc/ssl/certs/wordcamp.crt
+RUN cp ~/wordcamp.key /etc/ssl/private/wordcamp.key
+
+# Install cli
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+RUN chmod +x wp-cli.phar
+RUN mv wp-cli.phar /usr/local/bin/wp
+
+# Mail catcher.
+RUN apt-get install build-essential libsqlite3-dev ruby-dev -y
+RUN gem install mailcatcher --no-ri --no-rdoc
+RUN apt-get install ssmtp -y
+RUN sed -i -e "s|;sendmail_path =|sendmail_path = /usr/sbin/ssmtp -t |" /usr/local/etc/php/php.ini-development
+RUN sed -i -e "s/smtp_port = 25/smtp_port = 1025/" /usr/local/etc/php/php.ini-development
+RUN chown root:mail /etc/ssmtp/ssmtp.conf
+RUN sed -i -e "s/#FromLineOverride=YES/FromLineOverride=YES/" /etc/ssmtp/ssmtp.conf
+RUN sed -i -e "s/mailhub=mail/mailhub=127.0.0.1:1025/" /etc/ssmtp/ssmtp.conf
+RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
+
+# utils
+RUN apt-get install vim -y
+
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-www.conf
+
+# Setup Gutenberg blocks
+RUN apt-get install -y gnupg2 && curl -sL https://deb.nodesource.com/setup_11.x | bash -
+RUN apt-get install -y nodejs
+RUN npm --prefix ./wp-content/mu-plugins/blocks install ./wp-content/mu-plugins/blocks
+
+CMD tail -f /dev/null
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.2"
+services:
+  wordcamp.test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - "./public_html:/usr/src/public_html"
+    ports:
+      - "1234:80"
+      - "443:443"
+      - "1080:1080"
+    command: bash -c "nginx && mailcatcher --http-ip 0.0.0.0 && php-fpm"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,51 @@
+# Upstream to abstract backend connection(s) for php
+upstream php {
+        server unix:/tmp/php-cgi.socket;
+        server 127.0.0.1:9000;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name wordcamp.test;
+    return 301 https://wordcamp.test$request_uri;
+}
+
+server {
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+
+        server_name wordcamp.test;
+        ssl_certificate /etc/ssl/certs/wordcamp.crt;
+        ssl_certificate_key /etc/ssl/private/wordcamp.key;
+        ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
+
+        root /usr/src/public_html;
+        index index.php;
+
+        location = /favicon.ico {
+                log_not_found off;
+                access_log off;
+        }
+
+        location = /robots.txt {
+                allow all;
+                log_not_found off;
+                access_log off;
+        }
+
+        location / {
+                try_files $uri $uri/ /index.php?$args;
+        }
+
+        location ~ \.php$ {
+                include fastcgi.conf;
+                fastcgi_intercept_errors on;
+                fastcgi_pass php;
+        }
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+                expires max;
+                log_not_found off;
+        }
+}

--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -1,0 +1,6 @@
+[global]
+
+[www]
+php_flag[display_errors] = on
+php_admin_value[error_log] = /var/log/fpm-php.www.log
+php_admin_flag[log_errors] = on

--- a/wordcamp.ssl.conf
+++ b/wordcamp.ssl.conf
@@ -1,0 +1,28 @@
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+default_keyfile    = wordcamp.key
+
+[ dn ]
+C = IN
+ST = STATE
+L = Location
+O = WordCamp
+OU = WordCampDev
+CN = wordcamp
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = wordcamp.docker
+
+[ v3_ext ]
+authorityKeyIdentifier=keyid,issuer:always
+basicConstraints=CA:FALSE
+keyUsage=keyEncipherment,dataEncipherment
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=@alt_names%


### PR DESCRIPTION
This is adds initial docker configuration for running WordCamp meta environment. Right now expectation is to have a MySQL running on host and configured in wp-config. Eventually MySQL will be added as part of docker configuration.

These are pending tasks before its ready to be merged
- [ ] Add MySQL configuration with updated database
- [ ] Move files to new `provisioning` folder
- [ ] Add inbuilt wp-config file
- [ ] Add linting support