### PR TITLE
WIP: Try using React Context to pass values to child components within a block

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-content.js
@@ -15,6 +15,7 @@ import { AvatarImage }                                from '../../components/ima
 import { BlockNoContent, ItemTitle, ItemHTMLContent } from '../../components/block-content';
 import { PostList }                                   from '../../components/post-list';
 import { filterEntities }                             from '../../data';
+import { BlockContext }                               from './block-context';
 
 /**
  * Component for displaying the block content.
@@ -37,7 +38,7 @@ export class BlockContent extends Component {
 	 * @returns {Array}
 	 */
 	getFilteredPosts() {
-		const { attributes, entities } = this.props;
+		const { attributes, entities } = this.context;
 		const { wcb_organizer: posts } = entities;
 		const { mode, item_ids, sort } = attributes;
 
@@ -63,7 +64,7 @@ export class BlockContent extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes } = this.props;
+		const { attributes } = this.context;
 		const { show_avatars, avatar_size, avatar_align, content } = attributes;
 
 		const posts     = this.getFilteredPosts();
@@ -78,7 +79,7 @@ export class BlockContent extends Component {
 
 		return (
 			<PostList
-				{ ...this.props }
+				attributes={ attributes }
 				className="wordcamp-organizers-block"
 			>
 				{ posts.map( ( post ) => /* Note that organizer posts are not 'public', so there are no permalinks. */
@@ -113,3 +114,5 @@ export class BlockContent extends Component {
 		);
 	}
 }
+
+BlockContent.contextType = BlockContext;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-context.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-context.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+const { createContext } = wp.element;
+
+const defaultContext = {
+	attributes    : {},
+	definitions   : {},
+	entities      : {},
+	setAttributes : {},
+};
+
+export const BlockContext = createContext( defaultContext );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
@@ -16,6 +16,7 @@ const { __ }                  = wp.i18n;
 import { PlaceholderSpecificMode } from '../../components/block-controls';
 import { getOptionLabel }          from '../../components/item-select';
 import { BlockContent }            from './block-content';
+import { BlockContext }            from './block-context';
 import { ContentSelect }           from './content-select';
 import { LABEL }                   from './index';
 
@@ -29,16 +30,17 @@ export class BlockControls extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { icon, attributes, setAttributes, blockData } = this.props;
+		const { icon } = this.props;
+		const { attributes, definitions, setAttributes } = this.context;
 		const { mode } = attributes;
-		const { options } = blockData;
+		const { options } = definitions;
 
 		let output;
 
 		switch ( mode ) {
 			case 'all' :
 				output = (
-					<BlockContent { ...this.props } />
+					<BlockContent />
 				);
 				break;
 
@@ -49,10 +51,10 @@ export class BlockControls extends Component {
 						label={ getOptionLabel( mode, options.mode ) }
 						icon={ icon }
 						content={
-							<BlockContent { ...this.props } />
+							<BlockContent />
 						}
 						placeholderChildren={
-							<ContentSelect { ...this.props } />
+							<ContentSelect />
 						}
 					/>
 				);
@@ -80,7 +82,6 @@ export class BlockControls extends Component {
 						<div className="wordcamp-block-edit-mode-option">
 							<ContentSelect
 								label={ __( 'Choose specific organizers or teams', 'wordcamporg' ) }
-								{ ...this.props }
 							/>
 						</div>
 					</Placeholder>
@@ -91,3 +92,5 @@ export class BlockControls extends Component {
 		return output;
 	}
 }
+
+BlockControls.contextType = BlockContext;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
@@ -13,6 +13,7 @@ const { __ }        = wp.i18n;
  * Internal dependencies
  */
 import { buildOptions, ItemSelect, Option } from '../../components/item-select';
+import { BlockContext }                     from './block-context';
 
 /**
  * Component for selecting posts/terms for populating the block content.
@@ -37,7 +38,7 @@ export class ContentSelect extends Component {
 	 * @return {Array}
 	 */
 	buildSelectOptions() {
-		const { entities } = this.props;
+		const { entities } = this.context;
 		const { wcb_organizer, wcb_organizer_team } = entities;
 
 		const optionGroups = [
@@ -64,7 +65,7 @@ export class ContentSelect extends Component {
 	 * @return {Array}
 	 */
 	getCurrentSelectValue() {
-		const { attributes } = this.props;
+		const { attributes } = this.context;
 		const { mode, item_ids } = attributes;
 
 		const options = flatMap( this.buildSelectOptions(), ( group ) => {
@@ -88,7 +89,7 @@ export class ContentSelect extends Component {
 	 * @return {boolean}
 	 */
 	isLoading() {
-		const { entities } = this.props;
+		const { entities } = this.context;
 
 		return ! every( entities, ( value ) => {
 			return Array.isArray( value );
@@ -101,7 +102,8 @@ export class ContentSelect extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { label, setAttributes } = this.props;
+		const { setAttributes } = this.context;
+		const { label } = this.props;
 
 		return (
 			<ItemSelect
@@ -122,3 +124,5 @@ export class ContentSelect extends Component {
 		);
 	}
 }
+
+ContentSelect.contextType = BlockContext;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
@@ -9,44 +9,59 @@ const { Component, Fragment } = wp.element;
  */
 import { LayoutToolbar }     from '../../components/post-list';
 import { WC_BLOCKS_STORE }   from '../../data';
+import { BlockContext }      from './block-context';
 import { BlockControls }     from './block-controls';
 import { InspectorControls } from './inspector-controls';
 import { ICON }              from './index';
 
-const blockData = window.WordCampBlocks.organizers || {};
+const definitions = window.WordCampBlocks.organizers || {};
 
 /**
  * Top-level component for the editing UI for the block.
  */
 class OrganizersEdit extends Component {
+
+	constructor( props ) {
+		super( props );
+
+		this.getContextValue = this.getContextValue.bind( this );
+	}
+
+
+	getContextValue() {
+		const { attributes, entities, setAttributes } = this.props;
+
+		return { attributes, definitions, entities, setAttributes };
+	}
+
 	/**
 	 * Render the block's editing UI.
 	 *
 	 * @return {Element}
 	 */
 	render() {
+		const { Provider }                   = BlockContext;
 		const { attributes, setAttributes }  = this.props;
 		const { mode, layout }               = attributes;
-		const { layout: layoutOptions = {} } = blockData.options;
+		const { layout: layoutOptions = {} } = definitions.options;
 
 		return (
-			<Fragment>
-				<BlockControls
-					icon={ ICON }
-					{ ...this.props }
-				/>
+			<Provider value={ this.getContextValue() }>
+				<Fragment>
+					<BlockControls icon={ ICON } />
 
-				{ '' !== mode &&
-					<Fragment>
-						<InspectorControls { ...this.props } />
-						<LayoutToolbar
-							layout={ layout }
-							options={ layoutOptions }
-							setAttributes={ setAttributes }
-						/>
-					</Fragment>
-				}
-			</Fragment>
+					{ '' !== mode &&
+						<Fragment>
+							<InspectorControls { ...this.props } />
+							<LayoutToolbar
+								layout={ layout }
+								options={ layoutOptions }
+								setAttributes={ setAttributes }
+							/>
+						</Fragment>
+					}
+				</Fragment>
+			</Provider>
 		);
 	}
 }
@@ -60,7 +75,7 @@ const organizerSelect = ( select ) => {
 	};
 
 	return {
-		blockData,
+		blockData : definitions,
 		entities,
 	};
 };


### PR DESCRIPTION
@iandunn brought up with example of using React Context:
https://lucasmreis.github.io/blog/simple-react-patterns/

Which got me thinking about ways to fix #100. This is an experiment to see if contexts will work for that problem.

Some (not that great) documentation about React Context:
https://reactjs.org/docs/context.html

One problem I ran into was that the child components weren't receiving any data into `this.context`. It turned out it was because I was defining and exporting the context component in the **edit.js** file. Since **edit** was also where the child components were getting instantiated, it was creating [a circular dependency](https://github.com/facebook/react/issues/13969#issuecomment-433253469). When I moved the context definition and export to its own file, and imported it from there into all the other files that needed it, it started working.

I'm not sure about including `attributes` in the context, since that's the thing that will actually keep changing (everything else I'm putting in it should stay static after it has loaded). Every time the context changes, everything that is a child of it will update. It might be better to just feed each child component with the attributes it needs as individual props.

A couple of other things we could add into the context: `LABEL` and `ICON`. That way we aren't importing them from **index.js** and potentially creating another circular dependency.

Feel free to add to this PR if you have ideas. @iandunn @vedanshujain 