### PR TITLE
 Blocks: Remove eslint overrides for declaration spacing.

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
+++ b/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
@@ -1,16 +1,6 @@
 /*
  * @todo
  *
- * equals in assignment should be aligned          - needs a plugin: https://github.com/eslint/eslint/issues/11025
- * `from` in `import` statements should be aligned - needs a plugin: https://github.com/eslint/eslint/issues/11025
- *
- * indent things like
- * { mode &&
- * <GridToolbar
- * 	{ ...this.props }
- * />
- * }
- *
  * should use hasOwnProperty or Object.getOwnPropertyDescriptors(). the latter usually makes code more readable, but sometimes the former first better
  * assignment and control structures/returns/etc should be separate by a blank line for readability.
  *      same for div and other block-level html elements
@@ -69,18 +59,6 @@ module.exports = {
 		} ],
 
 		/*
-		 * Align object parameters on their assignment operator (:), just like assignment statements are
-		 * aligned on `=`.
-		 */
-		'key-spacing' : [ 'error', {
-			'align' : {
-				'beforeColon' : true,
-				'afterColon'  : true,
-				'on'          : 'colon',
-			},
-		} ],
-
-		/*
 		 * Force a line-length of 115 characters.
 		 *
 		 * We ignore URLs, trailing comments, strings, and template literals to prevent awkward fragmenting of
@@ -93,26 +71,6 @@ module.exports = {
 			'ignoreStrings'          : true,
 			'ignoreTemplateLiterals' : true,
 		} ],
-
-		/*
-		 * Allow multiple spaces in a row.
-		 *
-		 * Ideally this should be on, because we don't want to allow things like `const foo  == bar;`, but the rule
-		 * currently isn't flexible enough to allow all the exceptions we need. Specifically, there are times where
-		 * readability is vastly improved by aligning attributes in consecutive lines.
-		 *
-		 * Alternate configuration if we ever want to re-enable this:
-		 *
-		 * 'no-multi-spaces': [ 'error', {
-		 *      // Use the `type` value from the parser demo to find these properties: https://eslint.org/parser/.
-		 *	    exceptions: {
-		 *		    VariableDeclarator : true,
-		 *		    ImportDeclaration  : true,
-		 *		    JSXAttribute       : true,
-		 *	    },
-		 * } ],
-		 */
-		'no-multi-spaces' : 'off',
 
 		/*
 		 * Objects are harder to quickly scan when the formatting is inconsistent.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -6,8 +6,8 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import './_z-index.scss';           // Have z-index values, similar to https://github.com/WordPress/gutenberg/blob/master/assets/stylesheets/_z-index.scss
-import './styles.scss';               // Common styles for WordCamp Blocks.
+import './_z-index.scss'; // Have z-index values, similar to https://github.com/WordPress/gutenberg/blob/master/assets/stylesheets/_z-index.scss
+import './styles.scss'; // Common styles for WordCamp Blocks.
 import { BLOCKS } from './blocks/'; // Trailing slash required to differentiate the folder from the file.
 
 BLOCKS.forEach( ( { NAME, SETTINGS } ) => {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import * as organizers from './organizers';
-import * as sessions   from './sessions';
-import * as speakers   from './speakers';
-import * as sponsors   from './sponsors';
+import * as sessions from './sessions';
+import * as speakers from './speakers';
+import * as sponsors from './sponsors';
 
 export const BLOCKS = [
 	organizers,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-content.js
@@ -11,10 +11,10 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { AvatarImage }                                from '../../components/image';
+import { AvatarImage } from '../../components/image';
 import { BlockNoContent, ItemTitle, DangerousItemHTMLContent } from '../../components/block-content';
-import { PostList }                                   from '../../components/post-list';
-import { filterEntities }                             from '../../data';
+import { PostList } from '../../components/post-list';
+import { filterEntities } from '../../data';
 
 /**
  * Component for displaying the block content.
@@ -46,8 +46,8 @@ export class BlockContent extends Component {
 		if ( Array.isArray( item_ids ) && item_ids.length > 0 ) {
 			args.filter = [
 				{
-					fieldName  : mode === 'wcb_organizer' ? 'id' : 'organizer_team',
-					fieldValue : item_ids,
+					fieldName: mode === 'wcb_organizer' ? 'id' : 'organizer_team',
+					fieldValue: item_ids,
 				},
 			];
 		}
@@ -66,9 +66,9 @@ export class BlockContent extends Component {
 		const { attributes } = this.props;
 		const { show_avatars, avatar_size, avatar_align, content } = attributes;
 
-		const posts     = this.getFilteredPosts();
+		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
-		const hasPosts  = ! isLoading && posts.length > 0;
+		const hasPosts = ! isLoading && posts.length > 0;
 
 		if ( isLoading || ! hasPosts ) {
 			return (
@@ -104,7 +104,7 @@ export class BlockContent extends Component {
 						{ ( 'none' !== content ) &&
 							<DangerousItemHTMLContent
 								className={ classnames( 'wordcamp-organizers__content', 'is-' + content ) }
-								content={  'full' === content ? post.content.rendered.trim() : post.excerpt.rendered.trim() }
+								content={ 'full' === content ? post.content.rendered.trim() : post.excerpt.rendered.trim() }
 							/>
 						}
 					</div>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/block-controls.js
@@ -7,17 +7,17 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Button, Placeholder } from '@wordpress/components';
-import { Component }           from '@wordpress/element';
-import { __ }                  from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { PlaceholderSpecificMode } from '../../components/block-controls';
-import { getOptionLabel }          from '../../components/item-select';
-import { BlockContent }            from './block-content';
-import { ContentSelect }           from './content-select';
-import { LABEL }                   from './index';
+import { getOptionLabel } from '../../components/item-select';
+import { BlockContent } from './block-content';
+import { ContentSelect } from './content-select';
+import { LABEL } from './index';
 
 /**
  * Component for displaying a UI within the block.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
@@ -7,7 +7,7 @@ import { every, flatMap, includes } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ }        from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,9 +26,9 @@ export class ContentSelect extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.buildSelectOptions    = this.buildSelectOptions.bind( this );
+		this.buildSelectOptions = this.buildSelectOptions.bind( this );
 		this.getCurrentSelectValue = this.getCurrentSelectValue.bind( this );
-		this.isLoading             = this.isLoading.bind( this );
+		this.isLoading = this.isLoading.bind( this );
 	}
 
 	/**
@@ -42,16 +42,16 @@ export class ContentSelect extends Component {
 
 		const optionGroups = [
 			{
-				entityType : 'post',
-				type       : 'wcb_organizer',
-				label      : __( 'Organizers', 'wordcamporg' ),
-				items      : wcb_organizer,
+				entityType: 'post',
+				type: 'wcb_organizer',
+				label: __( 'Organizers', 'wordcamporg' ),
+				items: wcb_organizer,
 			},
 			{
-				entityType : 'term',
-				type       : 'wcb_organizer_team',
-				label      : __( 'Teams', 'wordcamporg' ),
-				items      : wcb_organizer_team,
+				entityType: 'term',
+				type: 'wcb_organizer_team',
+				label: __( 'Teams', 'wordcamporg' ),
+				items: wcb_organizer_team,
 			},
 		];
 
@@ -110,9 +110,9 @@ export class ContentSelect extends Component {
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
 				selectProps={ {
-					options           : this.buildSelectOptions(),
-					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData, { context } ) => (
+					options: this.buildSelectOptions(),
+					isLoading: this.isLoading(),
+					formatOptionLabel: ( optionData, { context } ) => (
 						<Option
 							context={ context }
 							icon={ 'wcb_organizer_team' === optionData.type ? icon : null }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
@@ -1,17 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { withSelect }          from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { LayoutToolbar }     from '../../components/post-list';
-import { WC_BLOCKS_STORE }   from '../../data';
-import { BlockControls }     from './block-controls';
+import { LayoutToolbar } from '../../components/post-list';
+import { WC_BLOCKS_STORE } from '../../data';
+import { BlockControls } from './block-controls';
 import { InspectorControls } from './inspector-controls';
-import { ICON }              from './index';
+import { ICON } from './index';
 
 const blockData = window.WordCampBlocks.organizers || {};
 
@@ -25,8 +25,8 @@ class OrganizersEdit extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes }  = this.props;
-		const { mode, layout }               = attributes;
+		const { attributes, setAttributes } = this.props;
+		const { mode, layout } = attributes;
 		const { layout: layoutOptions = {} } = blockData.options;
 
 		return (
@@ -55,8 +55,8 @@ const organizerSelect = ( select ) => {
 	const { getEntities } = select( WC_BLOCKS_STORE );
 
 	const entities = {
-		wcb_organizer      : getEntities( 'postType', 'wcb_organizer', { _embed: true } ),
-		wcb_organizer_team : getEntities( 'taxonomy', 'wcb_organizer_team' ),
+		wcb_organizer: getEntities( 'postType', 'wcb_organizer', { _embed: true } ),
+		wcb_organizer_team: getEntities( 'taxonomy', 'wcb_organizer_team' ),
 	};
 
 	return {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/index.js
@@ -8,20 +8,20 @@ import { __ } from '@wordpress/i18n';
  */
 import { Edit } from './edit';
 
