### PR TITLE
Blocks: Add jest infrastructure for component testing

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/package-lock.json
+++ b/public_html/wp-content/mu-plugins/blocks/package-lock.json
@@ -14,25 +14,118 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-			"integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.1.2",
-				"@babel/helpers": "^7.1.2",
-				"@babel/parser": "^7.1.2",
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.1.2",
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.5.5",
+				"@babel/helpers": "^7.5.5",
+				"@babel/parser": "^7.5.5",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.5.5",
+				"@babel/types": "^7.5.5",
 				"convert-source-map": "^1.1.0",
-				"debug": "^3.1.0",
-				"json5": "^0.5.0",
-				"lodash": "^4.17.10",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.13",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
@@ -258,15 +351,6 @@
 				}
 			}
 		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
 		"@babel/helper-module-imports": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
@@ -276,26 +360,62 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+			"integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/template": "^7.2.2",
-				"@babel/types": "^7.2.2",
-				"lodash": "^4.17.10"
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/types": "^7.5.5",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -305,12 +425,20 @@
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -323,18 +451,6 @@
 				"@babel/helper-wrap-function": "^7.1.0",
 				"@babel/template": "^7.1.0",
 				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-replace-supers": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
-			"integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.0.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.2.3",
 				"@babel/types": "^7.0.0"
 			}
 		},
@@ -370,14 +486,109 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.5",
-				"@babel/types": "^7.3.0"
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.5.5",
+				"@babel/types": "^7.5.5"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -468,6 +679,12 @@
 						"lodash": "^4.17.13"
 					}
 				},
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
 				"lodash": {
 					"version": "4.17.15",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -486,6 +703,33 @@
 						"regjsparser": "^0.6.0",
 						"unicode-match-property-ecmascript": "^1.0.4",
 						"unicode-match-property-value-ecmascript": "^1.1.0"
+					},
+					"dependencies": {
+						"regjsgen": {
+							"version": "0.5.0",
+							"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+							"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+							"dev": true
+						},
+						"regjsparser": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+							"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+							"dev": true,
+							"requires": {
+								"jsesc": "~0.5.0"
+							}
+						},
+						"unicode-match-property-ecmascript": {
+							"version": "1.0.4",
+							"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+							"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+							"dev": true,
+							"requires": {
+								"unicode-canonical-property-names-ecmascript": "^1.0.4",
+								"unicode-property-aliases-ecmascript": "^1.0.4"
+							}
+						}
 					}
 				}
 			}
@@ -638,6 +882,15 @@
 						"@babel/types": "^7.5.5"
 					}
 				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+					"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
 				"@babel/helper-replace-supers": {
 					"version": "7.5.5",
 					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
@@ -748,6 +1001,12 @@
 						"lodash": "^4.17.13"
 					}
 				},
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
 				"lodash": {
 					"version": "4.17.15",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -766,6 +1025,33 @@
 						"regjsparser": "^0.6.0",
 						"unicode-match-property-ecmascript": "^1.0.4",
 						"unicode-match-property-value-ecmascript": "^1.1.0"
+					},
+					"dependencies": {
+						"regjsgen": {
+							"version": "0.5.0",
+							"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+							"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+							"dev": true
+						},
+						"regjsparser": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+							"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+							"dev": true,
+							"requires": {
+								"jsesc": "~0.5.0"
+							}
+						},
+						"unicode-match-property-ecmascript": {
+							"version": "1.0.4",
+							"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+							"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+							"dev": true,
+							"requires": {
+								"unicode-canonical-property-names-ecmascript": "^1.0.4",
+								"unicode-property-aliases-ecmascript": "^1.0.4"
+							}
+						}
 					}
 				}
 			}
@@ -947,16 +1233,6 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-transform-object-super": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0"
-			}
-		},
 		"@babel/plugin-transform-parameters": {
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
@@ -1085,6 +1361,12 @@
 						"lodash": "^4.17.13"
 					}
 				},
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
 				"lodash": {
 					"version": "4.17.15",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -1103,6 +1385,33 @@
 						"regjsparser": "^0.6.0",
 						"unicode-match-property-ecmascript": "^1.0.4",
 						"unicode-match-property-value-ecmascript": "^1.1.0"
+					},
+					"dependencies": {
+						"regjsgen": {
+							"version": "0.5.0",
+							"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+							"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+							"dev": true
+						},
+						"regjsparser": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+							"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+							"dev": true,
+							"requires": {
+								"jsesc": "~0.5.0"
+							}
+						},
+						"unicode-match-property-ecmascript": {
+							"version": "1.0.4",
+							"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+							"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+							"dev": true,
+							"requires": {
+								"unicode-canonical-property-names-ecmascript": "^1.0.4",
+								"unicode-property-aliases-ecmascript": "^1.0.4"
+							}
+						}
 					}
 				}
 			}
@@ -1206,6 +1515,17 @@
 						"@babel/helper-optimise-call-expression": "^7.0.0",
 						"@babel/traverse": "^7.5.5",
 						"@babel/types": "^7.5.5"
+					},
+					"dependencies": {
+						"@babel/helper-optimise-call-expression": {
+							"version": "7.0.0",
+							"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+							"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.0.0"
+							}
+						}
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -1480,18 +1800,18 @@
 			"dev": true
 		},
 		"@hapi/topo": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-			"integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+			"integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
 			"dev": true,
 			"requires": {
 				"@hapi/hoek": "8.x.x"
 			},
 			"dependencies": {
 				"@hapi/hoek": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
-					"integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw==",
+					"version": "8.2.1",
+					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+					"integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==",
 					"dev": true
 				}
 			}
