### PR TITLE
Organizer Reminders: Split manual send onto a separate screen for UX.

### DIFF
--- a/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
+++ b/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
@@ -1,10 +1,12 @@
 <?php
 
 namespace WordCamp\Gutenberg_Tweaks;
+use WCOR_Reminder, WordCamp\Budgets\Sponsor_Invoices;
 
 defined( 'WPINC' ) || die();
 
 add_filter( 'classic_editor_network_default_settings', __NAMESPACE__ . '\classic_editor_default_settings' );
+add_filter( 'classic_editor_enabled_editors_for_post_type', __NAMESPACE__ . '\disable_editors_by_post_type', 10, 2 );
 
 
 /**
@@ -15,4 +17,50 @@ function classic_editor_default_settings( $defaults ) {
 	$defaults['allow-users'] = true;
 
 	return $defaults;
+}
+
+/**
+ * Disable editors in post types that don't support them.
+ *
+ * @param array  $editors
+ * @param string $post_type
+ *
+ * @return mixed
+ */
+function disable_editors_by_post_type( $editors, $post_type ) {
+	// Define post type slug constants.
+	require_once( WP_PLUGIN_DIR . '/wordcamp-organizer-reminders/wcor-reminder.php' );
+	require_once( WP_PLUGIN_DIR . '/wcpt/wcpt-event/class-event-loader.php' );
+	require_once( WP_PLUGIN_DIR . '/wcpt/wcpt-wordcamp/wordcamp-loader.php' );
+
+		// make sure there aren't any side-effects, these shouldn't execute any code, only define things
+
+	/*
+	 * All of our first-party custom post types should be added here as soon as they fully support Gutenberg.
+	 * Ideally the only post types that we have to support in both editors should be `post` and `page`.
+	 */
+	$disabled_in_classic = array( WCOR_Reminder::MANUAL_POST_TYPE_SLUG );
+
+	/*
+	 * These have custom interfaces/interactions that haven't been ported to Gutenberg yet. Over time, we should
+	 * port them to Gutenberg. Once a CPT is ported, it should be disabled in the Classic Editor so that we only
+	 * have to support the functionality in Gutenberg.
+	 */
+	$disabled_in_gutenberg = array(
+		WCPT_POST_TYPE_ID, WCPT_MEETUP_SLUG,
+		WCP_Payment_Request::POST_TYPE, MES_Sponsor::POST_TYPE_SLUG,
+		WordCamp\Budgets\Sponsor_Invoices\POST_TYPE,
+		WordCamp\Budgets\Reimbursement_Requests\POST_TYPE,
+	);
+		// todo include them where needed, test to make sure no fatals
+
+	if ( in_array( $post_type, $disabled_in_classic ) ) {
+		$editors['classic_editor'] = false;
+	}
+
+	if ( in_array( $post_type, $disabled_in_gutenberg ) ) {
+		$editors['block_editor'] = false;
+	}
+
+	return $editors;
 }

--- a/public_html/wp-content/mu-plugins/helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/helpers-wcpt.php
@@ -252,3 +252,60 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 
 	return ob_get_clean();
 }
+
+/**
+ * Get a <select> dropdown of `wordcamp` post statuses with a select2 UI.
+ *
+ * The calling plugin is responsible for validating and processing the form, this just outputs a single field.
+ *
+ * @param string $name          Optional. The `name` attribute for the `select` element. Defaults to `wordcamp_status`.
+ * @param array  $query_options Optional. Extra arguments to pass to `get_posts()`. Defaults to the values in `get_wordcamps()`.
+ * @param int    $selected      Optional. The list option to select. Defaults to not selecting any.
+ * @param string $label         Optinoal. The text for the wrapping <label> element.
+ *
+ * @return string The HTML for the <select> list.
+ */
+function get_wordcamp_status_dropdown( $name = 'wordcamp_status', $query_options = array(), $selected = 0, $label = null ) {
+	// todo make this a JS function instead? how to share it?
+	// should be a shared G component? does G already have a fancy dropdown? if so then use that instead
+
+	$statuses = WordCamp_Loader::get_post_statuses();
+
+	if ( ! $label ) {
+		$label = __( 'Select a Status:', 'wordcamporg' );
+	}
+
+	wp_enqueue_script( 'select2' );
+	wp_enqueue_style(  'select2' );
+
+	ob_start();
+
+	?>
+
+	<label for="<?php echo esc_attr( $name ); ?>">
+		<?php echo esc_html( $label ); ?>
+	</label>
+
+	<select id="<?php echo esc_attr( $name ); ?>" name="<?php echo esc_attr( $name ); ?>" class="select2">
+		<option value=""></option>
+
+		<?php foreach ( $statuses as $slug => $label ) : ?>
+			<option
+				value="<?php echo esc_attr( $slug ); ?>"
+				<?php selected( $selected, $slug ); ?>
+			>
+				<?php echo esc_html( $label ); ?>
+			</option>
+		<?php endforeach; ?>
+	</select>
+
+	<script>
+		jQuery( document ).ready( function() {
+			jQuery( '.select2' ).select2();
+		} );
+	</script>
+
+	<?php
+
+	return ob_get_clean();
+}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -236,4 +236,6 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			$result
 		);
 	}
