### PR TITLE
Blocks: Add session details to the dropdown

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -18,7 +18,6 @@ import { FeaturedImage }                                             from '../..
 import { PostList }                                                  from '../../components/post-list';
 import { filterEntities }                                            from '../../data';
 import { tokenSplit, arrayTokenReplace, intersperse, listify }       from '../../i18n';
-import { getSessionDetails }                                         from './utils';
 
 /**
  * Component for the section of each session post that displays information about the session's speakers.
@@ -239,7 +238,7 @@ export class BlockContent extends Component {
 							<div className="wordcamp-sessions__details">
 								{ show_meta && (
 									<div className="wordcamp-sessions__time-location">
-										{ getSessionDetails( post ) }
+										{ post.details }
 									</div>
 								) }
 								{ show_category &&

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/block-content.js
@@ -18,6 +18,7 @@ import { FeaturedImage }                                             from '../..
 import { PostList }                                                  from '../../components/post-list';
 import { filterEntities }                                            from '../../data';
 import { tokenSplit, arrayTokenReplace, intersperse, listify }       from '../../i18n';
+import { getSessionDetails }                                         from './utils';
 
 /**
  * Component for the section of each session post that displays information about the session's speakers.
@@ -65,56 +66,6 @@ function SessionSpeakers( { session } ) {
 		<p className="wordcamp-sessions__speakers">
 			{ speakers }
 		</p>
-	);
-}
-
-/**
- * Component for the section of each session post displaying metadata including date, time, and location (track).
- *
- * @param {Object} session
- *
- * @return {Element}
- */
-function SessionMeta( { session } ) {
-	let metaContent;
-	const terms = get( session, '_embedded[\'wp:term\']', [] ).flat();
-
-	if ( session.session_track.length ) {
-		const [ firstTrack ] = terms.filter( ( term ) => {
-			return 'wcb_track' === term.taxonomy;
-		} );
-
-		metaContent = arrayTokenReplace(
-			/* translators: 1: A date; 2: A time; 3: A location; */
-			tokenSplit( __( '%1$s at %2$s in %3$s', 'wordcamporg' ) ),
-			[
-				session.session_date_time.date,
-				session.session_date_time.time,
-				(
-					<span
-						key={ firstTrack.id }
-						className={ classnames( 'wordcamp-sessions__track', `slug-${ firstTrack.slug.trim() }` ) }
-					>
-						{ firstTrack.name.trim() }
-					</span>
-				),
-			]
-		);
-	} else {
-		metaContent = arrayTokenReplace(
-			/* translators: 1: A date; 2: A time; */
-			tokenSplit( __( '%1$s at %2$s', 'wordcamporg' ) ),
-			[
-				session.session_date_time.date,
-				session.session_date_time.time,
-			]
-		);
-	}
-
-	return (
-		<div className="wordcamp-sessions__time-location">
-			{ metaContent }
-		</div>
 	);
 }
 
