### PR TITLE
Blocks: add "Live update" option to Latest Posts block

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -15,6 +15,7 @@ function load_includes() {
 	$includes_dir   = PLUGIN_DIR . 'includes/';
 	$blocks_dir     = PLUGIN_DIR . 'source/blocks/';
 	$components_dir = PLUGIN_DIR . 'source/components/';
+	$hooks_dir      = PLUGIN_DIR . 'source/hooks/';
 
 	require_once $includes_dir . 'definitions.php';
 
@@ -37,6 +38,9 @@ function load_includes() {
 		|| in_array( get_current_blog_id(), [ 928 ], true ) // 2017.testing
 	) {
 		require_once $blocks_dir . 'live-schedule/controller.php';
+
+		// Hooks.
+		require_once $hooks_dir . 'latest-posts/controller.php';
 	}
 
 }

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -39,8 +39,8 @@
 		"*.min.js"
 	],
 	"scripts": {
-		"start": "wp-scripts start blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js",
-		"build": "wp-scripts build blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js",
+		"start": "wp-scripts start blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js live-posts=./source/hooks/latest-posts/front-end.js",
+		"build": "wp-scripts build blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js live-posts=./source/hooks/latest-posts/front-end.js",
 		"lint:js": "wp-scripts lint-js",
 		"lint:css": "wp-scripts lint-style '**/*.scss'",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -9,6 +9,8 @@ import { registerBlockType } from '@wordpress/blocks';
 import './_z-index.scss'; // Have z-index values, similar to https://github.com/WordPress/gutenberg/blob/master/assets/stylesheets/_z-index.scss
 import './styles.scss'; // Common styles for WordCamp Blocks.
 import { BLOCKS } from './blocks/'; // Trailing slash required to differentiate the folder from the file.
+// This attaches to the hook itself.
+import './hooks/latest-posts';
 
 const enabledBlocks = BLOCKS.filter( ( block ) =>
 	window.WordCampBlocks.hasOwnProperty( block.NAME.replace( 'wordcamp/', '' ) )

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -81,7 +81,9 @@ function render( $block_content, $block ) {
 	}
 
 	$enabled = isset( $block['attrs']['liveUpdateEnabled'] ) && $block['attrs']['liveUpdateEnabled'];
-	if ( $enabled ) {
+	// Order by date, desc is the default, so these properties are not set.
+	$order_date_desc = ! isset( $block['attrs']['orderBy'] ) && ! isset( $block['attrs']['order'] );
+	if ( $enabled && $order_date_desc ) {
 		$block_content = str_replace(
 			'wp-block-latest-posts ',
 			'wp-block-latest-posts has-live-update ',

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -1,0 +1,98 @@
+<?php
+namespace WordCamp\Blocks\Hooks\Latest_Posts;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register block types and enqueue scripts.
+ *
+ * @return void
+ */
+function init() {
+	$deps_path    = \WordCamp\Blocks\PLUGIN_DIR . 'build/live-posts.min.deps.json';
+	$dependencies = file_exists( $deps_path ) ? json_decode( file_get_contents( $deps_path ) ) : array();
+
+	wp_register_script(
+		'wordcamp-live-posts',
+		\WordCamp\Blocks\PLUGIN_URL . 'build/live-posts.min.js',
+		$dependencies,
+		filemtime( \WordCamp\Blocks\PLUGIN_DIR . 'build/live-posts.min.js' ),
+		true
+	);
+
+	/** This filter is documented in mu-plugins/blocks/blocks.php */
+	$data = apply_filters( 'wordcamp_blocks_script_data', [] );
+
+	wp_add_inline_script(
+		'wordcamp-live-posts',
+		sprintf(
+			'var WordCampBlocks = JSON.parse( decodeURIComponent( \'%s\' ) );',
+			rawurlencode( wp_json_encode( $data ) )
+		),
+		'before'
+	);
+
+	wp_set_script_translations( 'wordcamp-live-posts', 'wordcamporg' );
+
+	$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );
+	unregister_block_type( $block_type->name );
+	$block_type->attributes = array_merge(
+		$block_type->attributes,
+		array(
+			'liveUpdateEnabled' => array(
+				'type'    => 'boolean',
+				'default' => false,
+			),
+		)
+	);
+	$block_type->script = 'wordcamp-live-posts';
+
+	register_block_type( $block_type );
+}
+add_action( 'init', __NAMESPACE__ . '\init', 12 );
+
+/**
+ * Filter the content of the latest posts block.
+ *
+ * @param string $block_content The block content about to be appended.
+ * @param array  $block         The full block, including name and attributes.
+ * @return string
+ */
+function render( $block_content, $block ) {
+	if ( 'core/latest-posts' !== $block['blockName'] ) {
+		return $block_content;
+	}
+
+	$enabled = isset( $block['attrs']['liveUpdateEnabled'] ) && $block['attrs']['liveUpdateEnabled'];
+	if ( $enabled ) {
+		$block_content = str_replace(
+			'wp-block-latest-posts ',
+			'wp-block-latest-posts has-live-update ',
+			$block_content
+		);
+
+		$block_content = str_replace(
+			'ul class=',
+			sprintf( 'ul data-attributes="%s" class=', rawurlencode( wp_json_encode( $block['attrs'] ) ) ),
+			$block_content
+		);
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', __NAMESPACE__ . '\render', 10, 2 );
+
+
+/**
+ * Add data to be used by the JS scripts in the block editor.
+ *
+ * @param array $data
+ *
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['latest-posts'] = [];
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -52,6 +52,23 @@ function init() {
 add_action( 'init', __NAMESPACE__ . '\init', 12 );
 
 /**
+ * Allow all users to read the "Latest Posts" renderer endpoint.
+ *
+ * @param WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
+ * @param array                     $handler  Route handler used for the request.
+ * @param WP_REST_Request           $request  Request used to generate the response.
+ * @return WP_REST_Response Response returned by the callback.
+ */
+function safelist_block_renderer( $response, $handler, $request ) {
+	// Only apply to the latest posts block.
+	if ( '/wp/v2/block-renderer/core/latest-posts' === $request->get_route() ) {
+		return call_user_func( $handler['callback'], $request );
+	}
+	return $response;
+}
+add_filter( 'rest_request_after_callbacks', __NAMESPACE__ . '\safelist_block_renderer', 10, 3 );
+
+/**
  * Filter the content of the latest posts block.
  *
  * @param string $block_content The block content about to be appended.

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
@@ -1,4 +1,3 @@
-/* eslint-disable require-jsdoc */
 /**
  * WordPress dependencies
  */

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
@@ -18,7 +18,7 @@ class LivePosts extends Component {
 				// `forceUpdate` is a React internal that triggers a render cycle.
 				this.forceUpdate();
 			},
-			60 * 1000 // 1 minutes in ms.
+			5 * 60 * 1000 // 5 minutes in milliseconds.
 		);
 	}
 

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
@@ -1,0 +1,56 @@
+/* eslint-disable require-jsdoc */
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import ServerSideRender from '@wordpress/server-side-render';
+
+/**
+ * Internal dependencies
+ */
+import renderFrontend from '../../utils/render-frontend';
+
+class LivePosts extends Component {
+	constructor( props ) {
+		super( props );
+		this.renderInterval = setInterval(
+			() => {
+				// `forceUpdate` is a React internal that triggers a render cycle.
+				this.forceUpdate();
+			},
+			60 * 1000 // 1 minutes in ms.
+		);
+	}
+
+	componentWillUnmount() {
+		clearInterval( this.renderInterval );
+	}
+
+	render() {
+		const { attributes } = this.props;
+		// Remove the helper data-attribute.
+		delete attributes.attributes;
+
+		// Note: the `LoadingResponsePlaceholder` is intentionally an anonymous function to trigger re-render when
+		// `forceUpdate` happens.
+		return (
+			<ServerSideRender
+				block="core/latest-posts"
+				attributes={ attributes }
+				LoadingResponsePlaceholder={ () => ( <p>{ __( 'Loading', 'wordcamporg' ) }</p> ) }
+			/>
+		);
+	}
+}
+
+const getAttributesFromData = ( element ) => {
+	let parsedAttributes = {};
+	const { attributes } = element.dataset;
+	if ( attributes ) {
+		parsedAttributes = JSON.parse( decodeURIComponent( attributes ) );
+	}
+	return { attributes: parsedAttributes };
+};
+
+renderFrontend( '.wp-block-latest-posts.has-live-update', LivePosts, getAttributesFromData );

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
@@ -13,10 +13,17 @@ const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
 			return <BlockEdit { ...props } />;
 		}
 
-		const liveUpdateEnabled = props.attributes.liveUpdateEnabled;
+		const {
+			liveUpdateEnabled,
+			order,
+			orderBy,
+		} = props.attributes;
 		const help = liveUpdateEnabled ?
 			__( 'The block will automatically reload every minute to fetch new posts.', 'wordcamporg' ) :
 			__( 'The block will not update content until the page is reloaded.', 'wordcamporg' );
+
+		const orderDateDesc = 'desc' === order && 'date' === orderBy;
+		const orderWarning = __( 'Live update only works with "Order by: Newest to Oldest".', 'wordcamporg' );
 
 		return (
 			<Fragment>
@@ -26,6 +33,9 @@ const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
 						title="Front-end Display"
 						initialOpen={ true }
 					>
+						{ ! orderDateDesc && (
+							<p>{ orderWarning }</p>
+						) }
 						<ToggleControl
 							label={ liveUpdateEnabled ?
 								__( 'Live update on', 'wordcamporg' ) :

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
@@ -15,7 +15,7 @@ const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
 
 		const liveUpdateEnabled = props.attributes.liveUpdateEnabled;
 		const help = liveUpdateEnabled ?
-			__( '[some descriptive help text.]', 'wordcamporg' ) :
+			__( 'The block will automatically reload every minute to fetch new posts.', 'wordcamporg' ) :
 			__( 'The block will not update content until the page is reloaded.', 'wordcamporg' );
 
 		return (

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
@@ -18,9 +18,6 @@ const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
 			order,
 			orderBy,
 		} = props.attributes;
-		const help = liveUpdateEnabled ?
-			__( 'The block will automatically reload every minute to fetch new posts.', 'wordcamporg' ) :
-			__( 'The block will not update content until the page is reloaded.', 'wordcamporg' );
 
 		const orderDateDesc = 'desc' === order && 'date' === orderBy;
 		const orderWarning = __( 'Live update only works with "Order by: Newest to Oldest".', 'wordcamporg' );
@@ -30,18 +27,15 @@ const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
 				<BlockEdit { ...props } />
 				<InspectorControls>
 					<PanelBody
-						title="Front-end Display"
+						title={ __( 'Live Updates', 'wordcamporg' ) }
 						initialOpen={ true }
 					>
+						<p>{ __( "This feature helps your attendees keep up-to-date with your WordCamp's latest news. When active, new posts will be loaded as they're published without your attendees needing to refresh the page.", 'wordcamporg' ) }</p>
 						{ ! orderDateDesc && (
 							<p>{ orderWarning }</p>
 						) }
 						<ToggleControl
-							label={ liveUpdateEnabled ?
-								__( 'Live update on', 'wordcamporg' ) :
-								__( 'Live update off', 'wordcamporg' )
-							}
-							help={ help }
+							label={ __( 'Live update posts', 'wordcamporg' ) }
 							checked={ liveUpdateEnabled }
 							onChange={ ( value ) => props.setAttributes( { liveUpdateEnabled: value } ) }
 						/>

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
@@ -31,14 +31,15 @@ const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
 						initialOpen={ true }
 					>
 						<p>{ __( "This feature helps your attendees keep up-to-date with your WordCamp's latest news. When active, new posts will be loaded as they're published without your attendees needing to refresh the page.", 'wordcamporg' ) }</p>
-						{ ! orderDateDesc && (
+						{ orderDateDesc ? (
+							<ToggleControl
+								label={ __( 'Live update posts', 'wordcamporg' ) }
+								checked={ liveUpdateEnabled }
+								onChange={ ( value ) => props.setAttributes( { liveUpdateEnabled: value } ) }
+							/>
+						) : (
 							<p>{ orderWarning }</p>
 						) }
-						<ToggleControl
-							label={ __( 'Live update posts', 'wordcamporg' ) }
-							checked={ liveUpdateEnabled }
-							onChange={ ( value ) => props.setAttributes( { liveUpdateEnabled: value } ) }
-						/>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/index.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+
+const withLiveReloadOption = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		if ( props.name !== 'core/latest-posts' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const liveUpdateEnabled = props.attributes.liveUpdateEnabled;
+		const help = liveUpdateEnabled ?
+			__( '[some descriptive help text.]', 'wordcamporg' ) :
+			__( 'The block will not update content until the page is reloaded.', 'wordcamporg' );
+
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody
+						title="Front-end Display"
+						initialOpen={ true }
+					>
+						<ToggleControl
+							label={ liveUpdateEnabled ?
+								__( 'Live update on', 'wordcamporg' ) :
+								__( 'Live update off', 'wordcamporg' )
+							}
+							help={ help }
+							checked={ liveUpdateEnabled }
+							onChange={ ( value ) => props.setAttributes( { liveUpdateEnabled: value } ) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
+}, 'withLiveReloadOption' );
+
+if ( !! window.WordCampBlocks[ 'latest-posts' ] ) {
+	wp.hooks.addFilter( 'editor.BlockEdit', 'wordcamp/add-live-option-latest-posts', withLiveReloadOption );
+}


### PR DESCRIPTION
_Note: this is built off the branch in #243_ 

This will enable realtime updates of news posts on the frontend of the site, without refreshing the page. It can be used on the Day of Event template (or anywhere on the site) to always show the latest posts.

This hooks into the Latest Posts block to add a new "Live Update" toggle. We also need to hook into the `register_block_type` code to unregister the core block, and re-register it with this new attribute and to add our front-end script.

<img width="292" alt="enabled-off" src="https://user-images.githubusercontent.com/541093/66343635-11e2ab80-e91a-11e9-8676-d5062640a0f2.png">

<img width="298" alt="enabled-on" src="https://user-images.githubusercontent.com/541093/66343636-11e2ab80-e91a-11e9-844b-42b5a37dc6c1.png">

If the order is not "newest to oldest", we don't add the live-update script, so we should give the post author a warning about that:

<img width="295" alt="disabled-off" src="https://user-images.githubusercontent.com/541093/66343634-11e2ab80-e91a-11e9-98a3-8d477b27639a.png">

On the front-end, we filter the block content to inject the data-attribute and a special class, if live update is enabled and supported. This is used to trigger the JS rendering.

In JS, we take advantage of the ServerSideRender component & API to render the block using the same `render_callback` that's used to render the block in the editor. The API endpoint needs to be safelisted for anonymous visitor access, the alternative is building our own SSR component and endpoint.

<img width="505" alt="loading" src="https://user-images.githubusercontent.com/541093/66343639-11e2ab80-e91a-11e9-87ce-b7ab904d7dc5.png">

<img width="713" alt="list" src="https://user-images.githubusercontent.com/541093/66343637-11e2ab80-e91a-11e9-9f8a-397e1986fb9d.png">

cc @melchoyce for a quick design/copy review.

**To test**

- Add the Latest Posts block to your post/page
- Change any settings
- Turn on "Live update"
- Publish, and view on the frontend
- As the content loads, it shows the loading view
- Once loaded, it should look the same as the static Latest Posts block
- But after a minute, the block will reload, showing any posts that were published in the last minute.
