### PR TITLE
PWA: Remove comments that have been moved to github

### DIFF
--- a/public_html/wp-content/mu-plugins/service-worker-caching.php
+++ b/public_html/wp-content/mu-plugins/service-worker-caching.php
@@ -4,90 +4,12 @@ namespace WordCamp\PWA\Caching;
 use WP_Service_Worker_Caching_Routes;
 
 add_action( 'wp_front_service_worker', __NAMESPACE__ . '\register_caching_routes' );
-	// todo is this the most appropriate hook to register these?
-		// seemed to have problems when using `default_service_workers`, like infinite loop.
-	// But do caching routes always affect both workers regardless? Or should they?
-		// Even if the caching is restricted to front end worker, that would still affect Tagregator and others,
-		// so still need to worry about side-effects.
 add_action( 'wp_front_service_worker',    __NAMESPACE__ . '\set_navigation_caching_strategy' );
-
-
-// todo prompt to install app to home screen is automatically showing on mobile
-	// not sure we want it to
-	// not really related to this file, but nothing closer at the moment
-	// maybe want it to be eventually, but not until we do more work to really make the site use pwa features well?
-	// otherwise risk giving users bad impression of pwas
-
-// also, says "install wordcamp" instead of "install wordcamp europe" - maybe manifest issue?
-
-// after adding to home screen, there's a delay and a "wordcamp" interstitial screen before the site appears.
-	// why? can remove that? it should load instantly, right? that's the whole idea
-
-// experience on mid-level phone (moto e4) and fast bandwidth is pretty poor
-	// what's the cause? big images? too much markup to parse? server slow ttfb?
-	// maybe just needs to have better perceived speed rather than better actual speed? like transitions between screens
-		// maybe new default theme that's a SPA and has a subtle transition animation when fetching new page content from API
-
-// what's the point of adding to home screen? doesn't seem like it has anything extra cached for offline use
-	// maybe if can detect when it's installed, we should pre-cache more things, for faster loading and more offline accessibility?
-	// also persist storage - https://github.com/xwp/pwa-wp/issues/193
-
-// maybe avoid loading images on slow connections
-	// related https://github.com/xwp/pwa-wp/issues/110, probably better to contribute to that (or new issue in that repo), than build custom. would be good feature for core
-	// https://github.com/wceu/wordcamp-pwa-page/issues/5
-	// https://deanhume.com/dynamic-resources-using-the-network-information-api-and-service-workers/
-	// this isn't really caching, so maybe create a separate file for it, or refactor this to be everything related to service workers.
-		// probably the former, `service-worker-misc.php`
-
-// having multiple tabs open, when 1 has a youtube embed playing, then refresh other tab, the video in first tab stops playing
-	// doesn't happen every time though
-
-
-
-
-
-
-// open issue w/ pwa lpugin - this may be plugin territory, but save offline button to add to precache route?
-	// similar to that one site
-//	or does it do that automatically already?
-//
-//maybe button to download all pages (not all posts or other cotent types, just pages, so that whole site heirarchy is accessible offline)
-
 
 /**
  * Register caching routes with both service workers.
  */
 function register_caching_routes() {
-	/*
-	 * todo
-	 *
-	 * pre-cache important pages like home page, Location. what others?
-	 *      maybe schedule too, but it's already in the offline template, so don't want to waste bandwidth installing. same for location?
-	 *      how to detect location programatically?
-	 *          could match `location` slug, and also add a `service-worker-precache` postmeta field to post stubs that we create on new sites
-	 *          maybe pwa feature plugin already supports something like that? if not, maybe propose it
-	 *          offline and day-of-event templates could show warnings to logged-in admins if the key is missing b/c they didn't use the default page
-	 * Is the wp-content/includes caching route even working? Didn't cache assets for offline template.
-	 *      How can you tell if it's working, compared to regular browser caching?
-	 *      devtools Network panel should say "From service worker" for size?
-	 * Is this the most appropriate way to make the day-of template performant?
-	 *      Should an eTag be used in addition to -- or instead of -- this?
-	 *      See https://github.com/wceu/wordcamp-pwa-page/issues/6#issuecomment-499366120
-	 * Are the expiration periods here appropriate for all consumers of these resources?
-	 * What side effects does this introduce, if any?
-	 * Will cachebuster params in asset URLs still work?
-	 * Will Gutenberg, Tagregator, etc receive outdated responses to their GET requests?
-	 *      If so that would fundamentally break them, and this needs to be fixed.
-	 *      If not, then the reason should be documented here, because it's not obvious.
-	 *      Gutenberg probably ok as long as only registering caching route w/ front-end service worker.
-	 *      For tagregator, maybe should only cache the specific endpoints that the day-of-event template calls?
-	 *          Or maybe cache all routes, but then add an extra route that caches Tagregator less often?
-	 * All of this needs to be tested to verify that it's working as intended.
-	 *      What's the best way to do that? Document it here if it's not obvious.
-	 * need to explicitly remove older revisions of custom-css (and other assets?) from the cache when they change?
-	 * would it be better to use stale-while-revalidate, so they get automatically updated? would that waste bandwidth or have other problems?
-	 */
-
 	$custom_css_url_parts = wp_parse_url( wcorg_get_custom_css_url() );
 
 	$static_asset_route_params = array(
@@ -113,7 +35,6 @@ function register_caching_routes() {
 		);
 	}
 
-
 	wp_register_service_worker_caching_route(
 		'/wp-json/.*',
 		[
@@ -136,14 +57,6 @@ function set_navigation_caching_strategy() {
 	/*
 	 * Cache pages that the user visits, so that if they return to them while offline, they'll still be available.
 	 * If they're online, though, fetch the latest version since it could have changed since they last visited.
-	 *
-	 * todo
-	 * Would stale-while-revalidate be better? Seems like would still get offline access,
-	 *      but would also load instantly while online and revisiting a page, rather than re-downloading it.
-	 * Would it automatically update when stale, or would we need to configure etags, etc?
-	 * would it waste bandwidth by making lots of requests to check if page has updated?
-	 * any other side-effects to consider?
-	 *
 	 */
 	add_filter(
 		'wp_service_worker_navigation_caching_strategy',
@@ -152,7 +65,7 @@ function set_navigation_caching_strategy() {
 		}
 	);
 
-	// todo may no longer be needed after https://github.com/xwp/pwa-wp/issues/176 is resolved
+	// todo may no longer be needed after https://github.com/xwp/pwa-wp/issues/176 is resolved.
 	add_filter(
 		'wp_service_worker_navigation_caching_strategy_args',
 		function( $args ) {

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Theme-agnostic front end HTML templates.
  */
@@ -10,22 +9,12 @@ use WP_Service_Worker_Scripts;
 
 defined( 'WPINC' ) || die();
 
-
-/*
- * todo
- *
- * Add a drafted page titled "Day of Event" to new sites, assign to this template. Add note explaining what the template is/how to use/style it.
- * This needs more testing.
- * Probably integrate `bbpress-network-templates` into this, but only after this is network-activated.
- */
-
 add_filter( 'theme_page_templates',            __NAMESPACE__ . '\register_page_templates' );
 add_filter( 'template_include',                __NAMESPACE__ . '\set_page_template_locations' );
 add_filter( 'template_include',                __NAMESPACE__ . '\inject_offline_template', 20 );  // After others because being offline transcends other templates.
 add_action( 'wp_enqueue_scripts',              __NAMESPACe__ . '\enqueue_template_assets' );
 add_filter( 'wp_offline_error_precache_entry', __NAMESPACE__ . '\add_offline_template_cachebuster' );
 add_action( 'wp_front_service_worker',         __NAMESPACE__ . '\precache_offline_template_assets' );
-
 
 /**
  * Add new templates to the Page Template dropdown in the editor.
@@ -38,17 +27,6 @@ function register_page_templates( $templates ) {
 	/*
 	 * Remove CampSite 2017's Day of template, since it's redundant, and having multiple templates in the menu
 	 * would be confusing.
-	 *
-	 * @todo
-	 * when network-enable, this template should only be removed on WCEU and new sites, so need a feature flag
-	 *      there could be sites on the schedule now that have already configured it, cna't switch it up on them last minute
-	 *      or maybe it's ok to break back-compat since it's just used on the day of the event? old sites shouldn't be showing it
-	 *      also want existing sites that haven't happened yet to be able to to use it
-	 * also need to remove the day-of widgets
-	 *      same back-comapt considerations
-	 * need to provide a way for organizers to add arbitrary content to this new day-of event page?
-	 *      otherwise we'll be taking away flexibility when we disable the campsite day of template
-	 *      maybe just have the template call `the_content()` above or below the hardcoded stuff?
 	 */
 	if ( isset( $templates['templates/page-day-of.php'] ) ) {
 		unset( $templates['templates/page-day-of.php'] );
@@ -74,7 +52,7 @@ function set_page_template_locations( $template_path ) {
 		return $template_path;
 	}
 
-	switch( $post->_wp_page_template ) {
+	switch ( $post->_wp_page_template ) {
 		case 'day-of-event':
 			$template_path = __DIR__ . '/templates/day-of-event/day-of-event.php';
 			break;
@@ -93,7 +71,7 @@ function enqueue_template_assets() {
 		return;
 	}
 
-	switch( $post->_wp_page_template ) {
+	switch ( $post->_wp_page_template ) {
 		case 'day-of-event':
 			// todo this has poor readability, we wouldn't really want to do all this in a `switch` for multiple entries
 			// maybe move to separate function, but then it's kind of awkward to have this switch setup just for 1 template
@@ -102,22 +80,24 @@ function enqueue_template_assets() {
 			wp_enqueue_script(
 				'day-of-event-template',
 				plugins_url( '/templates/day-of-event/build/index.js', __FILE__ ),
+				// phpcs:disable WordPress.WP.AlternativeFunctions -- Allow file_get_contents
 				json_decode( file_get_contents( __DIR__ . '/templates/day-of-event/build/index.deps.json' ) ),
+				// phpcs:enable
 				filemtime( __DIR__ . '/templates/day-of-event/build/index.js' ),
 				true
 			);
 
 			$config = array(
 				'postsArchiveUrl' => esc_url( get_post_type_archive_link( 'post' ) ),
-				'scheduleUrl'     => esc_url( site_url( __( 'schedule', 'wordcamporg' ) ) ), // todo can't hardcode
+				'scheduleUrl'     => esc_url( site_url( __( 'schedule', 'wordcamporg' ) ) ),
 			);
 
-			$configScript = sprintf(
+			$config_script = sprintf(
 				'var dayOfEventConfig = JSON.parse( decodeURIComponent( \'%s\' ) );',
 				rawurlencode( wp_json_encode( $config ) )
 			);
 
-			wp_add_inline_script( 'day-of-event-template', $configScript, 'before' );
+			wp_add_inline_script( 'day-of-event-template', $config_script, 'before' );
 
 			/*
 			 * This depends on 'wp-components', but that is intentionally left out because the only part we need
@@ -134,7 +114,6 @@ function enqueue_template_assets() {
 			break;
 	}
 }
-
 
 /**
  * Inject the offline template when the service worker pre-caches the response to offline requests.
@@ -156,12 +135,19 @@ function inject_offline_template( $template_path ) {
 /**
  * Add a cache-buster to the offline template's pre-cache entry.
  *
- * @param string
+ * @param array|false $entry {
+ *     Offline error precache entry.
  *
- * @return string
+ *     @type string $url      URL to page that shows the offline error template.
+ *     @type string $revision Revision for the template. This defaults to the template and stylesheet names, with their respective theme versions.
+ * }
+ *
+ * @return array|false
  */
 function add_offline_template_cachebuster( $entry ) {
-	$entry['revision'] .= ';' . filemtime( __DIR__ . '/templates/offline.php' );    // todo test that this is working. doesn't seem like it is, WB_REVISION is 0.2.0 (pwa plugin version), rather than this.
+	if ( $entry && isset( $entry['revision'] ) ) {
+		$entry['revision'] .= ';' . filemtime( __DIR__ . '/templates/offline.php' );
+	}
 
 	return $entry;
 }
@@ -173,6 +159,8 @@ function add_offline_template_cachebuster( $entry ) {
  */
 function precache_offline_template_assets( WP_Service_Worker_Scripts $scripts ) {
 	$asset = get_custom_css_precache_details();
+
+	// todo precache header image too (if one is set).
 
 	/*
 	 * If we don't have a URL, that's probably because the custom CSS is empty or short enough to be printed
@@ -202,14 +190,12 @@ function get_custom_css_precache_details() {
 		$url_query_params
 	);
 
-	// todo precache header image too, but can't for wceu b/c they're specifying in CSS bg image, rather than using Core functions.
-
 	if ( ! $url || ! isset( $url_query_params['custom-css'] ) ) {
 		return false;
 	}
 
 	return array(
-		'url' => $url,
+		'url'      => $url,
 
 		/*
 		 * This could probably be anything, since `$url` actually contains a cachebuster, but a unique revision

--- a/public_html/wp-content/mu-plugins/theme-templates/parts/dates.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/parts/dates.php
@@ -4,7 +4,5 @@ namespace WordCamp\Theme_Templates;
 
 defined( 'WPINC' ) || die();
 
-// todo add dates
-	// pull from `wordcamp` post type
-
-// include from day-of-event template and offline template
+// todo add dates: pull from `wordcamp` post type.
+// include from day-of-event template and offline template.

--- a/public_html/wp-content/mu-plugins/theme-templates/parts/location.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/parts/location.php
@@ -4,15 +4,9 @@ namespace WordCamp\Theme_Templates;
 
 defined( 'WPINC' ) || die();
 
-// todo location of venue, directions, etc
-// how to get without hardcoding?
-	// can pull address from `wordcamp` post type, maybe create a link to Google Maps driving directions with the starting place blank so they type that
-	// it'd be nice to pull in content from the Location page, but don't have a way to programatically detect that, and could have lots of non-essential content mixed in with it
-		// could identify location page by post meta inserted into stub when site created
-		// if can't find page w/ that, then fall back to address from wordcamp post
-	// maybe the full location page would have too much content for this context though? it'd still be good to automatically cache that for offline use, though, and the above approach could work well for that
-		// for low-bandwidth users, probably only want to install if add to home screen
-			// maybe that kind of functionality should be built into pwa feature plugin instead of custom
+// todo display location of venue, directions, etc.
 
-// include this from day-of-event template and from offline template
-	// link to gmaps wouldn't make sense in offline scenario, though. maybe detect which template it's being included from and show link or not based on that
+// Can pull address from `wordcamp` post type, maybe create a link to Google Maps driving directions with the
+// starting place blank so they type that.
+
+// include from day-of-event template and offline template.

--- a/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event/day-of-event.css
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event/day-of-event.css
@@ -1,12 +1,4 @@
 /*
- * todo
- * match this to new Schedule block as much as possible, reuse markup/css wherever possible
- * convert to sass inside components folder when wp-scripts supports that
- */
-
-
-
-/*
  * Common
  */
 

--- a/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event/day-of-event.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event/day-of-event.php
@@ -1,33 +1,8 @@
 <?php
-
 /**
  * Template Name: Day of Event
  *
  * Shows attendees the content that is most relevant during the event (directions to the venue, schedule, etc).
- */
-
-/*
- * todo
- *
- * add important stuff like dates/times, location
- *
- * determine a good way to make this appear automatically before the event begins, and go away after it ends
- * 	need to make sure organizers will be aware that that will happen, though, and maybe give a way to opt-out
- * maybe it should be an explicit/intentional action on the organizer's part? but then how to make sure that
- * organizers know it's available beyond just handbook documentation? don't want to spend all this time building it
- * and then nobody uses it.
- *
- * integrate w/ mu-plugins/blocks to share any common components
- *
- * use static header/footer and styles, instead of the current site?
- * 	see https://github.com/wceu/wordcamp-pwa-page/issues/6#issuecomment-499562295 and replies,
- * 	also https://make.wordpress.org/community/2019/04/30/wordcamp-pwa-an-update/#comment-26927
- *
- * include sidebar?
- *
- * what about default content when js fails to load? should show the full schedule instead of live schedule? or too much hassle?
- *
- * could show last 3 posts from php. do those even need to be live-updated during the event? how often are new posts published _during_ the event?
  */
 
 namespace WordCamp\Theme_Templates;
@@ -39,7 +14,7 @@ get_header();
 ?>
 
 <main id="day-of-event">
-	<?php echo _e( 'Loading...', 'wordcamporg' ); ?>
+	<?php esc_html_e( 'Loading...', 'wordcamporg' ); ?>
 </main>
 
 <?php

--- a/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event/src/api.js
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event/src/api.js
@@ -5,9 +5,6 @@ import apiFetch         from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 export function fetchSessions() {
-	// todo this is REALLY slow, takes almost 10 seconds on reasonably fast connection
-		// need to pair down to only fields being used, maybe other optimizations discussed in #6
-
 	return apiFetch( {
 		path: addQueryArgs( `wp/v2/sessions`, {
 			per_page: 100,
@@ -35,5 +32,3 @@ export function fetchPosts() {
 		} ),
 	} );
 }
-
-// todo maybe don't need this file, just embed into maincontroller?

--- a/public_html/wp-content/mu-plugins/theme-templates/templates/offline.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/offline.php
@@ -1,38 +1,21 @@
 <?php
-
 /**
  * Template Name: Offline Notice
  *
  * The service worker will show this template to visitors who are browsing offline.
  *
- * To test changes to it, you'll need to
- * temporarily enable the `Bypass for network` setting in dev tools.
- * 		^ doesn't work when using `offline` in chrome dev tools
- * 		maybe when using urls directly?
+ * To test changes…
+ * - Temporarily enable the `Bypass for network` setting in dev tools.
+ * - View the template at this URL: https://your-site-name.com/?wp_error_template=offline
  *
+ * Can also test by going offline in dev tools, but the template is precached so you'll need to update the service
+ * worker and reload it before going offline.
  * See https://github.com/xwp/pwa-wp/issues/167#issuecomment-501004695
  */
 
 namespace WordCamp\Theme_Templates;
 
 get_header();
-
-/*
- * todo
- *
- * test this across themes
- * test with child themes to make sure parent theme stylesheet is cached too
- * 		should theoretically pre-cache all stylesheets, but don't need to in practice b/c caching route takes care of?
- * 		can't hurt. maybe needed if regular cached assets are evicted to free up space, whereas precached ones wouldn't be?
- * test with themes replacing and extending the theme stylesheet (via jetpack/remote-css)
- * add date/time, location, schedule, etc -- https://github.com/wceu/wordcamp-pwa-page/issues/9
- * Should we add `{{{error_details_iframe}}}` ?
- * Should we add `wp_service_worker_error_details_template()` ?
- * Maybe list all of the pages that are available offline, ala https://chrisruppel.com/travel/
- * 		Maybe do that instead of the regular navigation menu?
- * include sidebar?
- */
-
 ?>
 
 	<main>
@@ -44,44 +27,20 @@ get_header();
 			<?php esc_html_e( "This page couldn't be loaded because you appear to be offline. Please try again once you have a network connection.", 'wordcamporg' ); ?>
 		</p>
 
-		<div>
-			<?php
-			// todo repeats "please try again..." from above hardcoded string in some cases, but not all.
-			// need to detect when and avoid saying it twice?
-			// or just don't call this b/c it doesn't provide detailed error message that'd be useful to user?
-			// -- wp_service_worker_error_message_placeholder();
-			// ?>
-		</div>
-
 		<p>
-			<?php _e( "In the mean time, hopefully this information is useful:", 'wordcamporg' );
-			// todo that string needs a lot of work
-			// probably try to get it to be a single sentance merged with the one above, b/c otherwise the user might not see it if it's below the fold,
-			// and they might not realize that the schedule etc is available below
-			?>
+			<?php esc_html_e( 'In the mean time, hopefully this information is useful:', 'wordcamporg' ); ?>
 		</p>
 
 		<?php
-			require_once( dirname( __DIR__ ) . '/parts/dates.php' );
-			require_once( dirname( __DIR__ ) . '/parts/location.php' );
+			require_once dirname( __DIR__ ) . '/parts/dates.php';
+			require_once dirname( __DIR__ ) . '/parts/location.php';
 		?>
 
 		<h3>
 			<?php esc_html_e( 'Schedule' ); ?>
 		</h3>
 
-		<?php
-		/*
-		 * todo
-		 *
-		 * this doesn't have headlines for separate days. why not? will probably be fixed by replacing block with shortcode though
-		 * maybe need to specify params to show all days/all tracks/etc
-		 * disable "favorites" b/c it won't work? well, some parts will and some parts won't. probably better to leave it, but think about in more detail
-		 * replace w/ Schedule block once that's available, but use feature flag for back-compat
-		 */
-		echo do_shortcode( '[schedule]' );
-
-		?>
+		<?php echo do_shortcode( '[schedule]' ); ?>
 	</main>
 
 <?php


### PR DESCRIPTION
Leaving comments in files is good for future developers, but it's hard to have discussions or take action based on them. I've copied out all the issues described in these comments into issues with the [PWA](https://github.com/WordPress/wordcamp.org/issues?q=is%3Aissue+is%3Aopen+label%3A%22%5BComponent%5D+PWA%22) and [Theme Templates](https://github.com/WordPress/wordcamp.org/issues?q=is%3Aissue+is%3Aopen+label%3A%22%5BComponent%5D+Theme+Templates%22) labels, or in some cases into trello cards.

The issues with "PWA Discussion", #202 & #204, specifically need discussion, while the rest are tasks to complete. 

I also cleaned up some phpcs errors as I went 🧹

**To test**

- There should be no functionality change anywhere