### PR TITLE
Meetup Client: Refactor to stop using v2 API endpoints

### DIFF
--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -178,20 +178,6 @@ class Meetup_Client extends API_Client {
 	}
 
 	/**
-	 * Sign a request URL with our API key.
-	 *
-	 * @param string $request_url
-	 *
-	 * @return string
-	 */
-	protected function sign_request_url( $request_url ) {
-		return add_query_arg( array(
-			'sign' => true,
-			'key'  => $this->api_key,
-		), $request_url );
-	}
-
-	/**
 	 * Generate headers to use in a request.
 	 *
 	 * @return array

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -322,33 +322,40 @@ class Meetup_Client extends API_Client {
 	/**
 	 * Retrieve data about events associated with a set of groups.
 	 *
-	 * This automatically breaks up requests into chunks of 50 groups to avoid overloading the API.
+	 * Because of the way that the Meetup API v3 endpoints are structured, we unfortunately have to make one request
+	 * (or more, if there's pagination) for each group that we want events for. When there are hundreds of groups, and
+	 * we are throttling to make sure we don't get rate-limited, this process can literally take several minutes.
 	 *
-	 * @param array $group_ids The IDs of the groups to get events for.
-	 * @param array $args      Optional. Additional request parameters.
-	 *                         See https://www.meetup.com/meetup_api/docs/2/events/.
+	 * So, when building the array for the $group_slugs parameter, it's important to filter out groups that you know
+	 * will not provide relevant results. For example, if you want all events during a date range in the past, you can
+	 * filter out groups that didn't join the chapter program until after your date range.
+	 *
+	 * Note that when using date/time related parameters in the $args array, unlike other endpoints and fields in the
+	 * Meetup API which use an epoch timestamp in milliseconds, this one requires a date/time string formatted in
+	 * ISO 8601, without the timezone part. Because consistency is overrated.
+	 *
+	 * @param array $group_slugs The URL slugs of each group to retrieve events for. Also known as `urlname`.
+	 * @param array $args        Optional. Additional request parameters.
+	 *                           See https://www.meetup.com/meetup_api/docs/:urlname/events/#list
 	 *
 	 * @return array|WP_Error
 	 */
