### PR TITLE
Tomjn/vvv provisioner

### DIFF
--- a/.docker/bin/extra-setup.sh
+++ b/.docker/bin/extra-setup.sh
@@ -21,7 +21,9 @@ function install_composer() {
 }
 
 function do_extra_setup() {
-  PKG_PATH="/usr/src"
+  if [ -z ${PKG_PATH+x} ]; then
+    PKG_PATH="/usr/src"
+  fi
 
   if [ ! -f $PKG_PATH/composer.json ]; then
     echo 'ERROR: composer.json file not found'

--- a/.vvv/vvv-init.sh
+++ b/.vvv/vvv-init.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Provision WordPress Stable
+
+set -eo pipefail
+
+PKG_PATH=${VVV_PATH_TO_SITE}
+
+# Set up a database
+# Make a database, if we don't already have one
+echo -e "\nCreating database mysql (if it's not already there)"
+mysql -u root --password=root -e "CREATE DATABASE IF NOT EXISTS mysql"
+echo -e "\nGranting the wordcamp_dev user priviledges to the mysql database"
+mysql -u root --password=root -e "GRANT ALL PRIVILEGES ON mysql.* TO wordcamp_dev@localhost IDENTIFIED BY 'wordcamp_dev';"
+echo -e "\n DB operations done.\n\n"
+
+echo "Setting up the log subfolder for Nginx logs"
+noroot mkdir -p ${VVV_PATH_TO_SITE}/log
+noroot touch ${VVV_PATH_TO_SITE}/log/nginx-error.log
+noroot touch ${VVV_PATH_TO_SITE}/log/nginx-access.log
+
+# Add built files if they don't exist yet.
+noroot mkdir -p ${VVV_PATH_TO_SITE}/public_html/wp-content/mu-plugins/blocks/build
+noroot touch ${VVV_PATH_TO_SITE}/public_html/wp-content/mu-plugins/blocks/build/blocks.min.js
+noroot touch ${VVV_PATH_TO_SITE}/public_html/wp-content/mu-plugins/blocks/build/blocks.min.css
+
+noroot cp -f ${VVV_PATH_TO_SITE}/.docker/wp-config.php ${VVV_PATH_TO_SITE}/public_html/wp-config.php
+noroot cp -f ${VVV_PATH_TO_SITE}/.docker/wp-cli.yml ${VVV_PATH_TO_SITE}/public_html/wp-cli.yml
+
+if [[ ! -d ${VVV_PATH_TO_SITE}/public_html/mu/.git ]]; then
+	noroot git clone git://core.git.wordpress.org/ --depth="10" --branch="5.2" ${VVV_PATH_TO_SITE}/public_html/mu
+fi
+
+cd "${VVV_PATH_TO_SITE}/.docker/config/"
+noroot composer install --working-dir="${VVV_PATH_TO_SITE}"
+
+cd ${VVV_PATH_TO_SITE}
+
+# Install/update 3rd-party plugins and themes if they aren't included via SVN.
+if [ -d ${VVV_PATH_TO_SITE}/public_html/wp-content/.svn ]; then
+  echo "The wp-content directory appears to be a Subversion repository. Skipping additional setup... "
+else
+  ( cd ${VVV_PATH_TO_SITE}/.docker/bin &&  source extra-setup.sh && noroot do_extra_setup )
+fi

--- a/.vvv/vvv-nginx.conf
+++ b/.vvv/vvv-nginx.conf
@@ -1,0 +1,48 @@
+# Redirect HTTP to HTTPS
+#server {
+#    listen 80;
+#    listen [::]:80;
+#    server_name  {vvv_hosts};
+#    return 301 https://$host$request_uri;
+#}
+
+# HTTPS Server
+server {
+	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
+    server_name  {vvv_hosts};
+    root         {vvv_path_to_site}/public_html/mu;
+
+    error_log    {vvv_path_to_site}/log/nginx-error.log;
+    access_log   {vvv_path_to_site}/log/nginx-access.log;
+
+    {vvv_tls_cert}
+    {vvv_tls_key}
+   	ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
+   	set          $upstream {upstream};
+
+	index index.php;
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /robots.txt {
+		allow all;
+		log_not_found off;
+		access_log off;
+	}
+
+	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf)$ {
+		root {vvv_path_to_site}/public_html;
+		expires max;
+		log_not_found off;
+	}
+
+	location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+		expires max;
+		log_not_found off;
+	}
+	include      /etc/nginx/nginx-wp-common.conf;
+}


### PR DESCRIPTION
Holy moly was this a pain in the arse to get started, but I've gotten most of the way. It still needs some adjustments to get the WP install right, and it needs to install the database

A word of note: `/usr/src` is not a great place to put a WWW folder, for example linux headers get put in there amongst other things packages do during installation. Otherwise my job would have been much easier with a nice symlink

Once this is merged I'd like to eliminate the WordCamp sites from the WP Meta environment. It's clear they aren't maintained whereas this repo is, so it's better to consolidate

**Note:** The other option is to fix the meta environment so that it works on contributor days. Otherwise we'd have to bundle a tonne of various docker images, and write a tonne of docs on Hyper-V, command line, etc