### PR TITLE
Schedule shortcode: Improve accessibility of favorite buttons

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/css/shortcodes.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/shortcodes.css
@@ -1,16 +1,27 @@
 /*
  * [schedule]
  */
- .wcb-favourite-session {
+.wcb-favourite-session {
 	background: #e0f8ff;
 }
 
 .wcpt-schedule td {
 	vertical-align: top;
+	position: relative;
+}
+
+/* Make space for the favorite icon, which is absolutely positioned. */
+.wcpt-schedule td.wcpt-session-type-session:before {
+	content: '';
+	width: 35px;
+	height: 2em;
+	float: right;
 }
 
 .wcpt-schedule div.wcb-session-favourite-icon {
-	float: right;
+	position: absolute;
+	top: 10px;
+	right: 10px;
 	width: 35px;
 	text-align: center;
 }
@@ -42,6 +53,7 @@
 div.wcb-session-favourite-icon a.fav-session-button {
 	color: #e8e8e8;
 	text-decoration: none;
+	border-bottom: none;
 }
 
 

--- a/public_html/wp-content/plugins/wc-post-types/css/shortcodes.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/shortcodes.css
@@ -1,10 +1,6 @@
 /*
  * [schedule]
  */
-.wcb-favourite-session {
-	background: #e0f8ff;
-}
-
 .wcpt-schedule td {
 	vertical-align: top;
 	position: relative;
@@ -42,30 +38,27 @@
 	margin-right: 0px;
 }
 
-.wcpt-schedule .dashicons:after {
-	display: block;
-	font-size: 9px;
-	color: #999;
-	text-align: right;
-}
-
-
 div.wcb-session-favourite-icon a.fav-session-button {
-	color: #e8e8e8;
+	color: #aaa;
 	text-decoration: none;
 	border-bottom: none;
+	box-shadow: none;
 }
 
-
 div.wcb-session-favourite-icon a.fav-session-button:hover,
-#content a.fav-session-button:hover {
-	color: #fff689;
+div.wcb-session-favourite-icon a.fav-session-button:focus,
+#content a.fav-session-button:hover,
+#content a.fav-session-button:focus {
+	color: #ffb900;
 	text-decoration: none;
 }
 
