### PR TITLE
Blocks: Remove unnecessary API request

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
@@ -132,7 +132,7 @@ class Edit extends Component {
 }
 
 const sponsorSelect = ( select ) => {
-	const { getEntities, getSiteSettings } = select( WC_BLOCKS_STORE );
+	const { getEntities } = select( WC_BLOCKS_STORE );
 
 	const entities = {
 		wcb_sponsor: getEntities( 'postType', 'wcb_sponsor', { _embed: true } ),
@@ -140,8 +140,7 @@ const sponsorSelect = ( select ) => {
 	};
 
 	return {
-		entities: entities,
-		siteSettings: getSiteSettings(),
+		entities,
 	};
 };
 


### PR DESCRIPTION
The `siteSettings` value isn't used in this block, so we can remove this request to cut down on one API request.

**To test**

- Add the sponsors block
- It should only request the post type & taxonomy endpoints, not the general settings endpoint