-export const NAME  = 'wordcamp/organizers';
+export const NAME = 'wordcamp/organizers';
 export const LABEL = __( 'Organizers', 'wordcamporg' );
-export const ICON  = 'groups';
+export const ICON = 'groups';
 
 const supports = {
 	align: [ 'wide', 'full' ],
 };
 
 export const SETTINGS = {
-	title       : __( 'Organizers', 'wordcamporg' ),
-	description : __( 'Add a list of organizers.', 'wordcamporg' ),
-	icon        : ICON,
-	category    : 'wordcamp',
-	supports    : supports,
-	edit        : Edit,
-	save        : () => null,
+	title: __( 'Organizers', 'wordcamporg' ),
+	description: __( 'Add a list of organizers.', 'wordcamporg' ),
+	icon: ICON,
+	category: 'wordcamp',
+	supports: supports,
+	edit: Edit,
+	save: () => null,
 };

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/inspector-controls.js
@@ -2,34 +2,34 @@
  * WordPress dependencies
  */
 import { InspectorControls as CoreInspectorControlsContainer } from '@wordpress/block-editor';
-import { PanelBody, SelectControl }                            from '@wordpress/components';
-import { Component }                                           from '@wordpress/element';
-import { __ }                                                  from '@wordpress/i18n';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { avatarSizePresets, ImageInspectorPanel } from '../../components/image';
-import { GridInspectorPanel }                     from '../../components/post-list';
+import { GridInspectorPanel } from '../../components/post-list';
 
 const DEFAULT_SCHEMA = {
 	grid_columns: {
-		default : 2,
-		minimum : 2,
-		maximum : 4,
+		default: 2,
+		minimum: 2,
+		maximum: 4,
 	},
 
 	avatar_size: {
-		default : 150,
-		minimum : 25,
-		maximum : 600,
+		default: 150,
+		minimum: 25,
+		maximum: 600,
 	},
 };
 
 const DEFAULT_OPTIONS = {
-	align   : {},
-	content : {},
-	sort    : {},
+	align: {},
+	content: {},
+	sort: {},
 };
 
 /**
@@ -42,9 +42,9 @@ export class InspectorControls extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes, blockData }                   = this.props;
+		const { attributes, setAttributes, blockData } = this.props;
 		const { show_avatars, avatar_size, avatar_align, content, sort } = attributes;
-		const { schema = DEFAULT_SCHEMA, options = DEFAULT_OPTIONS }     = blockData;
+		const { schema = DEFAULT_SCHEMA, options = DEFAULT_OPTIONS } = blockData;
 
 		return (
 			<CoreInspectorControlsContainer>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -1,23 +1,23 @@
 /**
  * External dependencies
  */
