### PR TITLE
WCPT & Blocks: Update stub content to use WordCamp blocks

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
@@ -2,6 +2,4 @@
 <p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.', 'wordcamporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:shortcode -->
-[organizers]
-<!-- /wp:shortcode -->
+<!-- wp:wordcamp/organizers {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
@@ -2,6 +2,4 @@
 <p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:shortcode -->
-[sessions orderby="session_time" order="asc"]
-<!-- /wp:shortcode -->
+<!-- wp:wordcamp/sessions {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
@@ -2,6 +2,4 @@
 <p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.', 'wordcamporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:shortcode -->
-[speakers]
-<!-- /wp:shortcode -->
+<!-- wp:wordcamp/speakers {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
@@ -14,9 +14,7 @@
 <p><?php _e( 'Blurb thanking sponsors', 'wordcamporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:shortcode -->
-[sponsors]
-<!-- /wp:shortcode -->
+<!-- wp:wordcamp/sponsors {"mode":"all"} /-->
 
 <!-- wp:heading -->
 <h2><?php _e( 'Interested in sponsoring WordCamp this year?', 'wordcamporg' ) ?></h2>


### PR DESCRIPTION
Updates the Organizer, Speaker, Session, and Sponsor page stubs to use the new blocks. This will need to merge after #213 

To test

- Set up a new site
- It should use the blocks, not the shortcodes