### PR TITLE
Live Schedule: Update API endpoint and call to reduce bandwidth and TTFB

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/session.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/session.js
@@ -16,13 +16,13 @@ export default function( { headingLevel = 3, session, track } ) {
 	const Heading = `h${ headingLevel }`;
 
 	// Pull details out of the session object.
-	const { link, terms = {} } = session;
 	const title = get( session, 'title.rendered', '' );
+	const link = get( session, 'link', '' );
+	const categories = get( session, 'session_cats_rendered', '' );
 	const type = get( session, 'meta._wcpt_session_type', '' );
-	const categories = session.session_category || [];
 	const time = get( session, 'session_date_time.time', '' );
 
-	const speakers = get( session, '_embedded.speakers', [] );
+	const speakers = get( session, 'session_speakers', [] );
 	const validSpeakers = speakers.filter( ( speaker ) => !! speaker.id );
 
 	const cleanTitle = decodeEntities( stripTags( title ) );
@@ -44,31 +44,16 @@ export default function( { headingLevel = 3, session, track } ) {
 
 				<span className="wordcamp-live-schedule__session-speaker">
 					{ !! validSpeakers.length &&
-						validSpeakers.map( ( speaker ) => {
-							const {
-								id,
-								title: { rendered: name },
-								link: speakerLink,
-							} = speaker;
-
-							return (
-								<a key={ id } href={ speakerLink }>
-									{ decodeEntities( stripTags( name ) ) }
-								</a>
-							);
-						} ) }
+						validSpeakers.map( ( { id, name, link: speakerLink } ) => (
+							<a key={ id } href={ speakerLink }>
+								{ decodeEntities( stripTags( name ) ) }
+							</a>
+						) ) }
 				</span>
 
-				{ categories.map( ( catId ) => {
-					const name = terms[ catId ].name;
-					const slug = terms[ catId ].slug;
-
-					return (
-						<span key={ catId } className={ `wordcamp-live-schedule__session-cat category-${ slug }` }>
-							{ name }
-						</span>
-					);
-				} ) }
+				<span className="wordcamp-live-schedule__session-cats">
+					{ categories }
+				</span>
 			</div>
 		</div>
 	);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -19,10 +19,25 @@ function fetchFromAPI() {
 	const sessionPath = addQueryArgs( `wp/v2/sessions`, {
 		per_page: -1,
 		status: 'publish',
+		_fields: [
+			'id',
+			'title',
+			'link',
+			'meta',
+			'session_track',
+			'session_date_time',
+			'session_cats_rendered',
+			'session_speakers',
+		],
 	} );
 	const trackPath = addQueryArgs( `wp/v2/session_track`, {
 		per_page: -1,
 		status: 'publish',
+		_fields: [
+			'id',
+			'slug',
+			'name',
+		],
 	} );
 
 	return Promise.all( [

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flatten, get, keyBy, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,6 @@ function fetchFromAPI() {
 	const sessionPath = addQueryArgs( `wp/v2/sessions`, {
 		per_page: -1,
 		status: 'publish',
-		_embed: true,
 	} );
 	const trackPath = addQueryArgs( `wp/v2/session_track`, {
 		per_page: -1,
@@ -71,16 +70,7 @@ export function getCurrentSessions( { sessions, tracks } ) {
  * @return {Promise} The promise will resolve with a list of objects, `{track, now, next}`.
  */
 export async function getDataFromAPI() {
-	const data = await fetchFromAPI();
-	const sessions = data[ 0 ].map( ( session ) => {
-		const terms = flatten( get( session, '_embedded[wp:term]', [] ) );
-		return {
-			...session,
-			terms: keyBy( terms, 'id' ),
-		};
-	} );
-
-	const tracks = data[ 1 ];
+	const [ sessions, tracks ] = await fetchFromAPI();
 
 	return getCurrentSessions( { sessions, tracks } );
 }

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -132,6 +132,68 @@ function register_additional_rest_fields() {
 			),
 		)
 	);
+
+	// Session speakers.
+	register_rest_field(
+		'wcb_session',
+		'session_speakers',
+		array(
+			'get_callback' => function( $post ) {
+				$speaker_ids = get_post_meta( $post['id'], '_wcpt_speaker_id', false );
+				$speakers = array();
+
+				foreach ( $speaker_ids as $speaker_id ) {
+					$speakers[] = array(
+						'id' => $speaker_id,
+						'name' => get_the_title( $speaker_id ),
+						'link' => get_permalink( $speaker_id ),
+					);
+				}
+
+				return $speakers;
+			},
+			'schema'       => array(
+				'description' => __( 'List of speakers for session.', 'wordcamporg' ),
+				'type'        => 'integer',
+				'context'     => array( 'embed', 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'        => 'object',
+					'properties'  => array(
+						'id'   => array(
+							'type' => 'integer',
+						),
+						'name' => array(
+							'type' => 'string',
+						),
+						'link' => array(
+							'type' => 'string',
+						),
+					),
+				),
+			),
+		)
+	);
+
+	// Session Categories.
+	register_rest_field(
+		'wcb_session',
+		'session_cats_rendered',
+		array(
+			'get_callback' => function( $post ) {
+				$terms = get_terms( 'wcb_session_category', array( 'object_ids' => $post['id'] ) );
+				if ( $terms ) {
+					return implode( ', ', wp_list_pluck( $terms, 'name' ) );
+				}
+			},
+			'schema'       => array(
+				'description' => __( 'Rendered category list.', 'wordcamporg' ),
+				'type'        => 'string',
+				'context'     => array( 'embed', 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
 }
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_additional_rest_fields' );
@@ -221,7 +283,6 @@ function get_avatar_urls_from_username_email( $post ) {
 
 	return $avatar_urls;
 }
-
 
 /**
  * Register route for sending schedule of favourite sessions via e-mail.


### PR DESCRIPTION
Currently, the `sessions` endpoint used to fetch sessions for the Live Schedule needs to request the `_embed` version of the endpoint, which causes a much slower response (around 10s on 2019.us.wordcamp.org). We needed to do this to get the speaker names and category labels, but the rest of the data it outputs is unnecessary.

This PR pre-computes speakers and category names, and adds them to the API, so the request can be made for the default endpoint instead. It also restricts the data requested for the live schedule to only the fields needed for display, which drops the size of content downloaded significantly.

Fixes #207 by improving API size/response time, API responses are still currently being cached by the SW in the `rest-api` bucket.

**Metrics:**

I measured the TTFB and download size for 3 sites (2019.us.wc.org, 2017.testing.wc.org, and a local site on the docker setup). First is the current request, which is both large (size) and slow (time), second is just the pre-computed content, which cuts all the requests to just 2 seconds. The third data point is the field subset request, which reduces the filesize down to less than 10% of the current response.

![Screen Shot 2020-01-15 at 2 05 46 PM](https://user-images.githubusercontent.com/541093/72473219-38836e80-37b4-11ea-8a58-855214591b6d.png)

### How to test the changes in this Pull Request:

1. Query the sessions endpoint, and make sure `session_speakers` shows all selected (published) speakers.
2. Query the sessions endpoint, and make sure `session_cats_rendered` shows all selected categories 
3. Load up a site with the Live Schedule block, it should display as expected (no JS errors)
