### PR TITLE
Payments: Send a receipt to the sponsor after paying an invoice

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-payment-stripe.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-payment-stripe.php
@@ -231,6 +231,7 @@ function _handle_post_data( &$data ) {
 		// The card details have been entered and Stripe has submitted our form.
 		case STEP_PAYMENT_DETAILS:
 			$stripe_token           = filter_input( INPUT_POST, 'stripeToken' );
+			$stripe_email           = filter_input( INPUT_POST, 'stripeEmail' );
 			$payment_data_json      = filter_input( INPUT_POST, 'payment_data_json' );
 			$payment_data_signature = filter_input( INPUT_POST, 'payment_data_signature' );
 
@@ -275,11 +276,12 @@ function _handle_post_data( &$data ) {
 			}
 
 			$body = array(
-				'amount'      => $payment_data['decimal_amount'],
-				'currency'    => $payment_data['currency'],
-				'source'      => $stripe_token,
-				'description' => $description,
-				'metadata'    => $metadata,
+				'amount'        => $payment_data['decimal_amount'],
+				'currency'      => $payment_data['currency'],
+				'source'        => $stripe_token,
+				'description'   => $description,
+				'metadata'      => $metadata,
+				'receipt_email' => $stripe_email,
 			);
 
 			try {


### PR DESCRIPTION
Pass the email back to stripe when sending the charge request. Stripe expects a specific parameter in the API request in order to send a receipt.

Fixes #297 

### How to test the changes in this Pull Request:

You technically can't, since the sandbox uses the stripe test environment, and the test env doesn't trigger the automatic receipt. You can see in the API log for the request that the `receipt_email` is passed in. I'm basically trusting that the API is correct :|

If you could test, you would…

1. Submit a payment on https://central.wordcamp.org/sponsorship-payment/
2. You should get a receipt