@@ -1542,6 +1862,12 @@
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -1846,9 +2172,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.6.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.4.tgz",
-			"integrity": "sha512-ZKrDzI6KhrqtLpccI1YxMh4d+qzNnftNtp6iL9c4mLTNgzguFu7VR7pXH/C/MfzikMeoXjvISL9mlIGNGGDXDg==",
+			"version": "12.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+			"integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -1891,96 +2217,74 @@
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.10.tgz",
-			"integrity": "sha512-wTUeaByYN2EA6qVqhbgavtGc7fLTOx0glG2IBsFlrFG51uXIGlYBTyIZMf4SPLo3v1bgV/7lBN3l7Z0R6Hswew==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
+			"integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.7.10",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-				"@webassemblyjs/wast-parser": "1.7.10"
+				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+				"@webassemblyjs/wast-parser": "1.4.3",
+				"debug": "^3.1.0",
+				"webassemblyjs": "1.4.3"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.10.tgz",
-			"integrity": "sha512-gMsGbI6I3p/P1xL2UxqhNh1ga2HCsx5VBB2i5VvJFAaqAjd2PBTRULc3BpTydabUQEGlaZCzEUQhLoLG7TvEYQ==",
-			"dev": true
-		},
-		"@webassemblyjs/helper-api-error": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.10.tgz",
-			"integrity": "sha512-DoYRlPWtuw3yd5BOr9XhtrmB6X1enYF0/54yNvQWGXZEPDF5PJVNI7zQ7gkcKfTESzp8bIBWailaFXEK/jjCsw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
+			"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.10.tgz",
-			"integrity": "sha512-+RMU3dt/dPh4EpVX4u5jxsOlw22tp3zjqE0m3ftU2tsYxnPULb4cyHlgaNd2KoWuwasCQqn8Mhr+TTdbtj3LlA==",
-			"dev": true
-		},
-		"@webassemblyjs/helper-code-frame": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.10.tgz",
-			"integrity": "sha512-UiytbpKAULOEab2hUZK2ywXen4gWJVrgxtwY3Kn+eZaaSWaRM8z/7dAXRSoamhKFiBh1uaqxzE/XD9BLlug3gw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz",
+			"integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.7.10"
+				"debug": "^3.1.0"
+			}
+		},
+		"@webassemblyjs/helper-code-frame": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
+			"integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
+			"dev": true,
+			"requires": {
+				"@webassemblyjs/wast-printer": "1.4.3"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.10.tgz",
-			"integrity": "sha512-w2vDtUK9xeSRtt5+RnnlRCI7wHEvLjF0XdnxJpgx+LJOvklTZPqWkuy/NhwHSLP19sm9H8dWxKeReMR7sCkGZA==",
-			"dev": true
-		},
-		"@webassemblyjs/helper-module-context": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.10.tgz",
-			"integrity": "sha512-yE5x/LzZ3XdPdREmJijxzfrf+BDRewvO0zl8kvORgSWmxpRrkqY39KZSq6TSgIWBxkK4SrzlS3BsMCv2s1FpsQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
+			"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.10.tgz",
-			"integrity": "sha512-u5qy4SJ/OrxKxZqJ9N3qH4ZQgHaAzsopsYwLvoWJY6Q33r8PhT3VPyNMaJ7ZFoqzBnZlCcS/0f4Sp8WBxylXfg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
+			"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.10.tgz",
-			"integrity": "sha512-Ecvww6sCkcjatcyctUrn22neSJHLN/TTzolMGG/N7S9rpbsTZ8c6Bl98GpSpV77EvzNijiNRHBG0+JO99qKz6g==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.4.3.tgz",
+			"integrity": "sha512-p0yeeO/h2r30PyjnJX9xXSR6EDcvJd/jC6xa/Pxg4lpfcNi7JUswOpqDToZQ55HMMVhXDih/yqkaywHWGLxqyQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/helper-buffer": "1.7.10",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-				"@webassemblyjs/wasm-gen": "1.7.10"
-			}
-		},
-		"@webassemblyjs/ieee754": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.10.tgz",
-			"integrity": "sha512-HRcWcY+YWt4+s/CvQn+vnSPfRaD4KkuzQFt5MNaELXXHSjelHlSEA8ZcqT69q0GTIuLWZ6JaoKar4yWHVpZHsQ==",
-			"dev": true,
-			"requires": {
-				"@xtuc/ieee754": "^1.2.0"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/helper-buffer": "1.4.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+				"@webassemblyjs/wasm-gen": "1.4.3",
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.10.tgz",
-			"integrity": "sha512-og8MciYlA8hvzCLR71hCuZKPbVBfLQeHv7ImKZ4nlyxrYbG7uJHYtHiHu6OV9SqrGuD03H/HtXC4Bgdjfm9FHw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
+			"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
 			"dev": true,
 			"requires": {
-				"@xtuc/long": "4.2.1"
+				"leb": "^0.3.0"
 			}
-		},
-		"@webassemblyjs/utf8": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.10.tgz",
-			"integrity": "sha512-Ng6Pxv6siyZp635xCSnH3mKmIFgqWPCcGdoo0GBYgyGdxu7cUj4agV7Uu1a8REP66UYUFXJLudeGgd4RvuJAnQ==",
-			"dev": true
 		},
 		"@webassemblyjs/validation": {
 			"version": "1.4.3",
@@ -1989,152 +2293,85 @@
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3"
-			},
-			"dependencies": {
-				"@webassemblyjs/ast": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
-					"integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/wast-parser": "1.4.3",
-						"debug": "^3.1.0",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/floating-point-hex-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
-					"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-code-frame": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
-					"integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/wast-printer": "1.4.3"
-					}
-				},
-				"@webassemblyjs/helper-fsm": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
-					"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-wasm-bytecode": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
-					"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
-					"dev": true
-				},
-				"@webassemblyjs/wast-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
-					"integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/floating-point-hex-parser": "1.4.3",
-						"@webassemblyjs/helper-code-frame": "1.4.3",
-						"@webassemblyjs/helper-fsm": "1.4.3",
-						"long": "^3.2.0",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/wast-printer": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
-					"integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/wast-parser": "1.4.3",
-						"long": "^3.2.0"
-					}
-				}
 			}
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.10.tgz",
-			"integrity": "sha512-e9RZFQlb+ZuYcKRcW9yl+mqX/Ycj9+3/+ppDI8nEE/NCY6FoK8f3dKBcfubYV/HZn44b+ND4hjh+4BYBt+sDnA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.4.3.tgz",
+			"integrity": "sha512-qzuwUn771PV6/LilqkXcS0ozJYAeY/OKbXIWU3a8gexuqb6De2p4ya/baBeH5JQ2WJdfhWhSvSbu86Vienttpw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/helper-buffer": "1.7.10",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-				"@webassemblyjs/helper-wasm-section": "1.7.10",
-				"@webassemblyjs/wasm-gen": "1.7.10",
-				"@webassemblyjs/wasm-opt": "1.7.10",
-				"@webassemblyjs/wasm-parser": "1.7.10",
-				"@webassemblyjs/wast-printer": "1.7.10"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/helper-buffer": "1.4.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+				"@webassemblyjs/helper-wasm-section": "1.4.3",
+				"@webassemblyjs/wasm-gen": "1.4.3",
+				"@webassemblyjs/wasm-opt": "1.4.3",
+				"@webassemblyjs/wasm-parser": "1.4.3",
+				"@webassemblyjs/wast-printer": "1.4.3",
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.10.tgz",
-			"integrity": "sha512-M0lb6cO2Y0PzDye/L39PqwV+jvO+2YxEG5ax+7dgq7EwXdAlpOMx1jxyXJTScQoeTpzOPIb+fLgX/IkLF8h2yw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.4.3.tgz",
+			"integrity": "sha512-eR394T8dHZfpLJ7U/Z5pFSvxl1L63JdREebpv9gYc55zLhzzdJPAuxjBYT4XqevUdW67qU2s0nNA3kBuNJHbaQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-				"@webassemblyjs/ieee754": "1.7.10",
-				"@webassemblyjs/leb128": "1.7.10",
-				"@webassemblyjs/utf8": "1.7.10"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+				"@webassemblyjs/leb128": "1.4.3"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.10.tgz",
-			"integrity": "sha512-R66IHGCdicgF5ZliN10yn5HaC7vwYAqrSVJGjtJJQp5+QNPBye6heWdVH/at40uh0uoaDN/UVUfXK0gvuUqtVg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.4.3.tgz",
+			"integrity": "sha512-7Gp+nschuKiDuAL1xmp4Xz0rgEbxioFXw4nCFYEmy+ytynhBnTeGc9W9cB1XRu1w8pqRU2lbj2VBBA4cL5Z2Kw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/helper-buffer": "1.7.10",
-				"@webassemblyjs/wasm-gen": "1.7.10",
-				"@webassemblyjs/wasm-parser": "1.7.10"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/helper-buffer": "1.4.3",
+				"@webassemblyjs/wasm-gen": "1.4.3",
+				"@webassemblyjs/wasm-parser": "1.4.3",
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.10.tgz",
-			"integrity": "sha512-AEv8mkXVK63n/iDR3T693EzoGPnNAwKwT3iHmKJNBrrALAhhEjuPzo/lTE4U7LquEwyvg5nneSNdTdgrBaGJcA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
+			"integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/helper-api-error": "1.7.10",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-				"@webassemblyjs/ieee754": "1.7.10",
-				"@webassemblyjs/leb128": "1.7.10",
-				"@webassemblyjs/utf8": "1.7.10"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+				"@webassemblyjs/leb128": "1.4.3",
+				"@webassemblyjs/wasm-parser": "1.4.3",
+				"webassemblyjs": "1.4.3"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.10.tgz",
-			"integrity": "sha512-YTPEtOBljkCL0VjDp4sHe22dAYSm3ZwdJ9+2NTGdtC7ayNvuip1wAhaAS8Zt9Q6SW9E5Jf5PX7YE3XWlrzR9cw==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
+			"integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/floating-point-hex-parser": "1.7.10",
-				"@webassemblyjs/helper-api-error": "1.7.10",
-				"@webassemblyjs/helper-code-frame": "1.7.10",
-				"@webassemblyjs/helper-fsm": "1.7.10",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/floating-point-hex-parser": "1.4.3",
+				"@webassemblyjs/helper-code-frame": "1.4.3",
+				"@webassemblyjs/helper-fsm": "1.4.3",
+				"long": "^3.2.0",
+				"webassemblyjs": "1.4.3"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.7.10",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.10.tgz",
-			"integrity": "sha512-mJ3QKWtCchL1vhU/kZlJnLPuQZnlDOdZsyP0bbLWPGdYsQDnSBvyTLhzwBA3QAMlzEL9V4JHygEmK6/OTEyytA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
+			"integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/wast-parser": "1.7.10",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/wast-parser": "1.4.3",
+				"long": "^3.2.0"
 			}
 		},
 		"@wordpress/a11y": {
@@ -2486,9 +2723,9 @@
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.0.1.tgz",
-			"integrity": "sha512-Ov4IljSGSPDjQPKV79tXKk7Ljndo+f84aImKIH8mzTMRbZS+7wPzz6jHAa/FpGmf7R99QqaN4CNRpvBihu3o9Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.1.0.tgz",
+			"integrity": "sha512-tCyxy7hLzDdCHQ1xGPiMlE7fBp/pCuEum89gqzoiz2HQJld6F7BTNMo3XfTzxFO0SHh/C64yOZgBB8FvH+warQ==",
 			"dev": true,
 			"requires": {
 				"webpack": "^4.8.3",
@@ -2752,40 +2989,46 @@
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.1.0.tgz",
-			"integrity": "sha512-6ofKMrGnmDFUnc9zdxN8AfuD3IDrf4THnvJ2QEvz71FVZZbFRLlFZOGs4O/IFmPPOMa/0/lGvTEJr9THZ44wBw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.2.0.tgz",
+			"integrity": "sha512-WZl2eJH9g+OSTrFPpAKSCT7Pl7rvwatPnBm1Z4kpPZdOQDbF3w2a6yzfpjtBBD2BVEqHsaLAxn0jC6xHkqbAxw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"jest-matcher-utils": "^24.7.0",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
-					"integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
 					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
 				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
 				"regenerator-runtime": {
-					"version": "0.13.2",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
 					"dev": true
 				}
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-4.2.0.tgz",
-			"integrity": "sha512-EJUF7cwqqqpjx5H6exW4RcAZU3eTkzsPFb+Huh/R06t7D91clTQ3PG04h22sbGNDc245lG1ta3wyL04YaWo47A==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-4.3.0.tgz",
+			"integrity": "sha512-b8rucE3e7+VkD/gX9pB6c9ZysjUAOfNG2Lcp8OLtfzWvlzMkuJtl7+9P/D6GAWk2GEK54GdM018vl3IM5HkaHg==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "^3.1.0",
+				"@wordpress/jest-console": "^3.2.0",
 				"babel-jest": "^24.7.1",
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
@@ -2825,6 +3068,12 @@
 					"dev": true
 				}
 			}
