### PR TITLE
CampTix Tweaks: Fix keyboard accessibility of payment options

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -5,7 +5,7 @@
 
 namespace WordCamp\CampTix_Tweaks;
 
-defined( 'WPINC' ) or die();
+defined( 'WPINC' ) || die();
 
 use CampTix_Addon;
 
@@ -21,15 +21,15 @@ class Payment_Options extends CampTix_Addon {
 	/**
 	 * Initialize Payment_Options class
 	 */
-	function camptix_init() {
-		add_filter( 'tix_render_payment_options', array( $this, 'generate_payment_options'), 15, 4 );
+	public function camptix_init() {
+		add_filter( 'tix_render_payment_options', array( $this, 'generate_payment_options' ), 15, 4 );
 		$this->enqueue_scripts_and_styles();
 	}
 
 	/**
 	 * Enqueue styles and scripts needed for the addon to work
 	 */
-	function enqueue_scripts_and_styles() {
+	public function enqueue_scripts_and_styles() {
 		wp_register_script(
 			'payment_options',
 			plugins_url( 'js/payment-options.js', __FILE__ ),
@@ -51,13 +51,13 @@ class Payment_Options extends CampTix_Addon {
 	/**
 	 * We have stripe selected when there is no selected payment method, or when stripe is already selected
 	 *
-	 * @param array $payment_methods
+	 * @param array  $payment_methods
 	 * @param string $selected_payment_method
 	 *
 	 * @return bool
 	 */
-	private function has_stripe_selected( $payment_methods, $selected_payment_method ){
-		return array_key_exists( 'stripe', $payment_methods ) && ( ! isset( $selected_payment_method ) || $selected_payment_method === 'stripe' );
+	private function has_stripe_selected( $payment_methods, $selected_payment_method ) {
+		return array_key_exists( 'stripe', $payment_methods ) && ( ! isset( $selected_payment_method ) || 'stripe' === $selected_payment_method );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Payment_Options extends CampTix_Addon {
 	 * @param array  $payment_methods List of payment methods.
 	 * @param string $selected_payment_method Already selected payment method.
 	 */
-	function generate_payment_options( $payment_output, $total, $payment_methods, $selected_payment_method ) {
+	public function generate_payment_options( $payment_output, $total, $payment_methods, $selected_payment_method ) {
 		ob_start();
 		?>
 		<div class="tix-submit">
@@ -78,11 +78,11 @@ class Payment_Options extends CampTix_Addon {
 				</div>
 				<div class="tix-payment-method-container
 				<?php
-					if (
+				if (
 							$this->only_one_payment_method( $payment_methods ) ||
 							$this->has_stripe_selected( $payment_methods, $selected_payment_method ) ) {
-						echo 'tix-hidden ';
-					}
+					echo 'tix-hidden ';
+				}
 					echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab' : '';
 				?>">
 					<?php $this->render_alternate_payment_options( $payment_methods, $selected_payment_method ); ?>
@@ -98,30 +98,29 @@ class Payment_Options extends CampTix_Addon {
 	}
 
 	/**
-	 * Render a payment option as a separate tab. Used for rendering stripe tab, or a payment method tab incase only 1
-	 * is available.
+	 * Render a payment option as a separate tab. Used for rendering stripe tab, or a payment method tab when
+	 * only 1 is available.
 	 *
 	 * @param array  $payment_methods
 	 * @param string $key
-	 * @param bool   $selected Whether this option is pre selected
+	 * @param bool   $selected Whether this option is pre selected.
 	 */
 	private function render_payment_option_as_tab( $payment_methods, $key, $selected ) {
 		$is_only_payment_option = $this->only_one_payment_method( $payment_methods );
 		?>
 		<input type="radio" role="tab" name="tix_payment_method" id="tix-preferred-payment-option"
-			   value="<?php echo esc_html( $key ); ?>"
-			   autocomplete="off"
-				<?php echo $selected || $is_only_payment_option ? 'checked' : ''; ?>
-		>
+			autocomplete="off"
+			value="<?php echo esc_html( $key ); ?>"
+			<?php checked( $selected || $is_only_payment_option ); ?>
+		/>
 		<label for="tix-preferred-payment-option"
-			   class="tix-payment-tab
-			   <?php
-				   echo $is_only_payment_option ? 'tix-wide-tab' : ' ';
-				   echo $selected || $is_only_payment_option ? ' tix-tab-selected' : '';
-			   ?>
-			">
+			class="tix-payment-tab
 			<?php
-				//translators: %s: Name of the available payment method
+				echo $is_only_payment_option ? 'tix-wide-tab' : ' ';
+				echo $selected || $is_only_payment_option ? ' tix-tab-selected' : '';
+			?>">
+			<?php
+				// translators: %s: Name of the available payment method.
 				printf( esc_html__( 'Pay with %s', 'wordcamporg' ), esc_html( $payment_methods[ $key ]['name'] ) );
 			?>
 		</label>
@@ -133,9 +132,9 @@ class Payment_Options extends CampTix_Addon {
 	 * input
 	 *
 	 * @param array  $payment_methods
-	 * @param string $selected_payment_method Pre selected payment method
+	 * @param string $selected_payment_method Pre selected payment method.
 	 */
-	function render_tab_bar( $payment_methods, $selected_payment_method ) {
+	public function render_tab_bar( $payment_methods, $selected_payment_method ) {
 
 		if ( $this->only_one_payment_method( $payment_methods ) ) {
 			// render payment option as a tab and bail.
@@ -150,27 +149,27 @@ class Payment_Options extends CampTix_Addon {
 		if ( $this->is_stripe_available( $payment_methods ) ) {
 			$has_stripe_payments_tab = true;
 			$this->render_payment_option_as_tab(
-					$payment_methods,
-					'stripe',
-					$this->has_stripe_selected( $payment_methods, $selected_payment_method )
+				$payment_methods,
+				'stripe',
+				$this->has_stripe_selected( $payment_methods, $selected_payment_method )
 			);
 		}
 		?>
 		<button
-				role="tab"
-				class="tix_other_payment_options tix-payment-tab
-					<?php
-						echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
-						echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab ' : '';
-					?>"
-				type="button">
-			<?php
-				if ( $has_stripe_payments_tab ) {
-					esc_html_e( 'Other payment methods', 'wordcamporg' );
-				} else {
-					esc_html_e( 'Payment methods', 'wordcamporg' );
-				}
-			?>
+			role="tab"
+			class="tix_other_payment_options tix-payment-tab
+				<?php
+					echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
+					echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab ' : '';
+				?>"
+			type="button">
+		<?php
+		if ( $has_stripe_payments_tab ) {
+			esc_html_e( 'Other payment methods', 'wordcamporg' );
+		} else {
+			esc_html_e( 'Payment methods', 'wordcamporg' );
+		}
+		?>
 		</button>
 		<?php
 	}
@@ -201,15 +200,15 @@ class Payment_Options extends CampTix_Addon {
 	 * Renders all other payment methods except stripe
 	 *
 	 * @param array  $payment_methods
-	 * @param string $selected_payment_method Pre selected payment method
+	 * @param string $selected_payment_method Pre selected payment method.
 	 */
-	function render_alternate_payment_options( $payment_methods, $selected_payment_method ) {
+	public function render_alternate_payment_options( $payment_methods, $selected_payment_method ) {
 		if ( $this->only_one_payment_method( $payment_methods ) ) {
 			// bail if only one payment option is available.
 			return;
 		}
 
-		// Pre-select first payment method if stripe is not available
+		// Pre-select first payment method if stripe is not available.
 		if ( ! $this->is_stripe_available( $payment_methods ) && ! isset( $selected_payment_method ) ) {
 			$selected_payment_method = array_keys( $payment_methods )[0];
 		}
@@ -222,12 +221,12 @@ class Payment_Options extends CampTix_Addon {
 
 			<div class="tix-alternate-payment-option">
 				<input type="radio" name="tix_payment_method"
-						id="tix-payment-method_<?php echo esc_attr( $payment_method_key ); ?>"
-						value="<?php echo esc_attr( $payment_method_key ); ?>"
-						autocomplete="off"
-						required
-						<?php echo $selected_payment_method === $payment_method_key ? 'checked' : ''; ?>
-				>
+					id="tix-payment-method_<?php echo esc_attr( $payment_method_key ); ?>"
+					value="<?php echo esc_attr( $payment_method_key ); ?>"
+					autocomplete="off"
+					required
+					<?php checked( $selected_payment_method === $payment_method_key ); ?>
+				/>
 
 				<label for="tix-payment-method_<?php echo esc_attr( $payment_method_key ); ?>">
 					<?php echo esc_html( $payment_method['name'] ); ?>

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -166,36 +166,31 @@ class Payment_Options extends CampTix_Addon {
 			return;
 		}
 
-		// Stripe is the preferred payment method when it is available.
-		$has_stripe_payments_tab = false;
-
 		if ( $this->is_stripe_available( $payment_methods ) ) {
-			$has_stripe_payments_tab = true;
 			$this->render_payment_option_as_tab(
 				$payment_methods,
 				'stripe',
 				$this->has_stripe_selected( $payment_methods, $selected_payment_method )
 			);
-		}
-		?>
-		<button
-			type="button"
-			aria-pressed="false"
-			class="tix_other_payment_options tix-payment-tab
+			?>
+			<button
+				type="button"
+				aria-pressed="false"
+				class="tix_other_payment_options tix-payment-tab
+				<?php
+					echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
+				?>"
+			>
+				<?php esc_html_e( 'Other payment methods', 'wordcamporg' ); ?>
+			</button>
 			<?php
-				echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
-				echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab ' : '';
-			?>"
-		>
-		<?php
-		if ( $has_stripe_payments_tab ) {
-			esc_html_e( 'Other payment methods', 'wordcamporg' );
 		} else {
-			esc_html_e( 'Payment methods', 'wordcamporg' );
+			?>
+			<div class="tix_other_payment_options tix-payment-tab tix-wide-tab tix-tab-selected">
+				<?php esc_html_e( 'Payment methods', 'wordcamporg' ); ?>
+			</div>
+			<?php
 		}
-		?>
-		</button>
-		<?php
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -116,27 +116,38 @@ class Payment_Options extends CampTix_Addon {
 	 */
 	private function render_payment_option_as_tab( $payment_methods, $key, $selected ) {
 		$is_only_payment_option = $this->only_one_payment_method( $payment_methods );
-		?>
-		<input type="radio" name="tix_payment_method" id="tix-preferred-payment-option"
-			autocomplete="off"
-			value="<?php echo esc_html( $key ); ?>"
-			<?php checked( $selected || $is_only_payment_option ); ?>
-		/>
-		<button
-			type="button"
-			aria-pressed="true"
-			tabindex="0"
-			class="tix-payment-tab tix-preferred-payment-option
-			<?php
-				echo $is_only_payment_option ? 'tix-wide-tab' : ' ';
-				echo $selected || $is_only_payment_option ? ' tix-tab-selected' : '';
-			?>">
-			<?php
-				// translators: %s: Name of the available payment method.
-				printf( esc_html__( 'Pay with %s', 'wordcamporg' ), esc_html( $payment_methods[ $key ]['name'] ) );
-			?>
-		</button>
-		<?php
+		if ( $is_only_payment_option ) : ?>
+			<input
+				type="radio"
+				name="tix_payment_method"
+				value="<?php echo esc_html( $key ); ?>"
+				checked="checked"
+				style="display:none;"
+			/>
+			<div class="tix-payment-tab tix-wide-tab tix-tab-selected">
+				<?php
+					// translators: %s: Name of the available payment method.
+					printf( esc_html__( 'Pay with %s', 'wordcamporg' ), esc_html( $payment_methods[ $key ]['name'] ) );
+				?>
+			</div>
+		<?php else : ?>
+			<input type="radio" name="tix_payment_method" id="tix-preferred-payment-option"
+				style="display:none;"
+				autocomplete="off"
+				value="<?php echo esc_html( $key ); ?>"
+				<?php checked( $selected ); ?>
+			/>
+			<button
+				type="button"
+				aria-pressed="true"
+				tabindex="0"
+				class="tix-payment-tab tix-preferred-payment-option <?php echo $selected ? ' tix-tab-selected' : ''; ?>">
+				<?php
+					// translators: %s: Name of the available payment method.
+					printf( esc_html__( 'Pay with %s', 'wordcamporg' ), esc_html( $payment_methods[ $key ]['name'] ) );
+				?>
+			</button>
+		<?php endif;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -73,19 +73,28 @@ class Payment_Options extends CampTix_Addon {
 		?>
 		<div class="tix-submit">
 			<?php if ( $total > 0 ) : ?>
-				<div class="tix-payment-method" role="tabs">
+				<div class="tix-payment-method">
 					<?php $this->render_tab_bar( $payment_methods, $selected_payment_method ); ?>
 				</div>
-				<div class="tix-payment-method-container
-				<?php
-				if (
-							$this->only_one_payment_method( $payment_methods ) ||
-							$this->has_stripe_selected( $payment_methods, $selected_payment_method ) ) {
-					echo 'tix-hidden ';
-				}
+				<div
+					class="tix-payment-method-container
+					<?php
+					if (
+						$this->only_one_payment_method( $payment_methods ) ||
+						$this->has_stripe_selected( $payment_methods, $selected_payment_method )
+					) {
+						echo 'tix-hidden ';
+					}
 					echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab' : '';
-				?>">
-					<?php $this->render_alternate_payment_options( $payment_methods, $selected_payment_method ); ?>
+					?>"
+					id="tix-payment-options-list"
+				>
+					<fieldset>
+						<legend class="screen-reader-text">
+							<?php esc_html_e( 'Payment methods', 'wordcamporg' ); ?>
+						</legend>
+						<?php $this->render_alternate_payment_options( $payment_methods, $selected_payment_method ); ?>
+					</fieldset>
 				</div>
 				<input class="tix-checkout-button" type="submit" value="<?php esc_attr_e( 'Checkout &rarr;', 'wordcamporg' ); ?>" />
 			<?php else : ?>
@@ -108,13 +117,16 @@ class Payment_Options extends CampTix_Addon {
 	private function render_payment_option_as_tab( $payment_methods, $key, $selected ) {
 		$is_only_payment_option = $this->only_one_payment_method( $payment_methods );
 		?>
-		<input type="radio" role="tab" name="tix_payment_method" id="tix-preferred-payment-option"
+		<input type="radio" name="tix_payment_method" id="tix-preferred-payment-option"
 			autocomplete="off"
 			value="<?php echo esc_html( $key ); ?>"
 			<?php checked( $selected || $is_only_payment_option ); ?>
 		/>
-		<label for="tix-preferred-payment-option"
-			class="tix-payment-tab
+		<button
+			type="button"
+			aria-pressed="true"
+			tabindex="0"
+			class="tix-payment-tab tix-preferred-payment-option
 			<?php
 				echo $is_only_payment_option ? 'tix-wide-tab' : ' ';
 				echo $selected || $is_only_payment_option ? ' tix-tab-selected' : '';
@@ -123,7 +135,7 @@ class Payment_Options extends CampTix_Addon {
 				// translators: %s: Name of the available payment method.
 				printf( esc_html__( 'Pay with %s', 'wordcamporg' ), esc_html( $payment_methods[ $key ]['name'] ) );
 			?>
-		</label>
+		</button>
 		<?php
 	}
 
@@ -156,13 +168,14 @@ class Payment_Options extends CampTix_Addon {
 		}
 		?>
 		<button
-			role="tab"
+			type="button"
+			aria-pressed="false"
 			class="tix_other_payment_options tix-payment-tab
-				<?php
-					echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
-					echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab ' : '';
-				?>"
-			type="button">
+			<?php
+				echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
+				echo ! $this->is_stripe_available( $payment_methods ) ? 'tix-wide-tab ' : '';
+			?>"
+		>
 		<?php
 		if ( $has_stripe_payments_tab ) {
 			esc_html_e( 'Other payment methods', 'wordcamporg' );
@@ -213,11 +226,7 @@ class Payment_Options extends CampTix_Addon {
 			$selected_payment_method = array_keys( $payment_methods )[0];
 		}
 
-		foreach ( $payment_methods as $payment_method_key => $payment_method ) {
-			if ( 'stripe' === $payment_method_key ) {
-				continue;
-			}
-			?>
+		foreach ( $payment_methods as $payment_method_key => $payment_method ) : ?>
 
 			<div class="tix-alternate-payment-option">
 				<input type="radio" name="tix_payment_method"
@@ -234,7 +243,7 @@ class Payment_Options extends CampTix_Addon {
 			</div>
 
 			<?php
-		}
+		endforeach;
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -181,7 +181,7 @@ class Payment_Options extends CampTix_Addon {
 					echo ! $this->has_stripe_selected( $payment_methods, $selected_payment_method ) ? 'tix-tab-selected ' : '';
 				?>"
 			>
-				<?php esc_html_e( 'Other payment methods', 'wordcamporg' ); ?>
+				<?php esc_html_e( 'All payment methods', 'wordcamporg' ); ?>
 			</button>
 			<?php
 		} else {

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/css/payment-options.css
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/css/payment-options.css
@@ -56,14 +56,13 @@
 .tix-alternate-payment-option {
     float: left;
     clear: both;
-    padding-left: 15px;
-    padding-top: 15px;
 }
 
 #tix .tix-submit .tix-alternate-payment-option label {
     color: #191e23;
     font-size: 16px;
     padding-left: 15px;
+    display: inline-block;
 }
 
 #tix input[name=tix_payment_method]:required {

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/css/payment-options.css
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/css/payment-options.css
@@ -1,7 +1,3 @@
-#tix-preferred-payment-option {
-    display: none;
-}
-
 .tix-submit {
     display: block;
     float: right;
@@ -17,7 +13,6 @@
     line-height: 24px;
     border-bottom: 2px solid #0a0a0a;
     border-radius: 0;
-    cursor: pointer;
     padding: 10px;
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/js/payment-options.js
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/js/payment-options.js
@@ -3,7 +3,7 @@ jQuery( document ).ready( function initPaymentOptions( $ ) {
 	/**
 	 * Implements tab functionality in payment option selection
 	 */
-	$( '.tix-payment-tab' ).click( function( event ) {
+	$( '.tix-payment-tab:not(.tix-wide-tab)' ).click( function( event ) {
 		$( '.tix-payment-tab' ).removeClass( 'tix-tab-selected' );
 		$( '.tix-payment-tab[aria-pressed]' ).attr( 'aria-pressed', 'false' );
 		$( event.target ).addClass( 'tix-tab-selected' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/js/payment-options.js
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/js/payment-options.js
@@ -5,19 +5,21 @@ jQuery( document ).ready( function initPaymentOptions( $ ) {
 	 */
 	$( '.tix-payment-tab' ).click( function( event ) {
 		$( '.tix-payment-tab' ).removeClass( 'tix-tab-selected' );
+		$( '.tix-payment-tab[aria-pressed]' ).attr( 'aria-pressed', 'false' );
 		$( event.target ).addClass( 'tix-tab-selected' );
+		$( event.target ).attr( 'aria-pressed', 'true' );
 
-		if( $( event.target ).is( 'label[for=tix-preferred-payment-option]' ) ) {
+		if( $( event.target ).is( '.tix-preferred-payment-option' ) ) {
 			$( '.tix-payment-method-container' ).addClass( 'tix-hidden' );
+			$( 'input#tix-preferred-payment-option' ).prop( 'checked', true );
 		} else {
 			$( '.tix-payment-method-container' ).removeClass( 'tix-hidden' );
 			$( 'input#tix-preferred-payment-option' ).prop( 'checked', false );
 		}
-	});
+	} );
 
 	// Need to overwrite exiting function because it assumes `select` instead of `radio`
 	window.CampTixUtilities.getSelectedPaymentOption = function() {
 		return jQuery( '#tix [name="tix_payment_method"]:checked' ).val();
 	};
-
-});
+} );


### PR DESCRIPTION
This PR changes the tab markup to use buttons, which natively catch keyboard actions. The "preferred payment option" label can be a button, since the input itself is hidden, and a toggle button matches the expected behavior better. All payment options are now output in the "Payment Options" list. If there is only one payment option, it is now just output as text, not a clickable button.

This also improves the labelling of the other payment options by wrapping them in a fieldset.

Fixes https://meta.trac.wordpress.org/ticket/4421

### Screenshots

![Screen Shot 2019-12-20 at 3 51 57 PM](https://user-images.githubusercontent.com/541093/71291674-3fe46300-2341-11ea-9e32-6b0da4de9ec9.png)
![Screen Shot 2019-12-20 at 2 18 51 PM](https://user-images.githubusercontent.com/541093/71291676-3fe46300-2341-11ea-9d41-3f507f3065c7.png)

### How to test the changes in this Pull Request:

1. Turn on both Stripe & PayPal in the payment settings
2. Go try to buy a ticket
3. Using just a keyboard, tab through the page to the end
4. Hit space/enter on "Other payment methods", you can now select either stripe or paypal
5. You can also shift-tab back up to the "Pay with Stripe" button, and hit space/enter to flip back to that.

Basically, everything you can click with a mouse should now be activated by the keyboard too.