+
+	// new test for manual, or does this cover it still?
 }

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-manual-status.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-manual-status.php
@@ -1,0 +1,147 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @var WP_Post $post
+ * @var bool    $current_user_can_edit_request
+ * @var string  $submit_text
+ * @var string  $submit_note
+ * @var string  $submit_note_class
+ */
+// update ^
+
+?>
+
+<?php
+/**
+ * @var WP_Post             $post
+ * @var WCP_Payment_Request $this
+ * @var bool                $current_user_can_edit_request
+ * @var string              $submit_text
+ * @var string              $submit_note
+ * @var string              $submit_note_class
+ * @var bool                $date_vendor_paid_readonly
+ * @var string              $incomplete_notes
+ * @var bool                $incomplete_readonly
+ */
+?>
+<div id="submitpost" class="wcb submitbox">
+	<div id="minor-publishing">
+
+		<?php if ( $current_user_can_edit_request && ! current_user_can( 'manage_network' ) ) : ?>
+		<div id="minor-publishing-actions">
+			<div id="save-action">
+				<?php submit_button( esc_html__( 'Save Draft', 'wordcamporg' ), 'button', 'wcb-save-draft', false ); ?>
+				<span class="spinner"></span>
+			</div>
+			<div class="clear"></div>
+		</div>
+		<?php endif; ?>
+
+		<div id="misc-publishing-actions">
+			<div class="misc-pub-section">
+				<?php _e( 'ID:', 'wordcamporg' ); ?>
+				<span>
+					<?php echo esc_html( $this->get_field_value( 'request_id', $post ) ); ?>
+				</span>
+			</div>
+
+			<div class="misc-pub-section">
+				<?php _e( 'Requested By:', 'wordcamporg' ); ?>
+				<span>
+					<?php echo esc_html( $this->get_field_value( 'requester', $post ) ); ?>
+				</span>
+			</div>
+
+			<?php if ( $post->post_status != 'auto-draft' ) : ?>
+			<div class="misc-pub-section">
+				<?php $this->render_text_input( $post, 'Date Vendor was Paid', 'date_vendor_paid', '', 'date', array(), $date_vendor_paid_readonly, false ); ?>
+			</div>
+
+			<div class="misc-pub-section misc-pub-post-status">
+				<label>
+					<?php _e( 'Status:' ) ?>
+
+					<span id="post-status-display">
+						<?php if ( current_user_can( 'manage_network' ) ) : ?>
+
+							<select id="wcb_status" name="post_status">
+								<?php foreach ( WCP_Payment_Request::get_post_statuses() as $status ) : ?>
+									<?php $status = get_post_status_object( $status ); ?>
+									<option value="<?php echo esc_attr( $status->name ); ?>" <?php selected( $post->post_status, $status->name ); ?> >
+										<?php echo esc_html( $status->label ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+
+						<?php else : ?>
+
+							<?php $status = get_post_status_object( $post->post_status ); ?>
+							<?php echo esc_html( $status->label ); ?>
+							<input type="hidden" name="post_status" value="<?php echo esc_attr( $post->post_status ); ?>" />
+
+						<?php endif; ?>
+					</span>
+				</label>
+			</div>
+			<?php endif; ?>
+
+			<div class="misc-pub-section hide-if-js wcb-mark-incomplete-notes">
+				<label for="wcp_mark_incomplete_notes">
+					<?php esc_html_e( 'What information is needed?', 'wordcamporg' ); ?>
+				</label>
+
+				<textarea
+					id="wcp_mark_incomplete_notes"
+					name="wcp_mark_incomplete_notes"
+					class="large-text"
+					rows="5"
+					placeholder="<?php esc_html_e( 'Need to attach receipt, etc', 'wordcamporg' ); ?>"
+					<?php echo $incomplete_readonly; ?>
+				><?php
+					echo esc_textarea( $incomplete_notes );
+				?></textarea>
+			</div>
+
+			<div class="clear"></div>
+		</div> <!-- #misc-publishing-actions -->
+
+		<div class="clear"></div>
+	</div> <!-- #minor-publishing -->
+
+	<div id="major-publishing-actions">
+		want buttons to save draft, move to trash, or send
+		<?php if ( $current_user_can_edit_request ) : ?>
+
+			<?php if ( ! empty( $submit_note ) ) : ?>
+				<div class="notice notice-<?php echo esc_attr( $submit_note_class ); ?> inline">
+					<?php echo wpautop( esc_html( $submit_note ) ); ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( current_user_can( 'delete_post', $post->ID ) ) : ?>
+				<div id="delete-action">
+					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $post->ID ); ?>">
+						<?php _e( 'Delete', 'wordcamporg' ); ?>
+					</a>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( \WordCamp_Budgets::can_submit_request( $post ) ) : ?>
+				<div id="publishing-action">
+					<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr( $submit_text ) ?>" />
+					<?php submit_button( $submit_text, 'primary button-large', 'wcb-update', false, array( 'accesskey' => 'p' ) ); ?>
+				</div>
+			<?php endif; ?>
+
+			<div class="clear"></div>
+
+		<?php else : ?>
+
+			<?php _e( 'This request can not be edited.', 'wordcamporg' ); ?>
+
+		<?php endif; ?>
+	</div> <!-- #major-publishing-actions -->
+
+</div> <!-- .submitbox -->

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-manual-templates.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-manual-templates.php
@@ -1,0 +1,61 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+?>
+
+rework this to be a metabox, probably rename file
+
+
+
+<p>
+	<?php _e( 'Submit the form below to immediately send the message to the chosen recipients for WordCamps that match the selected criteria.', 'wordcamporg' ); ?>
+</p>
+
+<p>
+	<?php printf(
+		__(
+			'The placeholders in each message will use data from the corresponding camp;
+			e.g., the email to WordCamp Chicago would use <code>Chicago, IL, USA</code> as the <code>[wordcamp_location]</code>.',
+			'wordcamporg'
+		),
+		date( 'Y' )
+	); ?>
+</p>
+
+
+<p>
+	pick template
+	 - if textarea not empty, prompt before overwriting
+</p>
+
+// get feedback on UI from sarah
+// get feedback on code from corey/vedanshu
+// don't need form anymore
+
+<form name="manually-send" action="" method="POST">
+	<textarea></textarea>
+
+	<div>
+		placeholders
+			- floated to right side while editor on left, use grid though
+	</div>
+
+	<div>
+		recipients
+		- get DRY list
+	</div>
+
+	<div>
+		send by
+		- individual wordcamp: <?php echo get_wordcamp_dropdown(); ?>
+		- all camps in status: <?php echo get_wordcamp_status_dropdown( 'wcor_manually_send_by_status' ); ?>
+	</div>
+
+
+
+
+	<p>
+		<?php submit_button( 'Send', 'primary', 'manually-send' ); ?>
+	</p>
+</form>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-send-by-status.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-send-by-status.php
@@ -1,0 +1,35 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+// todo this'll be removed b/c have page now
+
+?>
+
+<p>
+	<?php _e( 'Check the box below and save the post to manually send this message to all WordCamps that have the given status. The assigned recipient(s) will <strong>not</strong> receive a copy.', 'wordcamporg' ); ?>
+</p>
+
+<p>
+	<?php printf(
+		__(
+			'The placeholders in each message will use data from the corresponding camp;
+			e.g., the email to WordCamp Chicago would use <code>Chicago, IL, USA</code> as the <code>[wordcamp_location]</code>.',
+			'wordcamporg'
+		),
+		date( 'Y' )
+	); ?>
+</p>
+
+<p>
+	<?php _e( 'It will be sent immediately, regardless of when it is scheduled to be sent automatically, and regardless of whether or not it has already been sent automatically.', 'wordcamporg' ); ?>
+</p>
+
+<p>
+	<?php echo get_wordcamp_status_dropdown( 'wcor_manually_send_by_status' ); ?>
+</p>
+
+<p>
+	<input id="wcor_manually_send_checkbox" name="wcor_manually_send" type="checkbox">
+	<label for="wcor_manually_send_checkbox"><?php _e( 'Manually send this e-mail by status', 'wordcamporg' ); ?></label>
+</p>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -414,11 +414,13 @@ class WCOR_Mailer {
 			$recipients[] = $dest;
 		}
 