+		},
+		"@wordpress/npm-package-json-lint-config": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.1.0.tgz",
+			"integrity": "sha512-NSwcK7GtlmW5O5ZMG7elRKBa9sPws17Sadjlztig6ShOuhlLFeHYk99tUenpmJ/PYOZex4fSJ5e9mqjPyKunjw==",
+			"dev": true
 		},
 		"@wordpress/priority-queue": {
 			"version": "1.3.0",
@@ -2926,16 +3175,17 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-3.3.0.tgz",
-			"integrity": "sha512-kQBzYMGNhAgTaguS0IZGT9LsmaeC1wgJ8pExjc7md8i9ldp4GPOJCOxVefLkxid6vVJrOi0GzBVYqEfiwpFFCQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-3.4.0.tgz",
+			"integrity": "sha512-PPOXYLLnqdxc/w0BU7YpJoa2G14WbukeWZGavjiYl98l5x4QO6Ddpo31D8Ev+kBMkmIWeyO7Pmgj0flrg8Vd/w==",
 			"dev": true,
 			"requires": {
-				"@wordpress/babel-preset-default": "^4.3.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1",
-				"@wordpress/eslint-plugin": "^2.3.0",
-				"@wordpress/jest-preset-default": "^4.2.0",
-				"@wordpress/npm-package-json-lint-config": "^2.0.0",
+				"@wordpress/babel-preset-default": "^4.4.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^1.1.0",
+				"@wordpress/eslint-plugin": "^2.4.0",
+				"@wordpress/jest-preset-default": "^4.3.0",
+				"@wordpress/npm-package-json-lint-config": "^2.1.0",
+				"babel-jest": "^24.7.1",
 				"babel-loader": "^8.0.5",
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
@@ -2958,689 +3208,10 @@
 				"webpack-livereload-plugin": "^2.2.0"
 			},
 			"dependencies": {
-				"@babel/core": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
-					"integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.5.0",
-						"@babel/helpers": "^7.5.4",
-						"@babel/parser": "^7.5.0",
-						"@babel/template": "^7.4.4",
-						"@babel/traverse": "^7.5.0",
-						"@babel/types": "^7.5.0",
-						"convert-source-map": "^1.1.0",
-						"debug": "^4.1.0",
-						"json5": "^2.1.0",
-						"lodash": "^4.17.11",
-						"resolve": "^1.3.2",
-						"semver": "^5.4.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
-					"integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.5.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-call-delegate": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-					"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-hoist-variables": "^7.4.4",
-						"@babel/traverse": "^7.4.4",
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/helper-define-map": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-					"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/types": "^7.4.4",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/helper-hoist-variables": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-					"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/helper-regex": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-					"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-					"integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.0.0",
-						"@babel/helper-optimise-call-expression": "^7.0.0",
-						"@babel/traverse": "^7.4.4",
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/helpers": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
-					"integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
-					"dev": true,
-					"requires": {
-						"@babel/template": "^7.4.4",
-						"@babel/traverse": "^7.5.0",
-						"@babel/types": "^7.5.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
-					"integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
-					"dev": true
-				},
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.4.tgz",
-					"integrity": "sha512-KCx0z3y7y8ipZUMAEEJOyNi11lMb/FOPUjjB113tfowgw0c16EGYos7worCKBcUAh2oG+OBnoUhsnTSoLpV9uA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-					}
-				},
-				"@babel/plugin-proposal-unicode-property-regex": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-					"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-regex": "^7.4.4",
-						"regexpu-core": "^4.5.4"
-					}
-				},
-				"@babel/plugin-transform-async-to-generator": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-					"integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-remap-async-to-generator": "^7.1.0"
-					}
-				},
-				"@babel/plugin-transform-block-scoping": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
-					"integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/plugin-transform-classes": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-					"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-define-map": "^7.4.4",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-optimise-call-expression": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-replace-supers": "^7.4.4",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"globals": "^11.1.0"
-					}
-				},
-				"@babel/plugin-transform-destructuring": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-					"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-dotall-regex": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-					"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-regex": "^7.4.4",
-						"regexpu-core": "^4.5.4"
-					}
-				},
-				"@babel/plugin-transform-duplicate-keys": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-					"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-for-of": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-					"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-function-name": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-					"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-modules-amd": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-					"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.1.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"babel-plugin-dynamic-import-node": "^2.3.0"
-					}
-				},
-				"@babel/plugin-transform-modules-commonjs": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-					"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.4.4",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-simple-access": "^7.1.0",
-						"babel-plugin-dynamic-import-node": "^2.3.0"
-					},
-					"dependencies": {
-						"@babel/helper-module-transforms": {
-							"version": "7.4.4",
-							"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-							"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
-							"dev": true,
-							"requires": {
-								"@babel/helper-module-imports": "^7.0.0",
-								"@babel/helper-simple-access": "^7.1.0",
-								"@babel/helper-split-export-declaration": "^7.4.4",
-								"@babel/template": "^7.4.4",
-								"@babel/types": "^7.4.4",
-								"lodash": "^4.17.11"
-							}
-						}
-					}
-				},
-				"@babel/plugin-transform-modules-systemjs": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-					"integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-hoist-variables": "^7.4.4",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"babel-plugin-dynamic-import-node": "^2.3.0"
-					}
-				},
-				"@babel/plugin-transform-named-capturing-groups-regex": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-					"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
-					"dev": true,
-					"requires": {
-						"regexp-tree": "^0.1.6"
-					}
-				},
-				"@babel/plugin-transform-new-target": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-					"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-parameters": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-					"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-call-delegate": "^7.4.4",
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-regenerator": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-					"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
-					"dev": true,
-					"requires": {
-						"regenerator-transform": "^0.14.0"
-					}
-				},
-				"@babel/plugin-transform-runtime": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.0.tgz",
-					"integrity": "sha512-LmPIZOAgTLl+86gR9KjLXex6P/lRz1fWEjTz6V6QZMmKie51ja3tvzdwORqhHc4RWR8TcZ5pClpRWs0mlaA2ng==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"resolve": "^1.8.1",
-						"semver": "^5.5.1"
-					}
-				},
-				"@babel/plugin-transform-template-literals": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-					"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-unicode-regex": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-					"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-regex": "^7.4.4",
-						"regexpu-core": "^4.5.4"
-					}
-				},
-				"@babel/preset-env": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.4.tgz",
-					"integrity": "sha512-hFnFnouyRNiH1rL8YkX1ANCNAUVC8Djwdqfev8i1415tnAG+7hlA5zhZ0Q/3Q5gkop4HioIPbCEWAalqcbxRoQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-						"@babel/plugin-proposal-dynamic-import": "^7.5.0",
-						"@babel/plugin-proposal-json-strings": "^7.2.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.5.4",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-						"@babel/plugin-syntax-async-generators": "^7.2.0",
-						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-						"@babel/plugin-syntax-json-strings": "^7.2.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-transform-arrow-functions": "^7.2.0",
-						"@babel/plugin-transform-async-to-generator": "^7.5.0",
-						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-						"@babel/plugin-transform-block-scoping": "^7.4.4",
-						"@babel/plugin-transform-classes": "^7.4.4",
-						"@babel/plugin-transform-computed-properties": "^7.2.0",
-						"@babel/plugin-transform-destructuring": "^7.5.0",
-						"@babel/plugin-transform-dotall-regex": "^7.4.4",
-						"@babel/plugin-transform-duplicate-keys": "^7.5.0",
-						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-						"@babel/plugin-transform-for-of": "^7.4.4",
-						"@babel/plugin-transform-function-name": "^7.4.4",
-						"@babel/plugin-transform-literals": "^7.2.0",
-						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-						"@babel/plugin-transform-modules-amd": "^7.5.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.5.0",
-						"@babel/plugin-transform-modules-systemjs": "^7.5.0",
-						"@babel/plugin-transform-modules-umd": "^7.2.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
-						"@babel/plugin-transform-new-target": "^7.4.4",
-						"@babel/plugin-transform-object-super": "^7.2.0",
-						"@babel/plugin-transform-parameters": "^7.4.4",
-						"@babel/plugin-transform-property-literals": "^7.2.0",
-						"@babel/plugin-transform-regenerator": "^7.4.5",
-						"@babel/plugin-transform-reserved-words": "^7.2.0",
-						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-						"@babel/plugin-transform-spread": "^7.2.0",
-						"@babel/plugin-transform-sticky-regex": "^7.2.0",
-						"@babel/plugin-transform-template-literals": "^7.4.4",
-						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-						"@babel/plugin-transform-unicode-regex": "^7.4.4",
-						"@babel/types": "^7.5.0",
-						"browserslist": "^4.6.0",
-						"core-js-compat": "^3.1.1",
-						"invariant": "^2.2.2",
-						"js-levenshtein": "^1.1.3",
-						"semver": "^5.5.0"
-					}
-				},
-				"@babel/runtime": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
-					"integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.2"
-					}
-				},
-				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.0.tgz",
-					"integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.5.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.0",
-						"@babel/types": "^7.5.0",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/types": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-					"integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"@webassemblyjs/ast": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
-					"integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/wast-parser": "1.4.3",
-						"debug": "^3.1.0",
-						"webassemblyjs": "1.4.3"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
-					}
-				},
-				"@webassemblyjs/floating-point-hex-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
-					"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-buffer": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz",
-					"integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
-					"dev": true,
-					"requires": {
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
-					}
-				},
-				"@webassemblyjs/helper-code-frame": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
-					"integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/wast-printer": "1.4.3"
-					}
-				},
-				"@webassemblyjs/helper-fsm": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
-					"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-wasm-bytecode": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
-					"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-wasm-section": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.4.3.tgz",
-					"integrity": "sha512-p0yeeO/h2r30PyjnJX9xXSR6EDcvJd/jC6xa/Pxg4lpfcNi7JUswOpqDToZQ55HMMVhXDih/yqkaywHWGLxqyQ==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/helper-buffer": "1.4.3",
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/wasm-gen": "1.4.3",
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
-					}
-				},
-				"@webassemblyjs/leb128": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
-					"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
-					"dev": true,
-					"requires": {
-						"leb": "^0.3.0"
-					}
-				},
-				"@webassemblyjs/wasm-edit": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.4.3.tgz",
-					"integrity": "sha512-qzuwUn771PV6/LilqkXcS0ozJYAeY/OKbXIWU3a8gexuqb6De2p4ya/baBeH5JQ2WJdfhWhSvSbu86Vienttpw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/helper-buffer": "1.4.3",
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/helper-wasm-section": "1.4.3",
-						"@webassemblyjs/wasm-gen": "1.4.3",
-						"@webassemblyjs/wasm-opt": "1.4.3",
-						"@webassemblyjs/wasm-parser": "1.4.3",
-						"@webassemblyjs/wast-printer": "1.4.3",
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
-					}
-				},
-				"@webassemblyjs/wasm-gen": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.4.3.tgz",
-					"integrity": "sha512-eR394T8dHZfpLJ7U/Z5pFSvxl1L63JdREebpv9gYc55zLhzzdJPAuxjBYT4XqevUdW67qU2s0nNA3kBuNJHbaQ==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/leb128": "1.4.3"
-					}
-				},
-				"@webassemblyjs/wasm-opt": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.4.3.tgz",
-					"integrity": "sha512-7Gp+nschuKiDuAL1xmp4Xz0rgEbxioFXw4nCFYEmy+ytynhBnTeGc9W9cB1XRu1w8pqRU2lbj2VBBA4cL5Z2Kw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/helper-buffer": "1.4.3",
-						"@webassemblyjs/wasm-gen": "1.4.3",
-						"@webassemblyjs/wasm-parser": "1.4.3",
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
-					}
-				},
-				"@webassemblyjs/wasm-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
-					"integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/leb128": "1.4.3",
-						"@webassemblyjs/wasm-parser": "1.4.3",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/wast-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
-					"integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/floating-point-hex-parser": "1.4.3",
-						"@webassemblyjs/helper-code-frame": "1.4.3",
-						"@webassemblyjs/helper-fsm": "1.4.3",
-						"long": "^3.2.0",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/wast-printer": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
-					"integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/wast-parser": "1.4.3",
-						"long": "^3.2.0"
-					}
-				},
-				"@wordpress/babel-plugin-import-jsx-pragma": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.2.0.tgz",
-					"integrity": "sha512-H31qqjbXrQebue4ho8bu/vCPkVCENalxQMMAQOGulmQxOQ6IF+9uwglCR6ZiAWhZmPo6LFq0NQ+IPLSUX8IS8Q==",
-					"dev": true
-				},
-				"@wordpress/babel-preset-default": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.3.0.tgz",
-					"integrity": "sha512-yj/JEQh8SJzI3d6h531iVnKvFSYssdFb2PwpMCL5BuIXk98U+FOKSmIHj134WJ1lm4viwMIQeH3UZ93bJ0MqTQ==",
-					"dev": true,
-					"requires": {
-						"@babel/core": "^7.4.4",
-						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-						"@babel/plugin-transform-react-jsx": "^7.3.0",
-						"@babel/plugin-transform-runtime": "^7.4.4",
-						"@babel/preset-env": "^7.4.4",
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/babel-plugin-import-jsx-pragma": "^2.2.0",
-						"@wordpress/browserslist-config": "^2.5.0"
-					}
-				},
-				"@wordpress/browserslist-config": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.5.0.tgz",
-					"integrity": "sha512-cspE4iJ87YjweKAtnIsCxm7ZJQ/ved3TdRJWS0DX/0AOukoRhOMYh7CP1aVc0M3J1kB4LtTY7u3HOcqF2Yf2VA==",
-					"dev": true
-				},
 				"@wordpress/eslint-plugin": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-2.3.0.tgz",
