### PR TITLE
Blocks: Remove `require-jsdoc` eslint rule

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
+++ b/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
@@ -106,23 +106,6 @@ module.exports = {
 		} ],
 
 		/*
-		 * A short description often makes a function easier to understand, and also provides a nice visual
-		 * delineation between functions.
-		 *
-		 * Given that closures should be short and contextually relevant, requiring documentation for them would
-		 * likely hurt readability more than it would help clarity.
-		 */
-		'require-jsdoc': [ 'error', {
-			'require': {
-				'FunctionDeclaration'     : true,
-				'MethodDefinition'        : true,
-				'ClassDeclaration'        : true,
-				'ArrowFunctionExpression' : false,
-				'FunctionExpression'      : true
-			}
-		} ],
-
-		/*
 		 * Sort imports alphabetically, at least inside multiple-member imports. Ignores declaration sorting since
 		 * this interfers with the External/WordPress/Internal groupings. For example, it will flag the following
 		 * as incorrect:


### PR DESCRIPTION
Remove `require-jsdoc` from our eslint config. I've been disabling this per-file in #243 & #250, since adding valid jsdoc comments to components (and each method in each component) is more noise than benefit. These are usually overly-generic and the components are just as understandable without them. For example…

```js
/**
 * Component for displaying the block content.
 */
class OrganizerList extends Component {
```

Sure, ^ this could be "Component to display the organizer list" but that's clear from the code. This doc for `render` is also not helpful, it's the render function in the edit component, of course it'll render editing UI.

```js
	/**
	 * Render the block's editing UI.
	 *
	 * @return {Element}
	 */
	render() {
```

Since components can be functions, classes, or anonymous functions, I've just removed the rule entirely – we can trust a developer's best judgement for whether a function needs documentation, and the `valid-jsdoc` rule will still kick in to check the formatting.