### PR TITLE
Blocks: Increase contrast of group names in dropdowns

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
@@ -24,6 +24,10 @@
 	align-items: center;
 }
 
+.wordcamp-item-select__option-group-label {
+	color: #555D66;
+}
+
 .wordcamp-item-select__option-avatar,
 .wordcamp-item-select__option-icon-container {
 	display: inline-flex;


### PR DESCRIPTION
The text color of section headers in the select dropdown is currently too light. It should be 4.5+ for best visibility.

Fixes #81 

**Screenshots**

| before | after |
| ------ | ------ |
| <img width="624" alt="before" src="https://user-images.githubusercontent.com/541093/61251689-2a7f6300-a729-11e9-9724-598e91d3cc44.png"> | <img width="545" alt="after" src="https://user-images.githubusercontent.com/541093/61251688-2a7f6300-a729-11e9-8ec4-8e9917bd06e3.png"> |

To test:

- Add any block, open the dropdown to insert specific groups
- The section headings (Sponsors, Sponsor Levels, Sessions, Tracks, etc) should pass color contrast (4.5+)