### PR TITLE
Blocks: Clean up the "add more" UI when some content is selected

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/_z-index.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/_z-index.scss
@@ -3,12 +3,25 @@
  * conflicting with.
 */
 
-.wordcamp__edit-placeholder .components-placeholder__fieldset {
+.wordcamp__edit-placeholder .components-placeholder__fieldset,
+.wordcamp-block__edit-appender .wordcamp-item-select {
 
 	/*
-	 * By default the fieldset has a `z-index` of `1`, and `.editor-block-list__insertion-point` has a value of
-	 * `6`, so the `Add Block` button will stack on top of things like an expanded `ItemSelect` list. This
-	 * corrects that.
+	 * By default the fieldset has a `z-index` of `1`, and `.block-editor-block-contextual-toolbar` has a value of
+	 * `21`. On smaller screens (<600px), this appears at the bottom of the block. When expanded, the ItemSelect
+	 * list drops below this, and the default z-index stacks the toolbar over the dropdown. Bumping the z-index
+	 * of the dropdown wrapper to `22` corrects that
 	 */
-	z-index: 7;
+	z-index: 22;
+
+	.wp-block.is-selected &,
+	.wp-block.is-typing & {
+
+		/*
+		 * If the block is placed before another WordCamp block, it's possible that the `ItemSelect` dropdown
+		 * extends over into the next block area. When two items have the same z-index (22), the later-in-dom
+		 * element "wins", so we bump this to 23 to avoid the conflict.
+		 */
+		z-index: 23;
+	}
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
@@ -46,13 +46,13 @@ export class BlockControls extends Component {
 			case 'wcb_organizer_team' :
 				output = (
 					<PlaceholderSpecificMode
-						label={ getOptionLabel( mode, options.mode ) }
-						icon={ icon }
 						content={
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							isSelected && <ContentSelect { ...this.props } />
+							isSelected && (
+								<ContentSelect label={ getOptionLabel( mode, options.mode ) } { ...this.props } />
+							)
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
@@ -29,7 +29,7 @@ export class BlockControls extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { icon, attributes, setAttributes, blockData } = this.props;
+		const { attributes, blockData, icon, isSelected, setAttributes } = this.props;
 		const { mode } = attributes;
 		const { options } = blockData;
 
@@ -52,7 +52,7 @@ export class BlockControls extends Component {
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							<ContentSelect { ...this.props } />
+							isSelected && <ContentSelect { ...this.props } />
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-controls.js
@@ -47,13 +47,13 @@ export class BlockControls extends Component {
 			case 'wcb_session_category' :
 				output = (
 					<PlaceholderSpecificMode
-						label={ getOptionLabel( mode, options.mode ) }
-						icon={ icon }
 						content={
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							isSelected && <ContentSelect { ...this.props } />
+							isSelected && (
+								<ContentSelect label={ getOptionLabel( mode, options.mode ) } { ...this.props } />
+							)
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-controls.js
@@ -29,7 +29,7 @@ export class BlockControls extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { icon, attributes, setAttributes, blockData } = this.props;
+		const { attributes, blockData, icon, isSelected, setAttributes } = this.props;
 		const { mode } = attributes;
 		const { options } = blockData;
 
@@ -53,7 +53,7 @@ export class BlockControls extends Component {
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							<ContentSelect { ...this.props } />
+							isSelected && <ContentSelect { ...this.props } />
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-controls.js
@@ -29,7 +29,7 @@ export class BlockControls extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { icon, attributes, setAttributes, blockData } = this.props;
+		const { attributes, blockData, icon, isSelected, setAttributes } = this.props;
 		const { mode } = attributes;
 		const { options } = blockData;
 
@@ -52,7 +52,7 @@ export class BlockControls extends Component {
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							<ContentSelect { ...this.props } />
+							isSelected && <ContentSelect { ...this.props } />
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-controls.js
@@ -46,13 +46,13 @@ export class BlockControls extends Component {
 			case 'wcb_speaker_group' :
 				output = (
 					<PlaceholderSpecificMode
-						label={ getOptionLabel( mode, options.mode ) }
-						icon={ icon }
 						content={
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							isSelected && <ContentSelect { ...this.props } />
+							isSelected && (
+								<ContentSelect label={ getOptionLabel( mode, options.mode ) } { ...this.props } />
+							)
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-controls.js
@@ -46,13 +46,13 @@ export class BlockControls extends Component {
 			case 'wcb_sponsor_level' :
 				output = (
 					<PlaceholderSpecificMode
-						label={ getOptionLabel( mode, options.mode ) }
-						icon={ icon }
 						content={
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							isSelected && <ContentSelect { ...this.props } />
+							isSelected && (
+								<ContentSelect label={ getOptionLabel( mode, options.mode ) } { ...this.props } />
+							)
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-controls.js
@@ -29,7 +29,7 @@ export class BlockControls extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { icon, attributes, setAttributes, blockData } = this.props;
+		const { attributes, blockData, icon, isSelected, setAttributes } = this.props;
 		const { mode } = attributes;
 		const { options } = blockData;
 
@@ -52,7 +52,7 @@ export class BlockControls extends Component {
 							<BlockContent { ...this.props } />
 						}
 						placeholderChildren={
-							<ContentSelect { ...this.props } />
+							isSelected && <ContentSelect { ...this.props } />
 						}
 					/>
 				);

--- a/public_html/wp-content/mu-plugins/blocks/source/components/block-controls/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/block-controls/index.js
@@ -23,22 +23,16 @@ import { Fragment }    from '@wordpress/element';
  * @return {Element}
  */
 export function PlaceholderSpecificMode( { className, label, icon, content, placeholderChildren } ) {
-	const classes = [
-		'wordcamp-block__edit-placeholder',
-		'has-specific-mode',
-		className,
-	];
+	const classes = [ 'wordcamp-block__edit-placeholder', 'has-specific-mode', className ];
 
 	return (
 		<Fragment>
 			{ content }
-			<Placeholder
-				className={ classnames( classes ) }
-				label={ label }
-				icon={ icon }
-			>
-				{ placeholderChildren }
-			</Placeholder>
+			{ placeholderChildren && (
+				<Placeholder className={ classnames( classes ) } label={ label } icon={ icon }>
+					{ placeholderChildren }
+				</Placeholder>
+			) }
 		</Fragment>
 	);
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/block-controls/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/block-controls/index.js
@@ -6,8 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Placeholder } from '@wordpress/components';
-import { Fragment }    from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
 /**
  * Component for block controls when the block has a specific mode selected.
@@ -16,22 +20,22 @@ import { Fragment }    from '@wordpress/element';
  *     @type {string} className
  *     @type {string} label
  *     @type {string} icon
- *     @type {string} content
- *     @type {Array}  placeholderChildren
+ *     @type {node}   content
+ *     @type {node}   placeholderChildren
  * }
  *
  * @return {Element}
  */
-export function PlaceholderSpecificMode( { className, label, icon, content, placeholderChildren } ) {
-	const classes = [ 'wordcamp-block__edit-placeholder', 'has-specific-mode', className ];
+export function PlaceholderSpecificMode( { className, content, placeholderChildren } ) {
+	const classes = [ 'wordcamp-block__edit-appender', 'has-specific-mode', className ];
 
 	return (
 		<Fragment>
 			{ content }
 			{ placeholderChildren && (
-				<Placeholder className={ classnames( classes ) } label={ label } icon={ icon }>
+				<div className={ classnames( classes ) }>
 					{ placeholderChildren }
-				</Placeholder>
+				</div>
 			) }
 		</Fragment>
 	);

--- a/public_html/wp-content/mu-plugins/blocks/source/components/block-controls/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/block-controls/style.scss
@@ -1,0 +1,15 @@
+.wordcamp-block__edit-appender {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 1em;
+	min-height: 100px;
+	width: 100%;
+	background: #f7f7f7;
+	text-align: center;
+
+	.wordcamp-item-select {
+		max-width: 400px;
+	}
+}


### PR DESCRIPTION
This PR does a few things to style the "placeholder" when adding content (I'm calling it an appender from here, though I did not change the component name).

- Only show the appender when the block is selected, which gives a cleaner preview of what the post will look like on the frontend
- Simplify the appender display to not use the full `Placeholder` setup
- Fix some bugs around z-index and class name consistency

Fixes #161, Fixes #75

![Screen Shot 2019-07-19 at 4 25 55 PM](https://user-images.githubusercontent.com/541093/61565196-4e52e980-aa46-11e9-98f3-691418410a09.png)

**To test**

- Add a block to a post, ex Speakers
- Select some content (a few speakers), hit select to show them
- You should see a smaller content selection UI now
- Click out of the block
- Only the selected items show, no selection UI
- Click back into the block, the selection UI is back and you can add/remove content.