### PR TITLE
Attendance UI: Allow searching for a Full name, ie. 'John Smith'

### DIFF
--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -258,8 +258,12 @@ class CampTix_Attendance extends CampTix_Addon {
 			";
 
 			$clauses['where'] .= $wpdb->prepare( "
-				AND ( tix_first_name.meta_value LIKE '%%%s%%' OR tix_last_name.meta_value LIKE '%%%s%%' )
-			", $search, $search );
+				AND (
+					tix_first_name.meta_value LIKE '%%%s%%' OR
+					tix_last_name.meta_value LIKE '%%%s%%' OR
+					CONCAT( tix_first_name.meta_value, ' ', tix_last_name.meta_value ) LIKE '%%%s%%'
+				)
+			", $search, $search, $search );
 
 			return $clauses;
 		} );

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -159,7 +159,7 @@ class CampTix_Attendance extends CampTix_Addon {
 			'tickets' => array(),
 		) );
 
-		$filters['search'] = ! empty( $_REQUEST['camptix_search'] ) ? $_REQUEST['camptix_search'] : '';
+		$filters['search'] = ! empty( $_REQUEST['camptix_search'] ) ? trim( $_REQUEST['camptix_search'] ) : '';
 
 		// Filter by attendance.
 		if ( in_array( $filters['attendance'], array( 'attending', 'not-attending' ) ) )


### PR DESCRIPTION
Currently the Attendance UI can only search on a First or Last Name.

If you enter a full name, ie. 'John Smith' it'll fail to find any results.
This attempts to work around it by matching on `FirstName LastName` in addition to them individually.