### PR TITLE
JS Code Standards: Enforce a line-length of 115 characters

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
+++ b/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
@@ -81,6 +81,20 @@ module.exports = {
 		} ],
 
 		/*
+		 * Force a line-length of 115 characters.
+		 *
+		 * We ignore URLs, trailing comments, strings, and template literals to prevent awkward fragmenting of
+		 * meaningful content.
+		 */
+		'max-len': [ 'error', {
+			'code'                   : 115,
+			'ignoreUrls'             : true,
+			'ignoreTrailingComments' : true,
+			'ignoreStrings'          : true,
+			'ignoreTemplateLiterals' : true,
+		} ],
+
+		/*
 		 * Allow multiple spaces in a row.
 		 *
 		 * Ideally this should be on, because we don't want to allow things like `const foo  == bar;`, but the rule

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -65,7 +65,7 @@ function SessionSpeakers( { session } ) {
 }
 
 /**
- * Component for the section of each session post that displays metadata including date, time, and location (track).
+ * Component for the section of each session post displaying metadata including date, time, and location (track).
  *
  * @param {Object} session
  *
@@ -236,7 +236,15 @@ export class BlockContent extends Component {
 	 */
 	render() {
 		const { attributes } = this.props;
-		const { show_speaker, show_images, image_align, featured_image_width, content, show_meta, show_category } = attributes;
+		const {
+			show_speaker,
+			show_images,
+			image_align,
+			featured_image_width,
+			content,
+			show_meta,
+			show_category,
+		} = attributes;
 
 		const posts     = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
@@ -23,7 +23,16 @@ export class InspectorControls extends Component {
 	 */
 	render() {
 		const { attributes, setAttributes, blockData } = this.props;
-		const { show_images, featured_image_width, image_align, show_speaker, content, show_meta, show_category, sort } = attributes;
+		const {
+			show_images,
+			featured_image_width,
+			image_align,
+			show_speaker,
+			content,
+			show_meta,
+			show_category,
+			sort,
+		} = attributes;
 		const { schema, options } = blockData;
 
 		return (

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/featured-image.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/featured-image.js
@@ -55,8 +55,9 @@ export const featuredImageSizePresets = [
 export class FeaturedImage extends Component {
 	/**
 	 * @param {Object} props
-	 * @param {Array}  props.imageData Meta data about the featured image, including available sizes and the image's
-	 *                                 alt text. This is the `_embedded.wp:featuredMedia[0]` object in a REST response.
+	 * @param {Array}  props.imageData Meta data about the featured image, including available sizes and the
+	 *                                 image's alt text. This is the `_embedded.wp:featuredMedia[0]` object in a
+	 *                                 REST response.
 	 * @param {number} props.width     Width in pixels for the image.
 	 * @param {string} props.className Additional class names for the image element
 	 * @param {string} props.imageLink URL for wrapping the image in an anchor tag

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls.js
@@ -7,9 +7,18 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-const { BaseControl, Button, ButtonGroup, PanelBody, PanelRow, RangeControl, ToggleControl, Toolbar } = wp.components;
-const { Component, Fragment }                                                                         = wp.element;
-const { __ }                                                                                          = wp.i18n;
+const {
+	BaseControl,
+	Button,
+	ButtonGroup,
+	PanelBody,
+	PanelRow,
+	RangeControl,
+	ToggleControl,
+	Toolbar,
+}                             = wp.components;
+const { Component, Fragment } = wp.element;
+const { __ }                  = wp.i18n;
 
 /**
  * Internal dependencies

--- a/public_html/wp-content/mu-plugins/blocks/source/components/post-list/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/post-list/inspector-controls.js
@@ -41,7 +41,8 @@ export function GridColumnsControl( {
 /**
  * Component to add an Inspector panel
  *
- * Should be used with rest of the components in this folder. Will use and set attributes `layout` and `grid_columns`.
+ * Should be used with rest of the components in this folder. Will use and set attributes `layout` and
+ * `grid_columns`.
  */
 export class GridInspectorPanel extends Component {
 	/**

--- a/public_html/wp-content/mu-plugins/blocks/source/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/data/index.js
@@ -56,7 +56,9 @@ export const filterEntities = ( entities, args ) => {
 					return false;
 				}
 
-				const compareValue = isArray( entity[ fieldName ] ) ? entity[ fieldName ] : [ entity[ fieldName ] ];
+				const compareValue = isArray( entity[ fieldName ] ) ?
+					entity[ fieldName ] :
+					[ entity[ fieldName ] ];
 
 				return intersection( fieldValue, compareValue ).length > 0;
 			} );


### PR DESCRIPTION
_This is one of a few issues/PRs dealing with code standards, created after a discussion in slack._

Currently, we  wrap code at 115 characters, but have no enforcement or documentation of this for JS files (we do have it set in [the `stylelint` config](https://github.com/WordPress/wordcamp.org/blob/production/public_html/wp-content/mu-plugins/blocks/.stylelintrc#L4)). We can set this up using [the `max-len` rule in eslint.](https://eslint.org/docs/rules/max-len) Unfortunately, `eslint --fix` won't fix these automatically, but there are only 8 violations in the code base right now (which are also fixed in this PR, in the second commit).

I've set up the rule to ignore line length in URLs, trailing comments, strings, and template literals. This prevents eslint from flagging "atomic" content, like a URL, that would be awkward to wrap.

**To test**

- Run `npm run lint:js`
- There should be no errors
- Open a file & add a line longer than 115 characters
- Run `npm run lint:js` again
- It should flag an error for that line