### PR TITLE
New Sites: Add a "Day of Event" page to new sites

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
@@ -7,12 +7,13 @@
 <h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:shortcode -->
-[schedule]
-<!-- /wp:shortcode -->
+<!-- wp:wordcamp/live-schedule -->
+<div data-now="<?php esc_html_e( 'On Now', 'wordcamporg' ); ?>" data-next="<?php esc_html_e( 'Next Up', 'wordcamporg' ); ?>" data-level="2" class="wp-block-wordcamp-live-schedule"></div>
+<!-- /wp:wordcamp/live-schedule -->
+
 
 <!-- wp:heading -->
 <h2><?php esc_html_e( 'Latest Posts', 'wordcamporg' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:latest-posts {"displayPostDate":true} /-->
+<!-- wp:latest-posts {"displayPostDate":true,"liveUpdateEnabled":true} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
@@ -1,0 +1,18 @@
+<!-- wp:paragraph -->
+<p><?php echo esc_html( get_wordcamp_date_range( $wordcamp ) ); ?><br>
+<?php echo nl2br( esc_html( get_wordcamp_location( $wordcamp ) ) ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:shortcode -->
+[schedule]
+<!-- /wp:shortcode -->
+
+<!-- wp:heading -->
+<h2><?php esc_html_e( 'Latest Posts', 'wordcamporg' ); ?></h2>
+<!-- /wp:heading -->
+
+<!-- wp:latest-posts {"displayPostDate":true} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
@@ -7,10 +7,9 @@
 <h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:wordcamp/live-schedule -->
-<div data-now="<?php esc_html_e( 'On Now', 'wordcamporg' ); ?>" data-next="<?php esc_html_e( 'Next Up', 'wordcamporg' ); ?>" data-level="2" class="wp-block-wordcamp-live-schedule"></div>
+<!-- wp:wordcamp/live-schedule {"level":3} -->
+<div data-now="<?php esc_html_e( 'On Now', 'wordcamporg' ); ?>" data-next="<?php esc_html_e( 'Next Up', 'wordcamporg' ); ?>" data-level="3" class="wp-block-wordcamp-live-schedule"></div>
 <!-- /wp:wordcamp/live-schedule -->
-
 
 <!-- wp:heading -->
 <h2><?php esc_html_e( 'Latest Posts', 'wordcamporg' ); ?></h2>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -615,6 +615,16 @@ class WordCamp_New_Site {
 					'wc_page_offline' => 'yes',
 				),
 			),
+
+			array(
+				'title'   => __( 'Day Of Event', 'wordcamporg' ),
+				'content' => $this->get_stub_content( 'page', 'day-of-event', $wordcamp ),
+				'status'  => 'publish',
+				'type'    => 'page',
+				'meta'    => array(
+					'_wp_page_template' => 'day-of-event', // Set the page template.
+				),
+			),
 		);
 
 		return $pages;

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -619,7 +619,7 @@ class WordCamp_New_Site {
 			array(
 				'title'   => __( 'Day Of Event', 'wordcamporg' ),
 				'content' => $this->get_stub_content( 'page', 'day-of-event', $wordcamp ),
-				'status'  => 'publish',
+				'status'  => 'draft',
 				'type'    => 'page',
 				'meta'    => array(
 					'_wp_page_template' => 'day-of-event', // Set the page template.

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -65,7 +65,7 @@ class WordCamp_New_Site {
 						Create site in network
 					</label>
 
-					<span class="description">(e.g., https://<?php echo esc_attr( date( 'Y' ) ); ?>.city.wordcamp.org)</span>
+					<span class="description">(e.g., https://<?php echo esc_attr( wp_date( 'Y' ) ); ?>.city.wordcamp.org)</span>
 				<?php endif; // Domain exists. ?>
 			<?php endif; // User can manage sites. ?>
 		<?php endif;
@@ -179,7 +179,7 @@ class WordCamp_New_Site {
 
 		$blog_name = apply_filters( 'the_title', $wordcamp->post_title );
 		if ( ! empty( $wordcamp->{'Start Date (YYYY-mm-dd)'} ) ) {
-			$blog_name .= date( ' Y', $wordcamp->{'Start Date (YYYY-mm-dd)'} );
+			$blog_name .= wp_date( ' Y', $wordcamp->{'Start Date (YYYY-mm-dd)'} );
 		}
 
 		$this->new_site_id = wp_insert_site( array(


### PR DESCRIPTION
This creates a new page that will use the Day of Event template on new sites. It includes the Live Schedule block from #243, and the live Latest Posts block from #250. Now that all this content is blocks, organizers can fully control the information & style of this page.

**To test**

- Create a new WordCamp site
- The new site should pre-populate with a page called "Day of Event", with useful information for during the camp (date, location, live schedule, latest posts).