### PR TITLE
Docker: Fix PDF library & viewing

### DIFF
--- a/.docker/Dockerfile.php-fpm
+++ b/.docker/Dockerfile.php-fpm
@@ -37,10 +37,9 @@ COPY wordcamp.test.pem     /etc/ssl/certs/wordcamp.test.pem
 COPY wordcamp.test.key.pem /etc/ssl/private/wordcamp.test.key.pem
 
 # Install `wkhtmltopdf` for WordCamp Docs, CampTix Invoices, etc. See https://stackoverflow.com/a/38336153/1845153
-RUN curl -L https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz > wkhtmltox.tar.xz
-RUN tar xvf wkhtmltox.tar.xz
-RUN mv wkhtmltox/bin/wkhtmlto* /usr/bin/
-RUN rm -rf wkhtmltox*
+RUN curl -L https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb > wkhtmltox.deb
+RUN apt install ./wkhtmltox.deb -y
+RUN rm ./wkhtmltox.deb
 
 # Install WP-CLI.
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar

--- a/.docker/config/nginx.conf
+++ b/.docker/config/nginx.conf
@@ -46,7 +46,7 @@ server {
 		fastcgi_pass php;
 	}
 
-	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf)$ {
+	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf|pdf)$ {
 		root /usr/src/public_html;
 		expires max;
 		log_not_found off;


### PR DESCRIPTION
I was having trouble with the PDF generation functionality, and it looks like the `wkhtmltopdf` library wasn't loaded correctly. I'm not entirely sure updating this in the docker is correct (or if this was just an issue with my install), but this fixed the issues for me.

When generating an invoice, I hit this error:

```
wkhtmltopdf: error while loading shared libraries: libXrender.so.1: cannot open shared object file: No such file or directory
```

So this PR updates the docker setup to install the Debian 9 (stretch) version of `wkhtmltopdf`, which does not rely on linked resources (see the [note about generic builds](https://wkhtmltopdf.org/downloads.html)). I also updated the nginx configuration to serve .pdf files from the uploads directory.

Note: I'm not sure that Debian 9 is actually the correct OS- it's what I've got, but it looks like [the `php:7.2-fpm` base](https://github.com/docker-library/php/blob/9bcb75e9dbd3a0ebafe3f825297724df30e3b254/7.2/buster/fpm/Dockerfile) should be installing Debian 10.

**To test**

1. Try generating a doc or a ticket invoice
2. It should work 🎉 
3. You should be able to load the invoice from the site

(not requesting reviews since I haven't take the time to test a clean install yet, but anyone should feel free to comment 🙂 )