-					"integrity": "sha512-1X1uvBfwx96dxz0NmLB22JhSNaJQCYP3bYAnaR5qMV+O9t6gwbdPl+1kpYhe2sSKFm72y6Tfi8CKRWsyKRCHUg==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-2.4.0.tgz",
+					"integrity": "sha512-FOsNM6cCKZKug/sXKAum1lceGiULm4sKZlBCHUHRNiGSbOlWs+kjoATQOuid9nGYVK/uzvQOCN1xwZJbQ9XjDw==",
 					"dev": true,
 					"requires": {
 						"babel-eslint": "^10.0.1",
@@ -3650,71 +3221,10 @@
 						"requireindex": "^1.2.0"
 					}
 				},
-				"@wordpress/npm-package-json-lint-config": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.0.0.tgz",
-					"integrity": "sha512-PF8wU2Vwo0TXsbK1Wj//9qpfcoFxs9A2gzHGNnyyH+npGlSqSE3tBXwz+sDNCVjRWgf8bIhPKQ9EmH2eXp4Ctw==",
-					"dev": true
-				},
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"babel-eslint": {
-					"version": "10.0.2",
-					"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
-					"integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"eslint-scope": "3.7.1",
-						"eslint-visitor-keys": "^1.0.0"
-					}
-				},
-				"babel-loader": {
-					"version": "8.0.6",
-					"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
-					"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
-					"dev": true,
-					"requires": {
-						"find-cache-dir": "^2.0.0",
-						"loader-utils": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"pify": "^4.0.1"
-					}
-				},
-				"browserslist": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000984",
-						"electron-to-chromium": "^1.3.191",
-						"node-releases": "^1.1.25"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000984",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz",
-					"integrity": "sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==",
-					"dev": true
-				},
-				"chrome-trace-event": {
-					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
-					"integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
 					"dev": true
 				},
 				"cliui": {
@@ -3737,32 +3247,6 @@
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"electron-to-chromium": {
-					"version": "1.3.191",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz",
-					"integrity": "sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==",
-					"dev": true
-				},
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
 					}
 				},
 				"get-caller-file": {
@@ -3791,120 +3275,17 @@
 						"which": "^1.3.1"
 					}
 				},
-				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
-				"node-releases": {
-					"version": "1.1.25",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.25.tgz",
-					"integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
-					"dev": true,
-					"requires": {
-						"semver": "^5.3.0"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				},
-				"regenerate-unicode-properties": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-					"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.13.2",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-					"dev": true
-				},
-				"regenerator-transform": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-					"integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
-					"dev": true,
-					"requires": {
-						"private": "^0.1.6"
-					}
-				},
-				"regexp-tree": {
-					"version": "0.1.11",
-					"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
-					"integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
-					"dev": true
-				},
-				"regexpu-core": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0",
-						"regenerate-unicode-properties": "^8.0.2",
-						"regjsgen": "^0.5.0",
-						"regjsparser": "^0.6.0",
-						"unicode-match-property-ecmascript": "^1.0.4",
-						"unicode-match-property-value-ecmascript": "^1.1.0"
-					}
-				},
 				"require-main-filename": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 					"dev": true
-				},
-				"schema-utils": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-					"dev": true,
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
 				},
 				"string-width": {
 					"version": "3.1.0",
@@ -3933,48 +3314,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
-					}
-				},
-				"unicode-match-property-value-ecmascript": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-					"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-					"dev": true
-				},
-				"v8-compile-cache": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-					"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
-					"dev": true
-				},
-				"webpack": {
-					"version": "4.8.3",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
-					"integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/wasm-edit": "1.4.3",
-						"@webassemblyjs/wasm-parser": "1.4.3",
-						"acorn": "^5.0.0",
-						"acorn-dynamic-import": "^3.0.0",
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0",
-						"chrome-trace-event": "^0.1.1",
-						"enhanced-resolve": "^4.0.0",
-						"eslint-scope": "^3.7.1",
-						"loader-runner": "^2.3.0",
-						"loader-utils": "^1.1.0",
-						"memory-fs": "~0.4.1",
-						"micromatch": "^3.1.8",
-						"mkdirp": "~0.5.0",
-						"neo-async": "^2.5.0",
-						"node-libs-browser": "^2.0.0",
-						"schema-utils": "^0.4.4",
-						"tapable": "^1.0.0",
-						"uglifyjs-webpack-plugin": "^1.2.4",
-						"watchpack": "^1.5.0",
-						"webpack-sources": "^1.0.1"
 					}
 				},
 				"webpack-cli": {
@@ -4080,18 +3419,6 @@
 				}
 			}
 		},
-		"@xtuc/ieee754": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true
-		},
-		"@xtuc/long": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
-			"dev": true
-		},
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -4132,9 +3459,9 @@
 			}
 		},
 		"acorn": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-			"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
 			"dev": true
 		},
 		"acorn-dynamic-import": {
@@ -4144,24 +3471,24 @@
 			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				}
 			}
 		},
 		"acorn-globals": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+			"integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
+				}
 			}
 		},
 		"acorn-jsx": {
@@ -4247,10 +3574,13 @@
 			"dev": true
 		},
 		"ansi-escapes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-			"dev": true
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+			"integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.5.2"
+			}
 		},
 		"ansi-regex": {
 			"version": "3.0.0",
@@ -4277,294 +3607,14 @@
 				"normalize-path": "^2.1.1"
 			},
 			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
+						"remove-trailing-separator": "^1.0.1"
 					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
@@ -4755,11 +3805,12 @@
 			}
 		},
 		"assert": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
 			"dev": true,
 			"requires": {
+				"object-assign": "^4.1.1",
 				"util": "0.10.3"
 			},
 			"dependencies": {
@@ -4814,17 +3865,17 @@
 			},
 			"dependencies": {
 				"lodash": {
-					"version": "4.17.14",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-					"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 					"dev": true
 				}
 			}
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
 		"async-foreach": {
@@ -4834,9 +3885,9 @@
 			"dev": true
 		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -4866,42 +3917,10 @@
 				"postcss-value-parser": "^4.0.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000984",
-						"electron-to-chromium": "^1.3.191",
-						"node-releases": "^1.1.25"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000984",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz",
-					"integrity": "sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.191",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz",
-					"integrity": "sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==",
-					"dev": true
-				},
-				"node-releases": {
-					"version": "1.1.25",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.25.tgz",
-					"integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
-					"dev": true,
-					"requires": {
-						"semver": "^5.3.0"
-					}
-				},
 				"postcss-value-parser": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-					"integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
 				}
 			}
@@ -5015,6 +4034,56 @@
 				"slash": "^2.0.0"
 			}
 		},
+		"babel-loader": {
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
+			"dev": true,
+			"requires": {
+				"find-cache-dir": "^2.0.0",
+				"loader-utils": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"pify": "^4.0.1"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				}
+			}
+		},
 		"babel-plugin-dynamic-import-node": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -5042,11 +4111,12 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-			"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
 				"find-up": "^3.0.0",
 				"istanbul-lib-instrument": "^3.3.0",
 				"test-exclude": "^5.2.3"
@@ -5165,25 +4235,13 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -5205,14 +4263,6 @@
 				"check-types": "^8.0.3",
 				"hoopy": "^0.1.4",
 				"tryer": "^1.0.1"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.5.5",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-					"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-					"dev": true
-				}
 			}
 		},
 		"big.js": {
@@ -5222,9 +4272,9 @@
 			"dev": true
 		},
 		"binary-extensions": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
 		"block-stream": {
@@ -5237,9 +4287,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -5567,14 +4617,6 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"call-me-maybe": {
@@ -5741,9 +4783,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
-			"integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
@@ -5757,127 +4799,20 @@
 				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
 				"readdirp": "^2.2.1",
-				"upath": "^1.1.0"
-			},
-			"dependencies": {
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				}
+				"upath": "^1.1.1"
 			}
 		},
 		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
 			"dev": true
 		},
 		"chrome-trace-event": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
-			}
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
+			"integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
+			"dev": true
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -5915,12 +4850,6 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
@@ -5930,12 +4859,12 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "^3.1.0"
 			}
 		},
 		"cli-width": {
@@ -5977,6 +4906,17 @@
 				"kind-of": "^3.0.2",
 				"lazy-cache": "^1.0.3",
 				"shallow-clone": "^0.1.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"clone-regexp": {
@@ -6054,9 +4994,9 @@
 			"dev": true
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
 		},
 		"concat-map": {
@@ -6075,32 +5015,6 @@
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"console-browserify": {
@@ -6198,69 +5112,22 @@
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+			"integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.2",
-				"core-js-pure": "3.1.4",
-				"semver": "^6.1.1"
+				"browserslist": "^4.6.6",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000984",
-						"electron-to-chromium": "^1.3.191",
-						"node-releases": "^1.1.25"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000984",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz",
-					"integrity": "sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.191",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz",
-					"integrity": "sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==",
-					"dev": true
-				},
-				"node-releases": {
-					"version": "1.1.25",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.25.tgz",
-					"integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
-					"dev": true,
-					"requires": {
-						"semver": "^5.3.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-							"dev": true
-						}
-					}
-				},
 				"semver": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-					"integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
-		},
-		"core-js-pure": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-			"integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
-			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -6618,18 +5485,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
@@ -6853,32 +5708,6 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0",
 				"stream-shift": "^1.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"ecc-jsbn": {
@@ -6910,9 +5739,9 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -7022,21 +5851,10 @@
 				"semver": "^5.7.0"
 			},
 			"dependencies": {
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -7053,28 +5871,23 @@
 				"object.fromentries": "^2.0.0",
 				"prop-types": "^15.7.2",
 				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				}
 			}
 		},
 		"enzyme-to-json": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz",
-			"integrity": "sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.0.tgz",
+			"integrity": "sha512-gbu8P8PMAtb+qtKuGVRdZIYxWHC03q1dGS3EKRmUzmTDIracu3o6cQ0d4xI2YWojbelbxjYOsmqM5EgAL0WgIA==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.4"
+				"lodash": "^4.17.12"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"equivalent-key-map": {
@@ -7162,9 +5975,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -7365,9 +6178,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-					"integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 					"dev": true
 				}
 			}
@@ -7704,12 +6517,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
@@ -7843,9 +6650,9 @@
 			}
 		},
 		"figures": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -8074,13 +6881,13 @@
 			"dev": true
 		},
 		"flush-write-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.0.tgz",
