### PR TITLE
Blocks: Add IDs to items for anchor links

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -14,7 +14,7 @@ defined( 'WPINC' ) || die();
 setup_postdata( $session );
 ?>
 
-<div class="wordcamp-session wordcamp-sessions__post slug-<?php echo sanitize_html_class( $session->post_name ); ?>">
+<div id="wcorg-session-<?php echo esc_attr( $session->ID ); ?>" class="wordcamp-session wordcamp-sessions__post slug-<?php echo sanitize_html_class( $session->post_name ); ?>">
 	<?php echo wp_kses_post(
 		render_item_title(
 			get_the_title( $session ),

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
@@ -14,7 +14,7 @@ defined( 'WPINC' ) || die();
 setup_postdata( $speaker ); // This is necessary for generating an excerpt from content if the excerpt field is empty.
 ?>
 
-<div class="wordcamp-speaker wordcamp-speakers__post slug-<?php echo esc_attr( $speaker->post_name ); ?>">
+<div id="wcorg-speaker-<?php echo sanitize_html_class( $speaker->post_name ); ?>" class="wordcamp-speaker wordcamp-speakers__post slug-<?php echo esc_attr( $speaker->post_name ); ?>">
 	<?php echo wp_kses_post(
 		render_item_title(
 			get_the_title( $speaker ),


### PR DESCRIPTION
Updates the blocks frontend render code (the `view.php` files) for Speaker & Session to add IDs matching the format of the shortcodes so that the `[schedule speaker_link="anchor" session_link="anchor"]` shortcode output will still work for blocks.

⚠️  This can mean that we have invalid HTML if someone adds more than one block with the same person/session on a page. It seems that we don't have this option at all on the new schedule block, so maybe blocks _shouldn't_ add the IDs to support anchor links?

There's also a note in the shortcode output, which looks like it was added because of [the invalid HTML issue.](https://meta.trac.wordpress.org/changeset/779)

```
<!-- Organizers note: The id attribute is deprecated and only remains for backwards compatibility, please use the corresponding class to target individual speakers -->
```

Right now I think we shouldn't merge this PR, and instead should just silently "deprecate" anchor links since they won't be possible once the schedule block comes out. But I'd already tested this code before coming to that conclusion, so I figured I'd write it up to get other opinions 🙂 

To test:

- Add a Speaker block to a page on your site
- On another page/post, add a schedule shortcode with `speaker_link="anchor"`
- View the schedule, the speaker link should have something like `speakers/#wcorg-speaker-full-name`
- Clicking the link should scroll you down to that specific speaker in the block's list.