### PR TITLE
PWA: Update Offline template

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( 'WPINC' ) or die();
+defined( 'WPINC' ) || die();
 
 /*
  * Helper functions related to the `wordcamp` post type.
@@ -15,13 +15,16 @@ defined( 'WPINC' ) or die();
  * @return array
  */
 function get_wordcamps( $args = array() ) {
-	$args = wp_parse_args( $args, array(
-		'post_type'   => WCPT_POST_TYPE_ID,
-		'post_status' => 'any',
-		'orderby'     => 'ID',
-		'numberposts' => -1,
-		'perm'        => 'readable',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'post_type'   => WCPT_POST_TYPE_ID,
+			'post_status' => 'any',
+			'orderby'     => 'ID',
+			'numberposts' => -1,
+			'perm'        => 'readable',
+		)
+	);
 
 	$wordcamps = get_posts( $args );
 
@@ -47,7 +50,8 @@ function get_wordcamp_post() {
 	$current_site_id  = get_current_blog_id();
 	$current_site_url = site_url();
 
-	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
+	// Switch to central.wordcamp.org to get posts.
+	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
 	$wordcamp = get_posts( array(
 		'post_type'   => 'wordcamp',
@@ -88,13 +92,16 @@ function get_wordcamp_post() {
  * @return mixed An integer if successful, or boolean false if failed
  */
 function get_wordcamp_site_id( $wordcamp_post ) {
-	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
+	// Switch to central.wordcamp.org to get post meta.
+	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
-	if ( ! $site_id = get_post_meta( $wordcamp_post->ID, '_site_id', true ) ) {
+	$site_id = get_post_meta( $wordcamp_post->ID, '_site_id', true );
+	if ( ! $site_id ) {
 		$url = parse_url( get_post_meta( $wordcamp_post->ID, 'URL', true ) );
 
 		if ( isset( $url['host'] ) && isset( $url['path'] ) ) {
-			if ( $site = get_site_by_path( $url['host'], $url['path'] ) ) {
+			$site = get_site_by_path( $url['host'], $url['path'] );
+			if ( $site ) {
 				$site_id = $site->blog_id;
 			}
 		}
@@ -121,7 +128,8 @@ function get_wordcamp_name( $site_id = 0 ) {
 
 	switch_to_blog( $site_id );
 
-	if ( $wordcamp = get_wordcamp_post() ) {
+	$wordcamp = get_wordcamp_post();
+	if ( $wordcamp ) {
 		if ( ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ) {
 			$name = $wordcamp->post_title . ' ' . date( 'Y', $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] );
 		}
@@ -143,7 +151,7 @@ function get_wordcamp_name( $site_id = 0 ) {
  * @todo find other code that's doing this same task in an ad-hoc manner, and convert it to use this instead
  *
  * @param string $url
- * @param string $part 'city', 'city-domain' (without the year, e.g. seattle.wordcamp.org), 'year'
+ * @param string $part 'city', 'city-domain' (without the year, e.g. seattle.wordcamp.org), 'year'.
  *
  * @return false|string|int False on errors; an integer for years; a string for city and city-domain
  */
@@ -151,7 +159,7 @@ function wcorg_get_url_part( $url, $part ) {
 	$url_parts = explode( '.', parse_url( $url, PHP_URL_HOST ) );
 	$result    = false;
 
-	// Make sure it matches the typical year.city.wordcamp.org structure
+	// Make sure it matches the typical year.city.wordcamp.org structure.
 	if ( 4 !== count( $url_parts ) ) {
 		return $result;
 	}
@@ -187,14 +195,14 @@ function wcorg_get_wordcamp_duration( WP_Post $wordcamp ) {
 	$start = get_post_meta( $wordcamp->ID, 'Start Date (YYYY-mm-dd)', true );
 	$end   = get_post_meta( $wordcamp->ID, 'End Date (YYYY-mm-dd)', true );
 
-	// Assume 1 day duration if there is no end date
+	// Assume 1 day duration if there is no end date.
 	if ( ! $end ) {
 		return 1;
 	}
 
 	$duration_raw = $end - $start;
 
-	// Add one second and round up to ensure the end date counts as a day as well
+	// Add one second and round up to ensure the end date counts as a day as well.
 	$duration_days = ceil( ( $duration_raw + 1 ) / DAY_IN_SECONDS );
 
 	return absint( $duration_days );
@@ -222,7 +230,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 	?>
 
 	<select name="<?php echo esc_attr( $name ); ?>" class="select2">
-		<option value=""><?php _e( 'Select a WordCamp', 'wordcamporg' ); ?></option>
+		<option value=""><?php esc_html_e( 'Select a WordCamp', 'wordcamporg' ); ?></option>
 		<option value=""></option>
 
 		<?php foreach ( $wordcamps as $wordcamp ) : ?>

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -252,3 +252,58 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 
 	return ob_get_clean();
 }
+
+/**
+ * Display a human-friendly date range for a given WordCamp.
+ *
+ * @param WP_Post $wordcamp
+ *
+ * @return string
+ */
+function get_wordcamp_date_range( $wordcamp ) {
+	if ( ! $wordcamp instanceof WP_Post || 'wordcamp' !== $wordcamp->post_type ) {
+		return;
+	}
+
+	// Switch to central.wordcamp.org to get post meta.
+	switch_to_blog( BLOG_ID_CURRENT_SITE );
+	$start = get_post_meta( $wordcamp->ID, 'Start Date (YYYY-mm-dd)', true );
+	$end   = get_post_meta( $wordcamp->ID, 'End Date (YYYY-mm-dd)', true );
+	restore_current_blog();
+
+	// Assume a single-day event if there is no end date.
+	if ( ! $end ) {
+		return date( 'F j, Y', $start );
+	}
+
+	$range_str = esc_html__( '%1$s to %2$s', 'wordcamporg' );
+
+	if ( date( 'Y', $start ) !== date( 'Y', $end ) ) {
+		return sprintf( $range_str, date( 'F j, Y', $start ), date( 'F j, Y', $end ) );
+	} else if ( date( 'm', $start ) !== date( 'm', $end ) ) {
+		return sprintf( $range_str, date( 'F j', $start ), date( 'F j, Y', $end ) );
+	} else {
+		return sprintf( $range_str, date( 'F j', $start ), date( 'j, Y', $end ) );
+	}
+}
+
+/**
+ * Display a human-friendly date range for a given WordCamp.
+ *
+ * @param WP_Post $wordcamp
+ *
+ * @return string
+ */
+function get_wordcamp_location( $wordcamp ) {
+	if ( ! $wordcamp instanceof WP_Post || 'wordcamp' !== $wordcamp->post_type ) {
+		return;
+	}
+
+	// Switch to central.wordcamp.org to get post meta.
+	switch_to_blog( BLOG_ID_CURRENT_SITE );
+	$venue   = get_post_meta( $wordcamp->ID, 'Venue Name', true );
+	$address = get_post_meta( $wordcamp->ID, 'Physical Address', true );
+	restore_current_blog();
+
+	return $venue . "\n" . $address;
+}

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -201,7 +201,7 @@ function add_offline_template_cachebuster( $entry ) {
 	$page = get_offline_content();
 
 	if ( $entry && isset( $entry['revision'] ) ) {
-		$entry['revision'] .= ';' . md5( $page['content'] );
+		$entry['revision'] .= ';' . filemtime( __DIR__ . '/templates/offline.php' ) . md5( $page['content'] );
 	}
 
 	return $entry;

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -147,7 +147,6 @@ function get_offline_page() {
 		'order'          => 'asc',
 		'meta_key'       => 'wc_page_offline',
 		'meta_value'     => 'yes',
-		'hierarchical'   => 0,
 	) );
 	if ( count( $found_pages ) ) {
 		return $found_pages[0];
@@ -170,7 +169,7 @@ function get_offline_content() {
 	$page = get_offline_page();
 	if ( $page ) {
 		return array(
-			'title'   => $page->post_title,
+			'title'   => apply_filters( 'the_title', $page->post_title, $page->ID ),
 			'content' => BlockUtilities\get_all_the_content( $page ),
 		);
 	}

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -6,6 +6,7 @@
 namespace WordCamp\Theme_Templates;
 use WP_Post;
 use WP_Service_Worker_Scripts;
+use WordCamp\Blocks\Utilities as BlockUtilities;
 
 defined( 'WPINC' ) || die();
 
@@ -132,7 +133,60 @@ function inject_offline_template( $template_path ) {
 }
 
 /**
- * Add a cache-buster to the offline template's pre-cache entry.
+ * Get the offline page.
+ *
+ * This is a page created when the WordCamp site is created, so it should exist with this post meta.
+ *
+ * @return WP_Post|false
+ */
+function get_offline_page() {
+	$found_pages = get_posts( array(
+		'posts_per_page' => 1,
+		'post_type'      => 'page',
+		'orderby'        => 'date',
+		'order'          => 'asc',
+		'meta_key'       => 'wc_page_offline',
+		'meta_value'     => 'yes',
+		'hierarchical'   => 0,
+	) );
+	if ( count( $found_pages ) ) {
+		return $found_pages[0];
+	}
+
+	return false;
+}
+
+/**
+ * Get the offline page content, if the page exists. Otherwise, use simple defaults.
+ *
+ * @return array {
+ *     Content for the offline template.
+ *
+ *     @type string $title   Title of the page, or a default title.
+ *     @type string $content Content of the page, or the PWA error callback.
+ * }
+ */
+function get_offline_content() {
+	$page = get_offline_page();
+	if ( $page ) {
+		return array(
+			'title'   => $page->post_title,
+			'content' => BlockUtilities\get_all_the_content( $page ),
+		);
+	}
+
+	ob_start();
+	wp_service_worker_error_message_placeholder();
+	$offline_content = ob_get_clean();
+
+	return array(
+		'title'   => esc_html__( 'Offline', 'wordcamporg' ),
+		'content' => $offline_content,
+	);
+}
+
+/**
+ * Add the Offline page content as a revision parameter, to bust the cache when the page is changed.
  *
  * @param array|false $entry {
  *     Offline error precache entry.
@@ -144,8 +198,10 @@ function inject_offline_template( $template_path ) {
  * @return array|false
  */
 function add_offline_template_cachebuster( $entry ) {
+	$page = get_offline_content();
+
 	if ( $entry && isset( $entry['revision'] ) ) {
-		$entry['revision'] .= ';' . filemtime( __DIR__ . '/templates/offline.php' );
+		$entry['revision'] .= ';' . md5( $page['content'] );
 	}
 
 	return $entry;

--- a/public_html/wp-content/mu-plugins/theme-templates/templates/offline.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/offline.php
@@ -24,7 +24,7 @@ $offline_page = get_offline_content();
 		<section class="error-offline">
 			<header class="page-header">
 				<h1 class="page-title">
-					<?php echo esc_html( $offline_page['title'] ); ?>
+					<?php echo wp_kses_post( $offline_page['title'] ); ?>
 				</h1>
 			</header>
 

--- a/public_html/wp-content/mu-plugins/theme-templates/templates/offline.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/offline.php
@@ -16,31 +16,22 @@
 namespace WordCamp\Theme_Templates;
 
 get_header();
+
+$offline_page = get_offline_content();
 ?>
 
-	<main>
-		<h1>
-			<?php echo esc_html( _x( 'Offline', 'Page Title', 'wordcamporg' ) ); ?>
-		</h1>
+	<main id="main" class="site-main">
+		<section class="error-offline">
+			<header class="page-header">
+				<h1 class="page-title">
+					<?php echo esc_html( $offline_page['title'] ); ?>
+				</h1>
+			</header>
 
-		<p>
-			<?php esc_html_e( "This page couldn't be loaded because you appear to be offline. Please try again once you have a network connection.", 'wordcamporg' ); ?>
-		</p>
-
-		<p>
-			<?php esc_html_e( 'In the mean time, hopefully this information is useful:', 'wordcamporg' ); ?>
-		</p>
-
-		<?php
-			require_once dirname( __DIR__ ) . '/parts/dates.php';
-			require_once dirname( __DIR__ ) . '/parts/location.php';
-		?>
-
-		<h3>
-			<?php esc_html_e( 'Schedule' ); ?>
-		</h3>
-
-		<?php echo do_shortcode( '[schedule]' ); ?>
+			<div class="page-content">
+				<?php echo wp_kses_post( $offline_page['content'] ); ?>
+			</div>
+		</section>
 	</main>
 
 <?php

--- a/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
@@ -6,13 +6,14 @@
 <p><?php esc_html_e( "This page couldn't be loaded because you appear to be offline. Please try again once you have a network connection.", 'wordcamporg' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p><?php esc_html_e( 'In the mean time, hopefully this information is useful:', 'wordcamporg' ); ?></p>
-<!-- /wp:paragraph -->
-
 <!-- wp:heading -->
-<h2><?php esc_html_e( 'Location', 'wordcamporg' ); ?></h2>
+<h2><?php esc_html_e( 'Location & Date', 'wordcamporg' ); ?></h2>
 <!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><?php echo esc_html( get_wordcamp_date_range( $wordcamp ) ); ?><br>
+<?php echo nl2br( esc_html( get_wordcamp_location( $wordcamp ) ) ); ?></p>
+<!-- /wp:paragraph -->
 
 <!-- wp:heading -->
 <h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>

--- a/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
@@ -19,5 +19,5 @@
 <!-- /wp:heading -->
 
 <!-- wp:shortcode -->
-[schedule date="YYYY-MM-DD" tracks="example-track,another-example-track,yet-another-example-track"]
+[schedule]
 <!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
@@ -1,0 +1,23 @@
+<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
+<p style="background-color:#eeeeee" class="has-background"><?php esc_html_e( "Organizers note: Update this page with some basic information about your WordCamp. It will be stored in site visitor's browsers, and automatically shown if they try to visit the site without an internet connection.", 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( "This page couldn't be loaded because you appear to be offline. Please try again once you have a network connection.", 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'In the mean time, hopefully this information is useful:', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2><?php esc_html_e( 'Location', 'wordcamporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:shortcode -->
+[schedule date="YYYY-MM-DD" tracks="example-track,another-example-track,yet-another-example-track"]
+<!-- /wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -1,7 +1,6 @@
 <?php
 
-// Nonces are verified in Event_Admin::metabox_save (if applicable), we don't need to re-verify.
-// phpcs:disable WordPress.Security.NonceVerification.Missing
+// PHPCS note: Nonces are verified in Event_Admin::metabox_save (if applicable), we don't need to re-verify.
 
 use \WordCamp\Logger;
 
@@ -89,16 +88,19 @@ class WordCamp_New_Site {
 
 		$field_name = wcpt_key_to_str( $key, 'wcpt_' );
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 		if ( 'URL' !== $key || 'wc-url' !== $field_type || ! isset( $_POST[ $field_name ] ) ) {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 		if ( empty( $_POST[ $field_name ] ) ) {
 			delete_post_meta( $wordcamp_id, 'URL' );
 			delete_post_meta( $wordcamp_id, '_site_id' );
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 		$url = strtolower( substr( $_POST[ $field_name ], 0, 4 ) ) == 'http' ? $_POST[ $field_name ] : 'http://' . $_POST[ $field_name ];
 		$url = set_url_scheme( esc_url_raw( $url ), 'https' );
 		$url = filter_var( $url, FILTER_VALIDATE_URL );
@@ -159,6 +161,7 @@ class WordCamp_New_Site {
 		}
 
 		$url = get_post_meta( $wordcamp_id, 'URL', true );
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 		if ( ! isset( $_POST[ wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ) ] ) || empty( $url ) ) {
 			Logger\log( 'return_no_request_or_url', compact( 'wordcamp_id', 'url' ) );
 			return;
@@ -229,6 +232,7 @@ class WordCamp_New_Site {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 		if ( empty( $_POST[ wcpt_key_to_str( 'push-mes-sponsors', 'wcpt_' ) ] ) ) {
 			return;
 		}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -1,11 +1,14 @@
 <?php
 
+// Nonces are verified in Event_Admin::metabox_save (if applicable), we don't need to re-verify.
+// phpcs:disable WordPress.Security.NonceVerification.Missing
+
 use \WordCamp\Logger;
 
 class WordCamp_New_Site {
 	protected $new_site_id;
 
-	/*
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -22,9 +25,9 @@ class WordCamp_New_Site {
 	 *
 	 * @action wcpt_metabox_value
 	 *
-	 * @param $key
-	 * @param $field_type
-	 * @param $object_name
+	 * @param string $key
+	 * @param string $field_type
+	 * @param string $object_name
 	 */
 	public function render_site_url_field( $key, $field_type, $object_name ) {
 		global $post_id;
@@ -41,11 +44,19 @@ class WordCamp_New_Site {
 			<?php if ( current_user_can( 'manage_sites' ) ) : ?>
 				<?php $url = parse_url( trailingslashit( get_post_meta( $post_id, $key, true ) ) ); ?>
 				<?php if ( isset( $url['host'], $url['path'] ) && domain_exists( $url['host'], $url['path'], 1 ) ) : ?>
-					<?php $blog_details = get_blog_details( array( 'domain' => $url['host'], 'path' => $url['path'] ), true ); ?>
+					<?php
+						$blog_details = get_blog_details(
+							array(
+								'domain' => $url['host'],
+								'path'   => $url['path'],
+							),
+							true
+						);
+					?>
 
-					<a target="_blank" href="<?php echo add_query_arg( 's', $blog_details->blog_id, network_admin_url( 'sites.php' ) ); ?>">Edit</a> |
-					<a target="_blank" href="<?php echo $blog_details->siteurl; ?>/wp-admin/">Dashboard</a> |
-					<a target="_blank" href="<?php echo $blog_details->siteurl; ?>">Visit</a>
+					<a target="_blank" href="<?php echo esc_url( add_query_arg( 's', $blog_details->blog_id, network_admin_url( 'sites.php' ) ) ); ?>">Edit</a> |
+					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>/wp-admin/">Dashboard</a> |
+					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
 
 				<?php else : ?>
 					<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ); ?>
@@ -55,9 +66,9 @@ class WordCamp_New_Site {
 						Create site in network
 					</label>
 
-					<span class="description">(e.g., https://<?php echo date( 'Y' ); ?>.city.wordcamp.org)</span>
-				<?php endif; // domain_exists ?>
-			<?php endif; // current_user_can ?>
+					<span class="description">(e.g., https://<?php echo esc_attr( date( 'Y' ) ); ?>.city.wordcamp.org)</span>
+				<?php endif; // Domain exists. ?>
+			<?php endif; // User can manage sites. ?>
 		<?php endif;
 	}
 
@@ -71,7 +82,7 @@ class WordCamp_New_Site {
 	public function save_site_url_field( $key, $field_type, $wordcamp_id ) {
 		global $switched;
 
-		// No updating if the blog has been switched
+		// No updating if the blog has been switched.
 		if ( $switched || 1 !== did_action( 'wcpt_metabox_save' ) ) {
 			return;
 		}
@@ -140,7 +151,7 @@ class WordCamp_New_Site {
 			return;
 		}
 
-		// The sponsor region is required so we can import the relevant sponsors and levels
+		// The sponsor region is required so we can import the relevant sponsors and levels.
 		$sponsor_region = get_post_meta( $wordcamp_id, 'Multi-Event Sponsor Region', true );
 		if ( ! $sponsor_region ) {
 			Logger\log( 'return_no_region', compact( 'wordcamp_id', 'sponsor_region' ) );
@@ -159,9 +170,9 @@ class WordCamp_New_Site {
 			return;
 		}
 
-		$path              = isset( $url_components['path'] ) ? $url_components['path'] : '';
-		$wordcamp_meta     = get_post_custom( $wordcamp_id );
-		$lead_organizer    = $this->get_user_or_current_user( $wordcamp_meta['WordPress.org Username'][0] );
+		$path           = isset( $url_components['path'] ) ? $url_components['path'] : '';
+		$wordcamp_meta  = get_post_custom( $wordcamp_id );
+		$lead_organizer = $this->get_user_or_current_user( $wordcamp_meta['WordPress.org Username'][0] );
 
 		$blog_name = apply_filters( 'the_title', $wordcamp->post_title );
 		if ( ! empty( $wordcamp->{'Start Date (YYYY-mm-dd)'} ) ) {
@@ -176,14 +187,19 @@ class WordCamp_New_Site {
 		) );
 
 		if ( is_int( $this->new_site_id ) ) {
-			update_post_meta( $wordcamp_id, '_site_id', $this->new_site_id );    // this is used in other plugins to map the `wordcamp` post to it's corresponding site
+			// This is used in other plugins to map the `wordcamp` post to it's corresponding site.
+			update_post_meta( $wordcamp_id, '_site_id', $this->new_site_id );
 			do_action( 'wcor_wordcamp_site_created', $wordcamp_id );
 
-			add_post_meta( $wordcamp_id, '_note', array(
-				'timestamp' => time(),
-				'user_id'   => get_current_user_id(),
-				'message'   => sprintf( 'Created site at <a href="%s">%s</a>', $url, $url ),
-			) );
+			add_post_meta(
+				$wordcamp_id,
+				'_note',
+				array(
+					'timestamp' => time(),
+					'user_id'   => get_current_user_id(),
+					'message'   => sprintf( 'Created site at <a href="%s">%s</a>', $url, $url ),
+				)
+			);
 
 			$this->configure_new_site( $wordcamp_id, $wordcamp );
 
@@ -208,7 +224,7 @@ class WordCamp_New_Site {
 			return;
 		}
 
-		// The sponsor region is required so we can import the relevant sponsors and levels
+		// The sponsor region is required so we can import the relevant sponsors and levels.
 		if ( ! get_post_meta( $wordcamp_id, 'Multi-Event Sponsor Region', true ) ) {
 			return;
 		}
@@ -269,7 +285,7 @@ class WordCamp_New_Site {
 					update_post_meta( $post_id, $key, $value );
 				}
 
-				// Set featured image
+				// Set featured image.
 				if ( ! empty( $sponsor['featured_image'] ) ) {
 					$results = media_sideload_image( $sponsor['featured_image'], $post_id );
 
@@ -394,10 +410,10 @@ class WordCamp_New_Site {
 	 */
 	protected function set_default_options( $wordcamp, $meta ) {
 		/** @var $WCCSP_Settings WCCSP_Settings */
-		global $WCCSP_Settings;
+		global $WCCSP_Settings; // phpcs:ignore WordPress.NamingConventions
 
 		$admin_email                     = is_email( $meta['E-mail Address'][0] ) ? $meta['E-mail Address'][0] : get_site_option( 'admin_email' );
-		$coming_soon_settings            = $WCCSP_Settings->get_settings();
+		$coming_soon_settings            = $WCCSP_Settings->get_settings(); // phpcs:ignore WordPress.NamingConventions
 		$coming_soon_settings['enabled'] = 'on';
 
 		update_option( 'admin_email',                  $admin_email );
@@ -424,7 +440,7 @@ class WordCamp_New_Site {
 		$assigned_sponsor_data = $this->get_assigned_sponsor_data( $wordcamp->ID );
 		$this->create_sponsorship_levels( $assigned_sponsor_data['assigned_sponsors'] );
 
-		// Get stub content
+		// Get stub content.
 		$stubs = array_merge(
 			$this->get_stub_posts( $wordcamp, $meta ),
 			$this->get_stub_pages( $wordcamp, $meta ),
@@ -432,29 +448,32 @@ class WordCamp_New_Site {
 			$this->get_stub_me_sponsor_thank_yous( $assigned_sponsor_data['assigned_sponsors'] )
 		);
 
-		// Create actual posts from stubs
+		// Create actual posts from stubs.
 		foreach ( $stubs as $page ) {
-			$page_id = wp_insert_post( array(
-				'post_type'    => $page['type'],
-				'post_status'  => $page['status'],
-				'post_author'  => $lead_organizer->ID,
-				'post_title'   => $page['title'],
-				'post_content' => $page['content']
-			), true );
+			$page_id = wp_insert_post(
+				array(
+					'post_type'    => $page['type'],
+					'post_status'  => $page['status'],
+					'post_author'  => $lead_organizer->ID,
+					'post_title'   => $page['title'],
+					'post_content' => $page['content'],
+				),
+				true
+			);
 
 			if ( is_wp_error( $page_id ) ) {
 				Logger\log( 'insert_post_failed', compact( 'page_id', 'page' ) );
 				continue;
 			}
 
-			// Save post meta
+			// Save post meta.
 			if ( ! empty( $page['meta'] ) ) {
 				foreach ( $page['meta'] as $key => $value ) {
 					update_post_meta( $page_id, $key, $value );
 				}
 			}
 
-			// Set featured image
+			// Set featured image.
 			if ( isset( $page['featured_image'] ) ) {
 				$results = media_sideload_image( $page['featured_image'], $page_id );
 
@@ -464,7 +483,7 @@ class WordCamp_New_Site {
 					$attachment_id = get_posts( array(
 						'posts_per_page' => 1,
 						'post_type'      => 'attachment',
-						'post_parent'    => $page_id
+						'post_parent'    => $page_id,
 					) );
 
 					if ( isset( $attachment_id[0]->ID ) ) {
@@ -473,7 +492,7 @@ class WordCamp_New_Site {
 				}
 			}
 
-			// Assign sponsorship level
+			// Assign sponsorship level.
 			if ( 'wcb_sponsor' == $page['type'] && isset( $page['term'] ) ) {
 				wp_set_object_terms( $page_id, $page['term'], 'wcb_sponsor_level', true );
 			}
@@ -598,7 +617,7 @@ class WordCamp_New_Site {
 	protected function get_stub_posts( $wordcamp, $meta ) {
 		$posts = array(
 			array(
-				// translators: %s: site title
+				// translators: %s: site title.
 				'title'   => sprintf( __( 'Welcome to %s', 'wordcamporg' ), get_option( 'blogname' ) ),
 				'content' => $this->get_stub_content( 'post', 'welcome' ),
 				'status'  => 'publish',
@@ -667,7 +686,7 @@ class WordCamp_New_Site {
 				$sponsorship_level->post_title,
 				'wcb_sponsor_level',
 				array(
-					'slug' => $sponsorship_level->post_name
+					'slug' => $sponsorship_level->post_name,
 				)
 			);
 		}
@@ -713,13 +732,13 @@ class WordCamp_New_Site {
 		$sponsor_meta    = array( '_mes_id' => $assigned_sponsor->ID );
 		$meta_field_keys = array(
 			'company_name', 'website', 'first_name', 'last_name', 'email_address', 'phone_number',
-			'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country'
+			'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country',
 		);
 
-		switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
+		switch_to_blog( BLOG_ID_CURRENT_SITE ); // Switch to central.wordcamp.org.
 
 		foreach ( $meta_field_keys as $key ) {
-			$sponsor_meta["_wcpt_sponsor_$key"] = get_post_meta( $assigned_sponsor->ID, "mes_$key", true );
+			$sponsor_meta[ "_wcpt_sponsor_$key" ] = get_post_meta( $assigned_sponsor->ID, "mes_$key", true );
 		}
 
 		restore_current_blog();
@@ -739,18 +758,20 @@ class WordCamp_New_Site {
 		global $multi_event_sponsors;
 		$data = array();
 
-		switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
+		switch_to_blog( BLOG_ID_CURRENT_SITE ); // Switch to central.wordcamp.org.
 
 		$data['featured_images']   = array();
 		$data['assigned_sponsors'] = $multi_event_sponsors->get_wordcamp_me_sponsors( $wordcamp_id, 'sponsor_level' );
 
 		foreach ( $data['assigned_sponsors'] as $sponsorship_level_id => $sponsors ) {
 			foreach ( $sponsors as $sponsor ) {
-				if ( ! $attachment_id = get_post_thumbnail_id( $sponsor->ID ) ) {
+				$attachment_id = get_post_thumbnail_id( $sponsor->ID );
+				if ( ! $attachment_id ) {
 					continue;
 				}
 
-				if ( ! $attachment = wp_get_attachment_image_src( $attachment_id, 'full' ) ) {
+				$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+				if ( ! $attachment ) {
 					continue;
 				}
 
@@ -782,7 +803,7 @@ class WordCamp_New_Site {
 			$sponsorship_level = $sponsorship_level_id[0]->sponsorship_level;
 
 			$pages[] = array(
-				// translators: %s: sponsorship level
+				// translators: %s: sponsorship level.
 				'title'   => sprintf( __( 'Thank you to our %s sponsors', 'wordcamporg' ), $sponsorship_level->post_title ),
 				'content' => sprintf(
 					'%s %s',

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -601,6 +601,16 @@ class WordCamp_New_Site {
 				'status'  => 'publish',
 				'type'    => 'page',
 			),
+
+			array(
+				'title'   => __( 'Offline', 'wordcamporg' ),
+				'content' => $this->get_stub_content( 'page', 'offline' ),
+				'status'  => 'publish',
+				'type'    => 'page',
+				'meta'    => array(
+					'wc_page_offline' => 'yes',
+				),
+			),
 		);
 
 		return $pages;

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -187,7 +187,7 @@ class WordCamp_New_Site {
 		) );
 
 		if ( is_int( $this->new_site_id ) ) {
-			// This is used in other plugins to map the `wordcamp` post to it's corresponding site.
+			// `_site_id` is used in other plugins to map the `wordcamp` post to it's corresponding site.
 			update_post_meta( $wordcamp_id, '_site_id', $this->new_site_id );
 			do_action( 'wcor_wordcamp_site_created', $wordcamp_id );
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -604,7 +604,7 @@ class WordCamp_New_Site {
 
 			array(
 				'title'   => __( 'Offline', 'wordcamporg' ),
-				'content' => $this->get_stub_content( 'page', 'offline' ),
+				'content' => $this->get_stub_content( 'page', 'offline', $wordcamp ),
 				'status'  => 'publish',
 				'type'    => 'page',
 				'meta'    => array(
@@ -665,12 +665,13 @@ class WordCamp_New_Site {
 	/**
 	 * Load the content for a stub from an include file.
 	 *
-	 * @param string $post_type
-	 * @param string $stub_name
+	 * @param string  $post_type
+	 * @param string  $stub_name
+	 * @param WP_Post $wordcamp
 	 *
 	 * @return string
 	 */
-	protected function get_stub_content( $post_type, $stub_name ) {
+	protected function get_stub_content( $post_type, $stub_name, $wordcamp = false ) {
 		$content   = '';
 		$stub_file = WCPT_DIR . "stubs/$post_type/$stub_name.php";
 


### PR DESCRIPTION
An alternate approach to the offline template– This PR adds a new Offline page to the default site content, that the organizer can then update with relevant info. We can set up an outline of content (using headings, shortcode/block placeholders, etc) and let organizers decide what's relevant.

This also updates the offline template itself with theme classes & markup (mirroring CampSite, but works with other themes - post merge of this PR I'll check against the other themes listed in #205). 

Fixes #128 

The default page on a newly-created site:

![offline-page](https://user-images.githubusercontent.com/541093/63794164-5ae12200-c8cf-11e9-8895-5d18bcbdc939.png)

If there's no page, we show… basically nothing, since ideally everyone will have this page. The exact content comes directly from the PWA 

![offline-no-page](https://user-images.githubusercontent.com/541093/63794165-5b79b880-c8cf-11e9-9e47-5ffcaf546c2d.png)

**To test**

- Create a new site to populate this default content
- Or create a new page on an existing site with the stub content, and add `wc_page_offline` = `yes` as a custom field.
- View the offline template by going to `site.com/?wp_error_template=offline`
- Cache the page by viewing the frontend while online (I _think_ the above will do that)
- Turn off your internet (Chrome: in dev tools, the Application tab, Service Workers, you can click the "Offline" checkbox)
- View any page, you should get the offline page.

- Test also on a site with no Offline page set up.

❓  Some other thoughts…

- Assuming we activate the PWA plugin only on new sites, they should always have the new offline content, so we can leave the fallback content to be very simple, only used if an org trashes the post. In that case, I think the very simple content is fine - but open to counterpoints.
- What do we think about the stub content as it is? Should/can I pull content out of the WordCamp post type (date, location, etc) to pre-populate the location section, or does this not usually exist yet?
- Should there be more content in the offline stub page?
