### PR TITLE
WC Campsite17: Adds featured image support with feature flag.

### DIFF
--- a/public_html/wp-content/themes/campsite-2017/template-parts/content-page.php
+++ b/public_html/wp-content/themes/campsite-2017/template-parts/content-page.php
@@ -13,6 +13,12 @@ namespace WordCamp\CampSite_2017;
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
+		<?php if ( has_post_thumbnail() && ! wcorg_skip_feature( 'cs17_display_featured_image' ) ) : ?>
+			<div class="entry-image">
+				<?php the_post_thumbnail(); ?>
+			</div>
+		<?php endif; ?>
+
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header>
 

--- a/public_html/wp-content/themes/campsite-2017/template-parts/content-search.php
+++ b/public_html/wp-content/themes/campsite-2017/template-parts/content-search.php
@@ -13,6 +13,12 @@ namespace WordCamp\CampSite_2017;
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
+		<?php if ( has_post_thumbnail() && ! wcorg_skip_feature( 'cs17_display_featured_image' ) ) : ?>
+			<div class="entry-image">
+				<?php the_post_thumbnail(); ?>
+			</div>
+		<?php endif; ?>
+
 		<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 
 		<?php if ( 'post' === get_post_type() ) : ?>

--- a/public_html/wp-content/themes/campsite-2017/template-parts/content.php
+++ b/public_html/wp-content/themes/campsite-2017/template-parts/content.php
@@ -15,6 +15,12 @@ namespace WordCamp\CampSite_2017;
 	<header class="entry-header">
 		<?php
 
+		if ( has_post_thumbnail() && ! wcorg_skip_feature( 'cs17_display_featured_image' ) ) : ?>
+			<div class="entry-image">
+				<?php the_post_thumbnail(); ?>
+			</div>
+		<?php endif;
+
 		if ( is_single() ) {
 			the_title( '<h1 class="entry-title">', '</h1>' );
 		} else {


### PR DESCRIPTION
In an earlier patch r8748, Jetpack's content options was used to add featured image support. For backwards compatibility, this was disabled by default using a feature flag on all existing sites.

This caused an issue because content options were removing featured images on *all* renders including in blocks and shortcode. Therefore r8748 was eventually reverted in r8753.

This patch adds featured image support natively instead of using Jetpack Content Support so as to not disable images in blocks and shortcodes. This also means that if any exisiting camp needs featured image supported, they would have to request to have the backwards compatibility flag removed for them.

See #3645 #4339