+		// Camera Wrangler.
 		if ( in_array( 'wcor_send_camera_wrangler', $send_where ) ) {
 			$region_id = get_post_meta( $wordcamp_id, 'Multi-Event Sponsor Region', true );
 			$recipients[] = MES_Region::get_camera_wranger_from_region( $region_id );
 		}
 
+		// Organizing Team.
 		if ( in_array( 'wcor_send_organizers', $send_where ) ) {
 			$email_address_key = wcpt_key_to_str( 'E-mail Address', 'wcpt_' );
 
@@ -430,6 +432,20 @@ class WCOR_Mailer {
 				$recipients[] = sanitize_email( $_POST[ $email_address_key ] );
 			} else {
 				$recipients[] = sanitize_email( get_post_meta( $wordcamp_id, 'E-mail Address', true ) );
+			}
+		}
+
+		// All camps in a given status.
+		if ( in_array( 'wcor_send_status', $send_where ) ) {
+			$status              = get_post_meta( $wordcamp_id, 'wcor_which_status', true );
+			$wordcamps_in_status = get_wordcamps( array( 'post_status' => $status ) );
+
+			foreach ( $wordcamps_in_status as $wordcamp ) {
+				$address = $wordcamp->{'E-mail Address'};
+
+				if ( is_email( $address ) ) {
+					$recipients[] = $address;
+				}
 			}
 		}
 
