### PR TITLE
PWA: Add caching support for uploaded files and Jetpack files.

### DIFF
--- a/public_html/wp-content/mu-plugins/service-worker-caching.php
+++ b/public_html/wp-content/mu-plugins/service-worker-caching.php
@@ -31,7 +31,15 @@ function register_caching_routes( WP_Service_Worker_Scripts $scripts ) {
 	 * Cache scripts, styles, images, etc from core, themes, and plugins.
 	 */
 	$scripts->caching_routes()->register(
-		'/wp-(content|includes)/.*\.(?:png|gif|jpg|jpeg|svg|webp|css|js)(\?.*)?$',
+		'/wp-(content|includes)/.*\.(png|gif|jpg|jpeg|svg|webp|css|js)(\?.*)?$',
+		$asset_cache_strategy_args
+	);
+
+	/*
+	 * Cache uploaded files.
+	 */
+	$scripts->caching_routes()->register(
+		'/files/.*\.(png|gif|jpg|jpeg)(\?.*)?$',
 		$asset_cache_strategy_args
 	);
 


### PR DESCRIPTION
Uploaded files on a multisite install use `files/…` as the path, and are not caught by the `wp-content` rule. Files cached by Jetpack (either core Jetpack assets or Photon-enabled images) use the wp.com domain, so these must also be added to the cache rules.

Fixes #203 

**To test**

- Try this on a site with uploaded files by navigating to a page with uploads
- Turn on offline mode/turn off your wifi
- Reload the page
- The page should still load, images and all
- You can also look for the images in the wp-assets cache (for uploaded filed) or `wc-jetpack` (for jetpack assets).