-import { get }    from 'lodash';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ }        from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { ItemTitle, DangerousItemHTMLContent, ItemPermalink, BlockNoContent } from '../../components/block-content';
-import { FeaturedImage }                                             from '../../components/image';
-import { PostList }                                                  from '../../components/post-list';
-import { filterEntities }                                            from '../../data';
-import { tokenSplit, arrayTokenReplace, intersperse, listify }       from '../../i18n';
+import { FeaturedImage } from '../../components/image';
+import { PostList } from '../../components/post-list';
+import { filterEntities } from '../../data';
+import { tokenSplit, arrayTokenReplace, intersperse, listify } from '../../i18n';
 
 /**
  * Component for the section of each session post that displays information about the session's speakers.
@@ -39,7 +39,7 @@ function SessionSpeakers( { session } ) {
 			return null;
 		}
 
-		const { link }     = speaker;
+		const { link } = speaker;
 		let { title = {} } = speaker;
 
 		title = title.rendered.trim() || __( 'Unnamed', 'wordcamporg' );
@@ -149,10 +149,10 @@ export class BlockContent extends Component {
 					break;
 			}
 
-			args.filter  = [
+			args.filter = [
 				{
-					fieldName  : fieldName,
-					fieldValue : item_ids,
+					fieldName: fieldName,
+					fieldValue: item_ids,
 				},
 			];
 		}
@@ -189,9 +189,9 @@ export class BlockContent extends Component {
 			show_category,
 		} = attributes;
 
-		const posts     = this.getFilteredPosts();
+		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
-		const hasPosts  = ! isLoading && posts.length > 0;
+		const hasPosts = ! isLoading && posts.length > 0;
 
 		if ( isLoading || ! hasPosts ) {
 			return (

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-controls.js
@@ -7,17 +7,17 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Button, Placeholder } from '@wordpress/components';
-import { Component }           from '@wordpress/element';
-import { __ }                  from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { PlaceholderSpecificMode } from '../../components/block-controls';
-import { getOptionLabel }          from '../../components/item-select';
-import { BlockContent }            from './block-content';
-import { ContentSelect }           from './content-select';
-import { LABEL }                   from './index';
+import { getOptionLabel } from '../../components/item-select';
+import { BlockContent } from './block-content';
+import { ContentSelect } from './content-select';
+import { LABEL } from './index';
 
 /**
  * Component for displaying a UI within the block.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/content-select.js
@@ -7,7 +7,7 @@ import { every, flatMap, includes } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ }        from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,9 +26,9 @@ export class ContentSelect extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.buildSelectOptions    = this.buildSelectOptions.bind( this );
+		this.buildSelectOptions = this.buildSelectOptions.bind( this );
 		this.getCurrentSelectValue = this.getCurrentSelectValue.bind( this );
-		this.isLoading             = this.isLoading.bind( this );
+		this.isLoading = this.isLoading.bind( this );
 	}
 
 	/**
@@ -42,22 +42,22 @@ export class ContentSelect extends Component {
 
 		const optionGroups = [
 			{
-				entityType : 'post',
-				type       : 'wcb_session',
-				label      : __( 'Sessions', 'wordcamporg' ),
-				items      : wcb_session,
+				entityType: 'post',
+				type: 'wcb_session',
+				label: __( 'Sessions', 'wordcamporg' ),
+				items: wcb_session,
 			},
 			{
-				entityType : 'term',
-				type       : 'wcb_track',
-				label      : __( 'Tracks', 'wordcamporg' ),
-				items      : wcb_track,
+				entityType: 'term',
+				type: 'wcb_track',
+				label: __( 'Tracks', 'wordcamporg' ),
+				items: wcb_track,
 			},
 			{
-				entityType : 'term',
-				type       : 'wcb_session_category',
-				label      : __( 'Session Categories', 'wordcamporg' ),
-				items      : wcb_session_category,
+				entityType: 'term',
+				type: 'wcb_session_category',
+				label: __( 'Session Categories', 'wordcamporg' ),
+				items: wcb_session_category,
 			},
 		];
 
@@ -116,9 +116,9 @@ export class ContentSelect extends Component {
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
 				selectProps={ {
-					options           : this.buildSelectOptions(),
-					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData, { context } ) => (
+					options: this.buildSelectOptions(),
+					isLoading: this.isLoading(),
+					formatOptionLabel: ( optionData, { context } ) => (
 						<Option
 							icon={ includes( [ 'wcb_track', 'wcb_session_category' ], optionData.type ) ? icon : null }
 							label={ optionData.label }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
@@ -1,17 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { withSelect }          from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { LayoutToolbar }     from '../../components/post-list';
-import { WC_BLOCKS_STORE }   from '../../data';
-import { BlockControls }     from './block-controls';
+import { LayoutToolbar } from '../../components/post-list';
+import { WC_BLOCKS_STORE } from '../../data';
+import { BlockControls } from './block-controls';
 import { InspectorControls } from './inspector-controls';
-import { ICON }              from './index';
+import { ICON } from './index';
 import { getSessionDetails } from './utils';
 
 const blockData = window.WordCampBlocks.sessions || {};
@@ -26,8 +26,8 @@ class SessionsEdit extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes }  = this.props;
-		const { mode, layout }               = attributes;
+		const { attributes, setAttributes } = this.props;
+		const { mode, layout } = attributes;
 		const { layout: layoutOptions = {} } = blockData.options;
 
 		return (
@@ -55,15 +55,15 @@ const sessionsSelect = ( select ) => {
 	const { getEntities } = select( WC_BLOCKS_STORE );
 
 	const sessionArgs = {
-		_embed        : true,
-		wc_meta_key   : '_wcpt_session_type',
-		wc_meta_value : 'session', // Regular sessions only, no breaks/lunch/etc sessions.
+		_embed: true,
+		wc_meta_key: '_wcpt_session_type',
+		wc_meta_value: 'session', // Regular sessions only, no breaks/lunch/etc sessions.
 	};
 
 	const entities = {
-		wcb_session          : null,
-		wcb_track            : getEntities( 'taxonomy', 'wcb_track' ),
-		wcb_session_category : getEntities( 'taxonomy', 'wcb_session_category' ),
+		wcb_session: null,
+		wcb_track: getEntities( 'taxonomy', 'wcb_track' ),
+		wcb_session_category: getEntities( 'taxonomy', 'wcb_session_category' ),
 	};
 
 	const sessions = getEntities( 'postType', 'wcb_session', sessionArgs );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/index.js
@@ -9,20 +9,20 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import { Edit } from './edit';
 
-export const NAME  = 'wordcamp/sessions';
+export const NAME = 'wordcamp/sessions';
 export const LABEL = __( 'Sessions', 'wordcamporg' );
-export const ICON  = 'list-view';
+export const ICON = 'list-view';
 
 const supports = {
 	align: [ 'wide', 'full' ],
 };
 
 export const SETTINGS = {
-	title       : __( 'Sessions', 'wordcamporg' ),
-	description : __( 'Add a list of sessions.', 'wordcamporg' ),
-	icon        : ICON,
-	category    : 'wordcamp',
-	supports    : supports,
-	edit        : Edit,
-	save        : () => null,
+	title: __( 'Sessions', 'wordcamporg' ),
+	description: __( 'Add a list of sessions.', 'wordcamporg' ),
+	icon: ICON,
+	category: 'wordcamp',
+	supports: supports,
+	edit: Edit,
+	save: () => null,
 };

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
@@ -2,15 +2,15 @@
  * WordPress dependencies
  */
 import { InspectorControls as CoreInspectorControlsContainer } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToggleControl }             from '@wordpress/components';
