### PR TITLE
Payments: Convert amount into zero-decimal format for Stripe

### DIFF
--- a/public_html/wp-content/mu-plugins/utilities/class-stripe-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-stripe-client.php
@@ -155,4 +155,56 @@ class Stripe_Client {
 
 		return $match;
 	}
+
+	/**
+	 * Convert an amount in the currency's base unit to its equivalent fractional unit.
+	 *
+	 * Stripe wants amounts in the fractional unit (e.g., pennies), not the base unit (e.g., dollars).  The data
+	 * here comes from https://stripe.com/docs/currencies.
+	 *
+	 * Note: This uses different data than `get_fractional_unit_multiplier` above, these have different data
+	 * sources. These should be reconciled in the future.
+	 *
+	 * @param string $order_currency
+	 * @param int    $base_unit_amount
+	 *
+	 * @return int
+	 * @throws Exception
+	 */
+	public static function get_fractional_unit_amount( $order_currency, $base_unit_amount ) {
+		$fractional_amount = null;
+
+		$currency_multipliers = array(
+			// Zero-decimal currencies.
+			1   => array(
+				'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF',
+				'XOF', 'XPF',
+			),
+			100 => array(
+				'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN', 'BAM', 'BBD', 'BDT', 'BGN',
+				'BMD', 'BND', 'BOB', 'BRL', 'BSD', 'BWP', 'BZD', 'CAD', 'CDF', 'CHF', 'CNY', 'COP',
+				'CRC', 'CVE', 'CZK', 'DKK', 'DOP', 'DZD', 'EGP', 'ETB', 'EUR', 'FJD', 'FKP',
+				'GBP', 'GEL', 'GIP', 'GMD', 'GTQ', 'GYD', 'HKD', 'HNL', 'HRK', 'HTG', 'HUF', 'IDR',
+				'ILS', 'INR', 'ISK', 'JMD', 'KES', 'KGS', 'KHR', 'KYD', 'KZT',
+				'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'MAD', 'MDL', 'MKD', 'MMK', 'MNT', 'MOP', 'MRO', 'MUR', 'MVR', 'MWK',
+				'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR',
+				'PLN', 'QAR', 'RON', 'RSD', 'RUB', 'SAR', 'SBD', 'SCR', 'SEK', 'SGD', 'SHP', 'SLL',
+				'SOS', 'SRD', 'STD', 'SZL', 'THB', 'TJS', 'TOP', 'TRY', 'TTD', 'TWD',
+				'TZS', 'UAH', 'USD', 'UYU', 'UZS', 'WST', 'XCD', 'YER', 'ZAR', 'ZMW',
+			),
+		);
+
+		foreach ( $currency_multipliers as $multiplier => $currencies ) {
+			if ( in_array( $order_currency, $currencies, true ) ) {
+				$fractional_amount = floatval( $base_unit_amount ) * $multiplier;
+				break;
+			}
+		}
+
+		if ( is_null( $fractional_amount ) ) {
+			throw new Exception( "Unknown currency multiplier for $order_currency." );
+		}
+
+		return intval( $fractional_amount );
+	}
 }

--- a/public_html/wp-content/mu-plugins/utilities/class-stripe-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-stripe-client.php
@@ -162,7 +162,7 @@ class Stripe_Client {
 	 * Stripe wants amounts in the fractional unit (e.g., pennies), not the base unit (e.g., dollars).  The data
 	 * here comes from https://stripe.com/docs/currencies.
 	 *
-	 * Note: This uses different data than `get_fractional_unit_multiplier` above, these have different data
+	 * @todo This uses different data than `get_fractional_unit_multiplier` above, these have different data
 	 * sources. These should be reconciled in the future.
 	 *
 	 * @param string $order_currency

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-payment-stripe.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-payment-stripe.php
@@ -199,15 +199,23 @@ function _handle_post_data( &$data ) {
 				return;
 			}
 
+			try {
+				$decimal_amount = Stripe_Client::get_fractional_unit_amount( $currency, $amount );
+			} catch ( Exception $e ) {
+				$data['errors'][] = $e->getMessage();
+				return;
+			}
+
 			// Next step is to collect the card details via Stripe.
 			$data['step']    = STEP_PAYMENT_DETAILS;
 			$data['payment'] = array(
-				'payment_type' => $payment_type,
-				'wordcamp_id'  => $wordcamp_id,
-				'invoice_id'   => $invoice_id,
-				'description'  => $description,
-				'currency'     => $currency,
-				'amount'       => $amount,
+				'payment_type'   => $payment_type,
+				'wordcamp_id'    => $wordcamp_id,
+				'invoice_id'     => $invoice_id,
+				'description'    => $description,
+				'currency'       => $currency,
+				'amount'         => $amount,
+				'decimal_amount' => $decimal_amount,
 			);
 
 			// Passed through to the charge step.

--- a/public_html/wp-content/plugins/wordcamp-payments/views/sponsor-payment/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/sponsor-payment/main.php
@@ -128,7 +128,7 @@ get_header();
 
 				<script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
 					data-key="<?php echo esc_attr( $data['keys']['publishable'] ); ?>"
-					data-amount="<?php echo esc_attr( round( $data['payment']['amount'], 2 ) * 100 ); ?>" <?php // @todo: Handle currencies with multipliers other than 100. ?>
+					data-amount="<?php echo esc_attr( $data['payment']['decimal_amount'] ); ?>"
 					data-currency="<?php echo esc_attr( $data['payment']['currency'] ); ?>"
 					data-name="WordPress Community Support, PBC"
 					data-description="<?php esc_attr_e( 'Event Sponsorship Payment', 'wordcamporg' ); ?>"


### PR DESCRIPTION
Stripe expects payment amounts in the smallest amount in a given currency – cents in USD, yen in JPY, etc. This function formats a given amount into the "zero decimal" amount. So, 10.00 USD would become 1000, while 10 JPY would stay 10. Using this function for Sponsor Payments fixes issue with JPY payments being inflated by 100.

**To test**

- Go to https://central.wordcamp.test/sponsorship-payment/
- Try submitting a payment for an invoice using Japanese Yen
- Click through to the stripe "Make a Payment" button, check that the correct value is listed in the modal.
- Try another payment for an invoice using USD
- Again, the value in the stripe modal should be correct.