### PR TITLE
PWA: Cache custom & remote CSS

### DIFF
--- a/public_html/wp-content/mu-plugins/service-worker-caching.php
+++ b/public_html/wp-content/mu-plugins/service-worker-caching.php
@@ -1,41 +1,69 @@
 <?php
 
 namespace WordCamp\PWA\Caching;
-use WP_Service_Worker_Caching_Routes;
+use WP_Service_Worker_Caching_Routes, WP_Service_Worker_Scripts;
 
 add_action( 'wp_front_service_worker', __NAMESPACE__ . '\register_caching_routes' );
-add_action( 'wp_front_service_worker',    __NAMESPACE__ . '\set_navigation_caching_strategy' );
+add_action( 'wp_front_service_worker', __NAMESPACE__ . '\set_navigation_caching_strategy' );
 
 /**
- * Register caching routes with both service workers.
+ * Register caching routes with the frontend service worker.
+ *
+ * @param WP_Service_Worker_Scripts $scripts
  */
-function register_caching_routes() {
-	$custom_css_url_parts = wp_parse_url( wcorg_get_custom_css_url() );
-
-	$static_asset_route_params = array(
+function register_caching_routes( WP_Service_Worker_Scripts $scripts ) {
+	/*
+	 * Set up asset cache strategy to pull from the cache first, with no network request if the resource is found,
+	 * and save up to 100 cached entries for 1 day.
+	 */
+	$asset_cache_strategy_args = array(
 		'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_FIRST,
 		'cacheName' => 'assets',
 		'plugins'   => [
 			'expiration' => [
-				'maxEntries'    => 60,
+				'maxEntries'    => 100,
 				'maxAgeSeconds' => DAY_IN_SECONDS,
 			],
 		],
 	);
 
-	wp_register_service_worker_caching_route(
+	/*
+	 * Cache scripts, styles, images, etc from core, themes, and plugins.
+	 */
+	$scripts->caching_routes()->register(
 		'/wp-(content|includes)/.*\.(?:png|gif|jpg|jpeg|svg|webp|css|js)(\?.*)?$',
-		$static_asset_route_params
+		$asset_cache_strategy_args
 	);
 
-	if ( isset( $custom_css_url_parts['path'], $custom_css_url_parts['query'] ) ) {
-		wp_register_service_worker_caching_route(
-			$custom_css_url_parts['path'] . $custom_css_url_parts['query'] . '$',
-			$static_asset_route_params
+	/*
+	 * Cache custom CSS (from customizer).
+	 * If we don't have a URL, that's probably because the custom CSS is empty or short enough to be printed
+	 * inline instead of enqueued. In that case, the cached pages will have it printed from the `wp_head()`
+	 * call anyway.
+	 */
+	$custom_css_url = wcorg_get_custom_css_url();
+	if ( $custom_css_url ) {
+		$scripts->caching_routes()->register(
+			preg_quote( '/?'. untrailingslashit( wp_parse_url( $custom_css_url, PHP_URL_QUERY ) ), '/' ),
+			$asset_cache_strategy_args
 		);
 	}
 
-	wp_register_service_worker_caching_route(
+	/*
+	 * Cache remote CSS endpoint, if Remote CSS has been set up.
+	 */
+	if ( \WordCamp\RemoteCSS\is_configured() ) {
+		$remote_css_url = preg_quote( 'admin-ajax.php?action=' . \WordCamp\RemoteCSS\CSS_HANDLE, '/' );
+		$scripts->caching_routes()->register(
+			$remote_css_url,
+			$asset_cache_strategy_args
+		);
+	}
+
+	/*
+	 * Cache API requests for 15 minutes.
+	 */
+	$scripts->caching_routes()->register(
 		'/wp-json/.*',
 		[
 			'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_FIRST,


### PR DESCRIPTION
Add custom CSS and remote CSS endpoints to the routes cached using the "asset" group and strategy. This means custom and remote CSS will be cached for 1 day, and fetched from the cache first, with no network request if the resource is found.

Previously, custom CSS (if it existed) was loading into precache, which is a "stickier" cache that's harder to invalidate, and can prevent the service worker from loading if it fails. We don't need to be that aggressive with the custom CSS (we're not doing so with the theme CSS, for example).

This also bumps the number of entries allowed in the asset cache to 100, since a logged in user can see potentially 90+ assets loaded (we can discuss on https://github.com/WordPress/wordcamp.org/issues/204 if we want to tweak this further).

Fixes #200 

**To test**

On a site with either (or both) remote CSS or custom CSS (needs enough custom CSS to create a stylesheet, rather than embedded in the `<head>`)…

- Load any page
- Check in your browser tools for the cached listings, in Chrome this is Application > Cache Storage
- Look at the one with a name like "wp-assets"
- If you have custom CSS, you should see an entry for `?custom-css=[…]`
- If you have remote CSS, you should see an entry for `wp-admin/admin-ajax.php?action=wordcamp_remote_css&ver=[…]`
- Alternately find the requests in the network tab, and it should tell you if it was loaded via ServiceWorker.