-			"integrity": "sha512-6MHED/cmsyux1G4/Cek2Z776y9t7WCNd3h2h/HW91vFeU7pzMhA8XvAlDhHcanG5IWuIh/xcC7JASY4WQpG6xg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"for-in": {
@@ -8144,32 +6951,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"fs-exists-sync": {
@@ -8188,32 +6969,6 @@
 				"iferr": "^0.1.5",
 				"imurmurhash": "^0.1.4",
 				"readable-stream": "1 || 2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"fs.realpath": {
@@ -8223,14 +6978,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -8242,8 +6997,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -8264,14 +7018,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -8286,20 +7038,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -8308,12 +7057,12 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
@@ -8416,8 +7165,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -8429,7 +7177,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -8444,7 +7191,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -8452,14 +7198,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -8478,30 +7222,29 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.4",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.3",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -8529,13 +7272,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.5",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.2.0",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -8559,8 +7302,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -8572,7 +7314,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -8658,8 +7399,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -8674,7 +7414,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.6.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -8695,7 +7435,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -8715,7 +7454,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -8759,14 +7497,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -9123,11 +7859,29 @@
 				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+					"dev": true,
+					"optional": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"uglify-js": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+					"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"commander": "~2.20.0",
+						"source-map": "~0.6.1"
+					}
 				}
 			}
 		},
@@ -9200,14 +7954,6 @@
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"has-values": {
@@ -9220,26 +7966,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -9310,9 +8036,9 @@
 			"dev": true
 		},
 		"html-element-map": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
-			"integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.1.0.tgz",
+			"integrity": "sha512-iqiG3dTZmy+uUaTmHarTL+3/A2VW9ox/9uasKEZC+R/wAtUrTcRlXPSaPqsnWPfIu8wqn09jQNwMRqzL54jSYA==",
 			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
@@ -9345,6 +8071,19 @@
 				"entities": "^1.1.1",
 				"inherits": "^2.0.1",
 				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"http-errors": {
@@ -9437,9 +8176,9 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
 			"dev": true
 		},
 		"iferr": {
@@ -9514,12 +8253,6 @@
 			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
 			"dev": true
 		},
-		"indexof": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-			"dev": true
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9543,22 +8276,22 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+			"integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.2.0",
+				"ansi-escapes": "^4.2.1",
 				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
+				"cli-cursor": "^3.1.0",
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.12",
-				"mute-stream": "0.0.7",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.15",
+				"mute-stream": "0.0.8",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
-				"string-width": "^2.1.0",
+				"string-width": "^4.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
@@ -9569,11 +8302,34 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"lodash": {
-					"version": "4.17.14",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-					"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+					"integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^5.2.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
@@ -9626,6 +8382,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-alphabetical": {
@@ -9698,6 +8465,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-date-object": {
@@ -9791,6 +8569,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-number-object": {
@@ -9995,14 +8784,14 @@
 			},
 			"dependencies": {
 				"@babel/generator": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
-					"integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.5.0",
+						"@babel/types": "^7.5.5",
 						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"source-map": "^0.5.0",
 						"trim-right": "^1.0.1"
 					}
@@ -10017,9 +8806,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
-					"integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
 					"dev": true
 				},
 				"@babel/template": {
@@ -10034,30 +8823,41 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.0.tgz",
-					"integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.5.0",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
 						"@babel/helper-function-name": "^7.1.0",
 						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.0",
-						"@babel/types": "^7.5.0",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-					"integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
 				},
@@ -10070,10 +8870,16 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
 				"semver": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-					"integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -10623,6 +9429,14 @@
 				"chalk": "^2.0.1",
 				"jest-util": "^24.8.0",
 				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				}
 			}
 		},
 		"jest-worker": {
@@ -10712,12 +9526,6 @@
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				},
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -10762,10 +9570,21 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -10789,13 +9608,10 @@
 			}
 		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5"
-			}
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
 		},
 		"kleur": {
 			"version": "3.0.3",
@@ -11332,6 +10148,17 @@
 				"arr-union": "^3.1.0",
 				"clone-deep": "^0.2.4",
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"merge-descriptors": {
@@ -11347,38 +10174,12 @@
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"merge2": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
 			"dev": true
 		},
 		"methods": {
@@ -11406,14 +10207,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
 			}
 		},
 		"miller-rabin": {
@@ -11532,9 +10325,9 @@
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -11618,9 +10411,9 @@
 			"dev": true
 		},
 		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
 		"nan": {
@@ -11646,26 +10439,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
 			}
 		},
 		"natural-compare": {
@@ -11675,9 +10448,9 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.18.0.tgz",
+			"integrity": "sha512-/zQOMCeJcioI0xJtd5RpBiWw2WP7wLe6vq8/3Yu0rEwgus/G/+pViX80oA87JdVgjRt2895mZSv2VfZmy4W1uw==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -11750,9 +10523,9 @@
 			"dev": true
 		},
 		"node-libs-browser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
 			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
@@ -11765,7 +10538,7 @@
 				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.0",
+				"path-browserify": "0.0.1",
 				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
@@ -11777,7 +10550,7 @@
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
 				"util": "^0.11.0",
-				"vm-browserify": "0.0.4"
+				"vm-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -11785,32 +10558,6 @@
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					},
-					"dependencies": {
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"dev": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
 				}
 			}
 		},
@@ -11821,9 +10568,9 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.1.tgz",
+			"integrity": "sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
@@ -12029,13 +10776,10 @@
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"normalize-range": {
 			"version": "0.1.2",
@@ -12182,6 +10926,15 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
 				}
 			}
 		},
@@ -12216,14 +10969,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"object.assign": {
@@ -12279,14 +11024,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"object.values": {
@@ -12320,12 +11057,20 @@
 			}
 		},
 		"onetime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "^2.1.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				}
 			}
 		},
 		"opener": {
@@ -12463,9 +11208,9 @@
 			"dev": true
 		},
 		"pako": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
-			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
 			"dev": true
 		},
 		"parallel-transform": {
@@ -12477,32 +11222,6 @@
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"parent-module": {
@@ -12523,9 +11242,9 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
-			"integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
 			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -12587,9 +11306,9 @@
 			"dev": true
 		},
 		"path-browserify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
 		},
 		"path-dirname": {
@@ -12845,138 +11564,12 @@
 			}
 		},
 		"postcss-jsx": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.1.tgz",
-			"integrity": "sha512-xaZpy01YR7ijsFUtu5rViYCFHurFIPHir+faiOQp8g/NfTfWqZCKDhKrydQZ4d8WlSAmVdXGwLjpFbsNUI26Sw==",
+			"version": "0.36.3",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.3.tgz",
+			"integrity": "sha512-yV8Ndo6KzU8eho5mCn7LoLUGPkXrRXRjhMpX4AaYJ9wLJPv099xbtpbRQ8FrPnzVxb/cuMebbPR7LweSt+hTfA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": ">=7.2.2"
-			},
-			"dependencies": {
-				"@babel/core": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
-					"integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.5.0",
-						"@babel/helpers": "^7.5.4",
-						"@babel/parser": "^7.5.0",
-						"@babel/template": "^7.4.4",
-						"@babel/traverse": "^7.5.0",
-						"@babel/types": "^7.5.0",
-						"convert-source-map": "^1.1.0",
-						"debug": "^4.1.0",
-						"json5": "^2.1.0",
-						"lodash": "^4.17.11",
-						"resolve": "^1.3.2",
-						"semver": "^5.4.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
-					"integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.5.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/helpers": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
-					"integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
-					"dev": true,
-					"requires": {
-						"@babel/template": "^7.4.4",
-						"@babel/traverse": "^7.5.0",
-						"@babel/types": "^7.5.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
-					"integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.0.tgz",
-					"integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.5.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.0",
-						"@babel/types": "^7.5.0",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/types": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
-					"integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"postcss-less": {
@@ -13254,13 +11847,13 @@
 			"dev": true
 		},
 		"prompts": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-			"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+			"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
 			"dev": true,
 			"requires": {
-				"kleur": "^3.0.2",
-				"sisteransi": "^1.0.0"
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.3"
 			}
 		},
 		"prop-types": {
@@ -13436,9 +12029,9 @@
 			}
 		},
 		"randombytes": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
@@ -13636,26 +12229,22 @@
 			}
 		},
 		"react-test-renderer": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
-			"integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
+			"integrity": "sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"react-is": "^16.8.6",
-				"scheduler": "^0.13.6"
+				"react-is": "^16.9.0",
+				"scheduler": "^0.15.0"
 			},
 			"dependencies": {
-				"scheduler": {
-					"version": "0.13.6",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-					"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
+				"react-is": {
+					"version": "16.9.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+					"integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+					"dev": true
 				}
 			}
 		},
@@ -13762,14 +12351,29 @@
 			}
 		},
 		"readable-stream": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-			"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
 			}
 		},
 		"readdirp": {
@@ -13781,321 +12385,6 @@
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"realpath-native": {
@@ -14215,29 +12504,6 @@
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
-				}
-			}
-		},
-		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-			"dev": true
-		},
-		"regjsparser": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-			"dev": true,
-			"requires": {
-				"jsesc": "~0.5.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
 				}
 			}
 		},
@@ -14467,12 +12733,12 @@
 			"dev": true
 		},
 		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
+				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
 			}
 		},
@@ -14920,9 +13186,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-			"integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
 			"dev": true
 		},
 		"serve-static": {
@@ -14944,9 +13210,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -15045,9 +13311,9 @@
 			"dev": true
 		},
 		"sisteransi": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.2.tgz",
-			"integrity": "sha512-ZcYcZcT69nSLAR2oLN2JwNmLkJEKGooFMCdvOkFrToUt/WfcRWqhIg4P4KwY4dmLbuyXIx4o4YmPsvMRJYJd/w==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+			"integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
 			"dev": true
 		},
 		"slash": {
@@ -15166,18 +13432,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
@@ -15188,6 +13442,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"source-list-map": {
@@ -15225,9 +13490,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.12",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -15426,32 +13691,6 @@
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"stream-each": {
@@ -15475,32 +13714,6 @@
 				"readable-stream": "^2.3.6",
 				"to-arraybuffer": "^1.0.0",
 				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"stream-shift": {
@@ -15536,23 +13749,31 @@
 			}
 		},
 		"string.prototype.trim": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+			"integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.0",
-				"function-bind": "^1.0.2"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.13.0",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string_decoder": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-			"integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "~5.2.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+					"dev": true
+				}
 			}
 		},
 		"stringify-entities": {
@@ -15714,12 +13935,6 @@
 					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
 					"dev": true
 				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -15781,9 +13996,9 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.9.1.tgz",
-			"integrity": "sha512-Z+q3z12QpkWEJsoWm/QLGvu3VJXpZbZYaEXdU4EIo3o6lVgXIwMj+ntW81Jj2bk9f6+aMVmtzfJVhdS7Sz5orA==",
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.9.3.tgz",
+			"integrity": "sha512-pLLpwSpUwiqpAga/C22ZuN/d5ql2zVWGzG8MO+P3DQYcDNue3eZGvda/bJdkx4mDcVy06jlDt+BgSvMYUrwleQ==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11",
@@ -15805,9 +14020,9 @@
 					}
 				},
 				"postcss-value-parser": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-					"integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
 				}
 			}
