### PR TITLE
Add end times for Session post type

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/css/admin.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/admin.css
@@ -40,3 +40,11 @@
 			display: table-caption;
 			font-weight: bold;
 		}
+
+#wcpt-session-duration-container input[type="number"] {
+	width: 55px;
+}
+
+#wcpt-session-duration-container label {
+	margin-right: 5px;
+}

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -26,8 +26,11 @@ function expose_public_post_meta() {
 		'single'       => true,
 	];
 
+	$default_integer = wp_parse_args( array( 'type' => 'integer' ), $meta_defaults );
+
 	// Session.
-	register_post_meta( 'wcb_session', '_wcpt_session_time', wp_parse_args( [ 'type' => 'integer' ], $meta_defaults ) );
+	register_post_meta( 'wcb_session', '_wcpt_session_time',     $default_integer );
+	register_post_meta( 'wcb_session', '_wcpt_session_duration', $default_integer );
 	register_post_meta( 'wcb_session', '_wcpt_session_type', $meta_defaults );
 	register_post_meta( 'wcb_session', '_wcpt_session_slides', $meta_defaults );
 	register_post_meta( 'wcb_session', '_wcpt_session_video', $meta_defaults );


### PR DESCRIPTION
Fixes https://meta.trac.wordpress.org/ticket/3623

Will be needed for the (full) Schedule block (see https://meta.trac.wordpress.org/ticket/3117), and the Live Schedule block.

I've tested it with the full Schedule block and it works well. @ryelle , can you test it w/ the Live Schedule block, and make sure it meets your needs for that? It adds new fields to the `Session Info` metabox.