### PR TITLE
Schedule: Fix session track labels on small screens

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/css/shortcodes.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/shortcodes.css
@@ -7,7 +7,7 @@
 }
 
 /* Make space for the favorite icon, which is absolutely positioned. */
-.wcpt-schedule td.wcpt-session-type-session:before {
+.wcpt-session-type-session .wcb-session-cell-content:before {
 	content: '';
 	width: 35px;
 	height: 2em;
@@ -272,6 +272,14 @@ td.wcb-favourite-session a.fav-session-button {
 
 	.global-session .wcpt-session-type-session:before {
 		display: none;
+	}
+
+	.wcpt-schedule div.wcb-session-favourite-icon {
+		top: calc( 1.5em + 20px );
+	}
+
+	.wcpt-schedule .global-session div.wcb-session-favourite-icon {
+		top: 20px;
 	}
 
 	.wcpt-session-title {


### PR DESCRIPTION
The mobile schedule view uses `before` to display track names. When the favorite button was refactored, we used the same element:before, which wiped the names from view. This changes the element used for the spacer, to prevent deleting the text, and updates the alignment of the button on mobile.

Fixes #238 

**To test**

- View the schedule on a small screen
- You should still see the track names above each session, and the favoriting star should not overlap any content.

<img width="405" alt="Screen Shot 2019-09-23 at 6 35 32 PM" src="https://user-images.githubusercontent.com/541093/65468060-f31be980-de30-11e9-9131-5ad4782b53ab.png">