### PR TITLE
Fix badge disappearing bug

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -44,9 +44,9 @@ class WordCamp_Participation_Notifier {
 		}
 
 		if ( 'publish' == $new_status && 'publish' == $old_status ) {
-			$this->published_speaker_post_updated( $post );
+			$this->published_post_updated( $post );
 		} elseif ( 'publish' == $new_status || 'publish' == $old_status ) {
-			$this->speaker_post_published_or_unpublished( $new_status, $old_status, $post );
+			$this->post_published_or_unpublished( $new_status, $old_status, $post );
 		}
 	}
 
@@ -116,7 +116,7 @@ class WordCamp_Participation_Notifier {
 	 *
 	 * @param WP_Post $post
 	 */
-	protected function published_speaker_post_updated( $post ) {
+	protected function published_post_updated( $post ) {
 		$previous_user_id = $this->get_saved_wporg_user_id( $post );
 		$new_user_id      = $this->get_new_wporg_user_id( $post );
 
@@ -156,7 +156,7 @@ class WordCamp_Participation_Notifier {
 	 * @param string  $old_status
 	 * @param WP_Post $post
 	 */
-	protected function speaker_post_published_or_unpublished( $new_status, $old_status, $post ) {
+	protected function post_published_or_unpublished( $new_status, $old_status, $post ) {
 		if ( 'publish' == $new_status ) {
 			$this->remote_post( self::PROFILES_HANDLER_URL, $this->get_post_activity_payload( $post ) );
 			$this->remote_post( self::PROFILES_HANDLER_URL, $this->get_post_association_payload( $post, 'add' ) );

--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -112,7 +112,7 @@ class WordCamp_Participation_Notifier {
 	 * Updates the activity and associations of a profile when the WordPress.org username on a published speaker
 	 * or organizer post changes.
 	 *
-	 * IMPORTANT NOTE: If a draft post is published via block editor, we will have to add badges and activity here instead of `post_published_or_unpublished` method.
+	 * IMPORTANT NOTE: When a draft post is published via the block editor, badges and activity must be managed here instead of in the `post_published_or_unpublished` method.
 	 * This is because when post is updated via Block editor, the status change request will not have any POST data, see @link https://github.com/WordPress/gutenberg/issues/12897
 	 *
 	 * @todo The handler doesn't support removing activity, but maybe do that here if support is added.
@@ -173,7 +173,7 @@ class WordCamp_Participation_Notifier {
 	 * @param int     $user_id  User ID to add badge for.
 	 */
 	protected function add_badge( $post, $user_id ) {
-		if ( ! in_array( $post->post_type, [ 'wcb_speaker', 'wcb_organizer' ] ) || ! $user_id ) {
+		if ( ! $this->is_post_notifiable( $post ) ) {
 			return;
 		}
 
@@ -198,7 +198,7 @@ class WordCamp_Participation_Notifier {
 	protected function maybe_remove_badge( $post, $user_id ) {
 		global $wpdb;
 
-		if ( ! in_array( $post->post_type, [ 'wcb_speaker', 'wcb_organizer' ] ) ) {
+		if ( ! $this->is_post_notifiable( $post ) ) {
 			return;
 		}
 


### PR DESCRIPTION
We currently assume that a profile will be associated with only single WordCamp, and handle adding and removing badges (speaker/organizer) with this assumption.
However, this assumption is incorrect and causes badge disappearing bug, as described in 703.

This patch refactors the participant-notifier class such that:

1. Whenever a badge is added, an entry is made in to usermeta table, with meta key as `wc_{post_type}_{blog_id}_{post_id}`. This has following benefits:
	a. Usermeta table is shared across all WordCamp, so this can act as a central place to record whenever a badge is added for a user.
	b. Since meta key columns is indexed, a count query can be done on `wc_{post_type}_%` with `user_id = {user_id}` clause.
		Because of how MySQL stores indexes, prefix queries are also as performant as full text queries. This gives us ability to find out in how many WordCamp a user is registered as a speaker/organizer using a single performant query.
		We can use the results of this query to decide if we want to remove a badge or not.

2. In block editor, as per WordPress/gutenberg#12897, POST data will not be there when publishing a draft post. This patch adds a workaround by checking if we need to add/remove badge even if both previous and next status are `publish`.

3. Uses a meta data to prevent duplicate activity log request. This is necessary because of workaround described in above patch.