### PR TITLE
PWA: Allow the manifest through while Coming Soon is on

### DIFF
--- a/public_html/wp-content/mu-plugins/service-worker-caching.php
+++ b/public_html/wp-content/mu-plugins/service-worker-caching.php
@@ -5,6 +5,7 @@ use WP_Service_Worker_Caching_Routes, WP_Service_Worker_Scripts;
 
 add_action( 'wp_front_service_worker', __NAMESPACE__ . '\register_caching_routes' );
 add_action( 'wp_front_service_worker', __NAMESPACE__ . '\set_navigation_caching_strategy' );
+add_filter( 'wccs_safelisted_namespaces', __NAMESPACE__ . '\safelist_manifest_api' );
 
 /**
  * Register caching routes with the frontend service worker.
@@ -104,3 +105,16 @@ function set_navigation_caching_strategy() {
 		}
 	);
 };
+
+/**
+ * Safelist the manifest for access through the Coming Soon API block.
+ *
+ * We disallow access to the API while a site is in Coming Soon mode, but we can safelist the manifest.
+ *
+ * @param Array $safelisted_namespaces A list of string matches for allowed endpoints.
+ * @return Array The safelist, with our manifest added.
+ */
+function safelist_manifest_api( $safelisted_namespaces ) {
+	$safelisted_namespaces[] = 'web-app-manifest';
+	return $safelisted_namespaces;
+}


### PR DESCRIPTION
This prevents "false" error messages for site admins who might still be building the site. When inaccessible, console and dev tools report the manifest as broken, but it might not be. If we allow the manifest through the API filter, we can get correct feedback from our dev tools.

**To test**

- Put a site into "coming soon" mode, make sure PWA plugin is active.
- View console on any page, you should see a big red error message from the service worker that the manifest is invalid.
- Or you can try to load the manifest directly (while logged out): `/wp-json/wp/v2/web-app-manifest`