-import { Component }                                           from '@wordpress/element';
-import { __ }                                                  from '@wordpress/i18n';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { featuredImageSizePresets, ImageInspectorPanel } from '../../components/image';
-import { GridInspectorPanel }                            from '../../components/post-list';
+import { GridInspectorPanel } from '../../components/post-list';
 
 /**
  * Component for block controls that appear in the Inspector Panel.
@@ -57,7 +57,7 @@ export class InspectorControls extends Component {
 				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ true }>
 					<SelectControl
 						label={ __( 'Description', 'wordcamporg' ) }
-						value={ content || 'full'  }
+						value={ content || 'full' }
 						options={ options.content }
 						onChange={ ( value ) => setAttributes( { content: value } ) }
 					/>
@@ -76,7 +76,7 @@ export class InspectorControls extends Component {
 					<ToggleControl
 						label={ __( 'Speakers', 'wordcamporg' ) }
 						help={ __( 'Show session speakers.', 'wordcamporg' ) }
-						checked={ show_speaker  === undefined ? false : show_speaker }
+						checked={ show_speaker === undefined ? false : show_speaker }
 						onChange={ ( value ) => setAttributes( { show_speaker: value } ) }
 					/>
 				</PanelBody>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-content.js
@@ -6,17 +6,17 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _n }    from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { ItemTitle, DangerousItemHTMLContent, ItemPermalink, BlockNoContent } from '../../components/block-content';
-import { AvatarImage }                                               from '../../components/image';
-import { PostList }                                                  from '../../components/post-list';
-import { filterEntities }                                            from '../../data';
-import { tokenSplit, arrayTokenReplace }                             from '../../i18n';
+import { AvatarImage } from '../../components/image';
+import { PostList } from '../../components/post-list';
+import { filterEntities } from '../../data';
+import { tokenSplit, arrayTokenReplace } from '../../i18n';
 
 /**
  * Component for the section of each speaker post that displays information about relevant sessions.
@@ -114,10 +114,10 @@ export class BlockContent extends Component {
 		const args = {};
 
 		if ( Array.isArray( item_ids ) && item_ids.length > 0 ) {
-			args.filter  = [
+			args.filter = [
 				{
-					fieldName  : mode === 'wcb_speaker' ? 'id' : 'speaker_group',
-					fieldValue : item_ids,
+					fieldName: mode === 'wcb_speaker' ? 'id' : 'speaker_group',
+					fieldValue: item_ids,
 				},
 			];
 		}
@@ -137,9 +137,9 @@ export class BlockContent extends Component {
 		const { wcb_track: tracks } = entities;
 		const { show_avatars, avatar_size, avatar_align, content, show_session } = attributes;
 
-		const posts     = this.getFilteredPosts();
+		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
-		const hasPosts  = ! isLoading && posts.length > 0;
+		const hasPosts = ! isLoading && posts.length > 0;
 
 		if ( isLoading || ! hasPosts ) {
 			return (

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/block-controls.js
@@ -7,17 +7,17 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Button, Placeholder } from '@wordpress/components';
-import { Component }           from '@wordpress/element';
-import { __ }                  from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { PlaceholderSpecificMode } from '../../components/block-controls';
-import { getOptionLabel }          from '../../components/item-select';
-import { BlockContent }            from './block-content';
-import { ContentSelect }           from './content-select';
-import { LABEL }                   from './index';
+import { getOptionLabel } from '../../components/item-select';
+import { BlockContent } from './block-content';
+import { ContentSelect } from './content-select';
+import { LABEL } from './index';
 
 /**
  * Component for displaying a UI within the block.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/content-select.js
@@ -7,7 +7,7 @@ import { every, flatMap, includes } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ }        from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,9 +26,9 @@ export class ContentSelect extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.buildSelectOptions    = this.buildSelectOptions.bind( this );
+		this.buildSelectOptions = this.buildSelectOptions.bind( this );
 		this.getCurrentSelectValue = this.getCurrentSelectValue.bind( this );
-		this.isLoading             = this.isLoading.bind( this );
+		this.isLoading = this.isLoading.bind( this );
 	}
 
 	/**
@@ -42,16 +42,16 @@ export class ContentSelect extends Component {
 
 		const optionGroups = [
 			{
-				entityType : 'post',
-				type       : 'wcb_speaker',
-				label      : __( 'Speakers', 'wordcamporg' ),
-				items      : wcb_speaker,
+				entityType: 'post',
+				type: 'wcb_speaker',
+				label: __( 'Speakers', 'wordcamporg' ),
+				items: wcb_speaker,
 			},
 			{
-				entityType : 'term',
-				type       : 'wcb_speaker_group',
-				label      : __( 'Groups', 'wordcamporg' ),
-				items      : wcb_speaker_group,
+				entityType: 'term',
+				type: 'wcb_speaker_group',
+				label: __( 'Groups', 'wordcamporg' ),
+				items: wcb_speaker_group,
 			},
 		];
 
@@ -110,9 +110,9 @@ export class ContentSelect extends Component {
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
 				selectProps={ {
-					options           : this.buildSelectOptions(),
-					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData, { context } ) => (
+					options: this.buildSelectOptions(),
+					isLoading: this.isLoading(),
+					formatOptionLabel: ( optionData, { context } ) => (
 						<Option
 							context={ context }
 							icon={ 'wcb_speaker_group' === optionData.type ? icon : null }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/edit.js
@@ -1,17 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { withSelect }          from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { LayoutToolbar }     from '../../components/post-list';
-import { WC_BLOCKS_STORE }   from '../../data';
-import { BlockControls }     from './block-controls';
+import { LayoutToolbar } from '../../components/post-list';
+import { WC_BLOCKS_STORE } from '../../data';
+import { BlockControls } from './block-controls';
 import { InspectorControls } from './inspector-controls';
-import { ICON }              from './index';
+import { ICON } from './index';
 
 const blockData = window.WordCampBlocks.speakers || {};
 
@@ -25,8 +25,8 @@ class SpeakersEdit extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes }  = this.props;
-		const { mode, layout }               = attributes;
+		const { attributes, setAttributes } = this.props;
+		const { mode, layout } = attributes;
 		const { layout: layoutOptions = {} } = blockData.options;
 
 		return (
@@ -54,9 +54,9 @@ const speakersSelect = ( select ) => {
 	const { getEntities } = select( WC_BLOCKS_STORE );
 
 	const entities = {
-		wcb_speaker       : getEntities( 'postType', 'wcb_speaker', { _embed: true } ),
-		wcb_speaker_group : getEntities( 'taxonomy', 'wcb_speaker_group' ),
-		wcb_track         : getEntities( 'taxonomy', 'wcb_track' ),
+		wcb_speaker: getEntities( 'postType', 'wcb_speaker', { _embed: true } ),
+		wcb_speaker_group: getEntities( 'taxonomy', 'wcb_speaker_group' ),
+		wcb_track: getEntities( 'taxonomy', 'wcb_track' ),
 	};
 
 	return {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/index.js
@@ -9,20 +9,20 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import { Edit } from './edit.js';
 
-export const NAME  = 'wordcamp/speakers';
+export const NAME = 'wordcamp/speakers';
 export const LABEL = __( 'Speakers', 'wordcamporg' );
-export const ICON  = 'megaphone';
+export const ICON = 'megaphone';
 
 const supports = {
 	align: [ 'wide', 'full' ],
 };
 
 export const SETTINGS = {
-	title       : __( 'Speakers', 'wordcamporg' ),
-	description : __( 'Add a list of speakers.', 'wordcamporg' ),
-	icon        : ICON,
-	category    : 'wordcamp',
-	supports    : supports,
-	edit        : Edit,
-	save        : () => null,
+	title: __( 'Speakers', 'wordcamporg' ),
+	description: __( 'Add a list of speakers.', 'wordcamporg' ),
+	icon: ICON,
+	category: 'wordcamp',
+	supports: supports,
+	edit: Edit,
+	save: () => null,
 };

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
@@ -2,33 +2,33 @@
  * WordPress dependencies
  */
 import { InspectorControls as CoreInspectorControlsContainer } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToggleControl }             from '@wordpress/components';
