### PR TITLE
Blocks: Update toggle help text to reflect current state.

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
@@ -64,19 +64,25 @@ export default class extends Component {
 					/>
 					<ToggleControl
 						label={ __( 'Details', 'wordcamporg' ) }
-						help={ __( 'Show date, time, and track.', 'wordcamporg' ) }
+						help={ show_meta ?
+							__( 'Date, time, and track are visible.', 'wordcamporg' ) :
+							__( 'Date, time, and track are hidden.', 'wordcamporg' ) }
 						checked={ show_meta === undefined ? false : show_meta }
 						onChange={ ( value ) => setAttributes( { show_meta: value } ) }
 					/>
 					<ToggleControl
 						label={ __( 'Categories', 'wordcamporg' ) }
-						help={ __( 'Show session categories.', 'wordcamporg' ) }
+						help={ show_category ?
+							__( 'Session categories are visible.', 'wordcamporg' ) :
+							__( 'Session categories are hidden.', 'wordcamporg' ) }
 						checked={ show_category === undefined ? false : show_category }
 						onChange={ ( value ) => setAttributes( { show_category: value } ) }
 					/>
 					<ToggleControl
 						label={ __( 'Speakers', 'wordcamporg' ) }
-						help={ __( 'Show session speakers.', 'wordcamporg' ) }
+						help={ show_speaker ?
+							__( 'Session speakers are visible.', 'wordcamporg' ) :
+							__( 'Session speakers are hidden.', 'wordcamporg' ) }
 						checked={ show_speaker === undefined ? false : show_speaker }
 						onChange={ ( value ) => setAttributes( { show_speaker: value } ) }
 					/>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
@@ -74,7 +74,9 @@ export default class extends Component {
 					/>
 					<ToggleControl
 						label={ __( 'Session Information', 'wordcamporg' ) }
-						help={ __( "Show speaker's session name, time, and track", 'wordcamporg' ) }
+						help={ show_session ?
+							__( "Speaker's session name, time, and track are visible.", 'wordcamporg' ) :
+							__( "Speaker's session name, time, and track are hidden.", 'wordcamporg' ) }
 						checked={ show_session }
 						onChange={ ( value ) => setAttributes( { show_session: value } ) }
 					/>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
@@ -58,7 +58,9 @@ export default class extends Component {
 				>
 					<ToggleControl
 						label={ __( 'Name', 'wordcamporg' ) }
-						help={ __( 'Show or hide sponsor name', 'wordcamporg' ) }
+						help={ show_name ?
+							__( 'Sponsor name is visible.', 'wordcamporg' ) :
+							__( 'Sponsor name is hidden.', 'wordcamporg' ) }
 						checked={ show_name }
 						onChange={ ( value ) => setAttributes( { show_name: value } ) }
 					/>
@@ -66,7 +68,7 @@ export default class extends Component {
 						label={ __( 'Description', 'wordcamporg' ) }
 						value={ content }
 						options={ options.content }
-						help={ __( 'Length of sponsor description', 'wordcamporg' ) }
+						help={ __( 'Length of sponsor description.', 'wordcamporg' ) }
 						onChange={ ( value ) => setAttributes( { content: value } ) }
 					/>
 				</PanelBody>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls/index.js
@@ -63,7 +63,14 @@ class ImageInspectorPanel extends Component {
 				initialOpen={ initialOpen }
 				className={ classnames( 'wordcamp-image__inspector-panel', className ) }
 			>
-				<ToggleControl label={ __( 'Show images', 'wordcamporg' ) } checked={ show } onChange={ onChangeShow } />
+				<ToggleControl
+					label={ __( 'Show images', 'wordcamporg' ) }
+					help={ show ?
+						__( 'Images are visible.', 'wordcamporg' ) :
+						__( 'Images are hidden.', 'wordcamporg' ) }
+					checked={ show }
+					onChange={ onChangeShow }
+				/>
 				{ show && (
 					<Fragment>
 						<ImageSizeControl


### PR DESCRIPTION
It can be confusing what "on" means in a toggle, so we add help text that reflects the current state. This makes the behavior of the toggle more clear, and follows a pattern of other core editor toggles.

Fixes #179 

**Screenshots**

![speaker](https://user-images.githubusercontent.com/541093/62484457-37bbca80-b788-11e9-906a-a6c92f98f6ed.png)
![session](https://user-images.githubusercontent.com/541093/62484456-37233400-b788-11e9-9d80-7918be892b46.png)

**To test**

1. Add any WordCamp block
2. In the "Image" panel, the show/hide toggle's help text should update based on the toggle state
3. On Sessions: the toggles for showing content should update
4. On Speakers: the toggle for showing speaker's session info should update
5. On Sponsors: the toggle for showing sponsor name should update
