### PR TITLE
Prevent duplicate title tag when in coming soon mode (#239)

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/views/template-coming-soon.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/views/template-coming-soon.php
@@ -3,8 +3,9 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width">
-	<title><?php echo esc_html( get_bloginfo( 'name' ) ); ?></title>
-
+	<?php if ( ! get_theme_support( 'title-tag' ) ) : ?>
+		<title><?php echo esc_html( get_bloginfo( 'name' ) ); ?></title>
+	<?php endif; ?>
 	<?php extract( $GLOBALS['WordCamp_Coming_Soon_Page']->get_template_variables() ); ?>
 	<?php wp_head(); ?>
 </head>


### PR DESCRIPTION
Prevents a duplicate `<title>` tag from being output when the theme has support for the title tag and the coming soon mode is activated.

**To test**

* On a WordCamp site that is using a theme that does not support the title tag, enable the "coming soon" mode (ex. Twenty Fourteen or earlier)
* In a logged out state the front page of the WordCamp site should only display one title tag

_Note_: Be mindful of the server cache when switching themes/activating the coming soon mode. Local testing required cache clears to consistently reproduce the original issue.

Fixes: WordPress/wordcamp.org#239