-import { Component }                                           from '@wordpress/element';
-import { __ }                                                  from '@wordpress/i18n';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { avatarSizePresets, ImageInspectorPanel } from '../../components/image';
-import { GridInspectorPanel }                     from '../../components/post-list';
+import { GridInspectorPanel } from '../../components/post-list';
 
 const DEFAULT_SCHEMA = {
 	grid_columns: {
-		default : 2,
-		minimum : 2,
-		maximum : 4,
+		default: 2,
+		minimum: 2,
+		maximum: 4,
 	},
 	avatar_size: {
-		default : 150,
-		minimum : 25,
-		maximum : 600,
+		default: 150,
+		minimum: 25,
+		maximum: 600,
 	},
 };
 
 const DEFAULT_OPTIONS = {
-	align_image : {},
-	content     : {},
-	sort        : {},
+	align_image: {},
+	content: {},
+	sort: {},
 };
 
 /**

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-content.js
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-import { get }    from 'lodash';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ }        from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { ItemTitle, DangerousItemHTMLContent, ItemPermalink, BlockNoContent } from '../../components/block-content';
-import { FeaturedImage }                                             from '../../components/image';
-import { PostList }                                                  from '../../components/post-list';
-import { filterEntities }                                            from '../../data';
+import { FeaturedImage } from '../../components/image';
+import { PostList } from '../../components/post-list';
+import { filterEntities } from '../../data';
 
 /**
  * Component for displaying the block content.
@@ -46,10 +46,10 @@ export class BlockContent extends Component {
 		const args = {};
 
 		if ( Array.isArray( item_ids ) && item_ids.length > 0 ) {
-			args.filter  = [
+			args.filter = [
 				{
-					fieldName  : mode === 'wcb_sponsor' ? 'id' : 'sponsor_level',
-					fieldValue : item_ids,
+					fieldName: mode === 'wcb_sponsor' ? 'id' : 'sponsor_level',
+					fieldValue: item_ids,
 				},
 			];
 		}
@@ -68,9 +68,9 @@ export class BlockContent extends Component {
 		const { attributes } = this.props;
 		const { show_name, show_logo, featured_image_width, image_align, content } = attributes;
 
-		const posts     = this.getFilteredPosts();
+		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
-		const hasPosts  = ! isLoading && posts.length > 0;
+		const hasPosts = ! isLoading && posts.length > 0;
 
 		if ( isLoading || ! hasPosts ) {
 			return (

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/block-controls.js
@@ -7,17 +7,17 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Button, Placeholder } from '@wordpress/components';
-import { Component }           from '@wordpress/element';
-import { __ }                  from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { PlaceholderSpecificMode } from '../../components/block-controls';
-import { getOptionLabel }          from '../../components/item-select';
-import { BlockContent }            from './block-content';
-import { ContentSelect }           from './content-select';
-import { LABEL }                   from './index';
+import { getOptionLabel } from '../../components/item-select';
+import { BlockContent } from './block-content';
+import { ContentSelect } from './content-select';
+import { LABEL } from './index';
 
 /**
  * Component for displaying a UI within the block.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/content-select.js
@@ -7,7 +7,7 @@ import { every, flatMap, includes } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ }        from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,9 +26,9 @@ export class ContentSelect extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.buildSelectOptions    = this.buildSelectOptions.bind( this );
+		this.buildSelectOptions = this.buildSelectOptions.bind( this );
 		this.getCurrentSelectValue = this.getCurrentSelectValue.bind( this );
-		this.isLoading             = this.isLoading.bind( this );
+		this.isLoading = this.isLoading.bind( this );
 	}
 
 	/**
@@ -42,16 +42,16 @@ export class ContentSelect extends Component {
 
 		const optionGroups = [
 			{
-				entityType : 'post',
-				type       : 'wcb_sponsor',
-				label      : __( 'Sponsors', 'wordcamporg' ),
-				items      : wcb_sponsor,
+				entityType: 'post',
+				type: 'wcb_sponsor',
+				label: __( 'Sponsors', 'wordcamporg' ),
+				items: wcb_sponsor,
 			},
 			{
-				entityType : 'term',
-				type       : 'wcb_sponsor_level',
-				label      : __( 'Sponsors Levels', 'wordcamporg' ),
-				items      : wcb_sponsor_level,
+				entityType: 'term',
+				type: 'wcb_sponsor_level',
+				label: __( 'Sponsors Levels', 'wordcamporg' ),
+				items: wcb_sponsor_level,
 			},
 		];
 
@@ -110,9 +110,9 @@ export class ContentSelect extends Component {
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
 				selectProps={ {
-					options           : this.buildSelectOptions(),
-					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData, { context } ) => (
+					options: this.buildSelectOptions(),
+					isLoading: this.isLoading(),
+					formatOptionLabel: ( optionData, { context } ) => (
 						<Option
 							context={ context }
 							icon={ 'wcb_sponsor_level' === optionData.type ? icon : null }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
@@ -1,17 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { withSelect }          from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { LayoutToolbar }     from '../../components/post-list';
-import { WC_BLOCKS_STORE }   from '../../data';
-import { BlockControls }     from './block-controls';
+import { LayoutToolbar } from '../../components/post-list';
+import { WC_BLOCKS_STORE } from '../../data';
+import { BlockControls } from './block-controls';
 import { InspectorControls } from './inspector-controls';
-import { ICON }              from './index';
+import { ICON } from './index';
 
 const blockData = window.WordCampBlocks.sponsors || {};
 
@@ -25,8 +25,8 @@ class SponsorsEdit extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes }  = this.props;
-		const { mode, layout }               = attributes;
+		const { attributes, setAttributes } = this.props;
+		const { mode, layout } = attributes;
 		const { layout: layoutOptions = {} } = blockData.options;
 
 		return (
@@ -54,14 +54,14 @@ const sponsorSelect = ( select ) => {
 	const { getEntities, getSiteSettings } = select( WC_BLOCKS_STORE );
 
 	const entities = {
-		wcb_sponsor       : getEntities( 'postType', 'wcb_sponsor', { _embed: true } ),
-		wcb_sponsor_level : getEntities( 'taxonomy', 'wcb_sponsor_level' ),
+		wcb_sponsor: getEntities( 'postType', 'wcb_sponsor', { _embed: true } ),
+		wcb_sponsor_level: getEntities( 'taxonomy', 'wcb_sponsor_level' ),
 	};
 
 	return {
-		blockData    : blockData,
-		entities     : entities,
-		siteSettings : getSiteSettings(),
+		blockData: blockData,
+		entities: entities,
+		siteSettings: getSiteSettings(),
 	};
 };
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/index.js
@@ -8,20 +8,20 @@ import { __ } from '@wordpress/i18n';
  */
 import { Edit } from './edit.js';
 
