### PR TITLE
Application tracker: improve log section notes

### DIFF
--- a/public_html/wp-content/plugins/wcpt/views/common/metabox-log.php
+++ b/public_html/wp-content/plugins/wcpt/views/common/metabox-log.php
@@ -1,4 +1,29 @@
-<?php defined( 'WPINC' ) || die(); ?>
+<?php defined( 'WPINC' ) || die();
+
+/**
+ * Slightly modify allowed html tags in entry message because default
+ * "data" set is too restrictive and "post" set too broad.
+ */
+$allowed_html = wp_kses_allowed_html( 'data' );
+$allowed_html['p'] = array(); // allow paragraph for easier reading
+$allowed_html['br'] = array(); // allow line changes for easier reading
+$allowed_html['a']['target'] = true; // target to ensure not losing application view
+$allowed_html['a']['rel'] = true; // we want to set nofollow so search engines don't use link for ranking, crawling or indexing
+
+/**
+ * Loop all entries and search for notes. In notes, turn plaintext links
+ * to linkified html links for easier usage. Add always target="_blank" and
+ * rel="nofollow".
+ */
+if ( $entries ) {
+	foreach ( $entries as $entry_key => $entry ) {
+		if ( 'note' !== $entry['type'] ) {
+			continue;
+		}
+
+		$entries[ $entry_key ]['message'] = preg_replace("/(^|[\n ])([\w]*?)(http(s)?:\/\/[\w]+[^ \,\"\n\r\t<]*)/is", "$1$2<a href=\"$3\" target=\"_blank\" rel=\"nofollow\">$3</a>", $entries[ $entry_key ]['message'] );
+	}
+} ?>
 
 <table class="widefat striped">
 	<thead>
@@ -18,7 +43,7 @@
 					<th><p><?php echo esc_html( date( 'Y-m-d h:ia', $entry['timestamp'] ) ); ?></p></th>
 					<th><p><?php echo esc_html( ucwords( str_replace( '_', ' ', $entry['type'] ) ) ); ?></p></th>
 					<th><p><?php echo esc_html( $entry['user_display_name'] ); ?></p></th>
-					<th><?php echo wp_kses( wpautop( $entry['message'] ), wp_kses_allowed_html( 'data' ) ); ?></th>
+					<th><?php echo wp_kses( wpautop( $entry['message'] ), $allowed_html ); ?></th>
 				</tr>
 			<?php endforeach; ?>
 

--- a/public_html/wp-content/plugins/wcpt/views/common/metabox-log.php
+++ b/public_html/wp-content/plugins/wcpt/views/common/metabox-log.php
@@ -7,23 +7,8 @@
 $allowed_html = wp_kses_allowed_html( 'data' );
 $allowed_html['p'] = array(); // allow paragraph for easier reading.
 $allowed_html['br'] = array(); // allow line changes for easier reading.
-$allowed_html['a']['target'] = true; // target to ensure not losing application view.
-$allowed_html['a']['rel'] = true; // we want to set nofollow so search engines don't use link for ranking, crawling or indexing.
 
-/**
- * Loop all entries and search for notes. In notes, turn plaintext links
- * to linkified html links for easier usage. Add always target="_blank" and
- * rel="nofollow".
- */
-if ( $entries ) {
-	foreach ( $entries as $entry_key => $entry ) {
-		if ( 'note' !== $entry['type'] ) {
-			continue;
-		}
-
-		$entries[ $entry_key ]['message'] = preg_replace( '/(^|[\n ])([\w]*?)(http(s)?:\/\/[\w]+[^ \,\"\n\r\t<]*)/i', '$1$2<a href="$3" target="_blank" rel="nofollow">$3</a>', $entries[ $entry_key ]['message'] );
-	}
-} ?>
+?>
 
 <table class="widefat striped">
 	<thead>