-	public function get_events( array $group_ids, array $args = array() ) {
-		$url_base     = $this->api_base . '2/events';
-		$group_chunks = array_chunk( $group_ids, 50, true ); // Meetup API sometimes throws an error with chunk size larger than 50.
-		$events       = array();
+	public function get_events( array $group_slugs, array $args = array() ) {
+		$events = array();
 
-		foreach ( $group_chunks as $chunk ) {
-			$query_args = array_merge( array(
-				'group_id' => implode( ',', $chunk ),
-			), $args );
+		if ( $this->debug ) {
+			$chunked     = array_chunk( $group_slugs, 10 );
+			$group_slugs = $chunked[0];
+		}
 
-			$request_url = add_query_arg( $query_args, $url_base );
+		foreach ( $group_slugs as $group_slug ) {
+			$response = $this->get_group_events( $group_slug, $args );
 
-			$data = $this->send_paginated_request( $request_url );
-
-			if ( is_wp_error( $data ) ) {
-				return $data;
+			if ( is_wp_error( $response ) ) {
+				return $response;
 			}
 
-			$events = array_merge( $events, $data );
+			$events = array_merge( $events, $response );
 		}
 
 		return $events;

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -187,6 +187,7 @@ class Meetup_Client extends API_Client {
 
 		return array(
 			'headers' => array(
+				'Accept'        => 'application/json',
 				'Authorization' => "Bearer $oauth_token",
 			),
 		);

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -371,15 +371,16 @@ class Meetup_Client extends API_Client {
 	}
 
 	/**
-	 * Retrieve data about the group. Calls https://www.meetup.com/meetup_api/docs/:urlname/#get
+	 * Retrieve details about a group.
 	 *
 	 * @param string $group_slug The slug/urlname of a group.
 	 * @param array  $args       Optional. Additional request parameters.
+	 *                           See https://www.meetup.com/meetup_api/docs/:urlname/#get
 	 *
 	 * @return array|WP_Error
 	 */
 	public function get_group_details( $group_slug, $args = array() ) {
-		$request_url = $this->api_base . "$group_slug";
+		$request_url = $this->api_base . sanitize_key( $group_slug );
 
 		if ( ! empty( $args ) ) {
 			$request_url = add_query_arg( $args, $request_url );
@@ -389,15 +390,16 @@ class Meetup_Client extends API_Client {
 	}
 
 	/**
-	 * Retrieve group members. Calls https://www.meetup.com/meetup_api/docs/:urlname/members/#list
+	 * Retrieve details about group members.
 	 *
 	 * @param string $group_slug The slug/urlname of a group.
 	 * @param array  $args       Optional. Additional request parameters.
+	 *                           See https://www.meetup.com/meetup_api/docs/:urlname/members/#list
 	 *
 	 * @return array|WP_Error
 	 */
 	public function get_group_members( $group_slug, $args = array() ) {
-		$request_url = $this->api_base . "$group_slug/members";
+		$request_url = $this->api_base . sanitize_key( $group_slug ) . '/members';
 
 		if ( ! empty( $args ) ) {
 			$request_url = add_query_arg( $args, $request_url );
@@ -411,12 +413,12 @@ class Meetup_Client extends API_Client {
 	 *
 	 * @param string $group_slug The slug/urlname of a group.
 	 * @param array  $args       Optional. Additional request parameters.
-	 *                           See https://www.meetup.com/meetup_api/docs/:urlname/events/.
+	 *                           See https://www.meetup.com/meetup_api/docs/:urlname/events/#list
 	 *
 	 * @return array|WP_Error
 	 */
 	public function get_group_events( $group_slug, array $args = array() ) {
-		$request_url = $this->api_base . "$group_slug/events";
+		$request_url = $this->api_base . sanitize_key( $group_slug ) . '/events';
 
 		if ( ! empty( $args ) ) {
 			$request_url = add_query_arg( $args, $request_url );

--- a/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-meetup-client.php
@@ -234,6 +234,8 @@ class Meetup_Client extends API_Client {
 	 * Check the rate limit status in an API response and delay further execution if necessary.
 	 *
 	 * @param array $headers
+	 *
+	 * @return void
 	 */
 	protected static function throttle( $response ) {
 		$headers = wp_remote_retrieve_headers( $response );
@@ -245,11 +247,17 @@ class Meetup_Client extends API_Client {
 		$remaining = absint( $headers['x-ratelimit-remaining'] );
 		$period    = absint( $headers['x-ratelimit-reset'] );
 
-		// Pause more frequently than we need to, and for longer, just to be safe.
-		if ( $remaining > 2 ) {
+		/**
+		 * Don't throttle if we have sufficient requests remaining.
+		 *
+		 * We don't let this number get to 0, though, because there are scenarios where multiple processes are using
+		 * the API at the same time, and there's no way for them to be aware of each other.
+		 */
+		if ( $remaining > 3 ) {
 			return;
 		}
 
+		// Pause for longer than we need to, just to be safe.
 		if ( $period < 2 ) {
 			$period = 2;
 		}

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-events.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-events.php
@@ -465,6 +465,7 @@ class Meetup_Events extends Base {
 		) {
 			$options = array(
 				'earliest_start' => new DateTime( '2015-01-01' ), // Chapter program started in 2015.
+				'max_interval'   => new DateInterval( 'P1Y' ),
 				'search_query'   => $search_query,
 				'search_fields'  => self::get_search_fields(),
 			);
@@ -513,6 +514,7 @@ class Meetup_Events extends Base {
 
 		$options = array(
 			'earliest_start' => new DateTime( '2015-01-01' ), // Chapter program started in 2015.
+			'max_interval'   => new DateInterval( 'P1Y' ),
 			'search_query'   => $search_query,
 			'search_fields'  => self::get_search_fields(),
 		);
@@ -608,6 +610,7 @@ class Meetup_Events extends Base {
 
 			$options = array(
 				'earliest_start' => new DateTime( '2015-01-01' ), // Chapter program started in 2015.
+				'max_interval'   => new DateInterval( 'P1Y' ),
 			);
 
 			$report = new self( $range->start, $range->end, $options );

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-events.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-events.php
@@ -176,6 +176,8 @@ class Meetup_Events extends Base {
 		$groups = $meetup->get_groups( array(
 			// Don't include groups that joined the chapter program later than the date range.
 			'pro_join_date_max' => $this->range->end->getTimestamp() * 1000,
+			// Don't include groups whose last event was before the start of the date range.
+			'last_event_min'    => $this->range->start->getTimestamp() * 1000,
 		) );
 
 		if ( is_wp_error( $groups ) ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-events.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-events.php
@@ -167,6 +167,10 @@ class Meetup_Events extends Base {
 			return $data;
 		}
 
+		// @todo Maybe find a way to run this without having to hack the ini.
+		ini_set( 'memory_limit', '900M' );
+		ini_set( 'max_execution_time', 500 );
+
 		$meetup = new Meetup_Client();
 
 		$groups = $meetup->get_groups( array(

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/meetup-events.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/meetup-events.php
@@ -57,6 +57,10 @@ defined( 'WPINC' ) || die();
 
 	<table class="striped widefat but-not-too-wide">
 		<tr>
+			<td>Total groups as of <?php echo esc_html( $end_date->format( 'M jS, Y' ) ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['total_groups'] ); ?></td>
+		</tr>
+		<tr>
 			<td>Groups with at least one event during the date range</td>
 			<td class="number"><?php echo number_format_i18n( $data['groups_with_events'] ); ?></td>
 		</tr>


### PR DESCRIPTION
Meetup will apparently shut down all of the v2 API endpoints on 2019-08-15. Our client was still using the v2 `events` endpoint, so this refactor changes that to get as close as possible to the same dataset using v3 endpoints. It's not a perfect match, though, and the v3 API is not friendly towards our use case of pulling events from a large number of different groups all at once.

Client changes:
* Refactor the `get_events` method
* Remove unused signing method
* Add a request header for accepting json content type
* Adjust the throttle mechanism to be a bit more conservative
* Sanitize group slugs before using them in API endpoint requests

This also refactors the Meetup Events report in the WordCamp Reports plugin, since the refactored `get_events` method isn't a dropin replacement.

**To test**

Load this changeset into your wporg sandbox and then try running the [Meetup Events report](https://central.wordcamp.org/wp-admin/index.php?page=wordcamp-reports&report=meetup-events). It will take a really long time, but should produce results.