-export const NAME  = 'wordcamp/sponsors';
+export const NAME = 'wordcamp/sponsors';
 export const LABEL = __( 'Sponsors', 'wordcamporg' );
-export const ICON  = 'heart';
+export const ICON = 'heart';
 
 const supports = {
 	align: [ 'wide', 'full' ],
 };
 
 export const SETTINGS = {
-	title       : __( 'Sponsors', 'wordcamporg' ),
-	description : __( "We wouldn't have WordCamp without their support.", 'wordcamporg' ),
-	icon        : ICON,
-	category    : 'wordcamp',
-	supports    : supports,
-	edit        : Edit,
-	save        : () => null,
+	title: __( 'Sponsors', 'wordcamporg' ),
+	description: __( "We wouldn't have WordCamp without their support.", 'wordcamporg' ),
+	icon: ICON,
+	category: 'wordcamp',
+	supports: supports,
+	edit: Edit,
+	save: () => null,
 };

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
@@ -2,20 +2,20 @@
  * WordPress dependencies
  */
 import { InspectorControls as CoreInspectorControlsContainer } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, SelectControl }             from '@wordpress/components';
-import { Component }                                           from '@wordpress/element';
-import { __ }                                                  from '@wordpress/i18n';
+import { PanelBody, ToggleControl, SelectControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { featuredImageSizePresets, ImageInspectorPanel } from '../../components/image';
-import { GridInspectorPanel }                            from '../../components/post-list';
+import { GridInspectorPanel } from '../../components/post-list';
 
 const DEFAULT_OPTIONS = {
-	align_image : {},
-	content     : {},
-	sort        : {},
+	align_image: {},
+	content: {},
+	sort: {},
 };
 
 /**

--- a/public_html/wp-content/mu-plugins/blocks/source/components/block-content/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/block-content/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { Disabled, Spinner } from '@wordpress/components';
 import { Fragment, RawHTML } from '@wordpress/element';
-import { __ }                from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/avatar.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/avatar.js
@@ -6,35 +6,35 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Disabled }            from '@wordpress/components';
-import { __, _x, sprintf }     from '@wordpress/i18n';
+import { Disabled } from '@wordpress/components';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { addQueryArgs, isURL } from '@wordpress/url';
 
 // Avatar-specific presets for the ImageSizeControl component.
 export const avatarSizePresets = [
 	{
-		name      : __( 'Small', 'wordcamporg' ),
-		shortName : _x( 'S', 'size small', 'wordcamporg' ),
-		size      : 90,
-		slug      : 'small',
+		name: __( 'Small', 'wordcamporg' ),
+		shortName: _x( 'S', 'size small', 'wordcamporg' ),
+		size: 90,
+		slug: 'small',
 	},
 	{
-		name      : __( 'Regular', 'wordcamporg' ),
-		shortName : _x( 'M', 'size medium', 'wordcamporg' ),
-		size      : 150,
-		slug      : 'regular',
+		name: __( 'Regular', 'wordcamporg' ),
+		shortName: _x( 'M', 'size medium', 'wordcamporg' ),
+		size: 150,
+		slug: 'regular',
 	},
 	{
-		name      : __( 'Large', 'wordcamporg' ),
-		shortName : _x( 'L', 'size large', 'wordcamporg' ),
-		size      : 300,
-		slug      : 'large',
+		name: __( 'Large', 'wordcamporg' ),
+		shortName: _x( 'L', 'size large', 'wordcamporg' ),
+		size: 300,
+		slug: 'large',
 	},
 	{
-		name      : __( 'Larger', 'wordcamporg' ),
-		shortName : _x( 'XL', 'size extra large', 'wordcamporg' ),
-		size      : 500,
-		slug      : 'larger',
+		name: __( 'Larger', 'wordcamporg' ),
+		shortName: _x( 'XL', 'size extra large', 'wordcamporg' ),
+		size: 500,
+		slug: 'larger',
 	},
 ];
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/featured-image.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/featured-image.js
@@ -7,10 +7,10 @@ import { sortBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Disabled }  from '@wordpress/components';
+import { Disabled } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { __, _x }    from '@wordpress/i18n';
-import { isURL }     from '@wordpress/url';
+import { __, _x } from '@wordpress/i18n';
+import { isURL } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -20,28 +20,28 @@ import './featured-image.scss';
 // Featured Image-specific presets for the ImageSizeControl component.
 export const featuredImageSizePresets = [
 	{
-		name      : __( 'Small', 'wordcamporg' ),
-		shortName : _x( 'S', 'size small', 'wordcamporg' ),
-		size      : 150,
-		slug      : 'small',
+		name: __( 'Small', 'wordcamporg' ),
+		shortName: _x( 'S', 'size small', 'wordcamporg' ),
+		size: 150,
+		slug: 'small',
 	},
 	{
-		name      : __( 'Regular', 'wordcamporg' ),
-		shortName : _x( 'M', 'size medium', 'wordcamporg' ),
-		size      : 300,
-		slug      : 'regular',
+		name: __( 'Regular', 'wordcamporg' ),
+		shortName: _x( 'M', 'size medium', 'wordcamporg' ),
+		size: 300,
+		slug: 'regular',
 	},
 	{
-		name      : __( 'Large', 'wordcamporg' ),
-		shortName : _x( 'L', 'size large', 'wordcamporg' ),
-		size      : 600,
-		slug      : 'large',
+		name: __( 'Large', 'wordcamporg' ),
+		shortName: _x( 'L', 'size large', 'wordcamporg' ),
+		size: 600,
+		slug: 'large',
 	},
 	{
-		name      : __( 'Larger', 'wordcamporg' ),
-		shortName : _x( 'XL', 'size extra large', 'wordcamporg' ),
-		size      : 1024,
-		slug      : 'larger',
+		name: __( 'Larger', 'wordcamporg' ),
+		shortName: _x( 'XL', 'size extra large', 'wordcamporg' ),
+		size: 1024,
+		slug: 'larger',
 	},
 ];
 
@@ -70,8 +70,8 @@ export class FeaturedImage extends Component {
 		const image = this.constructor.getWidestImage( media_details );
 
 		this.state = {
-			image : image,
-			alt   : alt_text,
+			image: image,
+			alt: alt_text,
 		};
 	}
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classnames   from 'classnames';
+import classnames from 'classnames';
 import { debounce } from 'lodash';
 
 /**
@@ -16,9 +16,9 @@ import {
 	RangeControl,
 	ToggleControl,
 	Toolbar,
-}                              from '@wordpress/components';
+} from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
-import { __ }                  from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -54,8 +54,8 @@ export class ImageSizeControl extends Component {
 		super( props );
 
 		this.state = {
-			value    : props.value,
-			onChange : debounce( props.onChange, 10 ), // Higher values lead to a noticeable degradation in visual feedback.
+			value: props.value,
+			onChange: debounce( props.onChange, 10 ), // Higher values lead to a noticeable degradation in visual feedback.
 		};
 
 		this.onChange = this.onChange.bind( this );
@@ -169,10 +169,10 @@ export function ImageAlignmentControl( {
 					const iconSlug = `align-${ alignment.value }`;
 
 					return {
-						title    : alignment.label,
-						icon     : iconSlug,
-						isActive : isActive,
-						onClick  : () => {
+						title: alignment.label,
+						icon: iconSlug,
+						isActive: isActive,
+						onClick: () => {
 							onChange( alignment.value );
 						},
 					};
@@ -238,8 +238,8 @@ export class ImageInspectorPanel extends Component {
 							sizePresets={ sizePresets }
 							onChange={ onChangeSize }
 							rangeProps={ {
-								min : Number( sizeSchema.minimum ),
-								max : Number( sizeSchema.maximum ),
+								min: Number( sizeSchema.minimum ),
+								max: Number( sizeSchema.maximum ),
 							} }
 						/>
 						{ /* The PanelRow wrapper prevents the toolbar from expanding to full width. */ }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import Select     from 'react-select';
