### PR TITLE
Enhancement: Add help text to WordCamp Info Twitter form fields (#264)

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1132,6 +1132,8 @@ function wcpt_metabox( $meta_keys ) {
 		'Telephone'                       => 'Required for shipping.',
 		'Mailing Address'                 => 'Shipping address.',
 		'Physical Address'                => 'Please include the city, state/province and country.', // So it can be geocoded correctly for the map.
+		'Twitter'                         => 'Should begin with @. Ex. @wordpress',
+		'WordCamp Hashtag'                => 'Should begin with #. Ex. #wcus',
 		'Global Sponsorship Grant Amount' => 'No commas, thousands separators or currency symbols. Ex. 1234.56',
 		'Global Sponsorship Grant'        => 'Deprecated.',
 	);


### PR DESCRIPTION
Adds help text to the WordCamp Information fields Twitter and WordCamp Hashtag to indicate desired format.

**To test**

* Edit or Add a new WordCamp through the admin
* The Twitter related fields in the WordCamp Info metabox should display help text to indicate the format a user should enter data into the fields