### PR TITLE
Blocks: Add shared definitions

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/assets/src/organizers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/organizers/inspector-controls.js
@@ -74,7 +74,7 @@ class OrganizerInspectorControls extends Component {
 									label={ __( 'Alignment', 'wordcamporg' ) }
 									value={ avatar_align }
 									onChange={ ( value ) => setAttributes( { avatar_align: value } ) }
-									alignOptions={ options.align }
+									alignOptions={ options.align_image }
 								/>
 							</PanelRow>
 						</Fragment>

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/speakers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/speakers/inspector-controls.js
@@ -27,9 +27,9 @@ const DEFAULT_SCHEMA = {
 };
 
 const DEFAULT_OPTIONS = {
-	align   : {},
-	content : {},
-	sort    : {},
+	align_image : {},
+	content     : {},
+	sort        : {},
 };
 
 class SpeakerInspectorControls extends Component {
@@ -70,7 +70,7 @@ class SpeakerInspectorControls extends Component {
 									label={ __( 'Alignment', 'wordcamporg' ) }
 									value={ avatar_align }
 									onChange={ ( value ) => setAttributes( { avatar_align: value } ) }
-									alignOptions={ options.align }
+									alignOptions={ options.align_image }
 								/>
 							</PanelRow>
 						</Fragment>

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -13,6 +13,7 @@ define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 function load() {
 	require_once PLUGIN_DIR . 'includes/shared/grid-layout.php';
 	require_once PLUGIN_DIR . 'includes/shared/featured-image.php';
+	require_once PLUGIN_DIR . 'includes/shared/definitions.php';
 
 	require_once PLUGIN_DIR . 'includes/shared.php';
 	require_once PLUGIN_DIR . 'includes/organizers.php';

--- a/public_html/wp-content/mu-plugins/blocks/includes/organizers.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/organizers.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\Blocks\Organizers;
 use WordCamp\Blocks;
+use function WordCamp\Blocks\Shared\Definitions\{ get_shared_definitions, get_shared_definition };
 
 defined( 'WPINC' ) || die();
 
@@ -124,68 +125,42 @@ function get_organizer_posts( array $attributes ) {
  * @return array
  */
 function get_attributes_schema() {
-	return [
-		'mode'         => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
-			'default' => '',
-		],
-		'item_ids'     => [
-			'type'    => 'array',
-			'default' => [],
-			'items'   => [
-				'type' => 'integer',
+	$schema = array_merge(
+		get_shared_definitions(
+			[
+				'content',
+				'grid_columns',
+				'item_ids',
+				'layout',
 			],
-		],
-		'sort'         => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
-			'default' => 'title_asc',
-		],
-		'layout'       => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'display' ), 'value' ),
-			'default' => 'list',
-		],
-		'grid_columns' => [
-			'type'    => 'integer',
-			'minimum' => 2,
-			'maximum' => 4,
-			'default' => 2,
-		],
-		'className'    => [
-			'type'    => 'string',
-			'default' => '',
-		],
-		'show_avatars' => [
-			'type'    => 'bool',
-			'default' => true,
-		],
-		'avatar_size'  => [
-			'type'    => 'integer',
-			'minimum' => 25,
-			'maximum' => 600,
-			'default' => 150,
-		],
-		'avatar_align' => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'align' ), 'value' ),
-			'default' => 'none',
-		],
-		'content'      => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'content' ), 'value' ),
-			'default' => 'full',
-		],
-		'excerpt_more' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-		'show_session' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-	];
+			'attribute'
+		),
+		[
+			'align'        => get_shared_definition( 'align_block', 'attribute' ),
+			'avatar_align' => get_shared_definition( 'align_image', 'attribute' ),
+			'avatar_size'  => [
+				'type'    => 'integer',
+				'minimum' => 25,
+				'maximum' => 600,
+				'default' => 150,
+			],
+			'className'    => get_shared_definition( 'string_empty', 'attribute' ),
+			'excerpt_more' => get_shared_definition( 'boolean_false', 'attribute' ),
+			'mode'         => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
+				'default' => '',
+			],
+			'show_avatars' => get_shared_definition( 'boolean_true', 'attribute' ),
+			'sort'         => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
+				'default' => 'title_asc',
+			],
+		]
+	);
+
+	return $schema;
 }
 
 /**
@@ -196,86 +171,41 @@ function get_attributes_schema() {
  * @return array
  */
 function get_options( $type = '' ) {
-	$options = [
-		'align'   => [
+	$options = array_merge(
+		get_shared_definitions(
 			[
-				'label' => _x( 'None', 'alignment option', 'wordcamporg' ),
-				'value' => 'none',
+				'align_block',
+				'align_image',
+				'content',
+				'layout',
 			],
-			[
-				'label' => _x( 'Left', 'alignment option', 'wordcamporg' ),
-				'value' => 'left',
+			'option'
+		),
+		[
+			'mode' => [
+				[
+					'label' => '',
+					'value' => '',
+				],
+				[
+					'label' => _x( 'List all organizers', 'mode option', 'wordcamporg' ),
+					'value' => 'all',
+				],
+				[
+					'label' => _x( 'Choose organizers', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_organizer',
+				],
+				[
+					'label' => _x( 'Choose teams', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_organizer_team',
+				],
 			],
-			[
-				'label' => _x( 'Center', 'alignment option', 'wordcamporg' ),
-				'value' => 'center',
-			],
-			[
-				'label' => _x( 'Right', 'alignment option', 'wordcamporg' ),
-				'value' => 'right',
-			],
-		],
-		'content' => [
-			[
-				'label' => _x( 'Full', 'content option', 'wordcamporg' ),
-				'value' => 'full',
-			],
-			[
-				'label' => _x( 'Excerpt', 'content option', 'wordcamporg' ),
-				'value' => 'excerpt',
-			],
-			[
-				'label' => _x( 'None', 'content option', 'wordcamporg' ),
-				'value' => 'none',
-			],
-		],
-		'layout'  => [
-			[
-				'label' => _x( 'List', 'content option', 'wordcamporg' ),
-				'value' => 'list',
-			],
-			[
-				'label' => _x( 'Grid', 'content option', 'wordcamporg' ),
-				'value' => 'grid',
-			],
-		],
-		'mode'    => [
-			[
-				'label' => '',
-				'value' => '',
-			],
-			[
-				'label' => _x( 'List all organizers', 'mode option', 'wordcamporg' ),
-				'value' => 'all',
-			],
-			[
-				'label' => _x( 'Choose organizers', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_organizer',
-			],
-			[
-				'label' => _x( 'Choose teams', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_organizer_team',
-			],
-		],
-		'sort'    => [
-			[
-				'label' => _x( 'A → Z', 'sort option', 'wordcamporg' ),
-				'value' => 'title_asc',
-			],
-			[
-				'label' => _x( 'Z → A', 'sort option', 'wordcamporg' ),
-				'value' => 'title_desc',
-			],
-			[
-				'label' => _x( 'Newest to Oldest', 'sort option', 'wordcamporg' ),
-				'value' => 'date_desc',
-			],
-			[
-				'label' => _x( 'Oldest to Newest', 'sort option', 'wordcamporg' ),
-				'value' => 'date_asc',
-			],
-		],
-	];
+			'sort' => array_merge(
+				get_shared_definition( 'sort_title', 'option' ),
+				get_shared_definition( 'sort_date', 'option' )
+			),
+		]
+	);
 
 	if ( $type ) {
 		return empty( $options[ $type ] ) ? [] : $options[ $type ];

--- a/public_html/wp-content/mu-plugins/blocks/includes/sessions.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/sessions.php
@@ -3,6 +3,7 @@
 namespace WordCamp\Blocks\Sessions;
 use WordCamp\Blocks;
 use function WordCamp\Blocks\Shared\Components\{ render_grid_layout };
+use function WordCamp\Blocks\Shared\Definitions\{ get_shared_definitions, get_shared_definition };
 
 defined( 'WPINC' ) || die();
 
@@ -96,99 +97,48 @@ add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );
  * @return array
  */
 function get_attributes_schema() {
-	return [
-		'mode' => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
-			'default' => '',
-		],
-
-		'item_ids' => [
-			'type'    => 'array',
-			'default' => [],
-			'items'   => [
-				'type' => 'integer',
+	$schema = array_merge(
+		get_shared_definitions(
+			[
+				'content',
+				'grid_columns',
+				'item_ids',
+				'layout',
 			],
-		],
-
-		'sort' => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
-			'default' => 'session_time',
-		],
-
-		'className' => [
-			'type'    => 'string',
-			'default' => '',
-		],
-
-		'show_speaker' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-
-		'show_images' => [
-			'type'    => 'bool',
-			'default' => true,
-		],
-
-		'image_size' => [
-			'type'    => 'integer',
-			'minimum' => 25,
-			'maximum' => 600,
-			'default' => 150,
-		],
-
-		'image_align' => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'align' ), 'value' ),
-			'default' => 'none',
-		],
-
-		'content' => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'content' ), 'value' ),
-			'default' => 'full',
-		],
-
-		'excerpt_more' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-
-		'show_meta' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-
-		'show_category' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-
-		'layout' => [
-			'type'    => 'string',
-			'enum'    => array( 'list', 'grid' ),
-			'default' => 'list',
-		],
-
-		'grid_columns' => array(
-			'type'    => 'integer',
-			'minimum' => 1,
-			'maximum' => 4,
-			'default' => 1,
+			'attribute'
 		),
+		[
+			'className'            => get_shared_definition( 'string_empty', 'attribute' ),
+			'excerpt_more'         => get_shared_definition( 'boolean_false', 'attribute' ),
+			'featured_image_width' => array(
+				'type'    => 'integer',
+				'default' => 150,
+			),
+			'image_align'          => get_shared_definition( 'align_image', 'attribute' ),
+			'image_size'           => [
+				'type'    => 'integer',
+				'minimum' => 25,
+				'maximum' => 600,
+				'default' => 150,
+			],
+			'mode'                 => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
+				'default' => '',
+			],
+			'show_category'        => get_shared_definition( 'boolean_false', 'attribute' ),
+			'show_images'          => get_shared_definition( 'boolean_true', 'attribute' ),
+			'show_meta'            => get_shared_definition( 'boolean_false', 'attribute' ),
+			'show_speaker'         => get_shared_definition( 'boolean_false', 'attribute' ),
+			'sort'                 => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
+				'default' => 'session_time',
+			],
+		]
+	);
 
