### PR TITLE
Blocks: Increase avatars to 50px

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
@@ -40,7 +40,7 @@ export function Option( { avatar, icon, label, count, context } ) {
 			<AvatarImage
 				className="wordcamp-item-select__option-avatar"
 				name={ label }
-				size={ 24 }
+				size={ 50 }
 				url={ avatar }
 			/>
 		);

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
@@ -33,6 +33,14 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+}
+
+.wordcamp-item-select__option-avatar {
+	flex: 0 0 50px;
+	height: 50px;
+}
+
+.wordcamp-item-select__option-icon-container {
 	flex: 0 0 24px;
 	height: 24px;
 	background-color: #f3f3f4;


### PR DESCRIPTION
Fixes #93 – The issue only references speakers, but this PR bumps the size of all avatars in the dropdown to be 50px, rather than having a separate style for Organizers and Speakers.

![Screen Shot 2019-07-26 at 3 56 20 PM](https://user-images.githubusercontent.com/541093/61977989-ee1bf480-afbd-11e9-9989-91aa6bfc4582.png)

**To test**

1. Add a Speakers or Organizers block
2. Click the dropdown or start searching for people
3. The avatars should be larger, while the icons (for example in Sponsors, "Sponsor Levels") should stay the smaller size