### PR TITLE
PWA: Use "stale while revalidate" strategy for page caching

### DIFF
--- a/public_html/wp-content/mu-plugins/service-worker-caching.php
+++ b/public_html/wp-content/mu-plugins/service-worker-caching.php
@@ -84,12 +84,12 @@ function register_caching_routes( WP_Service_Worker_Scripts $scripts ) {
 function set_navigation_caching_strategy() {
 	/*
 	 * Cache pages that the user visits, so that if they return to them while offline, they'll still be available.
-	 * If they're online, though, fetch the latest version since it could have changed since they last visited.
+	 * While showing them the cached value, also run a network request to get the latest content.
 	 */
 	add_filter(
 		'wp_service_worker_navigation_caching_strategy',
 		function() {
-			return WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST;
+			return WP_Service_Worker_Caching_Routes::STRATEGY_STALE_WHILE_REVALIDATE;
 		}
 	);
 


### PR DESCRIPTION
When visiting a page, it is cached locally. When re-visiting, the cached version is shown immediately, while there is a network request to check for an update. Visiting again will get that updated content.

See #202 – A future iteration could use the BroadcastUpdate plugin [described here to prompt the user](https://developers.google.com/web/tools/workbox/modules/workbox-broadcast-update) to reload the page to get the updated content. This PR does not do this.

**To test**

- View a page, or a few pages
- Revisit these pages, see that it fires two "network" requests, one of which is served by the service worker, the other triggered by the service worker which does hit the network:

<img width="373" alt="Screen Shot 2019-09-30 at 5 42 38 PM" src="https://user-images.githubusercontent.com/541093/65919231-b6f50580-e3a9-11e9-9206-d70c90f7c90e.png">

- You can also test this by visiting some pages, then going offline. The pages will still be served to you, immediately - no longer waiting for the network request to fail.