@@ -467,6 +483,15 @@ class WCOR_Mailer {
 	 */
 	public function send_manual_email( $email, $wordcamp ) {
 		$recipient = $this->get_recipients( $wordcamp->ID, $email->ID );
+
+		//var_dump($recipient);wp_die();
+		// if empty recip, return false, also log error details
+
+		// sending to all camps in a status is different than all otehrs. those all send to a single camp in the context of that camp
+		// for sending to all camps, if any placeholders are used, those'll have to be generated each time in the context of the current camp
+		// ugh
+
+		// maybe create a 2nd metabox for this, and rename the other to make the distinction between the two clear
 
 		return $this->mail( $recipient, $email->post_title, $email->post_content, array(), $email, $wordcamp );
 	}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -5,8 +5,15 @@
  * @package WordCampOrganizerReminders
  */
 
+// move reminder to new screen, w/out adding email by status
+// add email by status
+// move inline html to external view files
+// any other remaining comments
+// phpcs
+
 class WCOR_Reminder {
 	const AUTOMATED_POST_TYPE_SLUG = 'organizer-reminder';
+	const MANUAL_POST_TYPE_SLUG    = 'manual-reminder';
 	const REQUIRED_CAPABILITY      = 'manage_options';
 
 	/**
@@ -16,6 +23,7 @@ class WCOR_Reminder {
 		add_action( 'init',                              array( $this, 'register_post_type' ) );
 		add_action( 'admin_init',                        array( $this, 'add_meta_boxes' ) );
 		add_action( 'admin_menu',                        array( $this, 'register_menu_pages' ) );
+		add_action( 'add_meta_boxes',                    array( $this, 'replace_meta_boxes' ) );
 		add_action( 'save_post_' . self::AUTOMATED_POST_TYPE_SLUG, array( $this, 'save_post' ), 10, 2 );
 	}
 
@@ -43,6 +51,7 @@ class WCOR_Reminder {
 			'labels'              => $automated_labels,
 			'singular_label'      => 'Automated Reminder',
 			'public'              => true,
+			// ^ should be false? don't want these accessible on front end etc
 			'exclude_from_search' => true,
 			'publicly_queryable'  => false,
 			'show_ui'             => true,
@@ -57,6 +66,59 @@ class WCOR_Reminder {
 		);
 
 		register_post_type( self::AUTOMATED_POST_TYPE_SLUG, $automated_params );
+
+		$manual_labels = array(
+			'name'               => 'Manual Reminders',
+			'singular_name'      => 'Manual Reminder',
+			'add_new'            => 'Add New Manual',
+			'add_new_item'       => 'Add New Manual Reminder',
+			'edit'               => 'Edit',
+			'edit_item'          => 'Edit Manual Reminder',
+			'new_item'           => 'New Manual Reminder',
+			'view'               => 'View Manual Reminders',
+			'view_item'          => 'View Manual Reminder',
+			'search_items'       => 'Search Manual Reminders',
+			'not_found'          => 'No manual reminders',
+			'not_found_in_trash' => 'No manual reminders',
+			'parent'             => 'Parent Manual Reminder',
+		);
+
+		$manual_params = array(
+			'labels'              => $manual_labels,
+			'singular_label'      => 'Manual Reminder',
+			'public'              => true,	// should be false? don't want these accessible on front end etc
+			'exclude_from_search' => true,
+			'publicly_queryable'  => false,
+			// wanna change some of this prolly, some of the defaults don't make sense b/c don't want it to be editable, don't want to create new ones, etc
+			// need to setup map_meta_cap or has_cap to return false for current_user_can(edit_post, ID of a manual), but want them to be able to view it in the back end, not view on the front end. maybe just have a metabox to show the deets?
+			// why is public true in both of these types?
+			// replace status metabox with a custom one that just has a send button.
+				// oh, maybe let people save as drafts, and edit posts that are drafts, but not edit ones that are sent
+				// maybe just use JS to change the label in the DOM, rather than replacing w/ new button?
+			'show_ui'             => true,
+			'show_in_menu'        => 'organizer-reminders',
+			'show_in_nav_menus'   => false,
+			'hierarchical'        => false,
+			'capability_type'     => 'post',
+			'has_archive'         => false,
+			'rewrite'             => false,
+			'show_in_rest'        => true,
+				//for G, make sure posts won't be accessible to unauth'd users, even if they have author role on central. should need self::REQUIRED_CAPABILITY
+			'query_var'           => false,
+			'supports'            => array( 'title', 'editor', 'author', 'revisions' ),
+			// make this post type disabled in the _CLASSIC_ editor, so it can only be used in gutenberg, and make it gutenberg comapt from the beginning, include any JS customizations needed
+		);
+
+		register_post_type( self::MANUAL_POST_TYPE_SLUG,    $manual_params    );
+
+
+		// when open edior, there's a block already added to new post
+		// it has a dropdown of titles
+		// when you select a title, it should you the first N chars of post, and a "use as template" button
+		// when you click button, it removes itself, and adds the title/content of that template to the post, as G blocks
+
+		// restrict which blocks can be chosen
+		// add template block by default
 	}
 
 	/**
@@ -87,6 +149,15 @@ class WCOR_Reminder {
 			self::AUTOMATED_POST_TYPE_SLUG,
 			'side'
 		);
+
+		add_meta_box(
+			'wcorg_manual_templates',
+			'Templates',
+			array( $this, 'render_manual_templates' ),
+			self::MANUAL_POST_TYPE_SLUG,
+			'normal', // want it above the title, if that's possible. will 'advanced' let you? might need to use css to re-order. maybe grid or something.
+			'high'
+		);
 	}
 
 	/**
@@ -105,6 +176,11 @@ class WCOR_Reminder {
 	 */
 	public function render_available_placeholders() {
 		require_once( __DIR__ . '/views/metabox-placeholders.php' );
+	}
+
+	// phpdoc
+	public function render_manual_templates() {
+		require_once( __DIR__ . '/views/metabox-manual-templates.php' );
 	}
 
 	/**
@@ -147,6 +223,80 @@ class WCOR_Reminder {
 	}
 
 	/**
+	 * Replace Core's Publish metabox with a custom one.
+	 */
+	function replace_meta_boxes() {
+		remove_meta_box( 'submitdiv', self::MANUAL_POST_TYPE_SLUG, 'side' );
+
+		add_meta_box(
+			'submitdiv',
+			esc_html__( 'Status', 'wordcamporg' ),
+			array( $this, 'render_status_metabox' ),
+			self::MANUAL_POST_TYPE_SLUG,
+			'side',
+			'high'
+		);
+
+		// move this higer, next to add_meta_boxes()? or is it more logical here?
+
+		// hmmmm, maybe should use gutenberg instead?
+		// block template to only allow paragraph blocks. also want to remove html controls from the paragraph toolbar though, is that possible?
+			// maybe simpler and better to allow html emails instead? still restrict to basic stuff that works in emails
+		// would also want to remove the `preview`, `publish` ettc buttons and replace w/ a `send` button
+
+		// show placeholders -- make DRY w/ automated
+		// select2 box for titles -- or does G already have that built in? make it shared component if custom
+		// g controls/inspector/whatever for who it should be sent to (individual camp, or all camps in status)
+			// make list of who can receive DRY w/ automated
+
+		// require selecting who should receive etc before sending
+		// maybe some kind of pre-publish checks before sending
+		// allow previewing email w/ html stripped?
+		// only allow P blocks, no html - file bug report if still doesn't let you remove those 2 others
+	}
+
+	/**
+	 * Render the Status metabox
+	 *
+	 * @param WP_Post $post The invoice post
+	 */
+	public function render_status_metabox( $post ) {
+		return;
+		wp_nonce_field( 'status', 'status_nonce' );
+
+		$delete_text = EMPTY_TRASH_DAYS ? esc_html__( 'Move to Trash' ) : esc_html__( 'Delete Permanently' );
+		$wordcamp    = get_wordcamp_post();
+
+		// todo update all this
+
+		/*
+		 * We can't use current_user_can( 'edit_post', N ) in this case, because the restriction only applies when
+		 * submitting the edit form, not when viewing the post. We also want to allow editing by plugins, but not
+		 * always through the UI. So, instead, we simulate get the same result in a different way.
+		 *
+		 * Network admins can edit submitted invoices in order to correct them before they're sent to QuickBooks, but
+		 * not even network admins can edit them once they've been created in QuickBooks, because then our copy of the
+		 * invoice would no longer match QuickBooks.
+		 *
+		 * This intentionally only prevents editing through the UI; we still want plugins to be able to edit the
+		 * invoice, so that the status can be updated to paid, etc.
+		 */
+		$allowed_edit_statuses = array( 'auto-draft', 'draft' );
+
+		if ( current_user_can( 'manage_network' ) ) {
+			$allowed_edit_statuses[] = 'wcbsi_submitted';
+		}
+
+		$allowed_submit_statuses         = true; //WordCamp_Loader::get_after_contract_statuses();
+		$current_user_can_edit_request   = true; //in_array( $post->post_status, $allowed_edit_statuses, true );
+		$current_user_can_submit_request = true; // $wordcamp && in_array( $wordcamp->post_status, $allowed_submit_statuses, true );
+
+		$submit_text = 'hi';
+
+		require_once( __DIR__ . '/views/metabox-manual-status.php' );
+	}
+
+	/**
 	 * Checks to make sure the conditions for saving post meta are met
 	 *
 	 * @param int $post_id
@@ -168,7 +318,7 @@ class WCOR_Reminder {
 		}
 
 		$this->save_post_meta( $post, $_POST );
-		$this->send_manual_email( $post, $_POST );
+//		$this->send_manual_email( $post, $_POST );
 	}
 
 	/**
@@ -218,27 +368,49 @@ class WCOR_Reminder {
 		}
 	}
 
+	// move manual stuff to separate file, and then rename this to automated? maybe would have a common file too? see how the functions break down. maybe it's enough to have views separated
+
 	/**
 	 * Sends an e-mail manually.
 	 *
 	 * This provides a way to send e-mails at will, regardless of the time or trigger that the e-mail is normally
 	 * associated with, and regardless of whether or not the e-mail has already been sent to the recipient.
 	 *
-	 * @todo Add admin notices, but it's a pain to make them persist through the post/redirect/get process.
-	 *       Will be easy if #11515 lands in Core.
-	 *
-	 * @param WP_Post $email
 	 * @param array   $form_values
 	 */
-	protected function send_manual_email( $email, $form_values ) {
+	protected function send_manual_email( $form_values ) {
 		/** @var $WCOR_Mailer WCOR_Mailer */
 		global $WCOR_Mailer;
 
+		return array(
+			'success' => array(
+				'yay',
+			),
+
+			'warning' => array(
+				'huh', 'foo?'
+			),
+
+			'error' => array(
+				'doh'
+			),
+		);
+
 		if ( empty( $form_values['wcor_manually_send'] ) || 'on' != $form_values['wcor_manually_send'] || in_array( $form_values['wcor_manually_send_wordcamp'], array( 'instructions', 'spacer' ) ) ) {
 			return;
+			// edit ?
 		}
 
+		if ( ! current_user_can( self::REQUIRED_CAPABILITY ) ) {
+			return;
+		}
+		// verify nonce too
+
+		// so maybe we'd have a loop here that'd go through each camp in the chosen status, and call the mail function?
 		$wordcamp = get_post( $form_values['wcor_manually_send_wordcamp'] );
 		$WCOR_Mailer->send_manual_email( $email, $wordcamp );
+
+
+		// hmmm, maybe this should just return true/false? or true/WP_Error? and caller should format that raw data for displaying as error msgs?
 	}
 }


### PR DESCRIPTION
This doesn't yet reflect all of the design changes, but the direction that it should go in is to make the new screen a Gutenberg block.

Supercedes #59 