### PR TITLE
Blocks: Add groups icons back to Organizer teams

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/content-select.js
@@ -101,7 +101,7 @@ export class ContentSelect extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { label, setAttributes } = this.props;
+		const { label, icon, setAttributes } = this.props;
 
 		return (
 			<ItemSelect
@@ -115,6 +115,7 @@ export class ContentSelect extends Component {
 					formatOptionLabel : ( optionData, { context } ) => (
 						<Option
 							context={ context }
+							icon={ 'wcb_organizer_team' === optionData.type ? icon : null }
 							avatar={ optionData.avatar }
 							label={ optionData.label }
 							count={ optionData.count }


### PR DESCRIPTION
At some point in the past the icon was removed from organizer teams, this PR just adds it back. See https://github.com/WordPress/wordcamp.org/issues/62#issuecomment-516017168

![Screen Shot 2019-07-29 at 11 56 42 AM](https://user-images.githubusercontent.com/541093/62062918-f2cbed00-b1f7-11e9-9b94-b0fde148028d.png)
