### PR TITLE
Post Types: Fix escaping of HTML elements for speaker name links

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -2590,7 +2590,8 @@ class WordCamp_Post_Types_Plugin {
 					$output[] = sprintf( '<a href="%s">%s</a>', esc_url( get_edit_post_link( $speaker->ID ) ), esc_html( apply_filters( 'the_title', $speaker->post_title ) ) );
 				}
 
-				echo( esc_html( implode( ', ', $output ) ) );
+				// Output is escaped when the string is built, so we can ignore the PHPCS error.
+				echo implode( ', ', $output ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 				break;
 


### PR DESCRIPTION
Each speaker name is added to the session post type table row, as a link. The speaker name is escaped when the link is created, and escaping again before output is encoding the link HTML. We can remove this extra escaping, so that the link is correctly rendered in each row.

Before:

<img width="1112" alt="before" src="https://user-images.githubusercontent.com/541093/61747212-5cb54400-ad6b-11e9-9d63-f300c959e2fd.png">

After:

<img width="1114" alt="after" src="https://user-images.githubusercontent.com/541093/61747214-5cb54400-ad6b-11e9-9e53-5993d4fe6377.png">

**To test**

1. View the list of sessions (need to have speakers attached)
2. Speakers should be clickable links to the speaker post