### PR TITLE
Jetpack Tweaks: Add supplemental list of safe CSS properties

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/css-sanitization.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/css-sanitization.php
@@ -211,6 +211,10 @@ function get_custom_css_properties_safelist() {
 function update_csstidy_safelist() {
 	$properties = get_custom_css_properties_safelist();
 
+	/**
+	 * CSSTidy uses a config variable for CSS spec version to determine which properties are valid. This tells csstidy
+	 * that the properties we're adding are part of the CSS3.0 spec, even though they actually aren't yet.
+	 */
 	$properties_for_csstidy = array_fill_keys( $properties, 'CSS3.0' );
 
 	if ( ! empty( $GLOBALS['csstidy']['all_properties'] ) ) {

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/css-sanitization.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/css-sanitization.php
@@ -166,13 +166,13 @@ function sanitize_urls_in_css_properties( $url, $property ) {
 		return '';
 	}
 
-	$url = wp_kses_bad_protocol_once( $url, $allowed_protocols );
+	$good_protocol_url = wp_kses_bad_protocol( $url, $allowed_protocols );
 
-	if ( empty( $url ) ) {
+	if ( empty( $good_protocol_url ) || strtolower( $good_protocol_url ) !== strtolower( $url ) ) {
 		return '';
 	}
 
-	return "url('" . str_replace( "'", "\\'", $url ) . "')";
+	return "url('" . addcslashes( $good_protocol_url, '\'\\' ) . "')";
 }
 
 /**


### PR DESCRIPTION
There are many properties that have wide browser support but are not currently included in CSSTidy's validator. This adds a handful of these that are popular and supported so that WordCamp designers can use them while customizing the CSS of their sites.

**To test**

* Open `plugins/wordcamp-remote-css/app/synchronize-remote-css.php`.
* In the `synchronize_remote_css` method, comment out the first line that starts with `$unsafe_css`, and then reassign the `$unsafe_css` variable a static string of CSS that includes some of the newly safelisted properties.
* On your test site, go to the Remote CSS admin screen: `wp-admin/themes.php?page=remote-css`.
* Enter a fake URL that will still validate, `https://github.com/WordPress/style.css`, and click Update.
* In another tab, go to this URI on your test site: `wp-admin/admin-ajax.php?action=wordcamp_remote_css`.
* The safelisted properties should be included in the stylesheet.