@@ -286,9 +237,11 @@ export class BlockContent extends Component {
 
 						{ ( show_meta || show_category ) && (
 							<div className="wordcamp-sessions__details">
-								{ show_meta &&
-									<SessionMeta session={ post } />
-								}
+								{ show_meta && (
+									<div className="wordcamp-sessions__time-location">
+										{ getSessionDetails( post ) }
+									</div>
+								) }
 								{ show_category &&
 									<SessionCategory session={ post } />
 								}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/content-select.js
@@ -122,6 +122,7 @@ export class ContentSelect extends Component {
 						<Option
 							icon={ includes( [ 'wcb_track', 'wcb_session_category' ], optionData.type ) ? icon : null }
 							label={ optionData.label }
+							details={ optionData.details }
 							count={ optionData.count }
 							context={ context }
 						/>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
@@ -12,6 +12,7 @@ import { WC_BLOCKS_STORE }   from '../../data';
 import { BlockControls }     from './block-controls';
 import { InspectorControls } from './inspector-controls';
 import { ICON }              from './index';
+import { getSessionDetails } from './utils';
 
 const blockData = window.WordCampBlocks.sessions || {};
 
@@ -60,10 +61,15 @@ const sessionsSelect = ( select ) => {
 	};
 
 	const entities = {
-		wcb_session          : getEntities( 'postType', 'wcb_session', sessionArgs ),
+		wcb_session          : null,
 		wcb_track            : getEntities( 'taxonomy', 'wcb_track' ),
 		wcb_session_category : getEntities( 'taxonomy', 'wcb_session_category' ),
 	};
+
+	const sessions = getEntities( 'postType', 'wcb_session', sessionArgs );
+	if ( sessions ) {
+		entities.wcb_session = sessions.map( ( item ) => ( { ...item, details: getSessionDetails( item ) } ) );
+	}
 
 	return {
 		blockData,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { tokenSplit, arrayTokenReplace } from '../../i18n';
+
+/**
+ * Fetch the details for a session as a human-readable string, in array-parts from `arrayTokenReplace`. This can be
+ * passed to any react component and renders as text in the element on the browser.
+ *
+ * @param {Object} session
+ *
+ * @return {Array}
+ */
+export function getSessionDetails( session ) {
+	const terms = get( session, '_embedded[\'wp:term\']', [] ).flat();
+
+	if ( session.session_track.length ) {
+		const [ firstTrack ] = terms.filter( ( term ) => 'wcb_track' === term.taxonomy );
+
+		return arrayTokenReplace(
+			/* translators: 1: A date; 2: A time; 3: A location; */
+			tokenSplit( __( '%1$s at %2$s in %3$s', 'wordcamporg' ) ),
+			[
+				session.session_date_time.date,
+				session.session_date_time.time,
+				firstTrack.name.trim(),
+			]
+		);
+	}
+
+	return arrayTokenReplace(
+		/* translators: 1: A date; 2: A time; */
+		tokenSplit( __( '%1$s at %2$s', 'wordcamporg' ) ),
+		[
+			session.session_date_time.date,
+			session.session_date_time.time,
+		]
+	);
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -59,6 +59,11 @@ const customStyles = {
 			},
 		},
 	} ),
+	option: ( provided, { isDisabled } ) => ( {
+		...provided,
+		color   : 'inherit',
+		opacity : isDisabled ? 0.7 : 1,
+	} ),
 };
 
 /**

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
@@ -20,6 +20,7 @@ import { AvatarImage } from '../image';
  *     @type {string} label
  *     @type {number} count
  *     @type {string} context - `menu` or `value` for whether it's in the menu dropdown or the selected token.
+ *     @type {node}   details
  * }
  *
  * @return {Element}

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/option.js
@@ -24,7 +24,7 @@ import { AvatarImage } from '../image';
  *
  * @return {Element}
  */
-export function Option( { avatar, icon, label, count, context } ) {
+export function Option( { avatar, context, count, details, icon, label } ) {
 	let image;
 
 	if ( 'value' === context ) {
@@ -64,6 +64,11 @@ export function Option( { avatar, icon, label, count, context } ) {
 				{ 'undefined' !== typeof count && (
 					<span className="wordcamp-item-select__option-label-count">
 						{ count }
+					</span>
+				) }
+				{ 'undefined' !== typeof details && (
+					<span className="wordcamp-item-select__option-label-details">
+						{ details }
 					</span>
 				) }
 			</span>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
@@ -38,12 +38,13 @@
 .wordcamp-item-select__option-avatar {
 	flex: 0 0 50px;
 	height: 50px;
+	margin-right: 10px;
 }
 
 .wordcamp-item-select__option-icon-container {
 	flex: 0 0 24px;
 	height: 24px;
-	margin-right: 0.5em;
+	margin-right: 10px;
 	background-color: #f3f3f4;
 }
 
@@ -51,6 +52,7 @@
 	margin: 0;
 	white-space: normal;
 }
+
 
 .wordcamp-item-select__option-label-count {
 	font-size: 0.6em;

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
@@ -43,11 +43,12 @@
 .wordcamp-item-select__option-icon-container {
 	flex: 0 0 24px;
 	height: 24px;
+	margin-right: 0.5em;
 	background-color: #f3f3f4;
 }
 
 .wordcamp-item-select__option-label {
-	margin: 0 0.5em;
+	margin: 0;
 	white-space: normal;
 }
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/style.scss
@@ -64,6 +64,12 @@
 	vertical-align: text-top;
 }
 
+.wordcamp-item-select__option-label-details {
+	display: block;
+	color: #6c7781;
+	font-style: italic;
+}
+
 .wordcamp-item-select {
 	width: 100%;
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
@@ -13,7 +13,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { filterEntities }    from '../../data';
-import { getSessionDetails } from '../../blocks/sessions/utils';
 
 const buildOptionGroup = ( entityType, type, label, items ) => {
 	items = items.map( ( item ) => {
@@ -22,17 +21,14 @@ const buildOptionGroup = ( entityType, type, label, items ) => {
 		switch ( entityType ) {
 			case 'post':
 				parsedItem = {
-					label : item.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ),
-					value : item.id,
-					type  : type,
+					label   : item.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ),
+					value   : item.id,
+					type    : type,
+					details : item.details,
 				};
 
 				parsedItem.avatar = get( item, 'avatar_urls[\'24\']', '' );
 				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'][0].media_details.sizes.thumbnail.source_url', '' );
-
-				if ( 'wcb_session' === item.type ) {
-					parsedItem.details = getSessionDetails( item );
-				}
 
 				break;
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/utils.js
@@ -12,7 +12,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { filterEntities } from '../../data';
+import { filterEntities }    from '../../data';
+import { getSessionDetails } from '../../blocks/sessions/utils';
 
 const buildOptionGroup = ( entityType, type, label, items ) => {
 	items = items.map( ( item ) => {
@@ -28,6 +29,11 @@ const buildOptionGroup = ( entityType, type, label, items ) => {
 
 				parsedItem.avatar = get( item, 'avatar_urls[\'24\']', '' );
 				parsedItem.image  = get( item, '_embedded[\'wp:featuredmedia\'][0].media_details.sizes.thumbnail.source_url', '' );
+
+				if ( 'wcb_session' === item.type ) {
+					parsedItem.details = getSessionDetails( item );
+				}
+
 				break;
 
 			case 'term':


### PR DESCRIPTION
The individual sessions should also show the details (date, time, and track) in the select dropdown. To do this, I've extracted a function to get the session details in a human readable format from a session post object, which is then used when building up the select options if the item is a session. This could also allow us to pass more "details" for other post types, if we decide we need to.

Fixes #92.

![Screen Shot 2019-07-26 at 5 58 29 PM](https://user-images.githubusercontent.com/541093/61983616-119b6b00-afcf-11e9-9543-63d1c15f7164.png)

**To test**

1. Add a sessions block.
2. Open the dropdown or start searching to show the list.
3. Individual sessions in the list should have more details now.
4. Session tracks & categories should still show only the term names.
5. Other blocks shouldn't be affected by the change.