### PR TITLE
Tickets: Reset form throttle score upon successful transaction

### DIFF
--- a/public_html/wp-content/mu-plugins/utilities/class-form-spam-prevention.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-form-spam-prevention.php
@@ -277,6 +277,21 @@ class Form_Spam_Prevention {
 	}
 
 	/**
+	 * Remove the throttle score for a given IP address.
+	 *
+	 * @param string $ip_address An IP address.
+	 *
+	 * @return bool True if the score was successfully removed. Otherwise false.
+	 */
+	public function reset_score_for_ip_address( $ip_address = '' ) {
+		if ( ! $ip_address ) {
+			$ip_address = $this->get_ip_address();
+		}
+
+		return delete_transient( $this->generate_score_key( $ip_address ) );
+	}
+
+	/**
 	 * Checks the current throttle score for a given IP address.
 	 *
 	 * @param string $ip_address An IP address.


### PR DESCRIPTION
This allows multiple successful transactions to happen from the same IP address without reaching the throttle threshold. This is necessary for situations such as day-of ticket sales at the event venue, where all of the transactions would come from the same IP.

Fixes #135 