### PR TITLE
WordCamp Block: Add excerpt support to Sponsor block for consistency

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/grid-layout/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/grid-layout/style.scss
@@ -6,8 +6,11 @@
 
 .wordcamp-block-post-list {
 
-	li.wordcamp-grid-layout-item {
+	li {
 		list-style: none;
+	}
+
+	li.wordcamp-grid-layout-item {
 		margin: 0 0 1em 0;
 	}
 

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-content.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  */
 const { Component } = wp.element;
 const { escapeAttribute } = wp.escapeHtml;
+const { __ } = wp.i18n;
 
 /**
  * Internal dependencies.
@@ -28,10 +29,13 @@ import { ItemTitle, ItemHTMLContent } from '../shared/block-content';
  */
 function SponsorDetail( { sponsorPost, attributes, onFeatureImageChange } ) {
 	const {
-		show_name, show_logo, show_desc,
+		show_name, show_logo, show_desc, content, excerpt_more,
 	} = attributes;
 
 	const featuredImageSizes = get( sponsorPost, '_embedded.wp:featuredmedia[0].media_details.sizes', {} );
+	const displayContent = 'full' === content ? sponsorPost.content.rendered.trim() : sponsorPost.excerpt.rendered.trim();
+
+	console.log("content is: ", content, displayContent);
 
 	return (
 		<div className={ 'wordcamp-sponsor-details wordcamp-sponsor-details-' + escapeAttribute( sponsorPost.slug ) }>
@@ -52,10 +56,12 @@ function SponsorDetail( { sponsorPost, attributes, onFeatureImageChange } ) {
 				attributes={ attributes }
 			/>
 			}
-			{ ( show_desc || show_desc === undefined ) &&
+			{ ( 'none' !== content ) &&
 			<ItemHTMLContent
 				className={ classnames( 'wordcamp-sponsor-content' ) }
-				content={ sponsorPost.content.rendered.trim() }
+				content={ displayContent }
+				link={ ( 'full' === content || excerpt_more ) ? sponsorPost.link : null }
+				linkText={ 'full' === content ? __( 'Visit sponsor page', 'wordcamporg' ) : __( 'Read more', 'wordcamporg' ) }
 			/>
 			}
 		</div>

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/inspector-controls.js
@@ -26,9 +26,15 @@ class SponsorInspectorControls extends Component {
 			{ label: __( 'Sponsor Level', 'wordcamporg' ), value: 'sponsor_level' },
 		];
 
+		const contentOptions = [
+			{ label: __( 'Full', 'wordcamporg' ), value: 'full' },
+			{ label: __( 'Excerpt', 'wordcamporg' ), value: 'excerpt' },
+			{ label: __( 'None', 'wordcamporg'), value: 'none' },
+		];
+
 		const { attributes, setAttributes } = this.props;
 		const {
-			show_name, show_logo, show_desc, sort_by,
+			show_name, show_logo, sort_by, excerpt_more, content
 		} = attributes;
 
 		return (
@@ -57,13 +63,24 @@ class SponsorInspectorControls extends Component {
 						/>
 					</PanelRow>
 					<PanelRow>
-						<ToggleControl
+						<SelectControl
 							label={ __( 'Description', 'wordcamporg' ) }
-							help={ __( 'Show or hide sponsor description', 'wordcamporg' ) }
-							checked={ show_desc === undefined ? true : show_desc }
-							onChange={ ( value ) => setAttributes( { show_desc: value } ) }
+							value={ content }
+							options={ contentOptions }
+							help={ __( 'Length of sponsor description', 'wordcamporg' ) }
+							onChange={ ( value ) => setAttributes( { content: value } ) }
 						/>
 					</PanelRow>
+					{ 'excerpt' === content &&
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Read More Link', 'wordcamporg' ) }
+							help={ __( 'Show a link at the end of the excerpt (some themes already include this)', 'wordcamporg' ) }
+							checked={ excerpt_more }
+							onChange={ ( value ) => setAttributes( { excerpt_more: value } ) }
+						/>
+					</PanelRow>
+					}
 					<PanelRow>
 						<SelectControl
 							label={ __( 'Sort by', 'wordcamporg' ) }

--- a/public_html/wp-content/mu-plugins/blocks/includes/sponsors.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/sponsors.php
@@ -182,7 +182,11 @@ function get_attributes_schema() {
 			'type'    => 'bool',
 			'default' => true,
 		),
-		'show_desc'             => array(
+		'content'               => array(
+			'type'    => 'string',
+			'default' => 'full',
+		),
+		'excerpt_more'          => array(
 			'type'    => 'bool',
 			'default' => true,
 		),

--- a/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
@@ -31,8 +31,19 @@ setup_postdata( $sponsor );
 		); ?>
 	<?php } ?>
 
-	<?php if ( $attributes['show_desc'] ) { ?>
-		<?php echo wp_kses_post( wpautop( get_all_the_content( $sponsor ) ) ); ?>
+	<?php if ( 'none' !== $attributes['content'] ) { ?>
+		<?php if ( 'full' === $attributes['content'] ) { ?>
+			<?php echo wp_kses_post( wpautop( get_all_the_content( $sponsor ) ) ); ?>
+		<?php } elseif ( 'excerpt' === $attributes['content'] ) { ?>
+			<?php wpautop( the_excerpt() ); ?>
+			<?php if ( true === $attributes['excerpt_more'] ) { ?>
+				<p class="wordcamp-item-permalink">
+					<a href="<?php echo esc_url( get_permalink( $sponsor ) ); ?>" class="wordcamp-sponsor-permalink">
+						<?php esc_html_e( 'Read more', 'wordcamporg' ); ?>
+					</a>
+				</p>
+			<?php } ?>
+		<?php } ?>
 	<?php } ?>
 
 </div>

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -2294,7 +2294,7 @@ class WordCamp_Post_Types_Plugin {
 					'slug'       => 'sponsor',
 					'with_front' => false,
 				),
-				'supports'        => array( 'title', 'editor', 'revisions', 'thumbnail', 'custom-fields' ),
+				'supports'        => array( 'title', 'editor', 'excerpt', 'revisions', 'thumbnail', 'custom-fields' ),
 				'menu_position'   => 21,
 				'public'          => true,
 				'show_ui'         => true,


### PR DESCRIPTION
We already support excerpt in Speakers, Sessions and (WIP) Organizer block. This patch also adds support to show excerpt in Sponsor Block, thereby ensuring consistency among all blocks.

Fixes https://github.com/WordPress/wordcamp.org/issues/38