### PR TITLE
Blocks: Remove the item permalink when showing full content

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
@@ -15,7 +15,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	DangerousItemHTMLContent,
 	FeaturedImage,
-	ItemPermalink,
 	ItemTitle,
 	NoContent,
 	PostList,
@@ -224,14 +223,6 @@ class SessionList extends Component {
 								{ show_meta && <div className="wordcamp-sessions__time-location">{ post.details }</div> }
 								{ show_category && <SessionCategory session={ post } /> }
 							</div>
-						) }
-
-						{ 'full' === content && (
-							<ItemPermalink
-								link={ post.link }
-								linkText={ __( 'Visit session page', 'wordcamporg' ) }
-								className="wordcamp-sessions__permalink"
-							/>
 						) }
 					</div>
 				) ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -122,16 +122,6 @@ setup_postdata( $session );
 			<?php endif; ?>
 		</div>
 	<?php endif; ?>
-
-	<?php if ( 'full' === $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_permalink(
-				get_permalink( $session ),
-				__( 'Visit session page', 'wordcamporg' ),
-				[ 'wordcamp-sessions__permalink' ]
-			)
-		); ?>
-	<?php endif; ?>
 </div>
 
 <?php

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
@@ -15,7 +15,6 @@ import { Component } from '@wordpress/element';
 import {
 	AvatarImage,
 	DangerousItemHTMLContent,
-	ItemPermalink,
 	ItemTitle,
 	NoContent,
 	PostList,
@@ -175,14 +174,6 @@ class SpeakerList extends Component {
 						) }
 
 						{ true === show_session && <SpeakerSessions speaker={ post } tracks={ tracks } /> }
-
-						{ 'full' === content && (
-							<ItemPermalink
-								link={ post.link }
-								linkText={ __( 'Visit speaker page', 'wordcamporg' ) }
-								className="wordcamp-speakers__permalink"
-							/>
-						) }
 					</div>
 				) ) }
 			</PostList>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
@@ -91,16 +91,6 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 			</ul>
 		</div>
 	<?php endif; ?>
-
-	<?php if ( 'full' === $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_permalink(
-				get_permalink( $speaker ),
-				__( 'Visit speaker page', 'wordcamporg' ),
-				[ 'wordcamp-speakers__permalink' ]
-			)
-		); ?>
-	<?php endif; ?>
 </div>
 
 <?php

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/sponsor-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/sponsor-list.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	DangerousItemHTMLContent,
 	FeaturedImage,
-	ItemPermalink,
 	ItemTitle,
 	NoContent,
 	PostList,
@@ -111,14 +109,6 @@ class SponsorList extends Component {
 							<DangerousItemHTMLContent
 								className={ `wordcamp-sponsors__content is-${ content }` }
 								content={ 'full' === content ? post.content.rendered.trim() : post.excerpt.rendered.trim() }
-							/>
-						) }
-
-						{ 'full' === content && (
-							<ItemPermalink
-								link={ post.link }
-								linkText={ __( 'Visit sponsor page', 'wordcamporg' ) }
-								className="wordcamp-sponsors__permalink"
 							/>
 						) }
 					</div>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/view.php
@@ -46,16 +46,6 @@ setup_postdata( $sponsor ); // This is necessary for generating an excerpt from 
 			)
 		); ?>
 	<?php endif; ?>
-
-	<?php if ( 'full' === $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_permalink(
-				get_permalink( $sponsor ),
-				__( 'Visit sponsor page', 'wordcamporg' ),
-				[ 'wordcamp-sponsors__permalink' ]
-			)
-		); ?>
-	<?php endif; ?>
 </div>
 
 <?php


### PR DESCRIPTION
We previously added a link to the item page when showing "full" content, but it's somewhat redundant. We can rely on the names and avatars being linked to the Speaker/Session/etc pages if someone wants to view the single pages.

See #62.

**To test**

1. Add Speaker, Session, or Sponsor block
2. Show "Full" content in content settings
3. There should be no link at the bottom of each item
4. Publish or preview the post
3. There should be no link at the bottom of each item on the frontend either

To make sure nothing else changed…
1. Add Speaker, Session, or Sponsor block
2. Show "Excerpt" of content in content settings
3. There should be the theme-provided "continue reading" link after the excerpt (except Twenty Nineteen, which doesn't use this)