-		'featured_image_height' => array(
-			'type'    => 'integer',
-			'default' => 150,
-		),
-
-		'featured_image_width' => array(
-			'type'    => 'integer',
-			'default' => 150,
-		),
-	];
+	return $schema;
 }
 
 /**
@@ -199,84 +149,51 @@ function get_attributes_schema() {
  * @return array
  */
 function get_options( $type = '' ) {
-	$options = [
-		'align'   => [
+	$options = array_merge(
+		get_shared_definitions(
 			[
-				'label' => _x( 'None', 'alignment option', 'wordcamporg' ),
-				'value' => 'none',
+				'align_block',
+				'align_image',
+				'content',
+				'layout',
 			],
-			[
-				'label' => _x( 'Left', 'alignment option', 'wordcamporg' ),
-				'value' => 'left',
+			'option'
+		),
+		[
+			'mode' => [
+				[
+					'label' => '',
+					'value' => '',
+				],
+				[
+					'label' => _x( 'List all sessions', 'mode option', 'wordcamporg' ),
+					'value' => 'all',
+				],
+				[
+					'label' => _x( 'Choose sessions', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_session',
+				],
+				[
+					'label' => _x( 'Choose tracks', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_track',
+				],
+				[
+					'label' => _x( 'Choose session categories', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_session_category',
+				],
 			],
-			[
-				'label' => _x( 'Center', 'alignment option', 'wordcamporg' ),
-				'value' => 'center',
-			],
-			[
-				'label' => _x( 'Right', 'alignment option', 'wordcamporg' ),
-				'value' => 'right',
-			],
-		],
-		'content' => [
-			[
-				'label' => _x( 'Full', 'content option', 'wordcamporg' ),
-				'value' => 'full',
-			],
-			[
-				'label' => _x( 'Excerpt', 'content option', 'wordcamporg' ),
-				'value' => 'excerpt',
-			],
-			[
-				'label' => _x( 'None', 'content option', 'wordcamporg' ),
-				'value' => 'none',
-			],
-		],
-		'mode'    => [
-			[
-				'label' => '',
-				'value' => '',
-			],
-			[
-				'label' => _x( 'List all sessions', 'mode option', 'wordcamporg' ),
-				'value' => 'all',
-			],
-			[
-				'label' => _x( 'Choose sessions', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_session',
-			],
-			[
-				'label' => _x( 'Choose tracks', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_track',
-			],
-			[
-				'label' => _x( 'Choose session categories', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_session_category',
-			],
-		],
-		'sort'    => [
-			[
-				'label' => _x( 'Day and Time', 'sort option', 'wordcamporg' ),
-				'value' => 'session_time',
-			],
-			[
-				'label' => _x( 'A → Z', 'sort option', 'wordcamporg' ),
-				'value' => 'title_asc',
-			],
-			[
-				'label' => _x( 'Z → A', 'sort option', 'wordcamporg' ),
-				'value' => 'title_desc',
-			],
-			[
-				'label' => _x( 'Newest to Oldest', 'sort option', 'wordcamporg' ),
-				'value' => 'date_desc',
-			],
-			[
-				'label' => _x( 'Oldest to Newest', 'sort option', 'wordcamporg' ),
-				'value' => 'date_asc',
-			],
-		],
-	];
+			'sort' => array_merge(
+				[
+					[
+						'label' => _x( 'Day and Time', 'sort option', 'wordcamporg' ),
+						'value' => 'session_time',
+					],
+				],
+				get_shared_definition( 'sort_title', 'option' ),
+				get_shared_definition( 'sort_date', 'option' )
+			),
+		]
+	);
 
 	if ( $type ) {
 		if ( ! empty( $options[ $type ] ) ) {

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/definitions.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/definitions.php
@@ -175,6 +175,3 @@ function get_shared_definition( $key, $type ) {
 
 	return $result;
 }
-
-
-

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/definitions.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/definitions.php
@@ -1,0 +1,169 @@
+<?php
+namespace WordCamp\Blocks\Shared\Definitions;
+defined( 'WPINC' ) || die();
+
+/**
+ * Retrieve an array of definitions for use within a block.
+ *
+ * Currently there are two types of definitions: attributes, which make up a block's schema, and options, which
+ * are label/value pairs used in situations where the value of an attribute must come from an enumerated list.
+ *
+ * @param array|string $keys The keys of the definitions to retrieve. An array of strings, or 'all'.
+ * @param string       $type The type of definition to retrieve. 'attribute' or 'option'.
+ *
+ * @return array
+ */
+function get_shared_definitions( $keys, $type ) {
+	switch ( $type ) {
+		case 'attribute':
+			$definitions = [
+				'align'        => [
+					'type'    => 'string',
+					'enum'    => wp_list_pluck( get_shared_definition( 'align_block', 'option' ), 'value' ),
+					'default' => '',
+				],
+				'className'    => [
+					'type'    => 'string',
+					'default' => '',
+				],
+				'content'      => [
+					'type'    => 'string',
+					'enum'    => wp_list_pluck( get_shared_definition( 'content', 'option' ), 'value' ),
+					'default' => 'full',
+				],
+				'excerpt_more' => [
+					'type'    => 'bool',
+					'default' => false,
+				],
+				'grid_columns' => [
+					'type'    => 'integer',
+					'minimum' => 2,
+					'maximum' => 4,
+					'default' => 2,
+				],
+				'item_ids'     => [
+					'type'    => 'array',
+					'default' => [],
+					'items'   => [
+						'type' => 'integer',
+					],
+				],
+				'layout'       => [
+					'type'    => 'string',
+					'enum'    => wp_list_pluck( get_shared_definition( 'layout', 'option' ), 'value' ),
+					'default' => 'list',
+				],
+			];
+			break;
+
+		case 'option':
+			$definitions = [
+				'align_block' => [
+					[
+						'label' => _x( 'Wide', 'alignment option', 'wordcamporg' ),
+						'value' => 'wide',
+					],
+					[
+						'label' => _x( 'Full', 'alignment option', 'wordcamporg' ),
+						'value' => 'full',
+					],
+				],
+				'align_image' => [
+					[
+						'label' => _x( 'None', 'alignment option', 'wordcamporg' ),
+						'value' => 'none',
+					],
+					[
+						'label' => _x( 'Left', 'alignment option', 'wordcamporg' ),
+						'value' => 'left',
+					],
+					[
+						'label' => _x( 'Center', 'alignment option', 'wordcamporg' ),
+						'value' => 'center',
+					],
+					[
+						'label' => _x( 'Right', 'alignment option', 'wordcamporg' ),
+						'value' => 'right',
+					],
+				],
+				'content'     => [
+					[
+						'label' => _x( 'Full', 'content option', 'wordcamporg' ),
+						'value' => 'full',
+					],
+					[
+						'label' => _x( 'Excerpt', 'content option', 'wordcamporg' ),
+						'value' => 'excerpt',
+					],
+					[
+						'label' => _x( 'None', 'content option', 'wordcamporg' ),
+						'value' => 'none',
+					],
+				],
+				'layout'      => [
+					[
+						'label' => _x( 'List', 'content option', 'wordcamporg' ),
+						'value' => 'list',
+					],
+					[
+						'label' => _x( 'Grid', 'content option', 'wordcamporg' ),
+						'value' => 'grid',
+					],
+				],
+				'sort_title'  => [
+					[
+						'label' => _x( 'A → Z', 'sort option', 'wordcamporg' ),
+						'value' => 'title_asc',
+					],
+					[
+						'label' => _x( 'Z → A', 'sort option', 'wordcamporg' ),
+						'value' => 'title_desc',
+					],
+				],
+				'sort_date'   => [
+					[
+						'label' => _x( 'Newest to Oldest', 'sort option', 'wordcamporg' ),
+						'value' => 'date_desc',
+					],
+					[
+						'label' => _x( 'Oldest to Newest', 'sort option', 'wordcamporg' ),
+						'value' => 'date_asc',
+					],
+				],
+			];
+			break;
+
+		default:
+			$definitions = [];
+			break;
+	}
+
+	if ( 'all' === $keys ) {
+		return $definitions;
+	}
+
+	$keys = array_fill_keys( (array) $keys, '' );
+
+	return array_intersect_key( $definitions, $keys );
+}
+
+/**
+ * Retrieve a single definition for use within a block.
+ *
+ * @param string $key  The key of the definition to retrieve.
+ * @param string $type The type of definition to retrieve. 'attribute' or 'option'.
+ *
+ * @return array
+ */
+function get_shared_definition( $key, $type ) {
+	$result = get_shared_definitions( $key, $type );
+
+	if ( ! empty( $result ) ) {
+		$result = array_shift( $result );
+	}
+
+	return $result;
+}
+
+
+

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/definitions.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/definitions.php
@@ -17,38 +17,49 @@ function get_shared_definitions( $keys, $type ) {
 	switch ( $type ) {
 		case 'attribute':
 			$definitions = [
-				'align'        => [
+				// Generic attributes.
+				'boolean_false' => [
+					'type'    => 'bool',
+					'default' => false,
+				],
+				'boolean_true'  => [
+					'type'    => 'bool',
+					'default' => true,
+				],
+				'string_empty'  => [
+					'type'    => 'string',
+					'default' => '',
+				],
+				// Specific attributes.
+				'align_block'   => [
 					'type'    => 'string',
 					'enum'    => wp_list_pluck( get_shared_definition( 'align_block', 'option' ), 'value' ),
 					'default' => '',
 				],
-				'className'    => [
+				'align_image'   => [
 					'type'    => 'string',
-					'default' => '',
+					'enum'    => wp_list_pluck( get_shared_definition( 'align_image', 'option' ), 'value' ),
+					'default' => 'none',
 				],
-				'content'      => [
+				'content'       => [
 					'type'    => 'string',
 					'enum'    => wp_list_pluck( get_shared_definition( 'content', 'option' ), 'value' ),
 					'default' => 'full',
 				],
-				'excerpt_more' => [
-					'type'    => 'bool',
-					'default' => false,
-				],
-				'grid_columns' => [
+				'grid_columns'  => [
 					'type'    => 'integer',
 					'minimum' => 2,
 					'maximum' => 4,
 					'default' => 2,
 				],
-				'item_ids'     => [
+				'item_ids'      => [
 					'type'    => 'array',
 					'default' => [],
 					'items'   => [
 						'type' => 'integer',
 					],
 				],
-				'layout'       => [
+				'layout'        => [
 					'type'    => 'string',
 					'enum'    => wp_list_pluck( get_shared_definition( 'layout', 'option' ), 'value' ),
 					'default' => 'list',

--- a/public_html/wp-content/mu-plugins/blocks/includes/speakers.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/speakers.php
@@ -2,7 +2,7 @@
 
 namespace WordCamp\Blocks\Speakers;
 use WordCamp\Blocks;
-use WordCamp\Blocks\Shared\Definitions;
+use function WordCamp\Blocks\Shared\Definitions\{ get_shared_definitions, get_shared_definition };
 
 defined( 'WPINC' ) || die();
 
@@ -167,40 +167,33 @@ function get_speaker_sessions( array $speaker_ids ) {
  */
 function get_attributes_schema() {
 	$schema = array_merge(
-		Definitions\get_shared_definitions( [
-			'align',
-			'className',
-			'content',
-			'excerpt_more',
-			'grid_columns',
-			'item_ids',
-			'layout',
-		], 'attribute' ),
-		[
-			'avatar_align' => [
-				'type'    => 'string',
-				'enum'    => wp_list_pluck( get_options( 'align_image' ), 'value' ),
-				'default' => 'none',
+		get_shared_definitions(
+			[
+				'content',
+				'grid_columns',
+				'item_ids',
+				'layout',
 			],
+			'attribute'
+		),
+		[
+			'align'        => get_shared_definition( 'align_block', 'attribute' ),
+			'avatar_align' => get_shared_definition( 'align_image', 'attribute' ),
 			'avatar_size'  => [
 				'type'    => 'integer',
 				'minimum' => 25,
 				'maximum' => 600,
 				'default' => 150,
 			],
+			'className'    => get_shared_definition( 'string_empty', 'attribute' ),
+			'excerpt_more' => get_shared_definition( 'boolean_false', 'attribute' ),
 			'mode'         => [
 				'type'    => 'string',
 				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
 				'default' => '',
 			],
-			'show_avatars' => [
-				'type'    => 'bool',
-				'default' => true,
-			],
-			'show_session' => [
-				'type'    => 'bool',
-				'default' => false,
-			],
+			'show_avatars' => get_shared_definition( 'boolean_true', 'attribute' ),
+			'show_session' => get_shared_definition( 'boolean_false', 'attribute' ),
 			'sort'         => [
 				'type'    => 'string',
 				'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
@@ -221,12 +214,15 @@ function get_attributes_schema() {
  */
 function get_options( $type = '' ) {
 	$options = array_merge(
-		Definitions\get_shared_definitions( [
-			'align_block',
-			'align_image',
-			'content',
-			'layout',
-		], 'option' ),
+		get_shared_definitions(
+			[
+				'align_block',
+				'align_image',
+				'content',
+				'layout',
+			],
+			'option'
+		),
 		[
 			'mode' => [
 				[
@@ -247,8 +243,8 @@ function get_options( $type = '' ) {
 				],
 			],
 			'sort' => array_merge(
-				Definitions\get_shared_definition( 'sort_title', 'option' ),
-				Definitions\get_shared_definition( 'sort_date', 'option' )
+				get_shared_definition( 'sort_title', 'option' ),
+				get_shared_definition( 'sort_date', 'option' )
 			),
 		]
 	);

--- a/public_html/wp-content/mu-plugins/blocks/includes/speakers.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/speakers.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\Blocks\Speakers;
 use WordCamp\Blocks;
+use WordCamp\Blocks\Shared\Definitions;
 
 defined( 'WPINC' ) || die();
 
@@ -165,68 +166,50 @@ function get_speaker_sessions( array $speaker_ids ) {
  * @return array
  */
 function get_attributes_schema() {
-	return [
-		'mode'         => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
-			'default' => '',
-		],
-		'item_ids'     => [
-			'type'    => 'array',
-			'default' => [],
-			'items'   => [
-				'type' => 'integer',
+	$schema = array_merge(
+		Definitions\get_shared_definitions( [
+			'align',
+			'className',
+			'content',
+			'excerpt_more',
+			'grid_columns',
+			'item_ids',
+			'layout',
+		], 'attribute' ),
+		[
+			'avatar_align' => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'align_image' ), 'value' ),
+				'default' => 'none',
 			],
-		],
-		'sort'         => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
-			'default' => 'title_asc',
-		],
-		'layout'       => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'display' ), 'value' ),
-			'default' => 'list',
-		],
-		'grid_columns' => [
-			'type'    => 'integer',
-			'minimum' => 2,
-			'maximum' => 4,
-			'default' => 2,
-		],
-		'className'    => [
-			'type'    => 'string',
-			'default' => '',
-		],
-		'show_avatars' => [
-			'type'    => 'bool',
-			'default' => true,
-		],
-		'avatar_size'  => [
-			'type'    => 'integer',
-			'minimum' => 25,
-			'maximum' => 600,
-			'default' => 150,
-		],
-		'avatar_align' => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'align' ), 'value' ),
-			'default' => 'none',
-		],
-		'content'      => [
-			'type'    => 'string',
-			'enum'    => wp_list_pluck( get_options( 'content' ), 'value' ),
-			'default' => 'full',
-		],
-		'excerpt_more' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-		'show_session' => [
-			'type'    => 'bool',
-			'default' => false,
-		],
-	];
+			'avatar_size'  => [
+				'type'    => 'integer',
+				'minimum' => 25,
+				'maximum' => 600,
+				'default' => 150,
+			],
+			'mode'         => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),
+				'default' => '',
+			],
+			'show_avatars' => [
+				'type'    => 'bool',
+				'default' => true,
+			],
+			'show_session' => [
+				'type'    => 'bool',
+				'default' => false,
+			],
+			'sort'         => [
+				'type'    => 'string',
+				'enum'    => wp_list_pluck( get_options( 'sort' ), 'value' ),
+				'default' => 'title_asc',
+			],
+		]
+	);
+
+	return $schema;
 }
 
 /**
@@ -237,86 +220,38 @@ function get_attributes_schema() {
  * @return array
  */
 function get_options( $type = '' ) {
-	$options = [
-		'align'   => [
-			[
-				'label' => _x( 'None', 'alignment option', 'wordcamporg' ),
-				'value' => 'none',
+	$options = array_merge(
+		Definitions\get_shared_definitions( [
+			'align_block',
+			'align_image',
+			'content',
+			'layout',
+		], 'option' ),
+		[
+			'mode' => [
+				[
+					'label' => '',
+					'value' => '',
+				],
+				[
+					'label' => _x( 'List all speakers', 'mode option', 'wordcamporg' ),
+					'value' => 'all',
+				],
+				[
+					'label' => _x( 'Choose speakers', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_speaker',
+				],
+				[
+					'label' => _x( 'Choose groups', 'mode option', 'wordcamporg' ),
+					'value' => 'wcb_speaker_group',
+				],
 			],
-			[
-				'label' => _x( 'Left', 'alignment option', 'wordcamporg' ),
-				'value' => 'left',
-			],
-			[
-				'label' => _x( 'Center', 'alignment option', 'wordcamporg' ),
-				'value' => 'center',
-			],
-			[
-				'label' => _x( 'Right', 'alignment option', 'wordcamporg' ),
-				'value' => 'right',
-			],
-		],
-		'content' => [
-			[
-				'label' => _x( 'Full', 'content option', 'wordcamporg' ),
-				'value' => 'full',
-			],
-			[
-				'label' => _x( 'Excerpt', 'content option', 'wordcamporg' ),
-				'value' => 'excerpt',
-			],
-			[
-				'label' => _x( 'None', 'content option', 'wordcamporg' ),
-				'value' => 'none',
-			],
-		],
-		'layout'  => [
-			[
-				'label' => _x( 'List', 'content option', 'wordcamporg' ),
-				'value' => 'list',
-			],
-			[
-				'label' => _x( 'Grid', 'content option', 'wordcamporg' ),
-				'value' => 'grid',
-			],
-		],
-		'mode'    => [
-			[
-				'label' => '',
-				'value' => '',
-			],
-			[
-				'label' => _x( 'List all speakers', 'mode option', 'wordcamporg' ),
-				'value' => 'all',
-			],
-			[
-				'label' => _x( 'Choose speakers', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_speaker',
-			],
-			[
-				'label' => _x( 'Choose groups', 'mode option', 'wordcamporg' ),
-				'value' => 'wcb_speaker_group',
-			],
-		],
-		'sort'    => [
-			[
-				'label' => _x( 'A → Z', 'sort option', 'wordcamporg' ),
-				'value' => 'title_asc',
-			],
-			[
-				'label' => _x( 'Z → A', 'sort option', 'wordcamporg' ),
-				'value' => 'title_desc',
-			],
-			[
-				'label' => _x( 'Newest to Oldest', 'sort option', 'wordcamporg' ),
-				'value' => 'date_desc',
-			],
-			[
-				'label' => _x( 'Oldest to Newest', 'sort option', 'wordcamporg' ),
-				'value' => 'date_asc',
-			],
-		],
-	];
+			'sort' => array_merge(
+				Definitions\get_shared_definition( 'sort_title', 'option' ),
+				Definitions\get_shared_definition( 'sort_date', 'option' )
+			),
+		]
+	);
 
 	if ( $type ) {
 		if ( ! empty( $options[ $type ] ) ) {


### PR DESCRIPTION
Many of our blocks share several attribute definitions in their schemas, as well as several sets of option label/value pairs. This provides a centralized way to load those definitions to make our codebase DRYer, while still allowing the flexibility for blocks to define their own attributes/options, and even modify the shared definitions after loading them.