@@ -43,7 +28,7 @@ if ( $entries ) {
 					<th><p><?php echo esc_html( gmdate( 'Y-m-d h:ia', $entry['timestamp'] ) ); ?></p></th>
 					<th><p><?php echo esc_html( ucwords( str_replace( '_', ' ', $entry['type'] ) ) ); ?></p></th>
 					<th><p><?php echo esc_html( $entry['user_display_name'] ); ?></p></th>
-					<th><?php echo wp_kses( wpautop( $entry['message'] ), $allowed_html ); ?></th>
+					<th><?php echo wp_kses( wpautop( make_clickable( $entry['message'] ) ), $allowed_html ); ?></th>
 				</tr>
 			<?php endforeach; ?>
 

--- a/public_html/wp-content/plugins/wcpt/views/common/metabox-log.php
+++ b/public_html/wp-content/plugins/wcpt/views/common/metabox-log.php
@@ -5,10 +5,10 @@
  * "data" set is too restrictive and "post" set too broad.
  */
 $allowed_html = wp_kses_allowed_html( 'data' );
-$allowed_html['p'] = array(); // allow paragraph for easier reading
-$allowed_html['br'] = array(); // allow line changes for easier reading
-$allowed_html['a']['target'] = true; // target to ensure not losing application view
-$allowed_html['a']['rel'] = true; // we want to set nofollow so search engines don't use link for ranking, crawling or indexing
+$allowed_html['p'] = array(); // allow paragraph for easier reading.
+$allowed_html['br'] = array(); // allow line changes for easier reading.
+$allowed_html['a']['target'] = true; // target to ensure not losing application view.
+$allowed_html['a']['rel'] = true; // we want to set nofollow so search engines don't use link for ranking, crawling or indexing.
 
 /**
  * Loop all entries and search for notes. In notes, turn plaintext links
@@ -21,7 +21,7 @@ if ( $entries ) {
 			continue;
 		}
 
-		$entries[ $entry_key ]['message'] = preg_replace("/(^|[\n ])([\w]*?)(http(s)?:\/\/[\w]+[^ \,\"\n\r\t<]*)/is", "$1$2<a href=\"$3\" target=\"_blank\" rel=\"nofollow\">$3</a>", $entries[ $entry_key ]['message'] );
+		$entries[ $entry_key ]['message'] = preg_replace( '/(^|[\n ])([\w]*?)(http(s)?:\/\/[\w]+[^ \,\"\n\r\t<]*)/i', '$1$2<a href="$3" target="_blank" rel="nofollow">$3</a>', $entries[ $entry_key ]['message'] );
 	}
 } ?>
 
@@ -40,7 +40,7 @@ if ( $entries ) {
 
 			<?php foreach ( $entries as $entry ) : ?>
 				<tr class="<?php echo esc_attr( str_replace( '_', '-', $entry['type'] ) ); ?>">
-					<th><p><?php echo esc_html( date( 'Y-m-d h:ia', $entry['timestamp'] ) ); ?></p></th>
+					<th><p><?php echo esc_html( gmdate( 'Y-m-d h:ia', $entry['timestamp'] ) ); ?></p></th>
 					<th><p><?php echo esc_html( ucwords( str_replace( '_', ' ', $entry['type'] ) ) ); ?></p></th>
 					<th><p><?php echo esc_html( $entry['user_display_name'] ); ?></p></th>
 					<th><?php echo wp_kses( wpautop( $entry['message'] ), $allowed_html ); ?></th>


### PR DESCRIPTION
Changeset [8080](https://meta.trac.wordpress.org/changeset/8080) made improvements to log section view but did not fully complete the changes requested.

In the changeset `wp_kses_post` uses ruleset `data` which is too strict and does not allow `p` or `br` tags so in the end result of using `wpautop` reverts. Let's allow those tags to allowed html and really use `wpautop`. This make reading of long vetting notes much nicer.

Also linkify links in notes for slightly better user experience. Add `target="blank"` to ensure not losing application view and `rel=nofollow` so search engines don't use link for ranking, crawling or indexing.

Fixes #322 

### Screenshots

![](https://i.imgur.com/kkxKHPI.png)

### How to test the changes in this Pull Request:

1. Write a note to application with one of two paragraphs and links
2. Note should be outputted nicely instead of one long chunck of text
