### PR TITLE
Fonts: Support Font Awesome kits

### DIFF
--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -36,7 +36,8 @@ class WordCamp_Fonts_Plugin {
 			return;
 		}
 
-		printf( '<script type="text/javascript" src="https://use.typekit.com/%s.js"></script>' . "\n", $this->options['typekit-id'] );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		printf( '<script type="text/javascript" src="https://use.typekit.com/%s.js"></script>' . "\n", esc_attr( $this->options['typekit-id'] ) );
 		printf( '<script type="text/javascript">try{Typekit.load();}catch(e){}</script>' );
 	}
 
@@ -48,6 +49,7 @@ class WordCamp_Fonts_Plugin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		printf( '<style>%s</style>', $this->options['google-web-fonts'] );
 	}
 
@@ -78,9 +80,29 @@ class WordCamp_Fonts_Plugin {
 		register_setting( 'wc-fonts-options', 'wc-fonts-options', array( $this, 'validate_options' ) );
 		add_settings_section( 'general', '', '__return_null', 'wc-fonts-options' );
 
-		add_settings_field( 'typekit-id', 'Typekit ID', array( $this, 'field_typekit_id' ), 'wc-fonts-options', 'general' );
-		add_settings_field( 'google-web-fonts', 'Google Web Fonts', array( $this, 'field_google_web_fonts' ), 'wc-fonts-options', 'general' );
-		add_settings_field( 'font-awesome-url', 'Font Awesome',     array( $this, 'field_font_awesome_url' ), 'wc-fonts-options', 'general' );
+		add_settings_field(
+			'typekit-id',
+			__( 'Typekit ID', 'wordcamporg' ),
+			array( $this, 'field_typekit_id' ),
+			'wc-fonts-options',
+			'general'
+		);
+
+		add_settings_field(
+			'google-web-fonts',
+			__( 'Google Web Fonts', 'wordcamporg' ),
+			array( $this, 'field_google_web_fonts' ),
+			'wc-fonts-options',
+			'general'
+		);
+
+		add_settings_field(
+			'font-awesome-url',
+			__( 'Font Awesome', 'wordcamporg' ),
+			array( $this, 'field_font_awesome_url' ),
+			'wc-fonts-options',
+			'general'
+		);
 
 		add_settings_field(
 			'dashicons',

--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -204,7 +204,7 @@ class WordCamp_Fonts_Plugin {
 
 		<input type="text" name="wc-fonts-options[font-awesome-url]" value="<?php echo esc_url( $value ); ?>" class="large-text code" />
 		<p class="description">
-			<?php esc_html_e( 'Enter the BootstrapCDN URL for the version you want.', 'wordcamporg' ); ?>
+			<?php esc_html_e( 'For Font Awesome 4.7 and below. Enter the BootstrapCDN URL for the version you want.', 'wordcamporg' ); ?>
 		</p>
 
 		<?php
@@ -219,7 +219,7 @@ class WordCamp_Fonts_Plugin {
 
 		<input type="text" name="wc-fonts-options[font-awesome-kit]" value="<?php echo esc_attr( $value ); ?>" class="regular-text code" />
 		<p class="description">
-			<?php esc_html_e( 'Enter your Font Awesome Kit ID only. Do not add any URLs or JavaScript.', 'wordcamporg' ); ?>
+			<?php esc_html_e( 'For Font Awesome 5+. Enter your Font Awesome Kit ID only. Do not add any URLs or JavaScript.', 'wordcamporg' ); ?>
 		</p>
 
 		<?php

--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -36,8 +36,8 @@ class WordCamp_Fonts_Plugin {
 			return;
 		}
 
-		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		printf( '<script type="text/javascript" src="https://use.typekit.com/%s.js"></script>' . "\n", esc_attr( $this->options['typekit-id'] ) );
+		// phpcs:ignore -- Allow hardcoded script, and allow `sanitize_key` as an escaping function.
+		printf( '<script type="text/javascript" src="https://use.typekit.com/%s.js"></script>' . "\n", sanitize_key( $this->options['typekit-id'] ) );
 		printf( '<script type="text/javascript">try{Typekit.load();}catch(e){}</script>' );
 	}
 
@@ -57,13 +57,13 @@ class WordCamp_Fonts_Plugin {
 	 * Provides the <head> output for Font Awesome
 	 */
 	public function wp_head_font_awesome() {
-		if ( $this->options['font-awesome-url'] ) {
+		if ( ! empty( $this->options['font-awesome-url'] ) ) {
 			printf( "<style>@import url( '%s' );</style>", esc_url( $this->options['font-awesome-url'] ) );
 		}
 
-		if ( $this->options['font-awesome-kit'] ) {
-			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			printf( '<script src="https://kit.fontawesome.com/%s.js"></script>', esc_attr( $this->options['font-awesome-kit'] ) );
+		if ( ! empty( $this->options['font-awesome-kit'] ) ) {
+			// phpcs:ignore -- Allow hardcoded script, and allow `sanitize_key` as an escaping function.
+			printf( '<script src="https://kit.fontawesome.com/%s.js"></script>', sanitize_key( $this->options['font-awesome-kit'] ) );
 		}
 	}
 


### PR DESCRIPTION
As of Font Awesome 5, the CDN uses a kit system like typekit - a javascript file that in turn loads the necessary CSS. This adds a new field to the fonts section for this kit ID.

![Screen Shot 2019-09-03 at 7 42 28 PM](https://user-images.githubusercontent.com/541093/64215536-4ed30280-ce83-11e9-9b84-236d576d8d7d.png)

**To Test**

- Sign up for a kit at [fontawesome.com](https://fontawesome.com/)
- You'll get a kit script like `<script src="https://kit.fontawesome.com/[kit id].js"></script>`
- Use that ID for the input,
- Save, it should stay in the input field
- View the frontend of your site, you should see the script tags in the source, and see the JS and CSS files loading.