### PR TITLE
Attendance UI: Add a shortcut to the Search view - Click the header

### DIFF
--- a/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.js
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.js
@@ -397,6 +397,7 @@ jQuery(document).ready(function($){
 		events: {
 			'fastClick .dashicons-menu': 'menu',
 			'fastClick .submenu .search': 'searchView',
+			'fastClick header h1': 'searchView',
 			'fastClick .submenu .sort': 'sortView',
 			'fastClick .submenu .refresh': 'refresh',
 			'fastClick .submenu .filter': 'filterView'


### PR DESCRIPTION
Currently the only way to enter the Search view is to use Menu -> Search.

This adds a shortcut by allowing the user to click the header to open the search that's usually in that area.

Arguably the Search filter should always be visible, as it's an integral part of the UI, but this is better than changing the way the app works.