### PR TITLE
Add github issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,9 +5,11 @@ about: Let us know if something isn't working as you expect it to.
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -15,19 +17,24 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
-**WordCamp:**
-If this is a problem on a specific WordCamp's site, list that here.
+**WordCamp**
+
+If this is a problem on a specific WordCamp's site, list the site or page URL here.
 
 **System (please complete the following information):**
+
  - Device: [e.g. laptop, iPhone6]
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Additional context**
-- To report a security issue, please visit the WordPress HackerOne program: https://hackerone.com/wordpress.
+**Security Issues**
+
+To report a security issue, please visit the WordPress HackerOne program: https://hackerone.com/wordpress.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,33 @@
+---
+name: "\U0001F41E Bug report"
+about: Let us know if something isn't working as you expect it to.
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**WordCamp:**
+If this is a problem on a specific WordCamp's site, list that here.
+
+**System (please complete the following information):**
+ - Device: [e.g. laptop, iPhone6]
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+- To report a security issue, please visit the WordPress HackerOne program: https://hackerone.com/wordpress.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: "✨ Feature request"
+about: If you have an idea to improve an existing WordCamp feature, please let us know.
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,14 +4,10 @@ about: If you have an idea to improve an existing WordCamp feature, please let u
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Feature requests should be made on the Make Community P2, to ensure everyone can contribute to new ideas. Please follow this process for new features: https://make.wordpress.org/community/feature-requests-for-community-sites/
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+If you have a problem, go back and select the Bug Report option.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+---------------
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+If you've already made your feature proposal on the p2, you can summarize it here and make sure to include a link.

--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -1,0 +1,20 @@
+---
+name: "❓ Support Question"
+about: If you have a question please see our docs or try Slack.
+
+---
+
+If you have a question about using your site, or contributing to the platform, please email support@wordcamp.org or join the `#meta-wordcamp` channel in the official WordPress Slack workspace: https://make.wordpress.org/chat/
+
+**Helpful documentation**
+
+We have a handbook for WordCamp organizers which has a lot of information about running a WordCamp. Some sections that might help if you're looking here:
+
+- Setting up your WordCamp theme: https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/web-presence/setting-up-your-wordcamp-theme/
+- Custom tools for WordCamp content: https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/web-presence/custom-tools-for-building-wordcamp-content/
+- Selling Tickets: https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/selling-tickets/ 
+- Using the CampTix plugin: https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/web-presence/using-camptix-event-ticketing-plugin/
+
+**General WordCamp questions**
+
+There are always people to help around on the WordPress Slack workspace. You can use the `#community-events` channel for organizational help, or the `#meta-wordcamp` channel for website & technical help.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
+
+<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
+Fixes #, See #
+
+<!-- Don't forget to update the title with something descriptive. -->
+
+### Screenshots
+
+<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
+
+### How to test the changes in this Pull Request:
+
+1.
+2.
+3.
+
+<!-- If you can, add the appropriate [Component] and [Status] labels. -->

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,11 @@ There are two primary ways to setup this repo for local development.
 If you have a question about using your site, or contributing to the platform, please email [support@wordcamp.org](mailto:support@wordcamp.org) or join the `#meta-wordcamp` channel in [the official WordPress Slack workspace](https://make.wordpress.org/chat/).
 
 
+### Bugs & Feature Requests
+
+We encourage community members and organizers to [open issues for bugs & feature requests.](https://github.com/WordPress/wordcamp.org/issues/new/choose) We go through and prioritize issues at least once a month. We also have a monthly meeting where we discuss current tickets, patches, and PRs. This usually happens on the third Thursday of the month, you can watch for announcements on the [make.wordpress.org/meta blog.](https://make.wordpress.org/meta/)
+
+
 ## Security
 
 Please report security vulnerabilities via [our HackerOne bounty program](https://hackerone.com/wordpress).


### PR DESCRIPTION
This adds a simple PR template, you can [see it here.](https://raw.githubusercontent.com/WordPress/wordcamp.org/add/github-templates/.github/pull_request_template.md) We can add any extra notes or steps, but this seems like a good start.

There's also a set of issue templates, which will give people the ability to pick which template to use, like [woocommerce](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new/choose) and [gutenberg](https://github.com/wordpress/gutenberg/issues/new/choose). I've added "Bug Report", "Feature Request" and "Support Question" - with the last really linking people off to other places to get help.

Finally, I updated the main readme to let folks know that we address new issues/PRs once a month, and to add a note about the monthly meta bug scrubs.

Outside of this PR, I've also updated [the descriptions of labels](https://github.com/WordPress/wordcamp.org/labels) with some notes we made in team chats– specifically:

- [Status] Needs Decision: Needs full team input, decision should be reached within a week
- [Status] Blocked: Progress is blocked, and needs team input to move forward
- **NEW** [Status] On Hold: External blockers, or a de-prioritized project
- **NEW** [Status] Ready to Merge _I added this one a while ago, it's helpful for taking approved PRs out of the "Needs Review" state_

The On Hold status is to differentiate "blocked by team input/work" from "blocked by an external issue", and to give PRs that aren't a priority right now a place to live. 