### PR TITLE
New Sites: Update theme activated on new sites to Twenty Twenty

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -383,7 +383,7 @@ class WordCamp_New_Site {
 
 		$lead_organizer = $this->get_user_or_current_user( $meta['WordPress.org Username'][0] );
 
-		switch_theme( 'twentythirteen' );
+		switch_theme( 'twentytwenty' );
 
 		$this->set_default_options( $wordcamp, $meta );
 		$this->create_post_stubs( $wordcamp, $meta, $lead_organizer );


### PR DESCRIPTION
This changes the default theme activated from Twenty Thirteen to Twenty Twenty, to give organizers a more modern place to start their sites.

This PR can also be a place for feedback about whether we should do this in the first place. For past history, there has been discussion about [changing the default to CampSite 2017,](https://make.wordpress.org/community/2017/12/07/should-we-change-the-default-wordcamp-theme-to-campsite-2017/) but this was put on hold until some default styles were added. We can still revisit this idea in the future, but for now updating to Twenty Twenty will allow for more native gutenberg support, accessibility, and more modern code & design.

### How to test the changes in this Pull Request:

1. Create a new WordCamp (or delete a site for an existing camp), then check "create site" when filling out the form.
2. The new site should be created with Twenty Twenty as the default theme.