+import Select from 'react-select';
 
 /**
  * WordPress dependencies
  */
 import { BaseControl, Button } from '@wordpress/components';
-import { Component }           from '@wordpress/element';
-import { __ }                  from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -27,42 +27,42 @@ const customStyles = {
 	} ),
 	multiValue: ( provided ) => ( {
 		...provided,
-		backgroundColor : '#e2e4e7',
-		borderRadius    : '12px',
+		backgroundColor: '#e2e4e7',
+		borderRadius: '12px',
 	} ),
 	multiValueLabel: ( provided ) => ( {
 		...provided,
-		padding     : '6px 4px',
-		paddingLeft : '12px', // We need to specifically override `provided.paddingLeft`.
-		fontSize    : '0.9em',
-		lineHeight  : 1,
+		padding: '6px 4px',
+		paddingLeft: '12px', // We need to specifically override `provided.paddingLeft`.
+		fontSize: '0.9em',
+		lineHeight: 1,
 	} ),
 	multiValueRemove: ( provided, { isFocused } ) => ( {
 		...provided,
-		backgroundColor : isFocused ? '#fff' : '#e2e4e7',
-		boxShadow       : isFocused ? 'inset 0 0 0 1px #6c7781, inset 0 0 0 2px #fff' : null,
-		borderRadius    : '0 12px 12px 0',
+		backgroundColor: isFocused ? '#fff' : '#e2e4e7',
+		boxShadow: isFocused ? 'inset 0 0 0 1px #6c7781, inset 0 0 0 2px #fff' : null,
+		borderRadius: '0 12px 12px 0',
 
 		svg: {
-			color        : isFocused ? '#fff' : '#e2e4e7',
-			background   : isFocused ? '#191e23' : '#555d66',
-			borderRadius : '10px',
+			color: isFocused ? '#fff' : '#e2e4e7',
+			background: isFocused ? '#191e23' : '#555d66',
+			borderRadius: '10px',
 		},
 
 		':hover': {
-			backgroundColor : '#fff',
-			boxShadow       : 'inset 0 0 0 1px #6c7781, inset 0 0 0 2px #fff',
+			backgroundColor: '#fff',
+			boxShadow: 'inset 0 0 0 1px #6c7781, inset 0 0 0 2px #fff',
 
 			svg: {
-				color      : '#fff',
-				background : '#191e23',
+				color: '#fff',
+				background: '#191e23',
 			},
 		},
 	} ),
 	option: ( provided, { isDisabled } ) => ( {
 		...provided,
-		color   : 'inherit',
-		opacity : isDisabled ? 0.7 : 1,
+		color: 'inherit',
+		opacity: isDisabled ? 0.7 : 1,
 	} ),
 };
 
