### PR TITLE
 Blocks: Load blocks on all sites

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -10,6 +10,10 @@ import './_z-index.scss'; // Have z-index values, similar to https://github.com/
 import './styles.scss'; // Common styles for WordCamp Blocks.
 import { BLOCKS } from './blocks/'; // Trailing slash required to differentiate the folder from the file.
 
-BLOCKS.forEach( ( { NAME, SETTINGS } ) => {
+const enabledBlocks = BLOCKS.filter( ( b ) =>
+	window.WordCampBlocks.hasOwnProperty( b.NAME.replace( 'wordcamp/', '' ) )
+);
+
+enabledBlocks.forEach( ( { NAME, SETTINGS } ) => {
 	registerBlockType( NAME, SETTINGS );
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -10,8 +10,8 @@ import './_z-index.scss'; // Have z-index values, similar to https://github.com/
 import './styles.scss'; // Common styles for WordCamp Blocks.
 import { BLOCKS } from './blocks/'; // Trailing slash required to differentiate the folder from the file.
 
-const enabledBlocks = BLOCKS.filter( ( b ) =>
-	window.WordCampBlocks.hasOwnProperty( b.NAME.replace( 'wordcamp/', '' ) )
+const enabledBlocks = BLOCKS.filter( ( block ) =>
+	window.WordCampBlocks.hasOwnProperty( block.NAME.replace( 'wordcamp/', '' ) )
 );
 
 enabledBlocks.forEach( ( { NAME, SETTINGS } ) => {

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -104,19 +104,24 @@ function enable_pwa_alpha_test() {
 	 * `pwa` plugin, browsers will still be making requests to the API. This will short-circuit those, so that
 	 * the server isn't overloaded.
 	 */
-	add_action( 'rest_pre_dispatch', function( $result, $server, $request ) {
-		$overloaded_sites = array(
-			//1026, // 2019.europe
-		);
-
-		if ( in_array( get_current_blog_id(), $overloaded_sites, true ) ) {
-			$result = new WP_Error(
-				'api_temporarily_disabled',
-				'The REST API has been temporarily disabled on this site because of unexpected stability problems',
-				array( 'status' => 503 )
+	add_action(
+		'rest_pre_dispatch',
+		function( $result, $server, $request ) {
+			$overloaded_sites = array(
+				//1026, // 2019.europe
 			);
-		}
 
-		return $result;
-	}, 10, 3 );
+			if ( in_array( get_current_blog_id(), $overloaded_sites, true ) ) {
+				$result = new WP_Error(
+					'api_temporarily_disabled',
+					'The REST API has been temporarily disabled on this site because of unexpected stability problems',
+					array( 'status' => 503 )
+				);
+			}
+
+			return $result;
+		},
+		10,
+		3
+	);
 }

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -16,13 +16,7 @@ function wcorg_include_individual_mu_plugins() {
 
 	require_once( __DIR__ . '/wp-cli-commands/bootstrap.php' );
 	require_once( __DIR__ . '/camptix-tweaks/camptix-tweaks.php' );
-
-	if (
-		( defined( 'WORDCAMP_ENVIRONMENT' ) && 'production' !== WORDCAMP_ENVIRONMENT )
-		|| in_array( get_current_blog_id(), [ 928, 1028, 1126, 1099, 1156, 1160, 1093, 1192, 1114 ], true ) // Beta opt-ins.
-	) {
-		require_once( __DIR__ . '/blocks/blocks.php' );
-	}
+	require_once( __DIR__ . '/blocks/blocks.php' );
 
 	if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 		require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
Remove the feature gate, to load new blocks on all WordCamp sites. This also adds a check before we run `registerBlockType`, so we can conditionally load individual blocks (this way the Schedule block can be merged in pieces and tested on a few real sites).

We'll feature gate specific blocks by conditionally loading their controller (which populates `WordCampBlocks.[blockName]` with options and the schema). If the block is not set up in `WordCampBlocks`, we can assume it should not be loaded.

**To test**

- Switch your test site to production: `define( 'WORDCAMP_ENVIRONMENT', 'production' );`
- On production, the WC blocks should no longer be loading
- Using this branch, you get all the blocks 🎉 
- Feature gate a specific controller to test conditional block loading, for example we can do the following in `blocks/blocks.php`

```
if (
	( defined( 'WORDCAMP_ENVIRONMENT' ) && 'production' !== WORDCAMP_ENVIRONMENT )
	|| in_array( get_current_blog_id(), [ 928 ], true ) // 2017.testing
) {
	require_once $blocks_dir . 'sessions/controller.php';
}
```

- If you site is still in production mode, you should only see Speakers, Sponsors, and Organizers.
- Turn development mode back on
- You should see all 4 blocks now.