### PR TITLE
WC Shortcodes: Update link detection to find block content

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -673,12 +673,20 @@ class WordCamp_Post_Types_Plugin {
 
 		switch ( $anchor_target->post_type ) {
 			case 'wcb_speaker':
-				$permalink = has_block( 'wordcamp/speakers', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
+				if ( ! wcorg_skip_feature( 'content_blocks' ) ) {
+					$permalink = has_block( 'wordcamp/speakers', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
+				} else {
+					$permalink = has_shortcode( $post->post_content, 'speakers' ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
+				}
 				$anchor_id = $anchor_target->post_name;
 				break;
 
 			case 'wcb_session':
-				$permalink = has_block( 'wordcamp/sessions', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
+				if ( ! wcorg_skip_feature( 'content_blocks' ) ) {
+					$permalink = has_block( 'wordcamp/sessions', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
+				} else {
+					$permalink = has_shortcode( $post->post_content, 'sessions' ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
+				}
 				$anchor_id = $anchor_target->ID;
 				break;
 
@@ -728,7 +736,7 @@ class WordCamp_Post_Types_Plugin {
 		$wcpt_post = get_posts( array(
 			'post_type'      => array( 'post', 'page' ),
 			'post_status'    => 'publish',
-			's'              => '<!-- wp:wordcamp/' . $type,
+			's'              => wcorg_skip_feature( 'content_blocks' ) ? "[{$type}" : "<!-- wp:wordcamp/{$type}",
 			'posts_per_page' => 1,
 		) );
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -669,26 +669,26 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$anchor_target = get_post( $target_id );
 
-		if ( 'publish' != $anchor_target->post_status ) {
+		if ( 'publish' !== $anchor_target->post_status ) {
 			return '';
 		}
 
 		switch ( $anchor_target->post_type ) {
 			case 'wcb_speaker':
-				if ( ! wcorg_skip_feature( 'content_blocks' ) ) {
-					$permalink = has_block( 'wordcamp/speakers', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
-				} else {
-					$permalink = has_shortcode( $post->post_content, 'speakers' ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
-				}
+				$current_post_has_target = wcorg_skip_feature( 'content_blocks' ) ?
+					has_shortcode( $post->post_content, 'speakers' ) :
+					has_block( 'wordcamp/speakers', $post->post_content );
+
+				$permalink = $current_post_has_target ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
 				$anchor_id = $anchor_target->post_name;
 				break;
 
 			case 'wcb_session':
-				if ( ! wcorg_skip_feature( 'content_blocks' ) ) {
-					$permalink = has_block( 'wordcamp/sessions', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
-				} else {
-					$permalink = has_shortcode( $post->post_content, 'sessions' ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
-				}
+				$current_post_has_target = wcorg_skip_feature( 'content_blocks' ) ?
+					has_shortcode( $post->post_content, 'sessions' ) :
+					has_block( 'wordcamp/sessions', $post->post_content );
+
+				$permalink = $current_post_has_target ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
 				$anchor_id = $anchor_target->ID;
 				break;
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -654,9 +654,9 @@ class WordCamp_Post_Types_Plugin {
 	/**
 	 * Returns an anchor permalink for a Speaker or Session
 	 *
-	 * Any page with the [speakers | sessions] shortcode will contain IDs that can be used as anchors.
+	 * Any page with the Speakers or Sessions block will contain IDs that can be used as anchors.
 	 *
-	 * If the current page contains the corresponding shortcode, we'll assume the user wants to link there.
+	 * If the current page contains the corresponding block, we'll assume the user wants to link there.
 	 * Otherwise, we'll attempt to find another page that contains the shortcode.
 	 *
 	 * @param int $target_id The speaker/session's post ID.
@@ -673,12 +673,12 @@ class WordCamp_Post_Types_Plugin {
 
 		switch ( $anchor_target->post_type ) {
 			case 'wcb_speaker':
-				$permalink = has_shortcode( $post->post_content, 'speakers' ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
+				$permalink = has_block( 'wordcamp/speakers', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'speakers' );
 				$anchor_id = $anchor_target->post_name;
 				break;
 
 			case 'wcb_session':
-				$permalink = has_shortcode( $post->post_content, 'sessions' ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
+				$permalink = has_block( 'wordcamp/sessions', $post->post_content ) ? get_permalink( $post->id ) : $this->get_wcpt_permalink( 'sessions' );
 				$anchor_id = $anchor_target->ID;
 				break;
 
@@ -703,8 +703,8 @@ class WordCamp_Post_Types_Plugin {
 	/**
 	 * Returns the page permalink for speakers, sessions or organizers
 	 *
-	 * Fetches for a post or page with the [speakers | sessions | organizers] shortcode and
-	 * returns the permalink of whichever comes first.
+	 * Fetches for a post or page with the Speakers, Sessions, or Organizers block and returns the permalink of
+	 * whichever comes first.
 	 *
 	 * @param string $type
 	 *
@@ -728,7 +728,7 @@ class WordCamp_Post_Types_Plugin {
 		$wcpt_post = get_posts( array(
 			'post_type'      => array( 'post', 'page' ),
 			'post_status'    => 'publish',
-			's'              => '[' . $type,
+			's'              => '<!-- wp:wordcamp/' . $type,
 			'posts_per_page' => 1,
 		) );
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -652,12 +652,14 @@ class WordCamp_Post_Types_Plugin {
 	}
 
 	/**
-	 * Returns an anchor permalink for a Speaker or Session
+	 * Returns an anchor permalink for a Speaker or Session.
 	 *
-	 * Any page with the Speakers or Sessions block will contain IDs that can be used as anchors.
+	 * Any page with the Speakers or Sessions block will contain IDs that can be used as anchors. If the current
+	 * page contains the corresponding block, we'll assume the user wants to link there. Otherwise, we'll attempt
+	 * to find another page that contains the block.
 	 *
-	 * If the current page contains the corresponding block, we'll assume the user wants to link there.
-	 * Otherwise, we'll attempt to find another page that contains the shortcode.
+	 * Note: if `content_blocks` skip feature flag is set, this site still uses the shortcodes, and we search for
+	 * shortcode content instead.
 	 *
 	 * @param int $target_id The speaker/session's post ID.
 	 *
@@ -709,10 +711,13 @@ class WordCamp_Post_Types_Plugin {
 	}
 
 	/**
-	 * Returns the page permalink for speakers, sessions or organizers
+	 * Returns the page permalink for speakers, sessions, or organizers.
 	 *
-	 * Fetches for a post or page with the Speakers, Sessions, or Organizers block and returns the permalink of
-	 * whichever comes first.
+	 * Fetches for a page with the Speakers, Sessions, or Organizers block and returns the permalink of the oldest
+	 * page on the site (which should be the generated site content).
+	 *
+	 * Note: if `content_blocks` skip feature flag is set, this site still uses the shortcodes, and we search for
+	 * shortcode content instead.
 	 *
 	 * @param string $type
 	 *

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -724,7 +724,7 @@ class WordCamp_Post_Types_Plugin {
 	 * @return false | string
 	 */
 	public function get_wcpt_permalink( $type ) {
-		if ( ! in_array( $type, array( 'speakers', 'sessions', 'organizers' ) ) ) {
+		if ( ! in_array( $type, array( 'speakers', 'sessions', 'organizers' ), true ) ) {
 			return false;
 		}
 
@@ -739,8 +739,10 @@ class WordCamp_Post_Types_Plugin {
 		$this->wcpt_permalinks[ $type ] = false;
 
 		$wcpt_post = get_posts( array(
-			'post_type'      => array( 'post', 'page' ),
+			'post_type'      => array( 'page' ),
 			'post_status'    => 'publish',
+			'orderby'        => 'date',
+			'order'          => 'asc',
 			's'              => wcorg_skip_feature( 'content_blocks' ) ? "[{$type}" : "<!-- wp:wordcamp/{$type}",
 			'posts_per_page' => 1,
 		) );


### PR DESCRIPTION
(note this PR is based off #214)

Currently, the schedule block links off to sessions and speakers by searching the content to locate the first post/page with `[speakers` or `[sessions` shortcodes. It then uses this as the permalink for the canonical Sessions/Speakers page. When we move the base content to blocks, it will no longer be able to find these pages. 

This PR updates the search for the block comment delimiter, but only if the site doesn't have the skip flag of `content_blocks`. This way, current sites can get the flag set, and they will continue to search for shortcode content. New sites won't have the skip flag set, and will search for block content.

❓  Does this feature flag name/flow make sense? I feel like I have a tenuous idea of how this should work and want to make sure this makes sense to other devs too.

**To test**

- Set up a new site using #215, so it has blocks (or add blocks to an existing site)
- Check that the speaker link goes to the post/page with the speaker block when `[sessions speaker_link="permalink" show_meta="true"]` or with the schedule shortcode
- Switch to another site with shortcode content
- Set the flag: `wp wc-misc skip-feature-flag set content_blocks [siteId]`
- Check that the speaker link goes to the post/page with the speaker shortcode