### PR TITLE
Meetup API Client: Use OAuth for authentication instead of an API key

### DIFF
--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -139,6 +139,11 @@ define( 'WORDCAMP_DEV_GOOGLE_MAPS_API_KEY', '' );
 define( 'MEETUP_API_KEY',      '' );
 define( 'MEETUP_API_BASE_URL', 'https://api.meetup.com/' );
 define( 'MEETUP_MEMBER_ID',     72560962                 );
+define( 'MEETUP_OAUTH_CONSUMER_KEY', '' );
+define( 'MEETUP_OAUTH_CONSUMER_SECRET', '' );
+define( 'MEETUP_OAUTH_CONSUMER_REDIRECT_URI', '' );
+define( 'MEETUP_USER_EMAIL', '' );
+define( 'MEETUP_USER_PASSWORD', '' );
 
 define( 'WORDCAMP_FIXER_API_KEY', '' );
 define( 'WORDCAMP_OXR_API_KEY',   '' );

--- a/public_html/wp-content/mu-plugins/utilities/class-api-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-api-client.php
@@ -10,6 +10,15 @@ defined( 'WPINC' ) || die();
  *
  * A generic, extendable class for making requests to an API.
  *
+ * Important: This class is used in multiple locations in the WordPress/WordCamp ecosystem. Because of complexities
+ * around SVN externals and the reliability of GitHub's SVN bridge during deploys, it was decided to maintain multiple
+ * copies of this file rather than have SVN externals pointing to one canonical source.
+ *
+ * If you make changes to this file, make sure they are propagated to the other locations:
+ *
+ * - wordcamp: wp-content/mu-plugins/utilities
+ * - wporg: wp-content/plugins/official-wordpress-events/meetup
+ *
  * @package WordCamp\Utilities
  */
 class API_Client {

--- a/public_html/wp-content/mu-plugins/utilities/class-api-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-api-client.php
@@ -114,14 +114,14 @@ class API_Client {
 				$retry_after = wp_remote_retrieve_header( $response, 'retry-after' ) ?: 5;
 				$wait        = min( $retry_after * $attempt_count, 30 );
 
-				$this->cli_message( "\nRequest failed $attempt_count times. Pausing for $wait seconds before retrying." );
+				self::cli_message( "\nRequest failed $attempt_count times. Pausing for $wait seconds before retrying." );
 
 				sleep( $wait );
 			}
 		}
 
 		if ( $attempt_count === $max_attempts && ( 200 !== $response_code || is_wp_error( $response ) ) ) {
-			$this->cli_message( "\nRequest failed $attempt_count times. Giving up." );
+			self::cli_message( "\nRequest failed $attempt_count times. Giving up." );
 		}
 
 		return $response;
