### PR TITLE
WordCamp Camptix: Throttle ticket purchase request.

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -69,6 +69,7 @@ class Payment_Options extends CampTix_Addon {
 	 * @param string $selected_payment_method Already selected payment method.
 	 */
 	function generate_payment_options( $payment_output, $total, $payment_methods, $selected_payment_method ) {
+		ob_start();
 		?>
 		<div class="tix-submit">
 			<?php if ( $total > 0 ) : ?>
@@ -93,6 +94,7 @@ class Payment_Options extends CampTix_Addon {
 			<br class="tix-clear" />
 		</div>
 		<?php
+		return ob_get_clean();
 	}
 
 	/**


### PR DESCRIPTION
This patch adds throttling support to ticket purchase request to 39 per hour. This is not intended to prevent any kind of sophiscated attacks, but is just there so that we don't have to delete lots of failed tickets when a security runs any automated tests on us.

`Form_Spam_Prevention` provides honeypot feature as well, which we are intentionally not using here  because we want don't want to be aggressive in blocking ticket purchase form.

Also fixes a minor bug in `Payment_Options` where output was directly getting rendered instead of being returned.

Depends on https://github.com/Automattic/camptix/pull/238