@@ -15849,9 +14064,9 @@
 			"dev": true
 		},
 		"table": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
-			"integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+			"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",
@@ -15879,9 +14094,9 @@
 					"dev": true
 				},
 				"lodash": {
-					"version": "4.17.14",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-					"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 					"dev": true
 				},
 				"string-width": {
@@ -16013,9 +14228,9 @@
 			"dev": true
 		},
 		"thread-loader": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.2.tgz",
-			"integrity": "sha512-7xpuc9Ifg6WU+QYw/8uUqNdRwMD+N5gjwHKMqETrs96Qn+7BHwECpt2Brzr4HFlf4IAkZsayNhmGdbkBsTJ//w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
+			"integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
 			"dev": true,
 			"requires": {
 				"loader-runner": "^2.3.1",
@@ -16043,38 +14258,12 @@
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"timers-browserify": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
 			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
@@ -16139,6 +14328,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"to-regex": {
@@ -16161,17 +14361,6 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				}
 			}
 		},
 		"toidentifier": {
@@ -16251,9 +14440,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
 		"tty-browserify": {
@@ -16291,6 +14480,12 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
+		},
+		"type-fest": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+			"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -16331,30 +14526,27 @@
 			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
 			"dev": true
 		},
-		"uglify-js": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+		"uglify-es": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.13.0",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true,
-					"optional": true
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -16374,18 +14566,6 @@
 				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-					"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
-					"dev": true
-				},
-				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-					"dev": true
-				},
 				"schema-utils": {
 					"version": "0.4.7",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
@@ -16401,16 +14581,6 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"dev": true,
-					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
-					}
 				}
 			}
 		},
@@ -16430,16 +14600,6 @@
 			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
 			"dev": true
 		},
-		"unicode-match-property-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
-			"requires": {
-				"unicode-canonical-property-names-ecmascript": "^1.0.4",
-				"unicode-property-aliases-ecmascript": "^1.0.4"
-			}
-		},
 		"unicode-match-property-value-ecmascript": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
@@ -16447,9 +14607,9 @@
 			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
 		},
 		"unified": {
@@ -16469,38 +14629,15 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {
@@ -16519,9 +14656,9 @@
 			}
 		},
 		"unique-slug": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
@@ -16618,19 +14755,13 @@
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
 					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
 			"dev": true
 		},
 		"uri-js": {
@@ -16784,13 +14915,10 @@
 			}
 		},
 		"vm-browserify": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
-			"requires": {
-				"indexof": "0.0.1"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+			"dev": true
 		},
 		"w3c-hr-time": {
 			"version": "1.0.1",
@@ -16927,94 +15055,6 @@
 				"@webassemblyjs/wasm-parser": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
 				"long": "^3.2.0"
-			},
-			"dependencies": {
-				"@webassemblyjs/ast": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
-					"integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/wast-parser": "1.4.3",
-						"debug": "^3.1.0",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/floating-point-hex-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
-					"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-code-frame": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
-					"integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/wast-printer": "1.4.3"
-					}
-				},
-				"@webassemblyjs/helper-fsm": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
-					"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
-					"dev": true
-				},
-				"@webassemblyjs/helper-wasm-bytecode": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
-					"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
-					"dev": true
-				},
-				"@webassemblyjs/leb128": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
-					"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
-					"dev": true,
-					"requires": {
-						"leb": "^0.3.0"
-					}
-				},
-				"@webassemblyjs/wasm-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
-					"integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
-						"@webassemblyjs/leb128": "1.4.3",
-						"@webassemblyjs/wasm-parser": "1.4.3",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/wast-parser": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
-					"integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/floating-point-hex-parser": "1.4.3",
-						"@webassemblyjs/helper-code-frame": "1.4.3",
-						"@webassemblyjs/helper-fsm": "1.4.3",
-						"long": "^3.2.0",
-						"webassemblyjs": "1.4.3"
-					}
-				},
-				"@webassemblyjs/wast-printer": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
-					"integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/wast-parser": "1.4.3",
-						"long": "^3.2.0"
-					}
-				}
 			}
 		},
 		"webidl-conversions": {
@@ -17024,23 +15064,21 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.23.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.23.1.tgz",
-			"integrity": "sha512-iE5Cu4rGEDk7ONRjisTOjVHv3dDtcFfwitSxT7evtYj/rANJpt1OuC/Kozh1pBa99AUBr1L/LsaNB+D9Xz3CEg==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
+			"integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.7.10",
-				"@webassemblyjs/helper-module-context": "1.7.10",
-				"@webassemblyjs/wasm-edit": "1.7.10",
-				"@webassemblyjs/wasm-parser": "1.7.10",
-				"acorn": "^5.6.2",
+				"@webassemblyjs/ast": "1.4.3",
+				"@webassemblyjs/wasm-edit": "1.4.3",
+				"@webassemblyjs/wasm-parser": "1.4.3",
+				"acorn": "^5.0.0",
 				"acorn-dynamic-import": "^3.0.0",
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^1.0.0",
-				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.0",
-				"json-parse-better-errors": "^1.0.2",
+				"chrome-trace-event": "^0.1.1",
+				"enhanced-resolve": "^4.0.0",
+				"eslint-scope": "^3.7.1",
 				"loader-runner": "^2.3.0",
 				"loader-utils": "^1.1.0",
 				"memory-fs": "~0.4.1",
@@ -17049,323 +15087,12 @@
 				"neo-async": "^2.5.0",
 				"node-libs-browser": "^2.0.0",
 				"schema-utils": "^0.4.4",
-				"tapable": "^1.1.0",
+				"tapable": "^1.0.0",
 				"uglifyjs-webpack-plugin": "^1.2.4",
 				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.3.0"
+				"webpack-sources": "^1.0.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				},
-				"ajv-keywords": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.3.0.tgz",
-					"integrity": "sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==",
-					"dev": true
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"eslint-scope": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
 				"schema-utils": {
 					"version": "0.4.7",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
@@ -17379,9 +15106,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz",
-			"integrity": "sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz",
+			"integrity": "sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.7",
@@ -17393,16 +15120,22 @@
 				"express": "^4.16.3",
 				"filesize": "^3.6.1",
 				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.15",
 				"mkdirp": "^0.5.1",
 				"opener": "^1.5.1",
 				"ws": "^6.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-					"integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 					"dev": true
 				},
 				"ws": {
@@ -17542,9 +15275,9 @@
 			"dev": true
 		},
 		"worker-farm": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+			"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
@@ -17645,9 +15378,9 @@
 			"dev": true
 		},
 		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"y18n": {

--- a/public_html/wp-content/mu-plugins/blocks/package-lock.json
+++ b/public_html/wp-content/mu-plugins/blocks/package-lock.json
@@ -77,6 +77,129 @@
 				"esutils": "^2.0.0"
 			}
 		},
+		"@babel/helper-call-delegate": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+			"integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/types": "^7.5.5",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
@@ -105,6 +228,34 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -277,6 +428,16 @@
 				"@babel/plugin-syntax-json-strings": "^7.2.0"
 			}
 		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+			}
+		},
 		"@babel/plugin-proposal-optional-catch-binding": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
@@ -285,6 +446,48 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"@babel/helper-regex": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+					"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+					"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.1.0",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -350,6 +553,17 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+			"integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
+			}
+		},
 		"@babel/plugin-transform-block-scoped-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
@@ -359,10 +573,207 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+			"integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.5.5",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.5.5",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+					"integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+					"integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.5.5",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/traverse": "^7.5.5",
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/plugin-transform-computed-properties": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
 			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"@babel/helper-regex": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+					"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+					"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.1.0",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+			"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -375,6 +786,25 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -396,6 +826,99 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+			"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.4.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			},
+			"dependencies": {
+				"@babel/helper-module-transforms": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+					"integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/template": "^7.4.4",
+						"@babel/types": "^7.5.5",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+			"integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
 		"@babel/plugin-transform-modules-umd": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
@@ -403,6 +926,24 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"dev": true,
+			"requires": {
+				"regexp-tree": "^0.1.6"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+			"dev": true,
+			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -414,6 +955,17 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-call-delegate": "^7.4.4",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
@@ -436,6 +988,15 @@
 				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
 		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "^0.14.0"
+			}
+		},
 		"@babel/plugin-transform-reserved-words": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
@@ -443,6 +1004,18 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
+			"integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -473,6 +1046,16 @@
 				"@babel/helper-regex": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-typeof-symbol": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
@@ -480,6 +1063,219 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"@babel/helper-regex": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+					"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+					"integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.1.0",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				}
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
+				"@babel/plugin-proposal-json-strings": "^7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
+				"@babel/plugin-syntax-json-strings": "^7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-transform-arrow-functions": "^7.2.0",
+				"@babel/plugin-transform-async-to-generator": "^7.5.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+				"@babel/plugin-transform-block-scoping": "^7.5.5",
+				"@babel/plugin-transform-classes": "^7.5.5",
+				"@babel/plugin-transform-computed-properties": "^7.2.0",
+				"@babel/plugin-transform-destructuring": "^7.5.0",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+				"@babel/plugin-transform-for-of": "^7.4.4",
+				"@babel/plugin-transform-function-name": "^7.4.4",
+				"@babel/plugin-transform-literals": "^7.2.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+				"@babel/plugin-transform-modules-amd": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
+				"@babel/plugin-transform-modules-umd": "^7.2.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-new-target": "^7.4.4",
+				"@babel/plugin-transform-object-super": "^7.5.5",
+				"@babel/plugin-transform-parameters": "^7.4.4",
+				"@babel/plugin-transform-property-literals": "^7.2.0",
+				"@babel/plugin-transform-regenerator": "^7.4.5",
+				"@babel/plugin-transform-reserved-words": "^7.2.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-sticky-regex": "^7.2.0",
+				"@babel/plugin-transform-template-literals": "^7.4.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+				"@babel/plugin-transform-unicode-regex": "^7.4.4",
+				"@babel/types": "^7.5.5",
+				"browserslist": "^4.6.0",
+				"core-js-compat": "^3.1.1",
+				"invariant": "^2.2.2",
+				"js-levenshtein": "^1.1.3",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+					"integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+					"integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.5.5",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/traverse": "^7.5.5",
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+					"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.5.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime": {
@@ -929,6 +1725,37 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
+		"@tannin/compile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
+			"integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
+			"dev": true,
+			"requires": {
+				"@tannin/evaluate": "^1.1.1",
+				"@tannin/postfix": "^1.0.2"
+			}
+		},
+		"@tannin/evaluate": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
+			"integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q==",
+			"dev": true
+		},
+		"@tannin/plural-forms": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
+			"integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
+			"dev": true,
+			"requires": {
+				"@tannin/compile": "^1.0.3"
+			}
+		},
+		"@tannin/postfix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
+			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g==",
+			"dev": true
+		},
 		"@types/babel__core": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -1310,6 +2137,354 @@
 				"@xtuc/long": "4.2.1"
 			}
 		},
