### PR TITLE
Blocks: Set the fallback sort order for sessions

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
@@ -150,9 +150,7 @@ class SessionList extends Component {
 			];
 		}
 
-		if ( 'session_time' === sort ) {
-			args.sort = 'title_asc';
-		} else {
+		if ( 'session_time' !== sort ) {
 			args.sort = sort;
 		}
 
@@ -160,6 +158,11 @@ class SessionList extends Component {
 
 		if ( Array.isArray( filtered ) && 'session_time' === sort ) {
 			filtered = filtered.sort( ( a, b ) => {
+				if ( Number( a.meta._wcpt_session_time ) === Number( b.meta._wcpt_session_time ) ) {
+					const title = get( a, 'title.rendered', '' );
+					return title.localeCompare( b.title.rendered );
+				}
+
 				return Number( a.meta._wcpt_session_time ) - Number( b.meta._wcpt_session_time );
 			} );
 		}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-list.js
@@ -150,7 +150,9 @@ class SessionList extends Component {
 			];
 		}
 
-		if ( 'session_time' !== sort ) {
+		if ( 'session_time' === sort ) {
+			args.sort = 'title_asc';
+		} else {
 			args.sort = sort;
 		}
 


### PR DESCRIPTION
Sessions sorted by date have a fallback sorting of title on the frontend, but until now there wasn't a fallback on the backend leading to potentially different previews. This adds a title comparison to the custom sorting function, used when the date is equal.

Fixes #192

**To test**

- Create a few sessions at the same time as each other, best if they're not created in alphabetical order
- Handpick those sessions into a session block
- Confirm that the Sorting order is "Day and Time"
- Publish the post
- The editor preview and frontend should have the same order of items.
