### PR TITLE
Docker: Allow more file types to be loaded from theme or plugin directories

### DIFF
--- a/.docker/config/nginx.conf
+++ b/.docker/config/nginx.conf
@@ -46,10 +46,10 @@ server {
 		fastcgi_pass php;
 	}
 
-	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico)$ {
-	    root /usr/src/public_html;
-	    expires max;
-	    log_not_found off;
+	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf)$ {
+		root /usr/src/public_html;
+		expires max;
+		log_not_found off;
 	}
 
 	location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {


### PR DESCRIPTION
The nginx config blocks non-safelisted extensions from being found on the server. The safelist is pretty restricted though, and prevents some theme & plugin assets from loading. This was causing problems with Jetpack's icon font (and the ability to load SVGs from a theme).

I'm not sure if this was an oversight or an intentional reflection of the WordCamp infrastructure, but thought I'd PR it.

To test

- Activate Jetpack
- The Jetpack menu item should have an icon

![Screen Shot 2019-07-29 at 11 39 26 AM](https://user-images.githubusercontent.com/541093/62061605-8b14a280-b1f5-11e9-9d16-173289be226f.png)