+		"@wordpress/a11y": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.0.tgz",
+			"integrity": "sha512-KY+Z0NFQUH6cNbFnP9P58fTCLS93zBz+SIEDA633yG46u1NHOBfWDS4lIrx52fihFdaakSTS0f2OH6yeRb41HQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/dom-ready": "^2.5.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/babel-plugin-import-jsx-pragma": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.3.0.tgz",
+			"integrity": "sha512-b45c4x1+OvQm1f6egrBruO8eVF4bRVRZ8ojM1ttDcMi+K/qXfun3J6O8xXpSnA5eeNCZaJL3DhIk/aoNBbpwzw==",
+			"dev": true
+		},
+		"@wordpress/babel-preset-default": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.4.0.tgz",
+			"integrity": "sha512-cFdzlVSYe7M4lKojBxG/TaoRAL6r/UZhvFN7R7e49qlrNlB20YTGSkpKffO1h158mlPuunFIIt+425w/xQE8/g==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.4.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+				"@babel/plugin-transform-react-jsx": "^7.3.0",
+				"@babel/plugin-transform-runtime": "^7.4.4",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^2.3.0",
+				"@wordpress/browserslist-config": "^2.6.0",
+				"core-js": "^3.1.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+					"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helpers": "^7.5.5",
+						"@babel/parser": "^7.5.5",
+						"@babel/template": "^7.4.4",
+						"@babel/traverse": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"convert-source-map": "^1.1.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+					"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.4.4",
+						"@babel/traverse": "^7.5.5",
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.4.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.4",
+						"@babel/types": "^7.4.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"json5": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/browserslist-config": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.6.0.tgz",
+			"integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA==",
+			"dev": true
+		},
+		"@wordpress/components": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+			"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/a11y": "^2.5.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/rich-text": "^3.5.0",
+				"@wordpress/url": "^2.7.0",
+				"classnames": "^2.2.5",
+				"clipboard": "^2.0.1",
+				"diff": "^3.5.0",
+				"dom-scroll-into-view": "^1.2.1",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
+				"moment": "^2.22.1",
+				"mousetrap": "^1.6.2",
+				"re-resizable": "^5.0.1",
+				"react-click-outside": "^3.0.0",
+				"react-dates": "^17.1.1",
+				"react-spring": "^8.0.20",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.1",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/compose": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+			"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"lodash": "^4.17.14"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/data": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
+			"integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/priority-queue": "^1.3.0",
+				"@wordpress/redux-routine": "^3.5.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-promise": "^2.1.0",
+				"lodash": "^4.17.14",
+				"redux": "^4.0.0",
+				"turbo-combine-reducers": "^1.0.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.0.1.tgz",
@@ -1318,6 +2493,154 @@
 			"requires": {
 				"webpack": "^4.8.3",
 				"webpack-sources": "^1.3.0"
+			}
+		},
+		"@wordpress/deprecated": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
+			"integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/hooks": "^2.5.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/dom": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
+			"integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"lodash": "^4.17.14"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/dom-ready": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.0.tgz",
+			"integrity": "sha512-1CXRTZcQ0yn9Aj5x3e0xwYJeRv81NyuwoQUD2ZvDXRXCvaNq33fm79MDvpW5E2uYoo0t9jPHTCwadVXt7bzhwQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/element": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+			"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/escape-html": "^1.5.0",
+				"lodash": "^4.17.14",
+				"react": "^16.8.4",
+				"react-dom": "^16.8.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/escape-html": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.0.tgz",
+			"integrity": "sha512-9jGwPbpdJ309EP4Acf6/zwHWeuYi0Bi5RAZx9q+BIYC7bjxLs3oFDS5QkEAi2mzrVAhIz+BbEWBGRg70U1RLlA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -1331,6 +2654,101 @@
 				"eslint-plugin-react": "^7.12.4",
 				"eslint-plugin-react-hooks": "^1.6.0",
 				"requireindex": "^1.2.0"
+			}
+		},
+		"@wordpress/hooks": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+			"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/i18n": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+			"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"gettext-parser": "^1.3.1",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.1.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/is-shallow-equal": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
+			"integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/jest-console": {
@@ -1372,6 +2790,139 @@
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
 				"enzyme-to-json": "^3.3.5"
+			}
+		},
+		"@wordpress/keycodes": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.5.0.tgz",
+			"integrity": "sha512-4SMN3pmJnNBexpd3/6JB6gJw+wcahBaVZaeMcHyF+Uw7bKcG6hDkzEAN6dWFJuifpdxmvilDE4H5JS/Ex9C6sA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/i18n": "^3.6.0",
+				"lodash": "^4.17.14"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/priority-queue": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.3.0.tgz",
+			"integrity": "sha512-HlhHZUCnKW56b2KFg2cZcn6fnGdi6mrmfOn2lE3cBOibjQLYfOY3pe3TCd+AxS4GdfkgXFA7BHfAinaWCBpAyg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/redux-routine": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
+			"integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"is-promise": "^2.1.0",
+				"rungen": "^0.3.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/rich-text": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.5.0.tgz",
+			"integrity": "sha512-2Pi56SGcao0M0OjZtpwdIyYIXganIDg054InPpdE7zeJRUxf8gKvTGSXA2bYLdDJC0RgCLTtWp+45ItV6byZDg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/escape-html": "^1.5.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"classnames": "^2.2.5",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
+				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/scripts": {
@@ -2502,6 +4053,33 @@
 				}
 			}
 		},
+		"@wordpress/url": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+			"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"qs": "^6.5.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				}
+			}
+		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -3150,6 +4728,12 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
+		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3786,6 +5370,12 @@
 				}
 			}
 		},
+		"brcast": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+			"integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
+			"dev": true
+		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -3884,6 +5474,17 @@
 			"dev": true,
 			"requires": {
 				"pako": "~1.0.5"
+			}
+		},
+		"browserslist": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30000984",
+				"electron-to-chromium": "^1.3.191",
+				"node-releases": "^1.1.25"
 			}
 		},
 		"bser": {
@@ -4027,6 +5628,12 @@
 					"dev": true
 				}
 			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30000989",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+			"dev": true
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -4337,6 +5944,17 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
 		},
+		"clipboard": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+			"integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+			"dev": true,
+			"requires": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
+		},
 		"cliui": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -4500,6 +6118,12 @@
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
 		},
+		"consolidated-events": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
+			"dev": true
+		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -4565,6 +6189,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+			"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
 			"dev": true
 		},
 		"core-js-compat": {
@@ -4935,6 +6565,12 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
+		"deepmerge": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
+			"dev": true
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -5003,6 +6639,12 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
+		"delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"dev": true
+		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -5041,6 +6683,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
 		"diff-sequences": {
@@ -5086,6 +6734,12 @@
 				}
 			}
 		},
+		"direction": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
+			"integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w==",
+			"dev": true
+		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -5101,6 +6755,15 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"document.contains": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
+			"integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3"
+			}
+		},
 		"dom-helpers": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
@@ -5108,6 +6771,12 @@
 			"requires": {
 				"@babel/runtime": "^7.1.2"
 			}
+		},
+		"dom-scroll-into-view": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=",
+			"dev": true
 		},
 		"dom-serializer": {
 			"version": "0.1.1",
@@ -5234,6 +6903,12 @@
 			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
 			"dev": true
 		},
+		"electron-to-chromium": {
+			"version": "1.3.224",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.224.tgz",
+			"integrity": "sha512-vTH9UcMbi53x/pZKQrEcD83obE8agqQwUIx/G03/mpE1vzLm0KA3cHwuZXCysvxI1gXfNjV7Nu7Vjtp89kDzmg==",
+			"dev": true
+		},
 		"elliptic": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
@@ -5266,6 +6941,15 @@
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
 			"dev": true
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -5392,6 +7076,12 @@
 			"requires": {
 				"lodash": "^4.17.4"
 			}
+		},
+		"equivalent-key-map": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+			"dev": true
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -6090,6 +7780,12 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fast-memoize": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==",
+			"dev": true
+		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -6112,6 +7808,29 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"dev": true,
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
+				}
 			}
 		},
 		"fd-slicer": {
@@ -6523,7 +8242,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6544,12 +8264,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6564,17 +8286,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -6691,7 +8416,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -6703,6 +8429,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -6717,6 +8444,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -6724,12 +8452,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -6748,6 +8478,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -6828,7 +8559,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -6840,6 +8572,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -6925,7 +8658,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -6961,6 +8695,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -6980,6 +8715,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7023,12 +8759,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -7165,6 +8903,16 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"gettext-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+			"dev": true,
+			"requires": {
+				"encoding": "^0.1.12",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -7205,6 +8953,16 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
 			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
 			"dev": true
+		},
+		"global-cache": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+			"integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"is-symbol": "^1.0.1"
+			}
 		},
 		"global-modules": {
 			"version": "0.2.3",
@@ -7312,6 +9070,15 @@
 					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
 					"dev": true
 				}
+			}
+		},
+		"good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"dev": true,
+			"requires": {
+				"delegate": "^3.1.2"
 			}
 		},
 		"graceful-fs": {
@@ -7514,6 +9281,12 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+			"dev": true
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -8124,6 +9897,12 @@
 				"has-symbols": "^1.0.0"
 			}
 		},
+		"is-touch-device": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+			"integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==",
+			"dev": true
+		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -8177,6 +9956,16 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -9356,6 +11145,12 @@
 				"p-is-promise": "^2.0.0"
 			}
 		},
+		"memize": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
+			"integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg==",
+			"dev": true
+		},
 		"memoize-one": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
@@ -9784,10 +11579,22 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"moment": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+			"dev": true
+		},
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
 			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"dev": true
+		},
+		"mousetrap": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.3.tgz",
+			"integrity": "sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -9897,6 +11704,16 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
+			}
 		},
 		"node-gyp": {
 			"version": "3.8.0",
@@ -10014,6 +11831,15 @@
 				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
+			}
+		},
+		"node-releases": {
+			"version": "1.1.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+			"integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.3.0"
 			}
 		},
 		"node-sass": {
@@ -11412,6 +13238,15 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
+			"requires": {
+				"asap": "~2.0.3"
+			}
+		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -11637,6 +13472,78 @@
 				"unpipe": "1.0.0"
 			}
 		},
