### PR TITLE
Blocks: Match sessions output to mockup

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -29,6 +29,10 @@ import { tokenSplit, arrayTokenReplace, intersperse, listify }       from '../..
 function SessionSpeakers( { session } ) {
 	let speakerData = get( session, '_embedded.speakers', [] );
 
+	if ( speakerData.length === 0 ) {
+		return null;
+	}
+
 	speakerData = speakerData.map( ( speaker ) => {
 		if ( speaker.hasOwnProperty( 'code' ) ) {
 			// The wporg username given for this speaker returned an error.
@@ -169,17 +173,6 @@ export class BlockContent extends Component {
 	}
 
 	/**
-	 * Determine if a session has related speaker data.
-	 *
-	 * @param {Object} session
-	 *
-	 * @return {boolean}
-	 */
-	static hasSpeaker( session ) {
-		return get( session, '_embedded.speakers', [] ).length > 0;
-	}
-
-	/**
 	 * Filter and sort the content that will be rendered.
 	 *
 	 * @returns {Array}
@@ -273,9 +266,7 @@ export class BlockContent extends Component {
 							link={ post.link }
 						/>
 
-						{ show_speaker && this.constructor.hasSpeaker( post ) &&
-							<SessionSpeakers session={ post } />
-						}
+						{ show_speaker && <SessionSpeakers session={ post } /> }
 
 						{ show_images &&
 							<FeaturedImage

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -58,9 +58,9 @@ function SessionSpeakers( { session } ) {
 	);
 
 	return (
-		<div className="wordcamp-sessions__speakers">
+		<p className="wordcamp-sessions__speakers">
 			{ speakers }
-		</div>
+		</p>
 	);
 }
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -45,7 +45,7 @@ function SessionSpeakers( { session } ) {
 		}
 
 		return (
-			<a key={ link } href={ link }>
+			<a key={ link } href={ link } target="_blank" rel="noopener noreferrer">
 				{ title }
 			</a>
 		);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/style.scss
@@ -1,15 +1,17 @@
-.wordcamp-sessions__title {
-	margin-bottom: 8px;
-}
+.editor-styles-wrapper,
+.entry-content {
+	.wordcamp-sessions__title {
+		margin-bottom: 8px;
+	}
 
-.wordcamp-sessions__speakers,
-.wordcamp-sessions__details {
-	margin: 0 0 1.5em;
-	font-size: 0.875em;
-	font-style: italic;
-}
+	.wordcamp-sessions__speakers,
+	.wordcamp-sessions__details {
+		margin: 0 0 1.5em;
+		font-size: 0.875em;
+		font-style: italic;
+	}
 
-.wordcamp-sessions__categories {
-	color: #6C7781;
+	.wordcamp-sessions__categories {
+		color: #6C7781;
+	}
 }
-

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/style.scss
@@ -1,4 +1,15 @@
+.wordcamp-sessions__title {
+	margin-bottom: 8px;
+}
 
+.wordcamp-sessions__speakers,
 .wordcamp-sessions__details {
 	margin: 0 0 1.5em;
+	font-size: 0.875em;
+	font-style: italic;
 }
+
+.wordcamp-sessions__categories {
+	color: #6C7781;
+}
+

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -37,7 +37,7 @@ setup_postdata( $session );
 		);
 		?>
 
-		<div class="wordcamp-sessions__speakers">
+		<p class="wordcamp-sessions__speakers">
 			<?php
 			printf(
 				/* translators: %s is a list of names. */
@@ -45,7 +45,7 @@ setup_postdata( $session );
 				wp_kses_post( array_to_human_readable_list( $speaker_linked_names ) )
 			);
 			?>
-		</div>
+		</p>
 	<?php endif; ?>
 
 	<?php if ( true === $attributes['show_images'] ) : ?>


### PR DESCRIPTION
Style tweaks and some minor component cleanup.

Fixes #88, fixes #89.

![Screen Shot 2019-07-25 at 5 30 20 PM](https://user-images.githubusercontent.com/541093/61910212-fadb1280-af01-11e9-871f-bb6d2e5adb47.png)

To test:

- Add a session block to a post.
- Toggle the content settings on & off.
- Display should match the screenshot (given some flexibility for theme styles).