### PR TITLE
Tickets: Add rate limiting to the CampTix ticket purchase form

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/spam-prevention.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/spam-prevention.php
@@ -1,0 +1,71 @@
+<?php
+namespace WordCamp\CampTix_Tweaks;
+
+use CampTix_Plugin, CampTix_Addon;
+use WordCamp\Utilities\Form_Spam_Prevention;
+
+defined( 'WPINC' ) or die();
+
+/**
+ * Class Spam_Prevention
+ *
+ * This adds basic rate limiting to the CampTix attendee info form during the ticket purchase flow.
+ *
+ * @package WordCamp\CampTix_Tweaks
+ */
+class Spam_Prevention extends CampTix_Addon {
+	/**
+	 * @var Form_Spam_Prevention $attendee_info
+	 */
+	protected $attendee_info;
+
+	/**
+	 * Hook into WordPress and CampTix.
+	 */
+	public function camptix_init() {
+		$this->attendee_info = new Form_Spam_Prevention( [
+			'prefix' => 'camptix-fsp-attendee-info-',
+		] );
+
+		// Attendee info form, before checkout.
+		add_action( 'camptix_form_attendee_after_registration_information', [ $this->attendee_info, 'render_form_fields' ] );
+		add_action( 'camptix_checkout_start', [ $this, 'validate_form' ] );
+
+		// General.
+		add_action( 'camptix_form_attendee_info_errors', [ $this, 'validation_error' ] );
+	}
+
+	/**
+	 * Check the form submission and add a CampTix error if it doesn't pass validation.
+	 */
+	public function validate_form() {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		switch ( current_action() ) {
+			case 'camptix_checkout_start':
+				$pass = $this->attendee_info->validate_form_submission();
+				break;
+		}
+
+		if ( ! $pass ) {
+			$camptix->error_flag( 'form_spam_prevention' );
+		}
+	}
+
+	/**
+	 * Add the error notice text for our custom error flag.
+	 *
+	 * @param array $error_flags
+	 */
+	public function validation_error( $error_flags ) {
+		/* @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		if ( isset( $error_flags[ 'form_spam_prevention' ] ) ) {
+			$camptix->error( __( 'Your form submission could not be processed. Please try again.', 'wordcamporg' ) );
+		}
+	}
+}
+
+camptix_register_addon( __NAMESPACE__ . '\Spam_Prevention' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/spam-prevention.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/spam-prevention.php
@@ -24,7 +24,8 @@ class Spam_Prevention extends CampTix_Addon {
 	 */
 	public function camptix_init() {
 		$this->attendee_info = new Form_Spam_Prevention( [
-			'prefix' => 'camptix-fsp-attendee-info-',
+			'prefix'            => 'camptix-fsp-attendee-info-',
+			'individual_styles' => true,
 		] );
 
 		// Attendee info form, before checkout.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -570,6 +570,8 @@ function load_custom_addons() {
 	require_once( __DIR__ . '/addons/code-of-conduct.php' );
 	// Privacy field
 	require_once( __DIR__ . '/addons/privacy.php' );
+	// Spam prevention
+	require_once( __DIR__ . '/addons/spam-prevention.php' );
 
 	// Payment options
 	if ( in_array( filter_input( INPUT_GET, 'tix_action' ), array( 'attendee_info', 'checkout' ), true )


### PR DESCRIPTION
This uses the `WordCamp\Utilities\Form_Spam_Prevention` class to attempt to prevent spam and excessive test submissions to the ticket purchase form.