@@ -210,7 +210,7 @@ class API_Client {
 	 *
 	 * @return void
 	 */
-	protected function cli_message( $message ) {
+	protected static function cli_message( $message ) {
 		if ( 'cli' === php_sapi_name() ) {
 			echo $message;
 		}

--- a/public_html/wp-content/mu-plugins/utilities/class-api-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-api-client.php
@@ -1,9 +1,9 @@
 <?php
-
 namespace WordCamp\Utilities;
-defined( 'WPINC' ) || die();
 
 use WP_Error;
+
+defined( 'WPINC' ) || die();
 
 /**
  * Class API_Client

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -22,12 +22,18 @@ class Meetup_Client extends API_Client {
 	/**
 	 * @var bool If true, the client will fetch fewer results, for faster debugging.
 	 */
-	protected $debug_mode;
+	protected $debug = false;
 
 	/**
 	 * Meetup_Client constructor.
+	 *
+	 * @param array $settings {
+	 *     Optional. Settings for the client.
+	 *
+	 *     @type bool $debug If true, the client will fetch fewer results, for faster debugging.
+	 * }
 	 */
-	public function __construct() {
+	public function __construct( array $settings = [] ) {
 		parent::__construct( array(
 			/*
 			 * Response codes that should break the request loop.
@@ -49,6 +55,13 @@ class Meetup_Client extends API_Client {
 			'throttle_callback'       => array( $this, 'maybe_throttle' ),
 		) );
 
+		$settings = wp_parse_args(
+			$settings,
+			array(
+				'debug' => false,
+			)
+		);
+
 		if ( defined( 'MEETUP_API_KEY' ) ) {
 			$this->api_key = MEETUP_API_KEY;
 		} else {
@@ -58,7 +71,11 @@ class Meetup_Client extends API_Client {
 			);
 		}
 
-		$this->debug_mode = apply_filters( 'wcmc_debug_mode', false );
+		$this->debug = $settings['debug'];
+
+		if ( $this->debug ) {
+			$this->cli_message( "Meetup Client debug is ON. Results will be truncated." );
+		}
 	}
 
 	/**
@@ -109,7 +126,7 @@ class Meetup_Client extends API_Client {
 				break;
 			}
 
-			if ( $this->debug_mode ) {
+			if ( $this->debug ) {
 				break;
 			}
 		}

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -7,6 +7,16 @@ defined( 'WPINC' ) || die();
 
 /**
  * Class Meetup_Client
+ *
+ * Important: This class and its dependency classes are used in multiple locations in the WordPress/WordCamp
+ * ecosystem. Because of complexities around SVN externals and the reliability of GitHub's SVN bridge during deploys,
+ * it was decided to maintain multiple copies of these files rather than have SVN externals pointing to one canonical
+ * source.
+ *
+ * If you make changes to this file, make sure they are propagated to the other locations:
+ *
+ * - wordcamp: wp-content/mu-plugins/utilities
+ * - wporg: wp-content/plugins/official-wordpress-events/meetup
  */
 class Meetup_Client extends API_Client {
 	/**

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -262,6 +262,9 @@ class Meetup_Client extends API_Client {
 	/**
 	 * Extract error information from an API response and add it to our error handler.
 	 *
+	 * Make sure you don't include the full $response in the error as data, as that could expose sensitive information
+	 * from the request payload.
+	 *
 	 * @param array|WP_Error $response
 	 *
 	 * @return void
@@ -276,17 +279,26 @@ class Meetup_Client extends API_Client {
 
 		if ( isset( $data['errors'] ) ) {
 			foreach ( $data['errors'] as $error ) {
-				$this->error->add( $error['code'], $error['message'] );
+				$this->error->add(
+					$error['code'],
+					$error['message']
+				);
 			}
 		} elseif ( isset( $data['code'] ) && isset( $data['details'] ) ) {
-			$this->error->add( $data['code'], $data['details'] );
+			$this->error->add(
+				$data['code'],
+				$data['details']
+			);
 		} elseif ( $response_code ) {
 			$this->error->add(
 				'http_response_code',
 				sprintf( 'HTTP Status: %d', absint( $response_code ) )
 			);
 		} else {
-			$this->error->add( 'unknown_error', 'There was an unknown error.' );
+			$this->error->add(
+				'unknown_error',
+				'There was an unknown error.'
+			);
 		}
 	}
 

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -74,7 +74,7 @@ class Meetup_Client extends API_Client {
 		$this->debug = $settings['debug'];
 
 		if ( $this->debug ) {
-			$this->cli_message( "Meetup Client debug is ON. Results will be truncated." );
+			self::cli_message( "Meetup Client debug is ON. Results will be truncated." );
 		}
 	}
 
@@ -254,7 +254,7 @@ class Meetup_Client extends API_Client {
 			$period = 2;
 		}
 
-		$this->cli_message( "\nPausing for $period seconds to avoid rate-limiting." );
+		self::cli_message( "\nPausing for $period seconds to avoid rate-limiting." );
 
 		sleep( $period );
 	}

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -52,7 +52,7 @@ class Meetup_Client extends API_Client {
 				429, // Too many requests (rate-limited).
 				404, // Unable to find group
 			),
-			'throttle_callback'       => array( $this, 'maybe_throttle' ),
+			'throttle_callback'       => array( __CLASS__, 'throttle' ),
 		) );
 
 		$settings = wp_parse_args(
@@ -235,7 +235,7 @@ class Meetup_Client extends API_Client {
 	 *
 	 * @param array $headers
 	 */
-	protected function maybe_throttle( $response ) {
+	protected static function throttle( $response ) {
 		$headers = wp_remote_retrieve_headers( $response );
 
 		if ( ! isset( $headers['x-ratelimit-remaining'], $headers['x-ratelimit-reset'] ) ) {

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -1,0 +1,460 @@
+<?php
+namespace WordCamp\Utilities;
+
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Meetup_OAuth2_Client
+ *
+ * Implements the "Server Flow with User Credentials" for Meetup's OAuth2 authorization scheme.
+ *
+ * @see https://www.meetup.com/meetup_api/auth/#oauth2servercredentials
+ *
+ * @todo Maybe make some of the credential strings like consumer key, etc, class parameters that map to private
+ *       properties instead of constants. That way the client could be reused elsewhere in the Dotorg ecosystem with
+ *       different credentials, instead of being tightly coupled to WordCamp.
+ *
+ * @package WordCamp\Utilities
+ */
+class Meetup_OAuth2_Client extends API_Client {
+	/**
+	 * @var string
+	 */
+	const CONSUMER_KEY = MEETUP_OAUTH_CONSUMER_KEY;
+
+	/**
+	 * @var string
+	 */
+	const CONSUMER_SECRET = MEETUP_OAUTH_CONSUMER_SECRET;
+
+	/**
+	 * @var string
+	 */
+	const REDIRECT_URI = MEETUP_OAUTH_CONSUMER_REDIRECT_URI;
+
+	/**
+	 * @var string
+	 */
+	const EMAIL = MEETUP_USER_EMAIL;
+
+	/**
+	 * @var string
+	 */
+	const PASSWORD = MEETUP_USER_PASSWORD;
+
+	/**
+	 * @var string
+	 */
+	const URL_AUTHORIZE = 'https://secure.meetup.com/oauth2/authorize';
+
+	/**
+	 * @var string
+	 */
+	const URL_ACCESS_TOKEN = 'https://secure.meetup.com/oauth2/access';
+
+	/**
+	 * @var string
+	 */
+	const URL_OAUTH_TOKEN = 'https://api.meetup.com/sessions';
+
+	/**
+	 * @var string
+	 */
+	const SITE_OPTION_KEY_ACCESS = 'meetup_access_token';
+
+	/**
+	 * @var string
+	 */
+	const SITE_OPTION_KEY_OAUTH = 'meetup_oauth_token';
+
+	/**
+	 * @var array
+	 */
+	protected $oauth_token = array();
+
+	/**
+	 * Meetup_OAuth2_Client constructor.
+	 */
+	public function __construct() {
+		parent::__construct( array(
+			/**
+			 * Response codes that should break the request loop.
+			 *
+			 * Meetup's Oauth2 documentation doesn't provide a schema for error codes, so for the time being, we're
+			 * using the same ones as for the Meetup Client itself.
+			 * See https://www.meetup.com/meetup_api/docs/#errors.
+			 *
+			 * `200` (ok) is not in the list, because it needs to be handled conditionally.
+			 *  See API_Client::tenacious_remote_request.
+			 *
+			 * `400` (bad request) is not in the list, even though it seems like it _should_ indicate an unrecoverable
+			 * error. In practice we've observed that it's common for a seemingly valid request to be rejected with
+			 * a `400` response, but then get a `200` response if that exact same request is retried.
+			 */
+			'breaking_response_codes' => array(
+				401, // Unauthorized (invalid key).
+				429, // Too many requests (rate-limited).
+				404, // Unable to find group
+			),
+		) );
+	}
+
+	/**
+	 * Generate the headers for a request.
+	 *
+	 * @param string $access_token Optional. Providing an access token will add an extra header.
+	 *
+	 * @return array
+	 */
+	protected function get_headers( $access_token = '' ) {
+		$headers = array(
+			'Accept' => 'application/json',
+		);
+
+		if ( $access_token ) {
+			$headers['Authorization'] = "Bearer $access_token";
+		}
+
+		return $headers;
+	}
+
+	/**
+	 * Step 1 in "Server Flow with User Credentials".
+	 *
+	 * @see https://www.meetup.com/meetup_api/auth/#oauth2servercredentials-auth
+	 *
+	 * @return string
+	 */
+	protected function request_authorization_code() {
+		$authorization_code = '';
+
+		$request = array(
+			'client_id'     => self::CONSUMER_KEY,
+			'redirect_uri'  => self::REDIRECT_URI,
+			'response_type' => 'anonymous_code',
+			'scope'         => 'ageless',
+		);
+
+		$args = array(
+			'headers' => $this->get_headers(),
+			'body'    => $request,
+		);
+
+		$response = $this->tenacious_remote_post( self::URL_AUTHORIZE, $args );
+
+		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( ! empty( $body['code'] ) ) {
+				$authorization_code = $body['code'];
+			} else {
+				$this->error->add(
+					'unexpected_oauth_authorization_code_response',
+					'The Meetup OAuth API response did not provide the expected data.'
+				);
+			}
+		} else {
+			$this->handle_error_response( $response );
+		}
+
+		return $authorization_code;
+	}
+
+	/**
+	 * Step 2 in "Server Flow with User Credentials".
+	 *
+	 * @see https://www.meetup.com/meetup_api/auth/#oauth2servercredentials-access
+	 *
+	 * Also the step for refreshing an expired access token.
+	 *
+	 * @see https://www.meetup.com/meetup_api/auth/#oauth2server-refresh
+	 *
+	 * Note that this does not store the access token. See get_access_token().
+	 *
+	 * @param string $type The type of grant. Either 'anonymous_code' or 'refresh_token'.
+	 * @param string $code The code/token used with the grant.
+	 *
+	 * @return array A successfully retrieved token will be an associative array with several keys.
+	 */
+	protected function request_access_token( $type, $code ) {
+		$access_token = array();
+
+		$request = array(
+			'client_id'     => self::CONSUMER_KEY,
+			'client_secret' => self::CONSUMER_SECRET,
+			'redirect_uri'  => self::REDIRECT_URI,
+			'grant_type'    => $type,
+		);
+
+		switch( $type ) {
+			case 'anonymous_code':
+				$request['code'] = $code;
+				break;
+			default:
+				$request[ $type ] = $code;
+				break;
+		}
+
+		$args = array(
+			'headers' => $this->get_headers(),
+			'body'    => $request,
+		);
+
+		$response = $this->tenacious_remote_post( self::URL_ACCESS_TOKEN, $args );
+
+		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( $this->is_valid_token( $body, 'access' ) ) {
+				$access_token = $body;
+
+				$access_token['timestamp'] = time();
+			} else {
+				$this->error->add(
+					// Don't include the entire response in the error data, because it might include sensitive
+					// data from the request payload.
+					'unexpected_oauth_access_token_response',
+					'The Meetup OAuth API response did not provide the expected data.'
+				);
+			}
+		} else {
+			$this->handle_error_response( $response );
+		}
+
+		return $access_token;
+	}
+
+	/**
+	 * Get the current access token, either from the database or from a request.
+	 *
+	 * This stores a successfully retrieved token array to the database for repeated use, until it expires.
+	 *
+	 * @todo So far, I haven't been able to get this type of token to work again after it is used once to retrieve an
+	 *       oauth token in Step 3. The documentation makes it sound like this token should be good for up to two
+	 *       weeks (if the 'ageless' scope is set) so I'm not sure what's going wrong. In the mean time, the caching
+	 *       for this token is commented out. A new token will always be retrieved.
+	 *
+	 * @return string
+	 */
+	protected function get_access_token() {
+		$access_token  = '';
+		$needs_caching = false;
+
+		//$token = get_site_option( self::SITE_OPTION_KEY_ACCESS, array() );
+		$token = array();
+
+		if ( ! $this->is_valid_token( $token, 'access' ) ) {
+			$token         = $this->request_access_token( 'anonymous_code', $this->request_authorization_code() );
+			$needs_caching = true;
+		} elseif ( $this->is_valid_token( $token, 'access' ) && $this->is_expired_token( $token ) ) {
+			$token         = $this->request_access_token( 'refresh_token', $token['refresh_token'] );
+			$needs_caching = true;
+		}
+
+		if ( $this->is_valid_token( $token, 'access' ) ) {
+			$access_token = $token['access_token'];
+
+			if ( $needs_caching ) {
+				//update_site_option( self::SITE_OPTION_KEY_ACCESS, $token );
+			}
+		}
+
+		return $access_token;
+	}
+
+	/**
+	 * Step 3 in "Server Flow with User Credentials".
+	 *
+	 * Technically in the documentation, this token is also called an "access token", but here we're calling it the
+	 * "oauth token" to differentiate it from the other access token. Also, why are two separate access tokens
+	 * necessary??
+	 *
+	 * @see https://www.meetup.com/meetup_api/auth/#oauth2servercredentials-accesspro
+	 *
+	 * Note that this does not store the oauth token. See get_oauth_token().
+	 *
+	 * @return array A successfully retrieved token will be an associative array with several keys.
+	 */
+	protected function request_oauth_token() {
+		$oauth_token = array();
+
+		$access_token = $this->get_access_token();
+
+		if ( $access_token ) {
+			$request = array(
+				'email'    => self::EMAIL,
+				'password' => self::PASSWORD,
+				'scope'    => 'ageless',
+			);
+
+			$args = array(
+				'headers' => $this->get_headers( $access_token ),
+				'body'    => $request,
+			);
+
+			// @todo There aren't separate request "types" here because there's no documentation for refreshing the
+			//       oauth token, even though the token object it sends includes a `refresh_token` string.
+
+			$response = $this->tenacious_remote_post( self::URL_OAUTH_TOKEN, $args );
+
+			if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+				$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+				if ( $this->is_valid_token( $body, 'oauth' ) ) {
+					$oauth_token = $body;
+
+					$oauth_token['timestamp'] = time();
+				} else {
+					$this->error->add(
+						// Don't include the entire response in the error data, because it might include sensitive
+						// data from the request payload.
+						'unexpected_oauth_token_response',
+						'The Meetup OAuth API response did not provide the expected data.'
+					);
+				}
+			} else {
+				$this->handle_error_response( $response );
+			}
+		} else {
+			$this->error->add(
+				'no_access_token',
+				'Could not retrieve a valid Meetup OAuth access token.'
+			);
+		}
+
+		return $oauth_token;
+	}
+
+	/**
+	 * Get the token needed to make requests to the Meetup API.
+	 *
+	 * This encompasses all three of the steps in the "Server Flow with User Credentials" flow, so it's the only
+	 * method that should be called directly.
+	 *
+	 * This stores a successfully retrieved token array to the database for repeated use, until it expires.
+	 *
+	 * @return string
+	 */
+	public function get_oauth_token() {
+		if ( $this->oauth_token ) {
+			return $this->oauth_token['oauth_token'];
+		}
+
+		$oauth_token   = '';
+		$needs_caching = false;
+
+		$token = get_site_option( self::SITE_OPTION_KEY_OAUTH, array() );
+
+		if ( ! $this->is_valid_token( $token, 'oauth' ) || $this->is_expired_token( $token ) ) {
+			$token         = $this->request_oauth_token();
+			$needs_caching = true;
+		}
+
+		if ( $this->is_valid_token( $token, 'oauth' ) ) {
+			$this->oauth_token = $token;
+
+			if ( $needs_caching ) {
+				update_site_option( self::SITE_OPTION_KEY_OAUTH, $token );
+			}
+
+			$oauth_token = $this->oauth_token['oauth_token'];
+		}
+
+		return $oauth_token;
+	}
+
+	/**
+	 * Check if a token array has all the required keys.
+	 *
+	 * @param array $token
+	 *
+	 * @return bool
+	 */
+	protected function is_valid_token( $token, $type ) {
+		if ( ! is_array( $token ) ) {
+			return false;
+		}
+
+		switch ( $type ) {
+			case 'access':
+				$required_properties = array(
+					'access_token'  => '',
+					'refresh_token' => '',
+					'expires_in'    => '',
+				);
+				break;
+			case 'oauth':
+				$required_properties = array(
+					'oauth_token'   => '',
+					'refresh_token' => '',
+					'expires_in'    => '',
+				);
+				break;
+		}
+
+		$missing_properties = array_diff_key( $required_properties, $token );
+
+		return empty( $missing_properties );
+	}
+
+	/**
+	 * Check if a token has expired since it was retrieved from the OAuth API.
+	 *
+	 * @param array $token
+	 *
+	 * @return bool
+	 */
+	protected function is_expired_token( array $token ) {
+		return absint( $token['timestamp'] ) + absint( $token['expires_in'] ) <= time();
+	}
+
+	/**
+	 * Extract error information from an API response and add it to our error handler.
+	 *
+	 * Make sure you don't include the full $response in the error as data, as that could expose sensitive information
+	 * from the request payload.
+	 *
+	 * @param array|WP_Error $response
+	 *
+	 * @return void
+	 */
+	public function handle_error_response( $response ) {
+		if ( parent::handle_error_response( $response ) ) {
+			return;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$data          = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( isset( $data['errors'] ) ) {
+			foreach ( $data['errors'] as $error ) {
+				$this->error->add(
+					$error['code'],
+					$error['message']
+				);
+			}
+		} elseif ( isset( $data['error'] ) ) {
+			$this->error->add(
+				'oauth_error',
+				$data['error']
+			);
+		} elseif ( isset( $data['code'] ) && isset( $data['details'] ) ) {
+			$this->error->add(
+				$data['code'],
+				$data['details']
+			);
+		} elseif ( $response_code ) {
+			$this->error->add(
+				'http_response_code',
+				sprintf( 'HTTP Status: %d', absint( $response_code ) )
+			);
+		} else {
+			$this->error->add(
+				'unknown_error',
+				'There was an unknown error.'
+			);
+		}
+	}
+}

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -16,6 +16,15 @@ defined( 'WPINC' ) || die();
  *       properties instead of constants. That way the client could be reused elsewhere in the Dotorg ecosystem with
  *       different credentials, instead of being tightly coupled to WordCamp.
  *
+ * Important: This class is used in multiple locations in the WordPress/WordCamp ecosystem. Because of complexities
+ * around SVN externals and the reliability of GitHub's SVN bridge during deploys, it was decided to maintain multiple
+ * copies of this file rather than have SVN externals pointing to one canonical source.
+ *
+ * If you make changes to this file, make sure they are propagated to the other locations:
+ *
+ * - wordcamp: wp-content/mu-plugins/utilities
+ * - wporg: wp-content/plugins/official-wordpress-events/meetup
+ *
  * @package WordCamp\Utilities
  */
 class Meetup_OAuth2_Client extends API_Client {

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -188,10 +188,12 @@ class Meetup_OAuth2_Client extends API_Client {
 			'grant_type'    => $type,
 		);
 
+		// Add the code to the request payload using the correct parameter for the grant type.
 		switch( $type ) {
-			case 'anonymous_code':
+			case 'anonymous_code': // Request a new access token.
 				$request['code'] = $code;
 				break;
+			case 'refresh_token': // Refresh an expired access token.
 			default:
 				$request[ $type ] = $code;
 				break;

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -281,7 +281,7 @@ class Meetup_OAuth2_Client extends API_Client {
 			$server_token  = $this->request_token( 'server_token', $authorization ); // Step 2.
 			$token         = $this->request_token( 'oauth_token', $server_token ); // Step 3.
 			$needs_caching = true;
-		} elseif ( $this->is_valid_token( $token, 'oauth_token' ) && $this->is_expired_token( $token ) ) {
+		} elseif ( $this->is_expired_token( $token ) ) {
 			$server_token  = $this->request_token( 'refresh_token', $token ); // Alternate for Steps 1 & 2.
 			$token         = $this->request_token( 'oauth_token', $server_token ); // Step 3.
 			$needs_caching = true;

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -267,7 +267,7 @@ class Meetup_OAuth2_Client extends API_Client {
 	 * @return string
 	 */
 	public function get_oauth_token() {
-		if ( $this->oauth_token ) {
+		if ( $this->oauth_token && ! $this->is_expired_token( $this->oauth_token ) ) {
 			return $this->oauth_token['oauth_token'];
 		}
 

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -370,12 +370,15 @@ class Meetup_OAuth2_Client extends API_Client {
 	/**
 	 * Check if a token array has all the required keys.
 	 *
-	 * @param array $token
+	 * @param array  $token The token array to check.
+	 * @param string $type  The type of token. Either 'access' or 'oauth'.
 	 *
 	 * @return bool
 	 */
 	protected function is_valid_token( $token, $type ) {
-		if ( ! is_array( $token ) ) {
+		$valid_types = array( 'access', 'oauth' );
+
+		if ( ! is_array( $token ) || ! in_array( $type, $valid_types, true ) ) {
 			return false;
 		}
 
@@ -388,6 +391,7 @@ class Meetup_OAuth2_Client extends API_Client {
 				);
 				break;
 			case 'oauth':
+			default:
 				$required_properties = array(
 					'oauth_token'   => '',
 					'refresh_token' => '',


### PR DESCRIPTION
Meetup.com [announced](https://groups.google.com/forum/#!topic/meetup-api/R__7mPzWJc0) that it's API key method of authentication would be going away on August 15th, 2019. That's what we've been using, so we need to switch to their OAuth2 method instead.

In order to avoid having to manually redirect to Meetup.com and login with credentials before each time we need to pull the data from the API, we are using the [Server Flow with User Credentials](https://www.meetup.com/meetup_api/auth/#oauth2servercredentials) approach. Unfortunately this requires a non-standard grant type, and a strange extra step of using an access token to request a separate, more special access token. As such, existing OAuth client libraries don't support it out of the box (that I'm aware of). Instead, this PR adds a very simple, custom OAuth2 client.