### PR TITLE
Blocks: Update react-select package

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/package-lock.json
+++ b/public_html/wp-content/mu-plugins/blocks/package-lock.json
@@ -567,61 +567,101 @@
 				}
 			}
 		},
-		"@emotion/babel-utils": {
-			"version": "0.6.10",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
-			"integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
+		"@emotion/cache": {
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.14.tgz",
+			"integrity": "sha512-HNGEwWnPlNyy/WPXBXzbjzkzeZFV657Z99/xq2xs5yinJHbMfi3ioCvBJ6Y8Zc8DQzO9F5jDmVXJB41Ytx3QMw==",
 			"requires": {
-				"@emotion/hash": "^0.6.6",
-				"@emotion/memoize": "^0.6.6",
-				"@emotion/serialize": "^0.9.1",
-				"convert-source-map": "^1.5.1",
-				"find-root": "^1.1.0",
-				"source-map": "^0.7.2"
+				"@emotion/sheet": "0.9.3",
+				"@emotion/stylis": "0.8.4",
+				"@emotion/utils": "0.11.2",
+				"@emotion/weak-memoize": "0.2.3"
+			}
+		},
+		"@emotion/core": {
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.14.tgz",
+			"integrity": "sha512-G9FbyxLm3lSnPfLDcag8fcOQBKui/ueXmWOhV+LuEQg9HrqExuWnWaO6gm6S5rNe+AMcqLXVljf8pYgAdFLNSg==",
+			"requires": {
+				"@babel/runtime": "^7.4.3",
+				"@emotion/cache": "^10.0.14",
+				"@emotion/css": "^10.0.14",
+				"@emotion/serialize": "^0.11.8",
+				"@emotion/sheet": "0.9.3",
+				"@emotion/utils": "0.11.2"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+				"@babel/runtime": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+					"integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
 				}
 			}
 		},
-		"@emotion/hash": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-			"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
-		},
-		"@emotion/memoize": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-		},
-		"@emotion/serialize": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-			"integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+		"@emotion/css": {
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.14.tgz",
+			"integrity": "sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==",
 			"requires": {
-				"@emotion/hash": "^0.6.6",
-				"@emotion/memoize": "^0.6.6",
-				"@emotion/unitless": "^0.6.7",
-				"@emotion/utils": "^0.8.2"
+				"@emotion/serialize": "^0.11.8",
+				"@emotion/utils": "0.11.2",
+				"babel-plugin-emotion": "^10.0.14"
 			}
 		},
+		"@emotion/hash": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
+			"integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
+		},
+		"@emotion/memoize": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.2.tgz",
+			"integrity": "sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w=="
+		},
+		"@emotion/serialize": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.8.tgz",
+			"integrity": "sha512-Qb6Us2Yk1ZW8SOYH6s5z7qzXXb2iHwVeqc6FjXtac0vvxC416ki0eTtHNw4Q5smoyxdyZh3519NKGrQvvvrZ/Q==",
+			"requires": {
+				"@emotion/hash": "0.7.2",
+				"@emotion/memoize": "0.7.2",
+				"@emotion/unitless": "0.7.4",
+				"@emotion/utils": "0.11.2",
+				"csstype": "^2.5.7"
+			}
+		},
+		"@emotion/sheet": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
+			"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
+		},
 		"@emotion/stylis": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-			"integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
+			"integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ=="
 		},
 		"@emotion/unitless": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-			"integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
+			"integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
 		},
 		"@emotion/utils": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-			"integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
+			"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
+		},
+		"@emotion/weak-memoize": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz",
+			"integrity": "sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ=="
 		},
 		"@hapi/address": {
 			"version": "2.0.0",
@@ -2493,7 +2533,8 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -3422,22 +3463,20 @@
 			}
 		},
 		"babel-plugin-emotion": {
-			"version": "9.2.11",
-			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
-			"integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.14.tgz",
+			"integrity": "sha512-T7hdxJ4xXkKW3OXcizK0pnUJlBeNj/emjQZPDIZvGOuwl2adIgicQWRNkz6BuwKdDTrqaXQn1vayaL6aL8QW5A==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
-				"@emotion/babel-utils": "^0.6.4",
-				"@emotion/hash": "^0.6.2",
-				"@emotion/memoize": "^0.6.1",
-				"@emotion/stylis": "^0.7.0",
+				"@emotion/hash": "0.7.2",
+				"@emotion/memoize": "0.7.2",
+				"@emotion/serialize": "^0.11.8",
 				"babel-plugin-macros": "^2.0.0",
 				"babel-plugin-syntax-jsx": "^6.18.0",
 				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^1.0.5",
 				"find-root": "^1.1.0",
-				"mkdirp": "^0.5.1",
-				"source-map": "^0.5.7",
-				"touch": "^2.0.1"
+				"source-map": "^0.5.7"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -3461,12 +3500,28 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz",
-			"integrity": "sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
+			"integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
 			"requires": {
-				"cosmiconfig": "^5.0.5",
-				"resolve": "^1.8.1"
+				"@babel/runtime": "^7.4.2",
+				"cosmiconfig": "^5.2.0",
+				"resolve": "^1.10.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+					"integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+				}
 			}
 		},
 		"babel-plugin-syntax-jsx": {
@@ -4632,20 +4687,6 @@
 				"elliptic": "^6.0.0"
 			}
 		},
