### PR TITLE
WordCamp Sponsor Blocks: Change help text to make it more clearer.

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-content.js
@@ -34,7 +34,7 @@ function SponsorDetail( { sponsorPost, attributes, onFeatureImageChange } ) {
 	const featuredImageSizes = get( sponsorPost, "_embedded.wp:featuredmedia[0].media_details.sizes", {} );
 
 	return (
-		<div className={ "wordcamp-sponsor-details"}>
+		<div className={ "wordcamp-sponsor-details wordcamp-sponsor-details-" + sponsorPost.slug }>
 
 			{ ( show_name || show_name === undefined ) &&
 			<ItemTitle

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-controls.js
@@ -12,7 +12,7 @@ const { __ } = wp.i18n;
 import { BlockControls, PlaceholderNoContent } from "../shared/block-controls";
 import SponsorBlockContent from './block-content';
 import ItemSelect from '../shared/item-select'
-import { LABEL }                               from './index';
+import { LABEL } from './index';
 
 const { Button, Placeholder } = wp.components;
 
@@ -28,15 +28,6 @@ function SponsorPostOption( sponsor ) {
 	const imageUrl = get( sponsor.featuredImageData, 'sizes.thumbnail.source_url', false );
 	return(
 		<span>
-			{
-				imageUrl &&
-				<img
-					width={24}
-					height={24}
-					src={ imageUrl }
-					alt={ sponsor.label }
-				/>
-			}
 			{ sponsor.label }
 		</span>
 	);

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/inspector-controls.js
@@ -72,7 +72,7 @@ class SponsorInspectorControls extends Component {
 							options = { sortOptions }
 							value = { sort_by || 'name_asc' }
 							onChange={ ( value ) => setAttributes( { sort_by: value } ) }
-							help = { __( 'Select whether to sort by name or sponsor level. Order of sponsor level can be configure by going to Sponsor -> Order Sponsor Levels admin menu.') }
+							help = { __( 'Configure sponsor levels from the Sponsor -> Order Sponsor Levels page.', 'wordcamporg' ) }
 						/>
 					</PanelRow>
 				</PanelBody>

--- a/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
@@ -12,7 +12,7 @@ use function WordCamp\Blocks\Shared\Components\{ render_featured_image };
 setup_postdata( $sponsor );
 
 ?>
-<div class="wordcamp-sponsor-details <?php echo sanitize_html_class( $sponsor->post_name ); ?> ">
+<div class="wordcamp-sponsor-details wordcamp-sponsor-details-<?php echo sanitize_html_class( $sponsor->post_name ); ?> ">
 
 	<?php if ( $attributes['show_name'] ) { ?>
 		<h3 class="wordcamp-sponsor-title wordcamp-item-title">

--- a/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
@@ -16,21 +16,23 @@ setup_postdata( $sponsor );
 
 	<?php if ( $attributes['show_name'] ) { ?>
 		<h3 class="wordcamp-sponsor-title wordcamp-item-title">
-			<a href="<?php esc_attr_e( get_permalink( $sponsor->ID ) ) ?>"><?php echo get_the_title( $sponsor ) ?></a>
+			<a href="<?php echo esc_attr( get_permalink( $sponsor->ID ) ); ?>"><?php echo esc_html( get_the_title( $sponsor ) ); ?></a>
 		</h3>
 	<?php } ?>
 
 	<?php if ( $attributes['show_logo'] ) { ?>
-		<?php echo render_featured_image(
-			array( 'wordcamp-sponsor-featured-image' ),
-			$sponsor,
-			$attributes['featured_image_height'],
-			$attributes['featured_image_width']
+		<?php echo wp_kses_post(
+			render_featured_image(
+				array( 'wordcamp-sponsor-featured-image' ),
+				$sponsor,
+				$attributes['featured_image_height'],
+				$attributes['featured_image_width']
+			)
 		); ?>
 	<?php } ?>
 
 	<?php if ( $attributes['show_desc'] ) { ?>
-		<?php echo wpautop( get_all_the_content( $sponsor ) ) ?>
+		<?php echo wp_kses_post( wpautop( get_all_the_content( $sponsor ) ) ); ?>
 	<?php } ?>
 
 </div>


### PR DESCRIPTION
In `Order By` sponsor level control, help text has a bit of redundant instruction which is already implied by the SelectControl label.
This fixes https://github.com/WordPress/wordcamp.org/issues/41