### PR TITLE
Invoices: Respect new lines in the Customer Address

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-template.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-template.php
@@ -139,7 +139,7 @@ defined('WPINC') || die();
 			<strong><?php esc_html_e('To', 'wordcamporg'); ?>:</strong>
 			<p class="text-right">
 				<?php echo esc_html( $invoice_metas['name'] ); ?><br/>
-				<?php echo esc_html( $invoice_metas['address'] ); ?><br/>
+				<?php echo nl2br( esc_html( $invoice_metas['address'] ) ); ?><br/>
 			</p>
 			<?php if ( ! empty( $invoice_metas['vat-number'] ) ) { ?>
 				<strong><?php esc_html_e('VAT no', 'wordcamporg'); ?>:</strong>


### PR DESCRIPTION
When creating invoices the Custom Address is input as a multi-line element, however it's printed all one one line on the final invoice.

This simply processes it the same as it does the Company address, converting newlines in the output.