### PR TITLE
Blocks: Add fallback when no featured image is available

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sessions/block-content.js
@@ -166,10 +166,9 @@ class SessionsBlockContent extends Component {
 
 						{ show_images &&
 							<FeaturedImage
-								className={ classnames( 'wordcamp-session-image-container', 'align-' + image_align ) }
-								wpMediaDetails={ get( post, '_embedded.wp:featuredmedia[0].media_details.sizes', {} ) }
-								alt={ post.title.rendered.trim() }
+								imageData={ get( post, '_embedded.wp:featuredmedia[0]', {} ) }
 								width={ Number( featured_image_width ) }
+								className={ classnames( 'wordcamp-session-image-container', 'align-' + image_align ) }
 								imageLink={ post.link }
 							/>
 						}

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sessions/block-content.js
@@ -17,7 +17,6 @@ import {ItemTitle, ItemHTMLContent, ItemPermalink} from '../shared/block-content
 import { tokenSplit, arrayTokenReplace, intersperse, listify } from '../shared/i18n';
 import GridContentLayout from '../shared/grid-layout/block-content';
 import FeaturedImage from '../shared/featured-image';
-import { ICON } from './index';
 
 function SessionSpeakers( { session } ) {
 	let speakerData = get( session, '_embedded.speakers', [] );
@@ -172,7 +171,6 @@ class SessionsBlockContent extends Component {
 								alt={ post.title.rendered.trim() }
 								width={ Number( featured_image_width ) }
 								imageLink={ post.link }
-								fallbackIcon={ ICON }
 							/>
 						}
 

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sessions/block-content.js
@@ -17,6 +17,7 @@ import {ItemTitle, ItemHTMLContent, ItemPermalink} from '../shared/block-content
 import { tokenSplit, arrayTokenReplace, intersperse, listify } from '../shared/i18n';
 import GridContentLayout from '../shared/grid-layout/block-content';
 import FeaturedImage from '../shared/featured-image';
+import { ICON } from './index';
 
 function SessionSpeakers( { session } ) {
 	let speakerData = get( session, '_embedded.speakers', [] );
@@ -171,6 +172,7 @@ class SessionsBlockContent extends Component {
 								alt={ post.title.rendered.trim() }
 								width={ Number( featured_image_width ) }
 								imageLink={ post.link }
+								fallbackIcon={ ICON }
 							/>
 						}
 

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -23,14 +23,11 @@ export default class FeaturedImage extends Component {
 	 * @param {string} props.className      Class name for image element
 	 * @param {string} props.alt            Alt text for image
 	 * @param {string} props.imageLink      URL for wrapping the image in an anchor tag
-	 * @param {string} props.fallback       An element to use if no image is available
 	 */
 	constructor( props ) {
 		super( props );
 
 		this.state = {};
-
-		this.renderFallback = this.renderFallback.bind( this );
 	}
 
 	/**
@@ -76,7 +73,7 @@ export default class FeaturedImage extends Component {
 		const { source_url: src } = this.getFullImage();
 
 		if ( ! src ) {
-			return this.renderFallback();
+			return '';
 		}
 
 		let image = (
@@ -106,68 +103,4 @@ export default class FeaturedImage extends Component {
 
 		return image;
 	}
-
-	/**
-	 * Render a fallback element when no featured image is available.
-	 *
-	 * @return {Element}
-	 */
-	renderFallback() {
-		const { className, width, imageLink, fallbackIcon, fallbackElement } = this.props;
-
-		if ( isValidElement( fallbackElement ) ) {
-			return fallbackElement;
-		}
-
-		let output = '';
-
-		if ( fallbackIcon ) {
-			output = (
-				<FeaturedImageFallback
-					className={ className }
-					icon={ fallbackIcon }
-					width={ width }
-					link={ imageLink }
-				/>
-			);
-		}
-
-		return output;
-	}
-}
-
-function FeaturedImageFallback( { className, icon, width, link } ) {
-	const containerStyle = {
-		maxWidth: width,
-	};
-	let fallback;
-
-	fallback = (
-		<Dashicon
-			className="wordcamp-featured-image-fallback-icon"
-			icon={ icon }
-			size={ Number( width ) * 0.65 }
-		/>
-	);
-
-	if ( link ) {
-		fallback = (
-			<Disabled>
-				<a href={ link } className={ classnames( 'wordcamp-featured-image-link', 'wordcamp-featured-image-fallback-link' ) }>
-					{ fallback }
-				</a>
-			</Disabled>
-		);
-	}
-
-	return (
-		<div
-			className={ classnames( 'wordcamp-featured-image-fallback-container', className ) }
-			style={ containerStyle }
-		>
-			<div className="wordcamp-featured-image-fallback-container-inner">
-				{ fallback }
-			</div>
-		</div>
-	);
 }

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
+const { isValidElement } = React;
 
 /**
  * WordPress dependencies.
  */
-const { Disabled } = wp.components;
+const { Dashicon, Disabled } = wp.components;
 const { Component } = wp.element;
+const { __ } = wp.i18n;
 const { isURL } = wp.url;
 
 /**
@@ -20,11 +22,15 @@ export default class FeaturedImage extends Component {
 	 * @param {number} props.width          Width in pixels for image.
 	 * @param {string} props.className      Class name for image element
 	 * @param {string} props.alt            Alt text for image
+	 * @param {string} props.imageLink      URL for wrapping the image in an anchor tag
+	 * @param {string} props.fallback       An element to use if no image is available
 	 */
 	constructor( props ) {
 		super( props );
 
 		this.state = {};
+
+		this.renderFallback = this.renderFallback.bind( this );
 	}
 
 	/**
@@ -66,13 +72,17 @@ export default class FeaturedImage extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { className, alt, width = 150, imageLink } = this.props;
-		const fullImage = this.getFullImage();
+		const { className, alt, width, imageLink } = this.props;
+		const { source_url: src } = this.getFullImage();
+
+		if ( ! src ) {
+			return this.renderFallback();
+		}
 
 		let image = (
 			<img
-				className={ classnames( 'wordcamp-featured-image', className ) }
-				src={ fullImage.source_url }
+				className="wordcamp-featured-image"
+				src={ src }
 				alt={ alt }
 				width={ width + 'px' }
 			/>
@@ -96,4 +106,68 @@ export default class FeaturedImage extends Component {
 
 		return image;
 	}
+
+	/**
+	 * Render a fallback element when no featured image is available.
+	 *
+	 * @return {Element}
+	 */
+	renderFallback() {
+		const { className, width, imageLink, fallbackIcon, fallbackElement } = this.props;
+
+		if ( isValidElement( fallbackElement ) ) {
+			return fallbackElement;
+		}
+
+		let output = '';
+
+		if ( fallbackIcon ) {
+			output = (
+				<FeaturedImageFallback
+					className={ className }
+					icon={ fallbackIcon }
+					width={ width }
+					link={ imageLink }
+				/>
+			);
+		}
+
+		return output;
+	}
+}
+
+function FeaturedImageFallback( { className, icon, width, link } ) {
+	const containerStyle = {
+		maxWidth: width,
+	};
+	let fallback;
+
+	fallback = (
+		<Dashicon
+			className="wordcamp-featured-image-fallback-icon"
+			icon={ icon }
+			size={ Number( width ) * 0.65 }
+		/>
+	);
+
+	if ( link ) {
+		fallback = (
+			<Disabled>
+				<a href={ link } className={ classnames( 'wordcamp-featured-image-link', 'wordcamp-featured-image-fallback-link' ) }>
+					{ fallback }
+				</a>
+			</Disabled>
+		);
+	}
+
+	return (
+		<div
+			className={ classnames( 'wordcamp-featured-image-fallback-container', className ) }
+			style={ containerStyle }
+		>
+			<div className="wordcamp-featured-image-fallback-container-inner">
+				{ fallback }
+			</div>
+		</div>
+	);
 }

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-const { isValidElement } = React;
 
 /**
  * WordPress dependencies.
  */
 const { Dashicon, Disabled } = wp.components;
 const { Component } = wp.element;
-const { __ } = wp.i18n;
 const { isURL } = wp.url;
 
 /**

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -75,7 +75,7 @@ export default class FeaturedImage extends Component {
 
 		if ( width && height ) {
 			const aspectRatio = Number( height ) / Number( width );
-			newHeight = aspectRatio * newWidth;
+			newHeight = Number.parseFloat( aspectRatio * newWidth ).toFixed( 1 );
 		}
 
 		return newHeight;
@@ -99,7 +99,7 @@ export default class FeaturedImage extends Component {
 
 		let output = (
 			<img
-				className="wordcamp-featured-image"
+				className={ classnames( 'wordcamp-featured-image', 'wp-post-image' ) }
 				src={ src }
 				alt={ alt }
 				width={ width }

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -81,7 +81,7 @@ export default class FeaturedImage extends Component {
 				className="wordcamp-featured-image"
 				src={ src }
 				alt={ alt }
-				width={ width + 'px' }
+				width={ width }
 			/>
 		);
 

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { sortBy } from 'lodash';
 
 /**
  * WordPress dependencies.
@@ -11,54 +12,73 @@ const { Component } = wp.element;
 const { isURL } = wp.url;
 
 /**
- * Displays featured image, can be linked with block control for size.
+ * Displays a featured image, can be linked with block control for size.
+ *
+ * Unlike the PHP function that outputs a featured image, this doesn't bother with a `srcset` attribute, because
+ * it's assumed that this is being used in the block editor interface, and it just uses the largest image size
+ * available.
  */
 export default class FeaturedImage extends Component {
 	/**
 	 * @param {Object} props
-	 * @param {Array}  props.wpMediaDetails Available sizes of images in the format as returned by WP API. This is the `sizes` object inside `media_details` inside `wp:featuredMedia` object.
-	 * @param {number} props.width          Width in pixels for image.
-	 * @param {string} props.className      Class name for image element
-	 * @param {string} props.alt            Alt text for image
-	 * @param {string} props.imageLink      URL for wrapping the image in an anchor tag
+	 * @param {Array}  props.imageData Meta data about the featured image, including available sizes and the image's
+	 *                                 alt text. This is the `_embedded.wp:featuredMedia[0]` object in a REST response.
+	 * @param {number} props.width     Width in pixels for the image.
+	 * @param {string} props.className Additional class names for the image element
+	 * @param {string} props.imageLink URL for wrapping the image in an anchor tag
 	 */
 	constructor( props ) {
 		super( props );
 
-		this.state = {};
+		const { imageData } = props;
+		const { media_details = {}, alt_text = '' } = imageData;
+		const image = this.constructor.getWidestImage( media_details );
+
+		this.state = {
+			image : image,
+			alt   : alt_text,
+		};
 	}
 
 	/**
-	 * Get 'full' size image to be displayed in editor. Or get the widest one.
+	 * Get the details of the widest image size available.
+	 *
+	 * @param {Object} media_details
 	 *
 	 * @return {Object}
 	 */
-	getFullImage() {
-		const { getOwnPropertyDescriptors } = Object;
-		const availableSizes = this.props.wpMediaDetails;
+	static getWidestImage( media_details ) {
+		let image = {};
+		const { sizes = {} } = media_details;
 
-		const { selectedImage } = this.state;
-
-		if ( selectedImage && selectedImage.hasOwnProperty( 'source_url' ) ) {
-			return selectedImage;
+		if ( sizes.hasOwnProperty( 'full' ) && sizes.full.hasOwnProperty( 'source_url' ) ) {
+			image = sizes.full;
+		} else if ( Object.getOwnPropertyDescriptors( sizes ).length > 0 ) {
+			const sortedSizes = sortBy( sizes, 'width' );
+			image = sortedSizes.pop();
 		}
 
-		if ( availableSizes.hasOwnProperty( 'full' ) && availableSizes.full.hasOwnProperty( 'source_url' ) ) {
-			this.setState( { selectedImage: availableSizes.full } );
-			return availableSizes.full;
+		return image;
+	}
+
+	/**
+	 * Calculate a height based on the aspect ratio and a given width.
+	 *
+	 * @param {number} newWidth
+	 * @param {Object} image
+	 *
+	 * @return {number|null}
+	 */
+	static getNewHeight( newWidth, image ) {
+		let newHeight = null;
+		const { width, height } = image;
+
+		if ( width && height ) {
+			const aspectRatio = Number( height ) / Number( width );
+			newHeight = aspectRatio * newWidth;
 		}
 
-		let widestImage = { source_url: '' };
-
-		for ( const size in getOwnPropertyDescriptors( availableSizes ) ) {
-			if ( availableSizes[ size ].width > ( widestImage.width || 0 ) && availableSizes[ size ].hasOwnProperty( 'source_url' ) ) {
-				widestImage = availableSizes[ size ];
-			}
-		}
-
-		this.setState( { selectedImage: widestImage } );
-
-		return widestImage;
+		return newHeight;
 	}
 
 	/**
@@ -67,38 +87,42 @@ export default class FeaturedImage extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { className, alt, width, imageLink } = this.props;
-		const { source_url: src } = this.getFullImage();
+		const { width, className, imageLink } = this.props;
+		const { image, alt } = this.state;
+		const { source_url: src = '' } = image;
 
 		if ( ! src ) {
 			return '';
 		}
 
-		let image = (
+		const height = this.constructor.getNewHeight( width, image );
+
+		let output = (
 			<img
 				className="wordcamp-featured-image"
 				src={ src }
 				alt={ alt }
 				width={ width }
+				height={ height }
 			/>
 		);
 
 		if ( isURL( imageLink ) ) {
-			image = (
+			output = (
 				<Disabled>
 					<a href={ imageLink } className={ classnames( 'wordcamp-image-link', 'wordcamp-featured-image-link' ) }>
-						{ image }
+						{ output }
 					</a>
 				</Disabled>
 			);
 		}
 
-		image = (
+		output = (
 			<div className={ classnames( 'wordcamp-image-container', 'wordcamp-featured-image-container', className ) }>
-				{ image }
+				{ output }
 			</div>
 		);
 
-		return image;
+		return output;
 	}
 }

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies.
  */
-const { Dashicon, Disabled } = wp.components;
+const { Disabled } = wp.components;
 const { Component } = wp.element;
 const { isURL } = wp.url;
 

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/style.scss
@@ -2,43 +2,4 @@ img.wordcamp-featured-image {
 	height: auto;
 	max-width: 100%;
 	max-height: 100%;
-
-}
-
-$gray: #f3f3f4;
-
-// Maintain aspect ratio with dynamic width.
-// https://stackoverflow.com/a/6615994/402766
-.wordcamp-featured-image-fallback-container {
-	display: inline-block;
-	position: relative;
-	width: 100%;
-
-	&:after {
-		content: '';
-		display: block;
-		margin-top: 100%;
-	}
-}
-.wordcamp-featured-image-fallback-container-inner {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	right: 0;
-
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	border: 0.5em solid $gray;
-	color: $gray;
-
-	.dashicon {
-		display: block;
-	}
-}
-
-.wordcamp-featured-image-fallback-link {
-	color: $gray;
 }

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/style.scss
@@ -4,3 +4,41 @@ img.wordcamp-featured-image {
 	max-height: 100%;
 
 }
+
+$gray: #f3f3f4;
+
+// Maintain aspect ratio with dynamic width.
+// https://stackoverflow.com/a/6615994/402766
+.wordcamp-featured-image-fallback-container {
+	display: inline-block;
+	position: relative;
+	width: 100%;
+
+	&:after {
+		content: '';
+		display: block;
+		margin-top: 100%;
+	}
+}
+.wordcamp-featured-image-fallback-container-inner {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	border: 0.5em solid $gray;
+	color: $gray;
+
+	.dashicon {
+		display: block;
+	}
+}
+
+.wordcamp-featured-image-fallback-link {
+	color: $gray;
+}

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/shared/featured-image/style.scss
@@ -1,5 +1,4 @@
 img.wordcamp-featured-image {
-	height: auto;
 	max-width: 100%;
 	max-height: 100%;
 }

--- a/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/assets/src/sponsors/block-content.js
@@ -28,7 +28,6 @@ import {ItemTitle, ItemHTMLContent, ItemPermalink} from '../shared/block-content
  */
 function SponsorDetail( { sponsorPost, attributes } ) {
 	const { show_name, show_logo, content, featured_image_width } = attributes;
-	const featuredImageSizes = get( sponsorPost, '_embedded.wp:featuredmedia[0].media_details.sizes', {} );
 	const displayContent = 'full' === content ? sponsorPost.content.rendered.trim() : sponsorPost.excerpt.rendered.trim();
 
 	return (
@@ -45,10 +44,9 @@ function SponsorDetail( { sponsorPost, attributes } ) {
 
 			{ ( show_logo || show_logo === undefined ) &&
 				<FeaturedImage
-					className={ 'wordcamp-sponsor-featured-image wordcamp-sponsor-logo' }
-					wpMediaDetails={ featuredImageSizes }
-					alt={ sponsorPost.title.rendered }
+					imageData={ get( sponsorPost, '_embedded.wp:featuredmedia[0]', {} ) }
 					width={ featured_image_width }
+					className={ classnames( 'wordcamp-sponsor-featured-image', 'wordcamp-sponsor-logo' ) }
 					imageLink={ sponsorPost.link }
 				/>
 			}

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -53,7 +53,7 @@ function register_assets() {
 	wp_register_style(
 		'wordcamp-blocks',
 		PLUGIN_URL . 'assets/blocks.min.css',
-		[ 'dashicons' ],
+		[],
 		filemtime( PLUGIN_DIR . 'assets/blocks.min.css' )
 	);
 

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -53,7 +53,7 @@ function register_assets() {
 	wp_register_style(
 		'wordcamp-blocks',
 		PLUGIN_URL . 'assets/blocks.min.css',
-		[],
+		[ 'dashicons' ],
 		filemtime( PLUGIN_DIR . 'assets/blocks.min.css' )
 	);
 

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
@@ -1,18 +1,21 @@
 <?php
 
 namespace WordCamp\Blocks\Shared\Components;
+defined( 'WPINC' ) || die();
+
+use WP_Post;
 
 /**
  * Provides render backend for FeaturedImage component.
  *
- * @param array    $class_names        Additional classes to add inside <img> tag.
- * @param \WP_Post $post               Current post object. This will be used to calculate srcset attribute.
- * @param int      $width              Width of the image.
- * @param string   $image_link         URL link. If provided, image will be linked to this URL.
+ * @param WP_Post  $post        Current post object. This will be used to calculate srcset attribute.
+ * @param int      $width       Width of the image.
+ * @param array    $class_names Additional classes to add inside <img> tag.
+ * @param string   $image_link  URL link. If provided, image will be linked to this URL.
  *
  * @return string Output markup for featured image.
  */
-function render_featured_image( $class_names, $post, $width, $image_link = '' ) {
+function render_featured_image( $post, $width, $class_names = [], $image_link = '' ) {
 	$attachment_id = get_post_thumbnail_id( $post->ID );
 	$image_data    = wp_get_attachment_metadata( $attachment_id );
 
@@ -20,11 +23,15 @@ function render_featured_image( $class_names, $post, $width, $image_link = '' ) 
 		return '';
 	}
 
-	$aspect_ratio      = $image_data['height'] / $image_data['width'];
-	$height            = $aspect_ratio * $width;
-	$size              = array( $width, $height );
-	$class_names       = implode( ' ', $class_names );
-	$container_classes = "wordcamp-image-container wordcamp-featured-image-container $class_names";
+	$aspect_ratio = $image_data['height'] / $image_data['width'];
+	$height       = $aspect_ratio * $width;
+	$size         = array( $width, $height );
+
+	$container_classes = array_merge(
+		[ 'wordcamp-image-container', 'wordcamp-featured-image-container' ],
+		$class_names
+	);
+	$container_classes = implode( ' ', $container_classes );
 
 	$image = render_featured_image_element( $post, $size );
 

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
@@ -24,7 +24,7 @@ function render_featured_image( $post, $width, $class_names = [], $image_link = 
 	}
 
 	$aspect_ratio = $image_data['height'] / $image_data['width'];
-	$height       = $aspect_ratio * $width;
+	$height       = round( $aspect_ratio * $width, 1 );
 	$size         = array( $width, $height );
 
 	$container_classes = array_merge(
@@ -64,10 +64,6 @@ function render_featured_image_element( $post, $size ) {
 	$attr = [
 		'class' => 'wordcamp-featured-image',
 	];
-
-	if ( is_array( $size ) ) {
-		$attr = array_merge( $attr, $size );
-	}
 
 	return get_the_post_thumbnail( $post, $size, $attr );
 }

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
@@ -12,34 +12,32 @@ namespace WordCamp\Blocks\Shared\Components;
  *
  * @return string Output markup for featured image.
  */
-function render_featured_image( $class_names, $post, $width, $image_link = '' ) {
+function render_featured_image( $class_names, $post, $width, $image_link = '', $fallback_icon = '' ) {
+	$attachment_id = get_post_thumbnail_id( $post->ID );
+	$image_data    = wp_get_attachment_metadata( $attachment_id );
+	$size          = 'post-thumbnail';
 
-	$class_names[]     = 'wordcamp-featured-image';
-	$class_names       = implode( ' ', $class_names );
-	$container_classes = "wordcamp-image-container wordcamp-featured-image-container $class_names";
-	$attachment_id     = get_post_thumbnail_id( $post->ID );
-	$image_data        = wp_get_attachment_metadata( $attachment_id );
-	$size              = 'post-thumbnail';
-
-	if ( is_array( $image_data ) && isset( $image_data['sizes'] ) && isset( $image_data['sizes']['full'] ) ) {
-		$aspect_ratio = $image_data['sizes']['full']['height'] / $image_data['sizes']['full']['width'];
-		$height       = $aspect_ratio * $width;
-		$size         = array( $width, $height );
+	if ( ! isset( $image_data['width'], $image_data['height'] ) && $fallback_icon ) {
+		return render_featured_image_fallback( $fallback_icon, $width, $image_link, $class_names );
 	}
 
-	$image = render_featured_image_element( $post, $size, $class_names );
-	ob_start();
+	$aspect_ratio      = $image_data['height'] / $image_data['width'];
+	$height            = $aspect_ratio * $width;
+	$size              = array( $width, $height );
+	$class_names       = implode( ' ', $class_names );
+	$container_classes = "wordcamp-image-container wordcamp-featured-image-container $class_names";
 
+	$image = render_featured_image_element( $post, $size );
+
+	ob_start();
 	?>
 		<div class="<?php echo esc_attr( $container_classes ); ?>">
 			<?php if ( '' !== $image_link ) { ?>
-				<div class="components-disabled">
-					<a href="<?php echo esc_html( $image_link ); ?>" class="wordcamp-image-link wordcamp-featured-image-link">
-						<?php echo wp_kses_post( $image ); ?>
-					</a>
-				</div>
-			<?php } else { ?>
+				<a href="<?php echo esc_html( $image_link ); ?>" class="wordcamp-image-link wordcamp-featured-image-link">
 					<?php echo wp_kses_post( $image ); ?>
+				</a>
+			<?php } else { ?>
+				<?php echo wp_kses_post( $image ); ?>
 			<?php } ?>
 		</div>
 	<?php
@@ -56,13 +54,48 @@ function render_featured_image( $class_names, $post, $width, $image_link = '' ) 
  *
  * @return string
  */
-function render_featured_image_element( $post, $size, $class_names ) {
-	return get_the_post_thumbnail(
-		$post,
-		$size,
-		array(
-			'class' => esc_attr( $class_names ),
-			'alt'   => esc_attr( $post->post_name ),
-		)
+function render_featured_image_element( $post, $size ) {
+	$attr = [
+		'class' => 'wordcamp-featured-image',
+	];
+
+	if ( is_array( $size ) ) {
+		$attr = array_merge( $attr, $size );
+	}
+
+	return get_the_post_thumbnail( $post, $size, $attr );
+}
+
+
+function render_featured_image_fallback( $icon, $width, $link = '', $class_names = [] ) {
+	$class_names[]     = 'wordcamp-featured-image-fallback-container';
+	$container_classes = implode( ' ', $class_names );
+
+	$style = sprintf(
+		'max-width: %dpx;',
+		$width
 	);
+
+	$content = sprintf(
+		'<span class="dashicons dashicons-%s" style="font-size: %dpx" aria-hidden="true">&nbsp;</span>',
+		esc_attr( $icon ),
+		$width * 0.65
+	);
+
+	ob_start();
+	?>
+		<div class="<?php echo esc_attr( $container_classes ); ?>" style="<?php echo esc_attr( $style ); ?>">
+			<div class="wordcamp-featured-image-fallback-container-inner">
+				<?php if ( $link ) : ?>
+					<a href="<?php echo esc_url( $link ); ?>" class="wordcamp-featured-image-link wordcamp-featured-image-fallback-link">
+						<?php echo wp_kses_post( $content ); ?>
+					</a>
+				<?php else : ?>
+					<?php echo wp_kses_post( $content ); ?>
+				<?php endif; ?>
+			</div>
+		</div>
+	<?php
+
+	return ob_get_clean();
 }

--- a/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/shared/featured-image.php
@@ -12,13 +12,12 @@ namespace WordCamp\Blocks\Shared\Components;
  *
  * @return string Output markup for featured image.
  */
-function render_featured_image( $class_names, $post, $width, $image_link = '', $fallback_icon = '' ) {
+function render_featured_image( $class_names, $post, $width, $image_link = '' ) {
 	$attachment_id = get_post_thumbnail_id( $post->ID );
 	$image_data    = wp_get_attachment_metadata( $attachment_id );
-	$size          = 'post-thumbnail';
 
-	if ( ! isset( $image_data['width'], $image_data['height'] ) && $fallback_icon ) {
-		return render_featured_image_fallback( $fallback_icon, $width, $image_link, $class_names );
+	if ( ! isset( $image_data['width'], $image_data['height'] ) ) {
+		return '';
 	}
 
 	$aspect_ratio      = $image_data['height'] / $image_data['width'];
@@ -64,38 +63,4 @@ function render_featured_image_element( $post, $size ) {
 	}
 
 	return get_the_post_thumbnail( $post, $size, $attr );
-}
-
-
-function render_featured_image_fallback( $icon, $width, $link = '', $class_names = [] ) {
-	$class_names[]     = 'wordcamp-featured-image-fallback-container';
-	$container_classes = implode( ' ', $class_names );
-
-	$style = sprintf(
-		'max-width: %dpx;',
-		$width
-	);
-
-	$content = sprintf(
-		'<span class="dashicons dashicons-%s" style="font-size: %dpx" aria-hidden="true">&nbsp;</span>',
-		esc_attr( $icon ),
-		$width * 0.65
-	);
-
-	ob_start();
-	?>
-		<div class="<?php echo esc_attr( $container_classes ); ?>" style="<?php echo esc_attr( $style ); ?>">
-			<div class="wordcamp-featured-image-fallback-container-inner">
-				<?php if ( $link ) : ?>
-					<a href="<?php echo esc_url( $link ); ?>" class="wordcamp-featured-image-link wordcamp-featured-image-fallback-link">
-						<?php echo wp_kses_post( $content ); ?>
-					</a>
-				<?php else : ?>
-					<?php echo wp_kses_post( $content ); ?>
-				<?php endif; ?>
-			</div>
-		</div>
-	<?php
-
-	return ob_get_clean();
 }

--- a/public_html/wp-content/mu-plugins/blocks/view/sessions.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sessions.php
@@ -53,8 +53,7 @@ setup_postdata( $session );
 				array( 'wordcamp-session-image-container', 'align-' . esc_attr( $attributes['image_align'] ) ),
 				$session,
 				$attributes['featured_image_width'],
-				get_permalink( $session ),
-				'list-view'
+				get_permalink( $session )
 			) );
 		?>
 	<?php endif; ?>

--- a/public_html/wp-content/mu-plugins/blocks/view/sessions.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sessions.php
@@ -50,9 +50,9 @@ setup_postdata( $session );
 	<?php if ( true === $attributes['show_images'] ) : ?>
 		<?php
 			echo wp_kses_post( render_featured_image(
-				array( 'wordcamp-session-image-container', 'align-' . esc_attr( $attributes['image_align'] ) ),
 				$session,
 				$attributes['featured_image_width'],
+				[ 'wordcamp-session-image-container', 'align-' . esc_attr( $attributes['image_align'] ) ],
 				get_permalink( $session )
 			) );
 		?>

--- a/public_html/wp-content/mu-plugins/blocks/view/sessions.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sessions.php
@@ -53,7 +53,8 @@ setup_postdata( $session );
 				array( 'wordcamp-session-image-container', 'align-' . esc_attr( $attributes['image_align'] ) ),
 				$session,
 				$attributes['featured_image_width'],
-				get_permalink( $session )
+				get_permalink( $session ),
+				'list-view'
 			) );
 		?>
 	<?php endif; ?>

--- a/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
+++ b/public_html/wp-content/mu-plugins/blocks/view/sponsors.php
@@ -23,9 +23,9 @@ setup_postdata( $sponsor );
 	<?php if ( $attributes['show_logo'] ) { ?>
 		<?php echo wp_kses_post(
 			render_featured_image(
-				array( 'wordcamp-sponsor-featured-image', 'wordcamp-sponsor-logo' ),
 				$sponsor,
 				$attributes['featured_image_width'],
+				[ 'wordcamp-sponsor-featured-image', 'wordcamp-sponsor-logo' ],
 				get_permalink( $sponsor )
 			)
 		); ?>


### PR DESCRIPTION
~Modifies both JS and PHP to render a fallback container with icon when a post does not have a featured image.~

Ensures that an empty string is output instead of a broken image tag when a post does not have a featured image available.

This also makes some improvements to the featured image output when there _is_ a featured image both on the JS and the PHP side.

These blocks also need to be updated to work with this:

- [x] Sessions
- [x] Sponsors

Refs #95