### PR TITLE
Docker: Updates to docker setup instructions & script

### DIFF
--- a/.docker/mysql.Dockerfile
+++ b/.docker/mysql.Dockerfile
@@ -6,6 +6,7 @@ ENV MYSQL_DATABASE=wordcamp_dev
 
 ADD wordcamp_dev.sql /docker-entrypoint-initdb.d/data.sql
 
+RUN apt-get update
 RUN apt-get install nano -y
 
 EXPOSE 3306

--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -14,6 +14,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 
 1. Generate and trust the SSL certificates, so you get a green bar and can adequately test service workers.
 	```bash
+	cd .docker
 	brew install mkcert
 	brew install nss
 	mkcert -install


### PR DESCRIPTION
I ran into a few issues when setting up the script, so here's an attempt to prevent that from happening to other folks.

1. When I ran the ssl cert generation commands, I was in `public_html`, so the files were not where Docker expected them to be during build, and I got the following error. So I've added a note in the instructions to cd into `.docker`

```
ERROR: Service 'wordcamp.test' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder280577819/wordcamp.test.pem: no such file or directory
```

2. `nano` wouldn't install in the mysql container, running `apt-get update` seems to fix this

```
E: Unable to locate package nano
ERROR: Service 'wordcamp.db' failed to build: The command '/bin/sh -c apt-get install nano -y' returned a non-zero code: 100
```

3. Not added here but I also ran into an error because hyperdb doesn't exist– I fixed this by simply downloading [the hyperdb plugin](https://wordpress.org/plugins/hyperdb/) and dropping it into `wp-content/plugins`. If that's the right approach, we should add that to the docs. I'm not sure, so I didn't add it here.

```
Warning: require_once(/usr/src/public_html/wp-content/plugins/hyperdb/db.php): failed to open stream: No such file or directory in /usr/src/public_html/wp-content/db.php on line 3
Fatal error: require_once(): Failed opening required '/usr/src/public_html/wp-content/plugins/hyperdb/db.php' (include_path='.:/usr/local/lib/php') in /usr/src/public_html/wp-content/db.php on line 3
Error: The site is experiencing technical difficulties.
```