### PR TITLE
Blocks: Add a setting for name/title alignment

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/includes/definitions.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/definitions.php
@@ -37,6 +37,11 @@ function get_shared_definitions( $keys, $type ) {
 					'enum'    => wp_list_pluck( get_shared_definition( 'align_block', 'option' ), 'value' ),
 					'default' => '',
 				],
+				'align_content'     => [
+					'type'    => 'string',
+					'enum'    => wp_list_pluck( get_shared_definition( 'align_content', 'option' ), 'value' ),
+					'default' => '',
+				],
 				'align_image'       => [
 					'type'    => 'string',
 					'enum'    => wp_list_pluck( get_shared_definition( 'align_image', 'option' ), 'value' ),
@@ -82,7 +87,7 @@ function get_shared_definitions( $keys, $type ) {
 
 		case 'option':
 			$definitions = [
-				'align_block' => [
+				'align_block'   => [
 					[
 						'label' => _x( 'Wide', 'alignment option', 'wordcamporg' ),
 						'value' => 'wide',
@@ -92,7 +97,21 @@ function get_shared_definitions( $keys, $type ) {
 						'value' => 'full',
 					],
 				],
-				'align_image' => [
+				'align_content' => [
+					[
+						'label' => _x( 'Left', 'alignment option', 'wordcamporg' ),
+						'value' => 'left',
+					],
+					[
+						'label' => _x( 'Center', 'alignment option', 'wordcamporg' ),
+						'value' => 'center',
+					],
+					[
+						'label' => _x( 'Right', 'alignment option', 'wordcamporg' ),
+						'value' => 'right',
+					],
+				],
+				'align_image'   => [
 					[
 						'label' => _x( 'None', 'alignment option', 'wordcamporg' ),
 						'value' => 'none',
@@ -110,7 +129,7 @@ function get_shared_definitions( $keys, $type ) {
 						'value' => 'right',
 					],
 				],
-				'content'     => [
+				'content'       => [
 					[
 						'label' => _x( 'Full', 'content option', 'wordcamporg' ),
 						'value' => 'full',
@@ -124,7 +143,7 @@ function get_shared_definitions( $keys, $type ) {
 						'value' => 'none',
 					],
 				],
-				'layout'      => [
+				'layout'        => [
 					[
 						'label' => _x( 'List', 'content option', 'wordcamporg' ),
 						'value' => 'list',
@@ -134,7 +153,7 @@ function get_shared_definitions( $keys, $type ) {
 						'value' => 'grid',
 					],
 				],
-				'sort_title'  => [
+				'sort_title'    => [
 					[
 						'label' => _x( 'A → Z', 'sort option', 'wordcamporg' ),
 						'value' => 'title_asc',
@@ -144,7 +163,7 @@ function get_shared_definitions( $keys, $type ) {
 						'value' => 'title_desc',
 					],
 				],
-				'sort_date'   => [
+				'sort_date'     => [
 					[
 						'label' => _x( 'Newest to Oldest', 'sort option', 'wordcamporg' ),
 						'value' => 'date_desc',

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/controller.php
@@ -142,7 +142,7 @@ function get_attributes_schema() {
 			'avatar_align' => get_shared_definition( 'align_image', 'attribute' ),
 			'avatar_size'  => get_shared_definition( 'image_size_avatar', 'attribute' ),
 			'className'    => get_shared_definition( 'string_empty', 'attribute' ),
-			'headingAlign' => get_shared_definition( 'align_image', 'attribute' ),
+			'headingAlign' => get_shared_definition( 'align_content', 'attribute' ),
 			'mode'         => [
 				'type'    => 'string',
 				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/controller.php
@@ -7,7 +7,6 @@ use function WordCamp\Blocks\Definitions\{ get_shared_definitions, get_shared_de
 
 defined( 'WPINC' ) || die();
 
-
 /**
  * Register block types and enqueue scripts.
  *
@@ -25,6 +24,7 @@ function init() {
 		]
 	);
 }
+
 add_action( 'init', __NAMESPACE__ . '\init' );
 
 /**
@@ -74,6 +74,7 @@ function add_script_data( array $data ) {
 
 	return $data;
 }
+
 add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );
 
 /**
@@ -141,6 +142,7 @@ function get_attributes_schema() {
 			'avatar_align' => get_shared_definition( 'align_image', 'attribute' ),
 			'avatar_size'  => get_shared_definition( 'image_size_avatar', 'attribute' ),
 			'className'    => get_shared_definition( 'string_empty', 'attribute' ),
+			'headingAlign' => get_shared_definition( 'align_image', 'attribute' ),
 			'mode'         => [
 				'type'    => 'string',
 				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/inspector-controls.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { AlignmentToolbar, InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, PanelBody, SelectControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -41,9 +41,9 @@ export default class extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes, blockData } = this.props;
-		const { show_avatars, avatar_size, avatar_align, content, sort } = attributes;
-		const { schema = DEFAULT_SCHEMA, options = DEFAULT_OPTIONS } = blockData;
+		const { attributes, blockData, setAttributes } = this.props;
+		const { avatar_align, avatar_size, content, headingAlign, show_avatars, sort } = attributes;
+		const { options = DEFAULT_OPTIONS, schema = DEFAULT_SCHEMA } = blockData;
 
 		return (
 			<InspectorControls>
@@ -67,6 +67,19 @@ export default class extends Component {
 				/>
 
 				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ false }>
+					<BaseControl>
+						<span className="components-base-control__label">
+							{ __( 'Organizer name alignment', 'wordcamporg' ) }
+						</span>
+						<AlignmentToolbar
+							isCollapsed={ false }
+							value={ headingAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { headingAlign: nextAlign } );
+							} }
+						/>
+					</BaseControl>
+
 					<SelectControl
 						label={ __( 'Biography Length', 'wordcamporg' ) }
 						value={ content }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/organizer-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/organizer-list.js
@@ -63,7 +63,7 @@ class OrganizerList extends Component {
 	 */
 	render() {
 		const { attributes } = this.props;
-		const { show_avatars, avatar_size, avatar_align, content } = attributes;
+		const { avatar_size, avatar_align, content, headingAlign, show_avatars } = attributes;
 
 		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
@@ -80,6 +80,7 @@ class OrganizerList extends Component {
 					<div key={ post.slug } className={ `wordcamp-organizers__post slug-${ post.slug.trim() }` }>
 						<ItemTitle
 							className="wordcamp-organizers__title"
+							align={ headingAlign }
 							headingLevel={ 3 }
 							title={ post.title.rendered.trim() }
 						/>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/view.php
@@ -21,7 +21,8 @@ setup_postdata( $organizer ); // This is necessary for generating an excerpt fro
 			get_the_title( $organizer ),
 			'',
 			3,
-			[ 'wordcamp-organizers__title' ]
+			[ 'wordcamp-organizers__title' ],
+			$attributes['headingAlign']
 		)
 	); ?>
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/controller.php
@@ -102,7 +102,7 @@ function get_attributes_schema() {
 			'align'                => get_shared_definition( 'align_block', 'attribute' ),
 			'className'            => get_shared_definition( 'string_empty', 'attribute' ),
 			'featured_image_width' => get_shared_definition( 'image_size', 'attribute' ),
-			'headingAlign'         => get_shared_definition( 'align_image', 'attribute' ),
+			'headingAlign'         => get_shared_definition( 'align_content', 'attribute' ),
 			'image_align'          => get_shared_definition( 'align_image', 'attribute' ),
 			'mode'                 => [
 				'type'    => 'string',

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/controller.php
@@ -102,6 +102,7 @@ function get_attributes_schema() {
 			'align'                => get_shared_definition( 'align_block', 'attribute' ),
 			'className'            => get_shared_definition( 'string_empty', 'attribute' ),
 			'featured_image_width' => get_shared_definition( 'image_size', 'attribute' ),
+			'headingAlign'         => get_shared_definition( 'align_image', 'attribute' ),
 			'image_align'          => get_shared_definition( 'align_image', 'attribute' ),
 			'mode'                 => [
 				'type'    => 'string',

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { AlignmentToolbar, InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -21,18 +21,19 @@ export default class extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes, blockData } = this.props;
+		const { attributes, blockData, setAttributes } = this.props;
 		const {
-			show_images,
-			featured_image_width,
-			image_align,
-			show_speaker,
 			content,
-			show_meta,
+			featured_image_width,
+			headingAlign,
+			image_align,
 			show_category,
+			show_images,
+			show_meta,
+			show_speaker,
 			sort,
 		} = attributes;
-		const { schema, options } = blockData;
+		const { options, schema } = blockData;
 
 		return (
 			<InspectorControls>
@@ -56,6 +57,19 @@ export default class extends Component {
 				/>
 
 				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ true }>
+					<BaseControl>
+						<span className="components-base-control__label">
+							{ __( 'Session name alignment', 'wordcamporg' ) }
+						</span>
+						<AlignmentToolbar
+							isCollapsed={ false }
+							value={ headingAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { headingAlign: nextAlign } );
+							} }
+						/>
+					</BaseControl>
+
 					<SelectControl
 						label={ __( 'Description', 'wordcamporg' ) }
 						value={ content || 'full' }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
@@ -173,13 +173,14 @@ class SessionList extends Component {
 	render() {
 		const { attributes } = this.props;
 		const {
-			show_speaker,
-			show_images,
-			image_align,
-			featured_image_width,
 			content,
-			show_meta,
+			featured_image_width,
+			headingAlign,
+			image_align,
 			show_category,
+			show_images,
+			show_meta,
+			show_speaker,
 		} = attributes;
 
 		const posts = this.getFilteredPosts();
@@ -196,6 +197,7 @@ class SessionList extends Component {
 					<div key={ post.slug } className={ `wordcamp-sessions__post slug-${ post.slug }` }>
 						<ItemTitle
 							className="wordcamp-sessions__title"
+							align={ headingAlign }
 							headingLevel={ 3 }
 							title={ post.title.rendered.trim() }
 							link={ post.link }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -20,7 +20,8 @@ setup_postdata( $session );
 			get_the_title( $session ),
 			get_permalink( $session ),
 			3,
-			[ 'wordcamp-sessions__title' ]
+			[ 'wordcamp-sessions__title' ],
+			$attributes['headingAlign']
 		)
 	); ?>
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/controller.php
@@ -186,6 +186,7 @@ function get_attributes_schema() {
 			'avatar_align' => get_shared_definition( 'align_image', 'attribute' ),
 			'avatar_size'  => get_shared_definition( 'image_size_avatar', 'attribute' ),
 			'className'    => get_shared_definition( 'string_empty', 'attribute' ),
+			'headingAlign' => get_shared_definition( 'align_image', 'attribute' ),
 			'mode'         => [
 				'type'    => 'string',
 				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/controller.php
@@ -186,7 +186,7 @@ function get_attributes_schema() {
 			'avatar_align' => get_shared_definition( 'align_image', 'attribute' ),
 			'avatar_size'  => get_shared_definition( 'image_size_avatar', 'attribute' ),
 			'className'    => get_shared_definition( 'string_empty', 'attribute' ),
-			'headingAlign' => get_shared_definition( 'align_image', 'attribute' ),
+			'headingAlign' => get_shared_definition( 'align_content', 'attribute' ),
 			'mode'         => [
 				'type'    => 'string',
 				'enum'    => wp_list_pluck( get_options( 'mode' ), 'value' ),

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { AlignmentToolbar, InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -40,9 +40,9 @@ export default class extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes, blockData } = this.props;
-		const { show_avatars, avatar_size, avatar_align, content, show_session, sort } = attributes;
-		const { schema = DEFAULT_SCHEMA, options = DEFAULT_OPTIONS } = blockData;
+		const { attributes, blockData, setAttributes } = this.props;
+		const { avatar_align, avatar_size, content, headingAlign, show_avatars, show_session, sort } = attributes;
+		const { options = DEFAULT_OPTIONS, schema = DEFAULT_SCHEMA } = blockData;
 
 		return (
 			<InspectorControls>
@@ -66,6 +66,19 @@ export default class extends Component {
 				/>
 
 				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ false }>
+					<BaseControl>
+						<span className="components-base-control__label">
+							{ __( 'Speaker name alignment', 'wordcamporg' ) }
+						</span>
+						<AlignmentToolbar
+							isCollapsed={ false }
+							value={ headingAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { headingAlign: nextAlign } );
+							} }
+						/>
+					</BaseControl>
+
 					<SelectControl
 						label={ __( 'Biography Length', 'wordcamporg' ) }
 						value={ content }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
@@ -136,7 +136,7 @@ class SpeakerList extends Component {
 	render() {
 		const { attributes, entities } = this.props;
 		const { wcb_track: tracks } = entities;
-		const { show_avatars, avatar_size, avatar_align, content, show_session } = attributes;
+		const { avatar_align, avatar_size, content, headingAlign, show_avatars, show_session } = attributes;
 
 		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
@@ -152,6 +152,7 @@ class SpeakerList extends Component {
 					<div key={ post.slug } className={ `wordcamp-speakers__post slug-${ post.slug }` }>
 						<ItemTitle
 							className="wordcamp-speakers__title"
+							align={ headingAlign }
 							headingLevel={ 3 }
 							title={ post.title.rendered.trim() }
 							link={ post.link }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
@@ -20,7 +20,8 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 			get_the_title( $speaker ),
 			get_permalink( $speaker ),
 			3,
-			[ 'wordcamp-speakers__title' ]
+			[ 'wordcamp-speakers__title' ],
+			$attributes['headingAlign']
 		)
 	); ?>
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/controller.php
@@ -139,6 +139,7 @@ function get_attributes_schema() {
 			'align'                => get_shared_definition( 'align_block', 'attribute' ),
 			'className'            => get_shared_definition( 'string_empty', 'attribute' ),
 			'featured_image_width' => get_shared_definition( 'image_size', 'attribute', [ 'default' => 600 ] ),
+			'headingAlign'         => get_shared_definition( 'align_image', 'attribute' ),
 			'image_align'          => get_shared_definition( 'align_image', 'attribute' ),
 			'mode'                 => [
 				'type'    => 'string',

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/controller.php
@@ -139,7 +139,7 @@ function get_attributes_schema() {
 			'align'                => get_shared_definition( 'align_block', 'attribute' ),
 			'className'            => get_shared_definition( 'string_empty', 'attribute' ),
 			'featured_image_width' => get_shared_definition( 'image_size', 'attribute', [ 'default' => 600 ] ),
-			'headingAlign'         => get_shared_definition( 'align_image', 'attribute' ),
+			'headingAlign'         => get_shared_definition( 'align_content', 'attribute' ),
 			'image_align'          => get_shared_definition( 'align_image', 'attribute' ),
 			'mode'                 => [
 				'type'    => 'string',

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
@@ -61,25 +61,28 @@ export default class extends Component {
 				/>
 
 				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ true }>
-					<BaseControl>
-						<span className="components-base-control__label">
-							{ __( 'Sponsor name alignment', 'wordcamporg' ) }
-						</span>
-						<AlignmentToolbar
-							isCollapsed={ false }
-							value={ headingAlign }
-							onChange={ ( nextAlign ) => {
-								setAttributes( { headingAlign: nextAlign } );
-							} }
-						/>
-					</BaseControl>
-
 					<ToggleControl
 						label={ __( 'Name', 'wordcamporg' ) }
 						help={ __( 'Show or hide sponsor name', 'wordcamporg' ) }
 						checked={ show_name }
 						onChange={ ( value ) => setAttributes( { show_name: value } ) }
 					/>
+
+					{ show_name && (
+						<BaseControl>
+							<span className="components-base-control__label">
+								{ __( 'Sponsor name alignment', 'wordcamporg' ) }
+							</span>
+							<AlignmentToolbar
+								isCollapsed={ false }
+								value={ headingAlign }
+								onChange={ ( nextAlign ) => {
+									setAttributes( { headingAlign: nextAlign } );
+								} }
+							/>
+						</BaseControl>
+					) }
+
 					<SelectControl
 						label={ __( 'Description', 'wordcamporg' ) }
 						value={ content }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { AlignmentToolbar, InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -27,9 +27,17 @@ export default class extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { attributes, setAttributes, blockData } = this.props;
-		const { show_logo, featured_image_width, image_align, show_name, content, sort } = attributes;
-		const { schema, options = DEFAULT_OPTIONS } = blockData;
+		const { attributes, blockData, setAttributes } = this.props;
+		const {
+			content,
+			featured_image_width,
+			headingAlign,
+			image_align,
+			show_logo,
+			show_name,
+			sort,
+		} = attributes;
+		const { options = DEFAULT_OPTIONS, schema } = blockData;
 
 		return (
 			<InspectorControls>
@@ -52,10 +60,20 @@ export default class extends Component {
 					alignOptions={ options.align_image }
 				/>
 
-				<PanelBody
-					title={ __( 'Content Settings', 'wordcamporg' ) }
-					initialOpen={ true }
-				>
+				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ true }>
+					<BaseControl>
+						<span className="components-base-control__label">
+							{ __( 'Sponsor name alignment', 'wordcamporg' ) }
+						</span>
+						<AlignmentToolbar
+							isCollapsed={ false }
+							value={ headingAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { headingAlign: nextAlign } );
+							} }
+						/>
+					</BaseControl>
+
 					<ToggleControl
 						label={ __( 'Name', 'wordcamporg' ) }
 						help={ __( 'Show or hide sponsor name', 'wordcamporg' ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/sponsor-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/sponsor-list.js
@@ -71,7 +71,7 @@ class SponsorList extends Component {
 	 */
 	render() {
 		const { attributes } = this.props;
-		const { show_name, show_logo, featured_image_width, image_align, content } = attributes;
+		const { content, featured_image_width, headingAlign, image_align, show_logo, show_name } = attributes;
 
 		const posts = this.getFilteredPosts();
 		const isLoading = ! Array.isArray( posts );
@@ -88,6 +88,7 @@ class SponsorList extends Component {
 						{ show_name && (
 							<ItemTitle
 								className="wordcamp-sponsors__title"
+								align={ headingAlign }
 								headingLevel={ 3 }
 								title={ post.title.rendered.trim() }
 								link={ post.link }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/view.php
@@ -20,7 +20,8 @@ setup_postdata( $sponsor ); // This is necessary for generating an excerpt from 
 				get_the_title( $sponsor ),
 				get_permalink( $sponsor ),
 				3,
-				[ 'wordcamp-sponsors__title' ]
+				[ 'wordcamp-sponsors__title' ],
+				$attributes['headingAlign']
 			)
 		); ?>
 	<?php endif; ?>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/controller.php
@@ -12,10 +12,11 @@ defined( 'WPINC' ) || die();
  * @param string $link
  * @param int    $heading_level
  * @param array  $classes
+ * @param string $align
  *
  * @return false|string
  */
-function render_item_title( $title, $link = '', $heading_level = 3, array $classes = [] ) {
+function render_item_title( $title, $link = '', $heading_level = 3, array $classes = [], $align = 'none' ) {
 	$valid_heading_levels = [ 1, 2, 3, 4, 5, 6 ];
 
 	if ( ! in_array( $heading_level, $valid_heading_levels, true ) ) {
@@ -29,9 +30,15 @@ function render_item_title( $title, $link = '', $heading_level = 3, array $class
 		$classes
 	) );
 
+	$style = '';
+
+	if ( in_array( $align, [ 'left', 'center', 'right' ], true ) ) {
+		$style = "text-align:$align;";
+	}
+
 	ob_start();
 	?>
-	<<?php echo esc_html( $tag ); ?> class="<?php echo esc_attr( $classes ); ?>">
+	<<?php echo esc_html( $tag ); ?> class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $style ); ?>">
 	<?php if ( $link ) : ?>
 		<a href="<?php echo esc_url( $link ); ?>">
 	<?php endif; ?>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/item-title.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/item-title.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  *
  * @return {Element}
  */
-function ItemTitle( { headingLevel, className, title, link } ) {
+function ItemTitle( { align, className, headingLevel, link, title } ) {
 	const validLevels = [ 1, 2, 3, 4, 5, 6 ];
 	let Tag = 'h3';
 
@@ -23,11 +23,15 @@ function ItemTitle( { headingLevel, className, title, link } ) {
 	}
 
 	const classes = [ 'wordcamp-block__item-title', className ];
-
 	const content = title || __( '(Untitled)', 'wordcamporg' );
 
+	const style = {};
+	if ( align ) {
+		style.textAlign = align;
+	}
+
 	return (
-		<Tag className={ classnames( classes ) }>
+		<Tag className={ classnames( classes ) } style={ style }>
 			{ link ? (
 				<a href={ link } target="_blank" rel="noopener noreferrer">
 					{ content }


### PR DESCRIPTION
Adds an alignment setting to each block, which will control the name/title. The setting is added to the Content Settings panel, and lets you left/right/center align the content.

Fixes #141 

**Screenshots**

In the sidebar, this setting shows up first.

![Screen Shot 2019-08-02 at 5 39 04 PM](https://user-images.githubusercontent.com/541093/62400827-a4e41b80-b54e-11e9-95bc-08ae596419e3.png)

Except in sponsors, because the Name toggle can hide the setting (if name is hidden, there's no point to the alignment setting).

![Screen Shot 2019-08-02 at 5 43 22 PM](https://user-images.githubusercontent.com/541093/62400825-a4e41b80-b54e-11e9-8d6d-f27be45f9c39.png)

In the editor preview, this controls the heading:

![Screen Shot 2019-08-02 at 5 43 27 PM](https://user-images.githubusercontent.com/541093/62400830-a6154880-b54e-11e9-8c55-a391ad6af4f2.png)

**To test**

1. Add any WC block
2. Toggle the different alignments, it should update correctly across all content items.
3. Save the block, and make sure it works correctly on the frontend too.