### PR TITLE
Shortcodes: Deprecate anchor links for the schedule shortcode 

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -164,7 +164,7 @@ function preprocess_schedule_attributes( $attr ) {
 		array(
 			'date'         => null,
 			'tracks'       => 'all',
-			// Default to anchor links only if we're not using blocks on this site.
+			// Sites without the `content_blocks` skip flag use blocks, these do not support anchor links.
 			'speaker_link' => wcorg_skip_feature( 'content_blocks' ) ? 'anchor' : 'permalink',
 			'session_link' => 'permalink',
 		),
@@ -183,7 +183,7 @@ function preprocess_schedule_attributes( $attr ) {
 		$attr['session_link'] = 'permalink';
 	}
 
-	// Sites without the `content_blocks` skip flag use blocks, so we need to prevent these from using `anchor`.
+	// See above re: `content_blocks`.
 	if ( ! wcorg_skip_feature( 'content_blocks' ) ) {
 		$attr['speaker_link'] = 'anchor' !== $attr['speaker_link'] ? $attr['speaker_link'] : 'permalink';
 		$attr['session_link'] = 'anchor' !== $attr['session_link'] ? $attr['session_link'] : 'permalink';

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -164,9 +164,11 @@ function preprocess_schedule_attributes( $attr ) {
 		array(
 			'date'         => null,
 			'tracks'       => 'all',
-			'speaker_link' => 'anchor',    // anchor|wporg|permalink|none
-			'session_link' => 'permalink', // permalink|anchor|none
-		), $attr
+			// Default to anchor links only if we're not using blocks on this site.
+			'speaker_link' => wcorg_skip_feature( 'content_blocks' ) ? 'anchor' : 'permalink',
+			'session_link' => 'permalink',
+		),
+		$attr
 	);
 
 	foreach ( array( 'tracks', 'speaker_link', 'session_link' ) as $key_for_case_sensitive_value ) {
@@ -179,6 +181,12 @@ function preprocess_schedule_attributes( $attr ) {
 
 	if ( ! in_array( $attr['session_link'], array( 'permalink', 'anchor', 'none' ), true ) ) {
 		$attr['session_link'] = 'permalink';
+	}
+
+	// Sites without the `content_blocks` skip flag use blocks, so we need to prevent these from using `anchor`.
+	if ( ! wcorg_skip_feature( 'content_blocks' ) ) {
+		$attr['speaker_link'] = 'anchor' !== $attr['speaker_link'] ? $attr['speaker_link'] : 'permalink';
+		$attr['session_link'] = 'anchor' !== $attr['session_link'] ? $attr['session_link'] : 'permalink';
 	}
 
 	return $attr;

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -391,7 +391,8 @@ function send_favourite_sessions_email( WP_REST_Request $request ) {
 		return new WP_REST_Response(
 			array(
 				'message' => esc_html__( 'Email functionality disabled.', 'wordcamporg' ),
-			), 200
+			),
+			200
 		);
 	}
 
@@ -425,7 +426,8 @@ function send_favourite_sessions_email( WP_REST_Request $request ) {
 		return new WP_REST_Response(
 			array(
 				'message' => esc_html__( 'Email sent successfully to ', 'wordcamporg' ) . " $email_address.",
-			), 200
+			),
+			200
 		);
 	}
 


### PR DESCRIPTION
For all new sites that use blocks, we prevent use of the `anchor` setting for session and speaker links. The new default for `speaker_link` is now permalink. Any `schedule` shortcode that tries to use anchor will be silently switched to permalink.

Closes #217.

Note: this still uses the `content_blocks` flag rather than creating a new one, since it relies on whether blocks exist, which that flag will tell us.

**To test**

You can use the following to toggle the skip flag on your site

```
wp wc-misc skip-feature-flag set content_blocks [siteId]
wp wc-misc skip-feature-flag unset content_blocks [siteId]
```

1. Add the `[schedule]` shortcode to your site
2. If you have the flag set, speakers should link to your Speakers page, with anchors pointing to the individual speaker
3. If you don't have the flag set, speakers should link to the individual speaker pages.
4. Try adding `session_link="anchor"`
5. If you have the flag set, each session should be anchor links
6. If you don't have the flag set, sessions will link to the individual session pages (overriding the param set in the shortcode).
