### PR TITLE
Enhancement: Textfield resize for WordCamp and Meetup post types

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/admin.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/admin.css
@@ -12,6 +12,11 @@ span.swag-needed-icon {
     width: 100%;
 }
 
+body.wp-admin.post-type-wordcamp .postbox textarea,
+body.wp-admin.post-type-wp_meetup .postbox textarea {
+    resize: both;
+}
+
 #post-body input[type=text] {
     width: 50%;
 }


### PR DESCRIPTION
Allows all textareas in meta boxes for both the WordCamp and Meetup custom post types to be resized both vertically and horizontally

**To test**

* Edit or Add a new WordCamp or Meetup through the admin
* The textareas in all the meta boxes should be able to resize vertically and horizontally