### PR TITLE
Blocks: Update selected items to match design

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
@@ -112,11 +112,14 @@ export class ContentSelect extends Component {
 				selectProps={ {
 					options           : this.buildSelectOptions(),
 					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData ) => {
-						return (
-							<Option { ...optionData } />
-						);
-					},
+					formatOptionLabel : ( optionData, { context } ) => (
+						<Option
+							context={ context }
+							avatar={ optionData.avatar }
+							label={ optionData.label }
+							count={ optionData.count }
+						/>
+					),
 				} }
 			/>
 		);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/content-select.js
@@ -118,14 +118,14 @@ export class ContentSelect extends Component {
 				selectProps={ {
 					options           : this.buildSelectOptions(),
 					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData ) => {
-						return (
-							<Option
-								icon={ includes( [ 'wcb_track', 'wcb_session_category' ], optionData.type ) ? icon : null }
-								{ ...optionData }
-							/>
-						);
-					},
+					formatOptionLabel : ( optionData, { context } ) => (
+						<Option
+							icon={ includes( [ 'wcb_track', 'wcb_session_category' ], optionData.type ) ? icon : null }
+							label={ optionData.label }
+							count={ optionData.count }
+							context={ context }
+						/>
+					),
 				} }
 			/>
 		);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/content-select.js
@@ -112,14 +112,15 @@ export class ContentSelect extends Component {
 				selectProps={ {
 					options           : this.buildSelectOptions(),
 					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData ) => {
-						return (
-							<Option
-								icon={ 'wcb_speaker_group' === optionData.type ? icon : null }
-								{ ...optionData }
-							/>
-						);
-					},
+					formatOptionLabel : ( optionData, { context } ) => (
+						<Option
+							context={ context }
+							icon={ 'wcb_speaker_group' === optionData.type ? icon : null }
+							label={ optionData.label }
+							avatar={ optionData.avatar }
+							count={ optionData.count }
+						/>
+					),
 				} }
 			/>
 		);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/content-select.js
@@ -112,14 +112,14 @@ export class ContentSelect extends Component {
 				selectProps={ {
 					options           : this.buildSelectOptions(),
 					isLoading         : this.isLoading(),
-					formatOptionLabel : ( optionData ) => {
-						return (
-							<Option
-								icon={ 'wcb_sponsor_level' === optionData.type ? icon : null }
-								{ ...optionData }
-							/>
-						);
-					},
+					formatOptionLabel : ( optionData, { context } ) => (
+						<Option
+							context={ context }
+							icon={ 'wcb_sponsor_level' === optionData.type ? icon : null }
+							label={ optionData.label }
+							count={ optionData.count }
+						/>
+					),
 				} }
 			/>
 		);

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -165,4 +165,5 @@ export class ItemSelect extends Component {
 /**
  * Additional component exports
  */
-export * from './option';
+export { buildOptions, getOptionLabel } from './utils';
+export { Option } from './option';

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -25,6 +25,40 @@ const customStyles = {
 		...provided,
 		display: 'none',
 	} ),
