### PR TITLE
Blocks: Allow `noscript` tags in block output

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -100,25 +100,3 @@ function register_assets() {
 }
 
 add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
-
-/**
- * Update kses filter.
- *
- * Allow `noscript`: this is used by Jetpack's lazy-loading before we output the content, and by default is
- * stripped by the `wp_kses_post` function, causing duplicate images.
- *
- * @param array $tags
- * @return array
- */
-function allow_noscript_blocks( $tags, $context ) {
-	global $post;
-
-	// Only allow noscript through if we're showing a post with blocks.
-	if ( 'post' === $context && isset( $post, $post->post_content ) && has_blocks( $post->post_content ) ) {
-		$tags['noscript'] = array();
-	}
-
-	return $tags;
-}
-
-add_action( 'wp_kses_allowed_html', __NAMESPACE__ . '\allow_noscript_blocks', 10, 2 );

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -100,3 +100,25 @@ function register_assets() {
 }
 
 add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
+
+/**
+ * Update kses filter.
+ *
+ * Allow `noscript`: this is used by Jetpack's lazy-loading before we output the content, and by default is
+ * stripped by the `wp_kses_post` function, causing duplicate images.
+ *
+ * @param array $tags
+ * @return array
+ */
+function allow_noscript_blocks( $tags, $context ) {
+	global $post;
+
+	// Only allow noscript through if we're showing a post with blocks.
+	if ( 'post' === $context && isset( $post, $post->post_content ) && has_blocks( $post->post_content ) ) {
+		$tags['noscript'] = array();
+	}
+
+	return $tags;
+}
+
+add_action( 'wp_kses_allowed_html', __NAMESPACE__ . '\allow_noscript_blocks', 10, 2 );

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -3,7 +3,7 @@
 namespace WordCamp\Jetpack_Tweaks;
 defined( 'WPINC' ) || die();
 
-// Allow Photon to fetch images that are served via HTTPS
+// Allow Photon to fetch images that are served via HTTPS.
 add_filter( 'jetpack_photon_reject_https',    '__return_false' );
 
 /**
@@ -54,6 +54,27 @@ add_filter( 'contact_form_subject', __NAMESPACE__ . '\grunion_unique_subject' );
  * @return int
  */
 function lower_brute_protect_api_timeout( $timeout ) {
-	return 8; // seconds
+	return 8; // seconds.
 }
 add_filter( 'jetpack_protect_connect_timeout', __NAMESPACE__ . '\lower_brute_protect_api_timeout' );
+
+/**
+ * Update kses filter.
+ *
+ * Allow `noscript`: this is used by Jetpack's lazy-loading before we output the content, and by default is
+ * stripped by the `wp_kses_post` function, causing duplicate images.
+ *
+ * @param array $tags
+ * @return array
+ */
+function allow_noscript_blocks( $tags, $context ) {
+	global $post;
+
+	// Only allow noscript through if we're showing a post with blocks.
+	if ( 'post' === $context && isset( $post, $post->post_content ) && has_blocks( $post->post_content ) ) {
+		$tags['noscript'] = array();
+	}
+
+	return $tags;
+}
+add_action( 'wp_kses_allowed_html', __NAMESPACE__ . '\allow_noscript_blocks', 10, 2 );


### PR DESCRIPTION
When processing each image, Jetpack adds a `noscript` wrapper around the original image tag, so that users without JS will still get the original image - in addition to injecting the lazy-loaded image. When we run `wp_kses_post`, this strips out that `noscript`, so both the lazy image and original image are both included. This change permits noscript, so the original image is only shown is JS is disabled.

This is a draft PR: We use `wp_kses_post` all over the place, so the noscript is being stripped over and over again 🙃 

To test

- Turn on lazy images: Jetpack > Settings > Performance > "Enable Lazy Loading for images"
- View a block with avatars, ex the Speakers block
- There should be no duplicate avatars
- View the Sponsors block
- There should be no duplicate sponsor logos
- View a block with images in the item content
- There should be no duplicate images
