### PR TITLE
Twenty Twenty & WP 5.3 Compatibility

### DIFF
--- a/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/templates/day-of-event.php
@@ -15,16 +15,22 @@ get_header();
 <main id="main" class="site-main">
 <?php while ( have_posts() ) :
 	the_post();
-	?>
-	<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-		<header class="entry-header">
-			<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-		</header>
 
-		<div class="entry-content">
-			<?php the_content(); ?>
-		</div>
-	</article>
+	if ( locate_template( [ 'template-parts/content.php' ] ) ) :
+
+		get_template_part( 'template-parts/content' );
+
+	else : ?>
+		<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+			<header class="entry-header">
+				<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+			</header>
+
+			<div class="entry-content">
+				<?php the_content(); ?>
+			</div>
+		</article>
+	<?php endif; ?>
 <?php endwhile; ?>
 </main>
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -331,7 +331,13 @@ class WordCamp_Post_Types_Plugin {
 		$sessions                    = get_schedule_sessions( $attr['date'], $tracks_explicitly_specified, $tracks );
 		$columns                     = get_schedule_columns( $tracks, $sessions, $tracks_explicitly_specified );
 
-		$html  = '<table class="wcpt-schedule" border="0">';
+		$class_names = 'wcpt-schedule';
+		// Twenty Twenty has a very narrow content width, use wide width when displaying more than 2 tracks.
+		if ( 'twentytwenty' === get_stylesheet() && ( count( $tracks ) > 2 ) ) {
+			$class_names .= ' alignwide';
+		}
+
+		$html  = sprintf( '<table class="%s" border="0">', $class_names );
 		$html .= '<thead>';
 		$html .= '<tr>';
 


### PR DESCRIPTION
We're mostly all OK for compatibility with WordPress 5.3, the only exceptions are some display issues with Twenty Twenty. The content area is more narrow, and the markup is slightly different. This updates the schedule display to use `alignwide` styles if there are more than two tracks (otherwise it breaks out of the space), and now looks for and uses the theme's template for the Day of Event page. The offline page still looks wonky, but we can address that with #205.

Other core changes to note:

The media improvements seem to be mostly around resizing images or hooking into the upload process, so our uploads are good (we use the media library directly). There’s no change to `wp_unique_filename`, so obscuring the filenames should continue to work.

Things we should watch for:

- Any "mismatched function signature" PHP warnings in logs – [WP 5.3: Introducing the spread operator](https://make.wordpress.org/core/2019/10/09/wp-5-3-introducing-the-spread-operator/) 
- Any `TypeError` JS errors –  [WordPress 5.3: Backbone Upgrade Guide](https://make.wordpress.org/core/2019/10/10/wordpress-5-3-backbone-upgrade-guide/) 
- We should _maybe_ update the cron hooks to use `time()` instead of `current_time( ‘timestamp’ )`, but the latter should continue to work  –  [Date/Time component improvements in WordPress 5.3](https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/) 

An enhancement we could make: any meta fields exposed by the API can now define a schema in the `register_post_meta` call. We don't seem to need this anywhere ATM, but useful to know about. [WP 5.3 Supports Object and Array Meta Types in the REST API](https://make.wordpress.org/core/2019/10/03/wp-5-3-supports-object-and-array-meta-types-in-the-rest-api/)

**To test**

To test these changes specifically:

- Make sure a page with a schedule still looks OK
- Check that the Day of Event template works

Otherwise, checking out the `5.3` branch in `mu/` while you're working from now on would be a good way to test 👍  