@@ -137,13 +137,13 @@ export class ItemSelect extends Component {
 			const chosen = selectedOptions[ 0 ].type;
 
 			attributes = {
-				mode     : chosen,
-				item_ids : newValue,
+				mode: chosen,
+				item_ids: newValue,
 			};
 		} else {
 			attributes = {
-				mode     : '',
-				item_ids : [],
+				mode: '',
+				item_ids: [],
 			};
 		}
 
@@ -161,9 +161,9 @@ export class ItemSelect extends Component {
 		const id = `wordcamp-item-select-control-${ instanceId }`;
 
 		const mergedSelectProps = {
-			isMulti          : true,
-			isOptionDisabled : this.constructor.isOptionDisabled,
-			formatGroupLabel : this.constructor.formatGroupLabel,
+			isMulti: true,
+			isOptionDisabled: this.constructor.isOptionDisabled,
+			formatGroupLabel: this.constructor.formatGroupLabel,
 			...selectProps,
 		};
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get }        from 'lodash';
+import { get } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { filterEntities }    from '../../data';
+import { filterEntities } from '../../data';
 
 const buildOptionGroup = ( entityType, type, label, items ) => {
 	items = items.map( ( item ) => {
@@ -21,23 +21,23 @@ const buildOptionGroup = ( entityType, type, label, items ) => {
 		switch ( entityType ) {
 			case 'post':
 				parsedItem = {
-					label   : item.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ),
-					value   : item.id,
-					type    : type,
-					details : item.details,
+					label: item.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ),
+					value: item.id,
+					type: type,
+					details: item.details,
 				};
 
 				parsedItem.avatar = get( item, 'avatar_urls[\'24\']', '' );
-				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'][0].media_details.sizes.thumbnail.source_url', '' );
+				parsedItem.image = get( item, '_embedded[\'wp:featuredmedia\'][0].media_details.sizes.thumbnail.source_url', '' );
 
 				break;
 
 			case 'term':
 				parsedItem = {
-					label : item.name || __( '(Untitled)', 'wordcamporg' ),
-					value : item.id,
-					type  : type,
-					count : item.count,
+					label: item.name || __( '(Untitled)', 'wordcamporg' ),
+					value: item.id,
+					type: type,
+					count: item.count,
 				};
 				break;
 		}
@@ -46,8 +46,8 @@ const buildOptionGroup = ( entityType, type, label, items ) => {
 	} );
 
 	return {
-		label   : label,
-		options : items,
+		label: label,
+		options: items,
 	};
 };
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/post-list/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/post-list/inspector-controls.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { PanelBody, RangeControl } from '@wordpress/components';
-import { Component, Fragment }     from '@wordpress/element';
-import { __ }                      from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Component for a range control that adjusts the number of columns in a post list grid.

--- a/public_html/wp-content/mu-plugins/blocks/source/components/post-list/toolbar.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/post-list/toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Toolbar }       from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
 import { BlockControls } from '@wordpress/editor';
 
 /**
@@ -21,14 +21,14 @@ export function LayoutToolbar( {
 	setAttributes,
 } ) {
 	const controls = options.map( ( option ) => {
-		const icon     = `${ option.value }-view`;
+		const icon = `${ option.value }-view`;
 		const isActive = layout === option.value;
 
 		return {
-			icon     : icon,
-			title    : option.label,
-			isActive : isActive,
-			onClick  : () => {
+			icon: icon,
+			title: option.label,
+			isActive: isActive,
+			onClick: () => {
 				setAttributes( { layout: option.value } );
 			},
 		};

--- a/public_html/wp-content/mu-plugins/blocks/source/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/data/index.js
@@ -6,7 +6,7 @@ import { intersection, orderBy, split } from 'lodash';
 /**
  * WordPress dependencies
  */
-import apiFetch                            from '@wordpress/api-fetch';
+import apiFetch from '@wordpress/api-fetch';
 import { registerStore, select, dispatch } from '@wordpress/data';
 
 /**
@@ -103,8 +103,8 @@ const actions = {
 	 */
 	setSiteSettings( settings ) {
 		return {
-			type     : 'SET_SETTINGS',
-			settings : settings,
+			type: 'SET_SETTINGS',
+			settings: settings,
 		};
 	},
 };

--- a/public_html/wp-content/mu-plugins/blocks/webpack.config.js
+++ b/public_html/wp-content/mu-plugins/blocks/webpack.config.js
@@ -27,9 +27,9 @@ module.exports = {
 		rules: [
 			...defaultConfig.module.rules,
 			{
-				test    : /\.(sc|sa|c)ss$/,
-				exclude : [ /node_modules/ ],
-				use     : [ MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader' ],
+				test: /\.(sc|sa|c)ss$/,
+				exclude: [ /node_modules/ ],
+				use: [ MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader' ],
 			},
 		],
 	},


### PR DESCRIPTION
This PR removes the overrides to `no-multi-spaces` & `key-spacing`.

As a WordPress community project, we should be following the core coding standards with as few modifications as possible, so that anyone involved in a core project can jump into our codebase without needing to learn a new style. Additionally, by overriding the `no-multi-spaces` rule, we're also opening the possibility of incorrect spacing elsewhere in the code.

Fixes #148, fixes #149.

**To test**

1. Run `npm run lint:js`
2. There should be no errors