+.wcb-favourite-session {
+	background: #e0f8ff;
+}
 
 td.wcb-favourite-session a.fav-session-button {
-	color: #fff689;
+	color: #ffb900;
 }
 
 .fav-session-email-wait-spinner {

--- a/public_html/wp-content/plugins/wc-post-types/js/favourite-sessions.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/favourite-sessions.js
@@ -85,6 +85,13 @@ jQuery( document ).ready( function ( $ ) {
 
 		for ( var i = 0; i < tdElements.length; i ++ ) {
 			tdElements[ i ].classList.toggle( 'wcb-favourite-session' );
+
+			var button = tdElements[ i ].querySelector( '.fav-session-button' );
+			if ( button ) {
+				// The button should be "unpressed" if it's currently pressed.
+				var shouldUnpress = $( button ).attr( 'aria-pressed' ) !== 'false';
+				$( button ).attr( 'aria-pressed', shouldUnpress ? 'false' : 'true' );
+			}
 		}
 	}
 
@@ -241,8 +248,24 @@ jQuery( document ).ready( function ( $ ) {
 		} else {
 			alert( favSessionsPhpObject.i18n.buttonDisabledAlert );
 		}
+	} );
+	
+	$( '.fav-session-button' ).keydown( function ( event ) {
+		// Space (32) and enter (13) trigger the favoriting, anything else can be passed through.
+		if ( event.keyCode !== 32 && event.keyCode !== 13 ) {
+			return;
+		}
 
-		return false;
+		event.preventDefault();
+
+		if ( FavSessions.primarySource == FavSessions.useLocalStorage ) {
+			var elem      = $( this ),
+			    sessionId = elem.parent().parent().data( 'session-id' );
+
+			switchSessionFavourite( sessionId );
+		} else {
+			alert( favSessionsPhpObject.i18n.buttonDisabledAlert );
+		}
 	} );
 
 	$( '#fav-sessions-form' ).on( 'submit', function ( event ) {

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -4,10 +4,10 @@
  * Plugin Description: Sessions, Speakers, Sponsors and much more.
  */
 
-require( 'inc/back-compat.php' );
-require_once( 'inc/favorite-schedule-shortcode.php' );
-require_once( 'inc/privacy.php' );
-require_once( 'inc/deprecated.php' );
+require 'inc/back-compat.php';
+require_once 'inc/favorite-schedule-shortcode.php';
+require_once 'inc/privacy.php';
+require_once 'inc/deprecated.php';
 
 class WordCamp_Post_Types_Plugin {
 	protected $wcpt_permalinks;
@@ -77,9 +77,9 @@ class WordCamp_Post_Types_Plugin {
 				'wcb_sponsor_level_order',
 				array(
 					'sanitize_callback' => array( $this, 'validate_sponsor_options' ),
-					'show_in_rest' => array(
+					'show_in_rest'      => array(
 						'schema' => array(
-							'type' => 'array',
+							'type'  => 'array',
 							'items' => array(
 								'type' => 'integer',
 							),
@@ -101,7 +101,7 @@ class WordCamp_Post_Types_Plugin {
 	 * Runs during init, because rest_api_init is too late.
 	 */
 	public function rest_init() {
-		require_once( 'inc/rest-api.php' );
+		require_once 'inc/rest-api.php';
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WordCamp_Post_Types_Plugin {
 	 * Enqueues scripts and styles for the render_order_sponsors_level admin page.
 	 */
 	public function enqueue_order_sponsor_levels_scripts() {
-		wp_enqueue_script( 'wcb-sponsor-order', plugins_url( '/js/order-sponsor-levels.js', __FILE__ ), array( 'jquery-ui-sortable' ), '20110212' );
+		wp_enqueue_script( 'wcb-sponsor-order', plugins_url( '/js/order-sponsor-levels.js', __FILE__ ), array( 'jquery-ui-sortable' ), '20110212', true );
 		wp_enqueue_style( 'wcb-sponsor-order', plugins_url( '/css/order-sponsor-levels.css', __FILE__ ), array(), '20110212' );
 	}
 
@@ -246,7 +246,7 @@ class WordCamp_Post_Types_Plugin {
 			'wcb-spon',
 			'wcbSponsors',
 			array(
-				'l10n' => array(
+				'l10n'  => array(
 					'modalTitle' => __( 'Sponsor Agreement', 'wordcamporg' ),
 				),
 				'modal' => array(
@@ -364,7 +364,7 @@ class WordCamp_Post_Types_Plugin {
 		foreach ( $sessions as $time => $entry ) {
 
 			$skip_next = 0;
-			$colspan = 0;
+			$colspan   = 0;
 
 			$columns_html = '';
 			foreach ( $columns as $key => $term_id ) {
@@ -434,7 +434,7 @@ class WordCamp_Post_Types_Plugin {
 				$classes[] = 'wcb-session-' . $session->post_name;
 
 				// Favourite session star-icon.
-				$content = '<div class="wcb-session-favourite-icon">';
+				$content  = '<div class="wcb-session-favourite-icon">';
 				$content .= '<a class="fav-session-button"><span class="dashicons dashicons-star-filled"></span></a></div>';
 				$content .= '<div class="wcb-session-cell-content">';
 
@@ -535,8 +535,8 @@ class WordCamp_Post_Types_Plugin {
 			array(
 				'root' => esc_url_raw( rest_url() ),
 				'i18n' => array(
-					'reqTimeOut' => esc_html__( 'Sorry, the email request timed out.', 'wordcamporg' ),
-					'otherError' => esc_html__( 'Sorry, the email request failed.',    'wordcamporg' ),
+					'reqTimeOut'           => esc_html__( 'Sorry, the email request timed out.', 'wordcamporg' ),
+					'otherError'           => esc_html__( 'Sorry, the email request failed.',    'wordcamporg' ),
 					'overwriteFavSessions' => esc_html__( 'You already have some sessions saved. Would you like to overwrite those with the shared sessions that you are viewing?', 'wordcamporg' ),
 					'buttonDisabledAlert'  => esc_html__( 'Interaction with favorite sessions disabled in share sessions view. Please click on schedule menu link to pick sessions.', 'wordcamporg' ),
 					'buttonDisabledNote'   => esc_html__( 'Button disabled.', 'wordcamporg' ),
@@ -1332,7 +1332,7 @@ class WordCamp_Post_Types_Plugin {
 
 		wp_nonce_field( 'edit-sponsor-info', 'wcpt-meta-sponsor-info' );
 
-		require_once( __DIR__ . '/views/sponsors/metabox-sponsor-info.php' );
+		require_once __DIR__ . '/views/sponsors/metabox-sponsor-info.php';
 	}
 
 	/**
@@ -1368,7 +1368,7 @@ class WordCamp_Post_Types_Plugin {
 			restore_current_blog();
 		}
 
-		require_once( __DIR__ . '/views/sponsors/metabox-sponsor-agreement.php' );
+		require_once __DIR__ . '/views/sponsors/metabox-sponsor-agreement.php';
 	}
 
 	/**
@@ -1384,7 +1384,7 @@ class WordCamp_Post_Types_Plugin {
 			'post_status'    => 'any',
 			'posts_per_page' => - 1,
 
-			'meta_query' => array(
+			'meta_query'     => array(
 				array(
 					'key'   => '_wcbsi_sponsor_id',
 					'value' => $sponsor->ID,
@@ -1400,7 +1400,7 @@ class WordCamp_Post_Types_Plugin {
 			admin_url( 'post-new.php' )
 		);
 
-		require_once( __DIR__ . '/views/sponsors/metabox-invoice-sponsor.php' );
+		require_once __DIR__ . '/views/sponsors/metabox-invoice-sponsor.php';
 	}
 
 	/**
@@ -1488,7 +1488,7 @@ class WordCamp_Post_Types_Plugin {
 			update_post_meta( $post_id, '_wcpt_session_slides', esc_url_raw( $_POST['wcpt-session-slides'] ) );
 
 			// Update session video link.
-			if ( 'wordpress.tv' == str_replace( 'www.', '', strtolower( parse_url( $_POST['wcpt-session-video'], PHP_URL_HOST ) ) ) ) {
+			if ( 'wordpress.tv' == str_replace( 'www.', '', strtolower( wp_parse_url( $_POST['wcpt-session-video'], PHP_URL_HOST ) ) ) ) {
 				update_post_meta( $post_id, '_wcpt_session_video', esc_url_raw( $_POST['wcpt-session-video'] ) );
 			}
 		}
@@ -1584,7 +1584,7 @@ class WordCamp_Post_Types_Plugin {
 				$values['state'] = $this->get_sponsor_info_state_default_value();
 			}
 
-			$values['website']    = esc_url_raw( filter_input( INPUT_POST, '_wcpt_sponsor_website' ) );
+			$values['website'] = esc_url_raw( filter_input( INPUT_POST, '_wcpt_sponsor_website' ) );
 			// TODO: maybe only allows links to home page, depending on outcome of http://make.wordpress.org/community/2013/12/31/irs-rules-for-corporate-sponsorship-of-wordcamp/ .
 			$values['first_name'] = ucfirst( $values['first_name'] );
 			$values['last_name']  = ucfirst( $values['last_name'] );
@@ -1668,7 +1668,7 @@ class WordCamp_Post_Types_Plugin {
 			'wcb_session',
 			array(
 				'labels'          => $labels,
-				'rewrite' => array(
+				'rewrite'         => array(
 					'slug'       => 'session',
 					'with_front' => false,
 				),
@@ -1708,7 +1708,7 @@ class WordCamp_Post_Types_Plugin {
 			'wcb_sponsor',
 			array(
 				'labels'          => $labels,
-				'rewrite' => array(
+				'rewrite'         => array(
 					'slug'       => 'sponsor',
 					'with_front' => false,
 				),
@@ -1748,7 +1748,7 @@ class WordCamp_Post_Types_Plugin {
 			'wcb_organizer',
 			array(
 				'labels'          => $labels,
-				'rewrite' => array(
+				'rewrite'         => array(
 					'slug'       => 'organizer',
 					'with_front' => false,
 				),
@@ -1951,7 +1951,7 @@ class WordCamp_Post_Types_Plugin {
 
 			case 'manage_wcb_session_posts_columns':
 				$columns = array_slice( $columns, 0, 2, true ) + array( 'wcb_session_speakers' => __( 'Speakers', 'wordcamporg' ) ) + array_slice( $columns, 2, null, true );
-				$columns = array_slice( $columns, 0, 1, true ) + array( 'wcb_session_time'     => __( 'Time',     'wordcamporg' ) ) + array_slice( $columns, 1, null, true );
+				$columns = array_slice( $columns, 0, 1, true ) + array( 'wcb_session_time' => __( 'Time',     'wordcamporg' ) ) + array_slice( $columns, 1, null, true );
 				break;
 			default:
 		}
@@ -2064,7 +2064,7 @@ class WordCamp_Post_Types_Plugin {
 	 * Register some widgets.
 	 */
 	public function register_widgets() {
-		require_once( 'inc/widgets.php' );
+		require_once 'inc/widgets.php';
 
 		register_widget( 'WCB_Widget_Sponsors'    );
 		register_widget( 'WCPT_Widget_Speakers'   );

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -425,12 +425,7 @@ class WordCamp_Post_Types_Plugin {
 				$classes[] = 'wcpt-session-type-' . $session_type;
 				$classes[] = 'wcb-session-' . $session->post_name;
 
-				// Favourite session star-icon.
-				$content  = '<div class="wcb-session-favourite-icon">';
-				$content .= '<a href="#" role="button" class="fav-session-button" aria-pressed="false"><span class="screen-reader-text">';
-				$content .= sprintf( esc_html__( 'Favorite session: %s', 'wordcamporg' ), $session_title );
-				$content .= '</span><span class="dashicons dashicons-star-filled"></span></a></div>';
-				$content .= '<div class="wcb-session-cell-content">';
+				$content = '<div class="wcb-session-cell-content">';
 
 				// Determine the session title.
 				if ( 'permalink' == $attr['session_link'] && 'session' == $session_type ) {
@@ -472,6 +467,14 @@ class WordCamp_Post_Types_Plugin {
 
 				// End of cell-content.
 				$content .= '</div>';
+
+				// Favourite session star-icon.
+				if ( 'session' == $session_type ) {
+					$content .= '<div class="wcb-session-favourite-icon">';
+					$content .= '<a href="#" role="button" class="fav-session-button" aria-pressed="false"><span class="screen-reader-text">';
+					$content .= sprintf( esc_html__( 'Favorite session: %s', 'wordcamporg' ), $session_title );
+					$content .= '</span><span class="dashicons dashicons-star-filled"></span></a></div>';
+				}
 
 				$columns_clone = $columns;
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -288,7 +288,7 @@ class WordCamp_Post_Types_Plugin {
 	 * Enqueue scripts.
 	 */
 	public function wp_enqueue_scripts() {
-		wp_enqueue_style( 'wcb_shortcodes', plugins_url( 'css/shortcodes.css', __FILE__ ), array(), 2 );
+		wp_enqueue_style( 'wcb_shortcodes', plugins_url( 'css/shortcodes.css', __FILE__ ), array(), 3 );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -132,18 +132,10 @@ class WordCamp_Post_Types_Plugin {
 	 * Renders the Order Sponsor Levels admin page.
 	 */
 	public function render_order_sponsor_levels() {
-		if ( ! isset( $_REQUEST['updated'] ) ) {
-			$_REQUEST['updated'] = false;
-		}
-
 		$levels = $this->get_sponsor_levels();
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Order Sponsor Levels', 'wordcamporg' ); ?></h1>
-
-			<?php if ( false !== $_REQUEST['updated'] ) : ?>
-				<div class="updated fade"><p><strong><?php esc_html_e( 'Options saved', 'wordcamporg' ); ?></strong></p></div>
-			<?php endif; ?>
 
 			<form method="post" action="options.php">
 				<?php settings_fields( 'wcb_sponsor_options' ); ?>

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -427,7 +427,9 @@ class WordCamp_Post_Types_Plugin {
 
 				// Favourite session star-icon.
 				$content  = '<div class="wcb-session-favourite-icon">';
-				$content .= '<a class="fav-session-button"><span class="dashicons dashicons-star-filled"></span></a></div>';
+				$content .= '<a href="#" role="button" class="fav-session-button" aria-pressed="false"><span class="screen-reader-text">';
+				$content .= sprintf( esc_html__( 'Favorite session: %s', 'wordcamporg' ), $session_title );
+				$content .= '</span><span class="dashicons dashicons-star-filled"></span></a></div>';
 				$content .= '<div class="wcb-session-cell-content">';
 
 				// Determine the session title.


### PR DESCRIPTION
This starts to address [ticket 4247,](https://meta.trac.wordpress.org/ticket/4247) which lists a few accessibility issues with favoriting sessions. In particular, it makes the stars focusable by keyboards, and gives them some text for screen reader users. The stars are also slightly darker now, but still don't technically pass a "good" contrast ratio (IMO, 3.0+ would be best).

The favorite button is now moved _after_ the session information, so visual tab order is consistent and screen reader users hear the session title and speakers before being given the option to favorite it.

Lastly I want to address that this isn't an ideal solution– we're overloading this `a` with aria, rather than using a button. Basically it's for backwards compatibility with existing sites.

- Buttons are more likely to have aggressive styling from the theme, and it would take more work to reset this, and each theme does something slightly different
- The current CSS uses the elements in styling, so any organizer looking to override this probably copied the styles here, and if we swap it out for a button, current sites that have styled this will break

On Twenty Thirteen (Zero Hour Networking is selected, Opening Remarks is hovered):

<img width="639" alt="2013" src="https://user-images.githubusercontent.com/541093/63380306-3a134c80-c364-11e9-83bf-78fe5ebd1b1e.png">

On Twenty Sixteen (Zero Hour Networking is selected, Opening Remarks is hovered):

<img width="860" alt="2016" src="https://user-images.githubusercontent.com/541093/63380305-397ab600-c364-11e9-808e-d083c8ba50e7.png">

**To test**

1. View a schedule
2. Use a keyboard to tab through the sessions and try favoriting some
3. Try using a screen reader (Safari + [VoiceOver](https://webaim.org/articles/voiceover/) is a good test), navigate through the content, you should hear the favorite buttons, and it should tell you when one is selected/pressed.
