### PR TITLE
Git: Ignore the `node_modules` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 #
 wp-cli.yml
 script-backups/
+node_modules/
 public_html/.well-known/
 public_html/mu/
 public_html/bin/


### PR DESCRIPTION
Rather than assuming the developer has a global gitignore set up, the project should explicitly ignore any untracked files it creates.

This is a friendlier developer experience, and prevents accidentally committing all of `node_modules` 🙂 