+		"re-resizable": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+			"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+			"dev": true,
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
+		},
+		"react": {
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"react-addons-shallow-compare": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+			"integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+			"dev": true,
+			"requires": {
+				"fbjs": "^0.8.4",
+				"object-assign": "^4.1.0"
+			}
+		},
+		"react-click-outside": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
+			"integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
+			"dev": true,
+			"requires": {
+				"hoist-non-react-statics": "^2.1.1"
+			}
+		},
+		"react-dates": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
+			"integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.10.0",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"is-touch-device": "^1.0.1",
+				"lodash": "^4.1.1",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.1",
+				"react-addons-shallow-compare": "^15.6.2",
+				"react-moment-proptypes": "^1.6.0",
+				"react-outside-click-handler": "^1.2.0",
+				"react-portal": "^4.1.5",
+				"react-with-styles": "^3.2.0",
+				"react-with-styles-interface-css": "^4.0.2"
+			}
+		},
+		"react-dom": {
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.15.0"
+			}
+		},
 		"react-input-autosize": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
@@ -11654,6 +13561,37 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+		},
+		"react-moment-proptypes": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz",
+			"integrity": "sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==",
+			"dev": true,
+			"requires": {
+				"moment": ">=1.6.0"
+			}
+		},
+		"react-outside-click-handler": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
+			"integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.13.2",
+				"consolidated-events": "^1.1.1 || ^2.0.0",
+				"document.contains": "^1.0.1",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2"
+			}
+		},
+		"react-portal": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
+			"integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
 		},
 		"react-select": {
 			"version": "3.0.4",
@@ -11685,6 +13623,16 @@
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
 					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
 				}
+			}
+		},
+		"react-spring": {
+			"version": "8.0.27",
+			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+			"integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"prop-types": "^15.5.8"
 			}
 		},
 		"react-test-renderer": {
@@ -11720,6 +13668,55 @@
 				"loose-envify": "^1.4.0",
 				"prop-types": "^15.6.2",
 				"react-lifecycles-compat": "^3.0.4"
+			}
+		},
+		"react-with-direction": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
+			"integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+			"dev": true,
+			"requires": {
+				"airbnb-prop-types": "^2.8.1",
+				"brcast": "^2.0.2",
+				"deepmerge": "^1.5.1",
+				"direction": "^1.0.1",
+				"hoist-non-react-statics": "^2.3.1",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.0"
+			}
+		},
+		"react-with-styles": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
+			"dev": true,
+			"requires": {
+				"hoist-non-react-statics": "^3.2.1",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
+				"react-with-direction": "^1.3.0"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+					"dev": true,
+					"requires": {
+						"react-is": "^16.7.0"
+					}
+				}
+			}
+		},
+		"react-with-styles-interface-css": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+			"integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
+			"dev": true,
+			"requires": {
+				"array.prototype.flat": "^1.2.1",
+				"global-cache": "^1.2.1"
 			}
 		},
 		"read-pkg": {
@@ -12120,6 +14117,16 @@
 				"strip-indent": "^2.0.0"
 			}
 		},
+		"redux": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+			"integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"symbol-observable": "^1.2.0"
+			}
+		},
 		"reflect.ownkeys": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -12132,10 +14139,28 @@
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
 			"dev": true
 		},
+		"regenerate-unicode-properties": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+			"dev": true,
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.12.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
 			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+		},
+		"regenerator-transform": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+			"dev": true,
+			"requires": {
+				"private": "^0.1.6"
+			}
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -12146,6 +14171,12 @@
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
 			}
+		},
+		"regexp-tree": {
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+			"integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
+			"dev": true
 		},
 		"regexpp": {
 			"version": "2.0.1",
@@ -12510,6 +14541,12 @@
 				"aproba": "^1.1.1"
 			}
 		},
+		"rungen": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM=",
+			"dev": true
+		},
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -12782,6 +14819,16 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
 		},
+		"scheduler": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
 		"schema-utils": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -12813,6 +14860,12 @@
 					}
 				}
 			}
+		},
+		"select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -13783,6 +15836,12 @@
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
 		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
+		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13845,6 +15904,15 @@
 						"ansi-regex": "^4.1.0"
 					}
 				}
+			}
+		},
+		"tannin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
+			"integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
+			"dev": true,
+			"requires": {
+				"@tannin/plural-forms": "^1.0.3"
 			}
 		},
 		"tapable": {
@@ -14012,6 +16080,12 @@
 				"setimmediate": "^1.0.4"
 			}
 		},
+		"tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+			"dev": true
+		},
 		"tiny-lr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -14025,6 +16099,12 @@
 				"object-assign": "^4.1.0",
 				"qs": "^6.4.0"
 			}
+		},
+		"tinycolor2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -14191,6 +16271,12 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"turbo-combine-reducers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw==",
+			"dev": true
+		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -14237,6 +16323,12 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"ua-parser-js": {
+			"version": "0.7.20",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
 			"dev": true
 		},
 		"uglify-js": {
@@ -14347,6 +16439,12 @@
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
 			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.0.4",
@@ -15389,6 +17487,12 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -21,11 +21,10 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@wordpress/babel-preset-default": "4.4.0",
 		"@wordpress/components": "8.1.0",
 		"@wordpress/element": "2.6.0",
 		"@wordpress/eslint-plugin": "^2.3.0",
-		"@wordpress/scripts": "^3.3.0",
+		"@wordpress/scripts": "3.4.0",
 		"css-loader": "1.0.1",
 		"mini-css-extract-plugin": "0.4.4",
 		"node-sass": "4.11.0",

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -21,6 +21,9 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
+		"@wordpress/babel-preset-default": "4.4.0",
+		"@wordpress/components": "8.1.0",
+		"@wordpress/element": "2.6.0",
 		"@wordpress/eslint-plugin": "^2.3.0",
 		"@wordpress/scripts": "^3.3.0",
 		"css-loader": "1.0.1",
@@ -41,6 +44,7 @@
 		"build": "wp-scripts build",
 		"lint:js": "wp-scripts lint-js .",
 		"lint:css": "wp-scripts lint-style '**/*.scss'",
-		"lint:pkg-json": "wp-scripts lint-pkg-json"
+		"lint:pkg-json": "wp-scripts lint-pkg-json",
+		"test": "wp-scripts test-unit-js"
 	}
 }

--- a/public_html/wp-content/mu-plugins/blocks/readme.md
+++ b/public_html/wp-content/mu-plugins/blocks/readme.md
@@ -1,7 +1,30 @@
-**WordCamp Blocks**
+# WordCamp Blocks
 
-*Getting Started:*
+## Getting Started
 
 1. `cd` into this directory and run `npm install`.
 2. Run `npm run build` to initialize the build files.
-3. Run `npm start`  while developing to continuously watch the files. Alternatively, you can also run `npm run debug` to enable source maps.
+3. Run `npm start`  while developing to continuously watch the files.
+
+## Testing
+
+We use Jest for testing, run `npm test`. With Jest, you can create snapshot tests for components.
+
+**Writing tests**
+
+1. Follow the example in `source/components/item/tests/index.test.js`
+2. The first time you run `npm test` with new tests, it will generate the snapshots.
+3. If you need to update existing snapshots, run `npm test -- --updateSnapshot`
+
+You can also write non-snapshot tests using Jest to test regular function behavior, [see `expect` docs](https://jestjs.io/docs/en/expect) for examples.
+
+**Running tests**
+
+Run all tests with `npm test`, or run specific tests by passing in a path, `npm test [path-to-file-or-folder]`
+
+If the component's output doesn't match the snapshot, the test fails. This is usually because the component changed, either intentionally or not. If it's not an intentional change, you just caught a bug 🙂
+
+If the component changed intentionally:
+
+- Regenerate the snapshot: `npm test -- --updateSnapshot`
+- Review the changes, and commit the new snapshot with the component changes

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/tests/__snapshots__/index.test.js.snap
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ItemTitle should render a heading tag of level 1. 1`] = `
+<h1
+  className="wordcamp-block__item-title"
+  style={Object {}}
+>
+  Example Title
+</h1>
+`;
+
+exports[`ItemTitle should render a heading tag with a custom class. 1`] = `
+<h3
+  className="wordcamp-block__item-title my-test-heading"
+  style={Object {}}
+>
+  Example Title
+</h3>
+`;
+
+exports[`ItemTitle should render a heading tag with a link, custom class name, heading level, and alignment. 1`] = `
+<h1
+  className="wordcamp-block__item-title my-test-heading"
+  style={
+    Object {
+      "textAlign": "right",
+    }
+  }
+>
+  <a
+    href="https://wordpress.com"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    Example Title
+  </a>
+</h1>
+`;
+
+exports[`ItemTitle should render a heading tag with a link. 1`] = `
+<h3
+  className="wordcamp-block__item-title"
+  style={Object {}}
+>
+  <a
+    href="https://wordpress.com"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    Example Title
+  </a>
+</h3>
+`;
+
+exports[`ItemTitle should render a heading tag with a set alignment. 1`] = `
+<h3
+  className="wordcamp-block__item-title"
+  style={
+    Object {
+      "textAlign": "right",
+    }
+  }
+>
+  Example Title
+</h3>
+`;
+
+exports[`ItemTitle should render a heading tag with the default level. 1`] = `
+<h3
+  className="wordcamp-block__item-title"
+  style={Object {}}
+>
+  Example Title
+</h3>
+`;

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/tests/index.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+/* global describe, test, expect */
 /**
  * External dependencies
  */

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/tests/index.test.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-undef */
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { ItemTitle } from '../';
+
+describe( 'ItemTitle', () => {
+	test( 'should render a heading tag with the default level.', () => {
+		const component = renderer.create( <ItemTitle title="Example Title" /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a heading tag of level 1.', () => {
+		const component = renderer.create( <ItemTitle title="Example Title" headingLevel={ 1 } /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a heading tag with a custom class.', () => {
+		const component = renderer.create( <ItemTitle title="Example Title" className="my-test-heading" /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a heading tag with a set alignment.', () => {
+		const component = renderer.create( <ItemTitle title="Example Title" align="right" /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a heading tag with a link.', () => {
+		const component = renderer.create( <ItemTitle title="Example Title" link="https://wordpress.com" /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a heading tag with a link, custom class name, heading level, and alignment.', () => {
+		const component = renderer.create(
+			<ItemTitle
+				title="Example Title"
+				headingLevel={ 1 }
+				className="my-test-heading"
+				align="right"
+				link="https://wordpress.com"
+			/>
+		);
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
We need to add a few dev packages: `babel-preset-default` is needed locally for jest to detect it. The `@wordpress/*` packages are needed by jest since we're not loading the whole WP admin context for these tests. As we write more tests, we will probably have to add more packages (but these are not used by webpack, so they do not add to the bundle size).

This PR also adds a trivial test suite for `ItemTitle`, which tests each available prop using snapshot testing. The snapshot file is also version controlled, because it should be the same for everyone (though we probably don't need to commit snapshots to SVN). For more about testing, I've also updated [the readme for this folder.](https://github.com/WordPress/wordcamp.org/tree/try/blocks-add-testing/public_html/wp-content/mu-plugins/blocks/)

**To test**

1. `npm install` to update the dev dependencies
2. `npm test` to run the tests