+	multiValue: ( provided ) => ( {
+		...provided,
+		backgroundColor : '#e2e4e7',
+		borderRadius    : '12px',
+	} ),
+	multiValueLabel: ( provided ) => ( {
+		...provided,
+		padding     : '6px 4px',
+		paddingLeft : '12px', // We need to specifically override `provided.paddingLeft`.
+		fontSize    : '0.9em',
+		lineHeight  : 1,
+	} ),
+	multiValueRemove: ( provided, { isFocused } ) => ( {
+		...provided,
+		backgroundColor : isFocused ? '#fff' : '#e2e4e7',
+		boxShadow       : isFocused ? 'inset 0 0 0 1px #6c7781, inset 0 0 0 2px #fff' : null,
+		borderRadius    : '0 12px 12px 0',
+
+		svg: {
+			color        : isFocused ? '#fff' : '#e2e4e7',
+			background   : isFocused ? '#191e23' : '#555d66',
+			borderRadius : '10px',
+		},
+
+		':hover': {
+			backgroundColor : '#fff',
+			boxShadow       : 'inset 0 0 0 1px #6c7781, inset 0 0 0 2px #fff',
+
+			svg: {
+				color      : '#fff',
+				background : '#191e23',
+			},
+		},
+	} ),
 };
 
 /**

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -144,6 +144,7 @@ export class ItemSelect extends Component {
 						onChange={ ( selectedOptions ) => {
 							this.setState( { selectedOptions: selectedOptions || [] } );
 						} }
+						isClearable={ false }
 						styles={ customStyles }
 						{ ...mergedSelectProps }
 					/>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -17,6 +17,17 @@ import { __ }                  from '@wordpress/i18n';
 import './style.scss';
 
 /**
+ * Style object passed to ReactSelect component.
+ * See https://react-select.com/styles
+ */
+const customStyles = {
+	indicatorSeparator: ( provided ) => ( {
+		...provided,
+		display: 'none',
+	} ),
+};
+
+/**
  * Component for selecting one or more related entities to be used as content in a block.
  */
 export class ItemSelect extends Component {
@@ -133,6 +144,7 @@ export class ItemSelect extends Component {
 						onChange={ ( selectedOptions ) => {
 							this.setState( { selectedOptions: selectedOptions || [] } );
 						} }
+						styles={ customStyles }
 						{ ...mergedSelectProps }
 					/>
 					<Button

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
@@ -19,12 +19,21 @@ import { AvatarImage } from '../image';
  *     @type {string} icon
  *     @type {string} label
  *     @type {number} count
+ *     @type {string} context - `menu` or `value` for whether it's in the menu dropdown or the selected token.
  * }
  *
  * @return {Element}
  */
-export function Option( { avatar, icon, label, count } ) {
+export function Option( { avatar, icon, label, count, context } ) {
 	let image;
+
+	if ( 'value' === context ) {
+		return (
+			<div className="wordcamp-item-select__token">
+				{ label }
+			</div>
+		);
+	}
 
 	if ( avatar ) {
 		image = (
@@ -47,21 +56,17 @@ export function Option( { avatar, icon, label, count } ) {
 		);
 	}
 
-	const content = (
-		<span className="wordcamp-item-select__option-label">
-			{ label }
-			{ 'undefined' !== typeof count &&
-				<span className="wordcamp-item-select__option-label-count">
-					{ count }
-				</span>
-			}
-		</span>
-	);
-
 	return (
 		<div className="wordcamp-item-select__option">
 			{ image }
-			{ content }
+			<span className="wordcamp-item-select__option-label">
+				{ label }
+				{ 'undefined' !== typeof count && (
+					<span className="wordcamp-item-select__option-label-count">
+						{ count }
+					</span>
+				) }
+			</span>
 		</div>
 	);
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
@@ -1,121 +1,12 @@
 /**
- * External dependencies
- */
-import { get }        from 'lodash';
-import createSelector from 'rememo';
-
-/**
  * WordPress dependencies
  */
 import { Dashicon } from '@wordpress/components';
-import { __ }       from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { filterEntities } from '../../data';
-import { AvatarImage }    from '../image';
-
-const buildOptionGroup = ( entityType, type, label, items ) => {
-	items = items.map( ( item ) => {
-		let parsedItem;
-
-		switch ( entityType ) {
-			case 'post':
-				parsedItem = {
-					label : item.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ),
-					value : item.id,
-					type  : type,
-				};
-
-				parsedItem.avatar = get( item, 'avatar_urls[\'24\']', '' );
-				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'].media_details.sizes.thumbnail.source_url', '' );
-				break;
-
-			case 'term':
-				parsedItem = {
-					label : item.name || __( '(Untitled)', 'wordcamporg' ),
-					value : item.id,
-					type  : type,
-					count : item.count,
-				};
-				break;
-		}
-
-		return parsedItem;
-	} );
-
-	return {
-		label   : label,
-		options : items,
-	};
-};
-
-/**
- * A memoized function that parses structured data into a format used as an option set by ItemSelect.
- *
- * @return {Array}
- */
-export const buildOptions = createSelector(
-	( groups ) => {
-		const options = [];
-
-		groups.forEach( ( group ) => {
-			const { entityType, type, label, items } = group;
-			let orderby;
-
-			switch ( entityType ) {
-				case 'post':
-					orderby = 'title.rendered';
-					break;
-				case 'term':
-					orderby = 'name';
-					break;
-			}
-
-			if ( Array.isArray( items ) && items.length ) {
-				const sortedItems = filterEntities( items, { sort: orderby + '_asc' } );
-
-				options.push( buildOptionGroup( entityType, type, label, sortedItems ) );
-			}
-		} );
-
-		return options;
-	},
-	( groups ) => {
-		const references = [];
-
-		groups.forEach( ( group ) => {
-			const { items } = group;
-
-			references.push( items );
-		} );
-
-		return references;
-	}
-);
-
-/**
- * Find the label for an option with a specific value.
- *
- * @param {string} value
- * @param {Array}  options
- *
- * @return {string}
- */
-export function getOptionLabel( value, options ) {
-	let label = '';
-
-	const selectedOption = options.find( ( option ) => {
-		return value === option.value;
-	} );
-
-	if ( selectedOption.hasOwnProperty( 'label' ) ) {
-		label = selectedOption.label;
-	}
-
-	return label;
-}
+import { AvatarImage } from '../image';
 
 /**
  * Component for a single option in an ItemSelect dropdown.

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
@@ -58,4 +58,10 @@
 
 .wordcamp-item-select {
 	width: 100%;
+
+	.wordcamp-item-select__button.components-button {
+		padding-top: 4px;
+		padding-bottom: 4px;
+		height: auto;
+	}
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
@@ -27,7 +27,7 @@ const buildOptionGroup = ( entityType, type, label, items ) => {
 				};
 
 				parsedItem.avatar = get( item, 'avatar_urls[\'24\']', '' );
-				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'].media_details.sizes.thumbnail.source_url', '' );
+				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'][0].media_details.sizes.thumbnail.source_url', '' );
 				break;
 
 			case 'term':

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { get }        from 'lodash';
+import createSelector from 'rememo';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { filterEntities } from '../../data';
+
+const buildOptionGroup = ( entityType, type, label, items ) => {
+	items = items.map( ( item ) => {
+		let parsedItem;
+
+		switch ( entityType ) {
+			case 'post':
+				parsedItem = {
+					label : item.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ),
+					value : item.id,
+					type  : type,
+				};
+
+				parsedItem.avatar = get( item, 'avatar_urls[\'24\']', '' );
+				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'].media_details.sizes.thumbnail.source_url', '' );
+				break;
+
+			case 'term':
+				parsedItem = {
+					label : item.name || __( '(Untitled)', 'wordcamporg' ),
+					value : item.id,
+					type  : type,
+					count : item.count,
+				};
+				break;
+		}
+
+		return parsedItem;
+	} );
+
+	return {
+		label   : label,
+		options : items,
+	};
+};
+
+/**
+ * A memoized function that parses structured data into a format used as an option set by ItemSelect.
+ *
+ * @return {Array}
+ */
+export const buildOptions = createSelector(
+	( groups ) => {
+		const options = [];
+
+		groups.forEach( ( group ) => {
+			const { entityType, type, label, items } = group;
+			let orderby;
+
+			switch ( entityType ) {
+				case 'post':
+					orderby = 'title.rendered';
+					break;
+				case 'term':
+					orderby = 'name';
+					break;
+			}
+
+			if ( Array.isArray( items ) && items.length ) {
+				const sortedItems = filterEntities( items, { sort: orderby + '_asc' } );
+
+				options.push( buildOptionGroup( entityType, type, label, sortedItems ) );
+			}
+		} );
+
+		return options;
+	},
+	( groups ) => {
+		const references = [];
+
+		groups.forEach( ( group ) => {
+			const { items } = group;
+
+			references.push( items );
+		} );
+
+		return references;
+	}
+);
+
+/**
+ * Find the label for an option with a specific value.
+ *
+ * @param {string} value
+ * @param {Array}  options
+ *
+ * @return {string}
+ */
+export function getOptionLabel( value, options ) {
+	let label = '';
+
+	const selectedOption = options.find( ( option ) => {
+		return value === option.value;
+	} );
+
+	if ( selectedOption.hasOwnProperty( 'label' ) ) {
+		label = selectedOption.label;
+	}
+
+	return label;
+}


### PR DESCRIPTION
Fixes #80 – clean up the UI of the select input and selected tokens. `react-select` uses `formatOptionLabel` for both options in the list and selected tokens (or chips), but differentiates by passing in `context`. So I've updated `Option` to render a simplified view when context is `value`, while keeping more detail in the list (`menu`) view.

To style the tokens themselves, I needed to hook into react-select's use of [emotion,](https://emotion.sh/docs/introduction) which is a CSS-in-JS solution, so now we have some CSS-esque code in `ItemSelect` 🙃 but the things we needed to style are available, so it's all fine.

**Screenshots**

<img width="475" alt="list" src="https://user-images.githubusercontent.com/541093/61828853-a79b8e00-ae35-11e9-86df-08f8da66f29c.png">

<img width="477" alt="picked" src="https://user-images.githubusercontent.com/541093/61828854-a79b8e00-ae35-11e9-9e3b-30a51c2ad9bd.png">

<img width="480" alt="remove-focus" src="https://user-images.githubusercontent.com/541093/61828855-a79b8e00-ae35-11e9-95dc-ef3e91bb9a78.png">

**To test**

1. Add any WC block.
2. Select items.
3. Check that nothing is misaligned, that it looks like the screenshots above.