-		"create-emotion": {
-			"version": "9.2.12",
-			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
-			"integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
-			"requires": {
-				"@emotion/hash": "^0.6.2",
-				"@emotion/memoize": "^0.6.1",
-				"@emotion/stylis": "^0.7.0",
-				"@emotion/unitless": "^0.6.2",
-				"csstype": "^2.5.2",
-				"stylis": "^3.5.0",
-				"stylis-rule-sheet": "^0.0.10"
-			}
-		},
 		"create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -4845,9 +4886,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
-			"integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+			"integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -5290,15 +5331,6 @@
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
 		},
-		"emotion": {
-			"version": "9.2.12",
-			"resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
-			"integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
-			"requires": {
-				"babel-plugin-emotion": "^9.2.11",
-				"create-emotion": "^9.2.12"
-			}
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5507,8 +5539,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.11.1",
@@ -9396,9 +9427,9 @@
 			}
 		},
 		"memoize-one": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.0.tgz",
-			"integrity": "sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw=="
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
+			"integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -9732,7 +9763,8 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -9817,6 +9849,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -10225,14 +10258,6 @@
 					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
 					"dev": true
 				}
-			}
-		},
-		"nopt": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-			"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-			"requires": {
-				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -11701,17 +11726,35 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-select": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.2.tgz",
-			"integrity": "sha512-5xFOQ6JJktkY5NTaHrc6x9mKwIjhNIiBkGic1j71uyY+ulFpRFra6f4WKLd9fuCylk4WjLpO5zDhdF4CAcwFzA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-select/-/react-select-3.0.4.tgz",
+			"integrity": "sha512-fbVISKa/lSUlLsltuatfUiKcWCNvdLXxFFyrzVQCBUsjxJZH/m7UMPdw/ywmRixAmwXAP++MdbNNZypOsiDEfA==",
 			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@emotion/cache": "^10.0.9",
+				"@emotion/core": "^10.0.9",
+				"@emotion/css": "^10.0.9",
 				"classnames": "^2.2.5",
-				"emotion": "^9.1.2",
 				"memoize-one": "^5.0.0",
 				"prop-types": "^15.6.0",
 				"raf": "^3.4.0",
 				"react-input-autosize": "^2.2.1",
 				"react-transition-group": "^2.2.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+					"integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+				}
 			}
 		},
 		"react-test-renderer": {
@@ -11739,11 +11782,11 @@
 			}
 		},
 		"react-transition-group": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.7.1.tgz",
-			"integrity": "sha512-b0VJTzNRnXxRpCuxng6QJbAzmmrhBn1BZJfPPnHbH2PIo8msdkajqwtfdyGm/OypPXZNfAHKEqeN15wjMXrRJQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
 			"requires": {
-				"dom-helpers": "^3.3.1",
+				"dom-helpers": "^3.4.0",
 				"loose-envify": "^1.4.0",
 				"prop-types": "^15.6.2",
 				"react-lifecycles-compat": "^3.0.4"
@@ -13760,16 +13803,6 @@
 				}
 			}
 		},
-		"stylis": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-			"integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-		},
-		"stylis-rule-sheet": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
-		},
 		"sugarss": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -14110,14 +14143,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
-		},
-		"touch": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
-			"integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
-			"requires": {
-				"nopt": "~1.0.10"
-			}
 		},
 		"tough-cookie": {
 			"version": "2.5.0",

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"classnames": "2.2.6",
-		"react-select": "2.4.2",
+		"react-select": "3.0.4",
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -131,7 +131,7 @@ export class ItemSelect extends Component {
 						value={ value }
 						aria-label={ label }
 						onChange={ ( selectedOptions ) => {
-							this.setState( { selectedOptions } );
+							this.setState( { selectedOptions: selectedOptions || [] } );
 						} }
 						{ ...mergedSelectProps }
 					/>


### PR DESCRIPTION
_Note: this branch is based off the wordpress-scripts branch, once that's merged I'll rebase this on `production`_

`react-select` is now at v3.0.4, which comes with some bugfixes and improvements - notably some code splitting which shrinks our build 13% (to 141 KiB). This update needs almost no changes, except that the `onChange` callback now receives a null value when the last selected item is cleared, which causes `ContentSelect` to default back to the passed in `value`, rather than deleting the last item.

**To test**

- Run `npm install` to update packages
- `npm run build`
- Add any block to a post
- Select a few items, clear some of them, select more, clear the whole input… etc
- Select a few items, then click "Select" to display them
- Try to clear all the items from the input by clicking each item's X, you should be able to clear all of them, back to the initial placeholder screen.