### PR TITLE
Blocks: Live Schedule: Decode html entities before displaying on schedule

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/session.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/session.js
@@ -6,7 +6,8 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { stripTagsAndEncodeText } from '@wordpress/sanitize';
+import { decodeEntities } from '@wordpress/html-entities';
+import { stripTags } from '@wordpress/sanitize';
 
 /**
  * Component
@@ -29,6 +30,8 @@ export default function( { headingLevel = 3, session, track } ) {
 	const speakers = get( session, '_embedded.speakers', [] );
 	const validSpeakers = speakers.filter( ( speaker ) => !! speaker.id );
 
+	const cleanTitle = decodeEntities( stripTags( title ) );
+
 	return (
 		<div className={ `wordcamp-live-schedule__session type-${ type }` }>
 			<span className={ `wordcamp-live-schedule__session-track track-${ track.slug }` }>{ track.name }</span>
@@ -36,9 +39,9 @@ export default function( { headingLevel = 3, session, track } ) {
 			<div className="wordcamp-live-schedule__session-details">
 				<Heading className="wordcamp-live-schedule__session-title">
 					{ !! link ? (
-						<a href={ link }>{ stripTagsAndEncodeText( title ) }</a>
+						<a href={ link }>{ cleanTitle }</a>
 					) : (
-						stripTagsAndEncodeText( title )
+						cleanTitle
 					) }
 				</Heading>
 
@@ -55,7 +58,7 @@ export default function( { headingLevel = 3, session, track } ) {
 
 							return (
 								<a key={ id } href={ speakerLink }>
-									{ stripTagsAndEncodeText( name ) }
+									{ decodeEntities( stripTags( name ) ) }
 								</a>
 							);
 						} ) }


### PR DESCRIPTION
If a session name has an HTML entity, like an em-dash, it is now correctly decoded before being displayed to the site visitor.

This replaces `stripTagsAndEncodeText` with `decodeEntities( stripTags( … ) )`. I think `stripTags` alone does enough sanitization, and we want the entities decoded, not encoded, but I'm asking for a review just to confirm that. I'd like to merge this in the next 24hrs so we can deploy it before WCUS, since we have some sessions it affects.

To test: 

- Add a Live Schedule block to a page
- Add or update some sessions to be happening "now", add an emdash or some other fancy html entity
- Check that it displays correctly on the frontend of your site