### PR TITLE
Post Types: Allow any speaker to be attached to a session

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1731,7 +1731,7 @@ class WordCamp_Post_Types_Plugin {
 		$speakers_names   = array();
 		$speakers_objects = get_posts( array(
 			'post_type'      => 'wcb_speaker',
-			'post_status'    => 'publish',
+			'post_status'    => 'any',
 			'posts_per_page' => -1,
 		) );
 


### PR DESCRIPTION
When content is created, speakers are left as drafts to not "prematurely announce" speakers. If the posts are created by the form, the speakers + sessions are correctly attached, but if you're manually creating or updating sessions, you can't add draft speakers to sessions.

This shouldn't be displayed on the frontend since `add_speaker_info_to_session_posts` queries for published speakers (though "private" speakers will be shown to users on the site, as is the current behavior).

The issue came up from a conversation with WCUS organizers about how we can attach speakers to sessions without publishing (and thereby revealing) the speakers. Ideally we can create sessions, attach speakers, and then once we're ready to announce accepted speakers, just publish everyone.