### PR TITLE
Block Live Schedule: Use duration to find currently running sessions

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/schedule.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/schedule.js
@@ -24,9 +24,14 @@ export default function( { attributes, isFetching, sessions } ) {
 	const { level = 2 } = attributes;
 	const Heading = `h${ level }`;
 
+	const hasNow = !! sessions.filter( ( { now } ) => !! now ).length;
+	const hasNext = !! sessions.filter( ( { next } ) => !! next ).length;
+
 	return (
 		<Fragment>
-			<Heading className="wordcamp-live-schedule__title">{ attributes.now }</Heading>
+			{ hasNow && (
+				<Heading className="wordcamp-live-schedule__title">{ attributes.now }</Heading>
+			) }
 
 			{ sessions.map( ( trackPair, index ) => {
 				const session = trackPair.now;
@@ -43,7 +48,9 @@ export default function( { attributes, isFetching, sessions } ) {
 				);
 			} ) }
 
-			<Heading className="wordcamp-live-schedule__title">{ attributes.next }</Heading>
+			{ hasNext && (
+				<Heading className="wordcamp-live-schedule__title">{ attributes.next }</Heading>
+			) }
 
 			{ sessions.map( ( trackPair, index ) => {
 				const session = trackPair.next;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/controller.php
@@ -1,5 +1,6 @@
 <?php
 namespace WordCamp\Blocks\Live_Schedule;
+use WordCamp_Post_Types_Plugin;
 
 defined( 'WPINC' ) || die();
 
@@ -70,6 +71,7 @@ add_action( 'init', __NAMESPACE__ . '\init' );
 function add_script_data( array $data ) {
 	$data['live-schedule'] = array(
 		'scheduleUrl' => esc_url( site_url( __( 'schedule', 'wordcamporg' ) ) ),
+		'fallbackDuration' => WordCamp_Post_Types_Plugin::SESSION_DEFAULT_DURATION,
 	);
 
 	return $data;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -62,7 +62,7 @@ export function getCurrentSessions( { sessions, tracks } ) {
 		);
 
 		const index = sessionsInTrack.findIndex( ( session ) => {
-			const duration = session.meta._wcpt_session_duration * 1000;
+			const duration = ( session.meta._wcpt_session_duration || window.WordCampBlocks[ 'live-schedule' ].fallbackDuration ) * 1000;
 			const startTimestamp = ( session.meta._wcpt_session_time * 1000 ) - tzOffset;
 			const endTimestamp = startTimestamp + duration;
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -62,6 +62,18 @@ export function getCurrentSessions( { sessions, tracks } ) {
 			sessions.filter( ( session ) => session.session_track.includes( track.id ) ),
 			'meta._wcpt_session_time'
 		) );
+		if ( ! sessionsInTrack.length ) {
+			return {};
+		}
+
+		// Check if we're more than a day out from the earliest session (so that we don't show "up next" before
+		// the WordCamp starts).
+		const firstSession = sessionsInTrack[ sessionsInTrack.length - 1 ];
+		const firstSessionTimestamp = ( firstSession.meta._wcpt_session_time * 1000 ) - tzOffset;
+		const dayInMiliseconds = 24 * 60 * 60 * 1000;
+		if ( nowTimestamp < ( firstSessionTimestamp - dayInMiliseconds ) ) {
+			return {};
+		}
 
 		const index = sessionsInTrack.findIndex( ( { meta } ) => {
 			const duration = ( meta._wcpt_session_duration || window.WordCampBlocks[ 'live-schedule' ].fallbackDuration ) * 1000;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions.json
@@ -336,6 +336,22 @@
     }
   },
   {
+    "id": 12054,
+    "meta": {
+      "_wcpt_session_time": 1572613200,
+      "_wcpt_session_duration": 6300
+    },
+    "session_date_time": {
+      "date": "November 1, 2019",
+      "time": "1:00 pm"
+    },
+    "session_track": [ 84 ],
+    "slug": "performing-a-live-a11y-audit",
+    "title": {
+      "rendered": "Making Your Website Work for Everyone: Accessibility and Inclusive Design"
+    }
+  },
+  {
     "id": 12050,
     "meta": {
       "_wcpt_session_time": 1572621300,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions.json
@@ -734,5 +734,37 @@
     "title": {
       "rendered": "The Cost of Contribution"
     }
+  },
+  {
+    "id": 1,
+    "meta": {
+      "_wcpt_session_time": 1572688800,
+      "_wcpt_session_duration": 1800
+    },
+    "session_date_time": {
+      "date": "November 2, 2019",
+      "time": "10:00 am"
+    },
+    "session_track": [ 55 ],
+    "slug": "session-a",
+    "title": {
+      "rendered": "Session A"
+    }
+  },
+  {
+    "id": 2,
+    "meta": {
+      "_wcpt_session_time": 1572696000,
+      "_wcpt_session_duration": 1800
+    },
+    "session_date_time": {
+      "date": "November 2, 2019",
+      "time": "12:00 pm"
+    },
+    "session_track": [ 55 ],
+    "slug": "session-b",
+    "title": {
+      "rendered": "Session B"
+    }
   }
 ]

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions.json
@@ -1,23 +1,9 @@
 [
   {
-    "id": 36790,
-    "meta": {
-      "_wcpt_session_time": 1572681600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "8:00 am"
-    },
-    "session_track": [ 55, 71, 72, 73, 83, 84 ],
-    "slug": "registration-3",
-    "title": {
-      "rendered": "Registration"
-    }
-  },
-  {
     "id": 36788,
     "meta": {
-      "_wcpt_session_time": 1572595200
+      "_wcpt_session_time": 1572595200,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -32,7 +18,8 @@
   {
     "id": 35597,
     "meta": {
-      "_wcpt_session_time": 1572599700
+      "_wcpt_session_time": 1572599700,
+      "_wcpt_session_duration": 2700
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -45,69 +32,10 @@
     }
   },
   {
-    "id": 35573,
-    "meta": {
-      "_wcpt_session_time": 1572690600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "10:30 am"
-    },
-    "session_track": [ 72 ],
-    "slug": "unlocking-six-figure-ecommerce-growth-with-automations",
-    "title": {
-      "rendered": "Unlocking six-figure eCommerce growth with automations"
-    }
-  },
-  {
-    "id": 35568,
-    "meta": {
-      "_wcpt_session_time": 1572694200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "11:30 am"
-    },
-    "session_track": [ 73 ],
-    "slug": "defining-fast-the-hardest-problem-in-performance-engineering",
-    "title": {
-      "rendered": "Defining Fast: The Hardest Problem in Performance Engineering"
-    }
-  },
-  {
-    "id": 35564,
-    "meta": {
-      "_wcpt_session_time": 1572694200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "11:30 am"
-    },
-    "session_track": [ 72 ],
-    "slug": "design-systems-crafting-for-crafters",
-    "title": {
-      "rendered": "Design Systems: Crafting For Crafters"
-    }
-  },
-  {
-    "id": 34667,
-    "meta": {
-      "_wcpt_session_time": 1572687000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:30 am"
-    },
-    "session_track": [ 73 ],
-    "slug": "automated-updates-panel",
-    "title": {
-      "rendered": "WordPress Automated Updates: A Panel Discussion"
-    }
-  },
-  {
     "id": 34662,
     "meta": {
-      "_wcpt_session_time": 1572599700
+      "_wcpt_session_time": 1572599700,
+      "_wcpt_session_duration": 2700
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -120,24 +48,10 @@
     }
   },
   {
-    "id": 34655,
-    "meta": {
-      "_wcpt_session_time": 1572690600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "10:30 am"
-    },
-    "session_track": [ 71 ],
-    "slug": "just-enough-react-for-wordpress",
-    "title": {
-      "rendered": "Just Enough React for WordPress"
-    }
-  },
-  {
     "id": 34170,
     "meta": {
-      "_wcpt_session_time": 1572634800
+      "_wcpt_session_time": 1572634800,
+      "_wcpt_session_duration": 10800
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -150,54 +64,10 @@
     }
   },
   {
-    "id": 31049,
-    "meta": {
-      "_wcpt_session_time": 1572685200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:00 am"
-    },
-    "session_track": [ 84 ],
-    "slug": "everyone-can-help-make-wordpress-better-how-to-contribute-to-wordpress",
-    "title": {
-      "rendered": "Everyone Can Help Make WordPress Better – How to Contribute to WordPress"
-    }
-  },
-  {
-    "id": 12880,
-    "meta": {
-      "_wcpt_session_time": 1572685200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:00 am"
-    },
-    "session_track": [ 55 ],
-    "slug": "the-gameshow",
-    "title": {
-      "rendered": "The Gameshow!"
-    }
-  },
-  {
-    "id": 12876,
-    "meta": {
-      "_wcpt_session_time": 1572685200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:00 am"
-    },
-    "session_track": [ 71, 72, 73 ],
-    "slug": "morning-office-yoga",
-    "title": {
-      "rendered": "Morning Office Yoga: Second Floor Atrium"
-    }
-  },
-  {
     "id": 12765,
     "meta": {
-      "_wcpt_session_time": 1572599700
+      "_wcpt_session_time": 1572599700,
+      "_wcpt_session_duration": 2700
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -210,39 +80,10 @@
     }
   },
   {
-    "id": 12727,
-    "meta": {
-      "_wcpt_session_time": 1572705000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "2:30 pm"
-    },
-    "session_track": [ 73 ],
-    "slug": "take-back-your-web",
-    "title": {
-      "rendered": "Take Back Your Web"
-    }
-  },
-  {
-    "id": 12384,
-    "meta": {
-      "_wcpt_session_time": 1572694200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "11:30 am"
-    },
-    "session_track": [ 83 ],
-    "slug": "webwewant",
-    "title": {
-      "rendered": "WebWeWant"
-    }
-  },
-  {
     "id": 12360,
     "meta": {
-      "_wcpt_session_time": 1572615000
+      "_wcpt_session_time": 1572615000,
+      "_wcpt_session_duration": 1800
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -255,39 +96,10 @@
     }
   },
   {
-    "id": 12338,
-    "meta": {
-      "_wcpt_session_time": 1572701400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 71 ],
-    "slug": "sotw-setup",
-    "title": {
-      "rendered": "SOTW Setup"
-    }
-  },
-  {
-    "id": 12319,
-    "meta": {
-      "_wcpt_session_time": 1572787800
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 64 ],
-    "slug": "afternoon-session-2",
-    "title": {
-      "rendered": "Afternoon Session"
-    }
-  },
-  {
     "id": 12314,
     "meta": {
-      "_wcpt_session_time": 1572621300
+      "_wcpt_session_time": 1572621300,
+      "_wcpt_session_duration": 7200
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -300,114 +112,10 @@
     }
   },
   {
-    "id": 12294,
-    "meta": {
-      "_wcpt_session_time": 1572710400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "4:00 pm"
-    },
-    "session_track": [ 71 ],
-    "slug": "state-of-the-word",
-    "title": {
-      "rendered": "State of the Word"
-    }
-  },
-  {
-    "id": 12311,
-    "meta": {
-      "_wcpt_session_time": 1572775200
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "10:00 am"
-    },
-    "session_track": [ 64 ],
-    "slug": "kids-camp",
-    "title": {
-      "rendered": "Morning Session"
-    }
-  },
-  {
-    "id": 12307,
-    "meta": {
-      "_wcpt_session_time": 1572798600
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "4:30 pm"
-    },
-    "session_track": [ 57 ],
-    "slug": "closing-remarks",
-    "title": {
-      "rendered": "Closing Remarks"
-    }
-  },
-  {
-    "id": 12304,
-    "meta": {
-      "_wcpt_session_time": 1572787800
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 57 ],
-    "slug": "afternoon-session",
-    "title": {
-      "rendered": "Afternoon Session"
-    }
-  },
-  {
-    "id": 12301,
-    "meta": {
-      "_wcpt_session_time": 1572784200
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "12:30 pm"
-    },
-    "session_track": [ 57, 64 ],
-    "slug": "lunch-2",
-    "title": {
-      "rendered": "Lunch"
-    }
-  },
-  {
-    "id": 12298,
-    "meta": {
-      "_wcpt_session_time": 1572775200
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "10:00 am"
-    },
-    "session_track": [ 57 ],
-    "slug": "morning-session",
-    "title": {
-      "rendered": "Morning Session"
-    }
-  },
-  {
-    "id": 12296,
-    "meta": {
-      "_wcpt_session_time": 1572771600
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "9:00 am"
-    },
-    "session_track": [ 57, 64 ],
-    "slug": "registration",
-    "title": {
-      "rendered": "Registration"
-    }
-  },
-  {
     "id": 12120,
     "meta": {
-      "_wcpt_session_time": 1572616800
+      "_wcpt_session_time": 1572616800,
+      "_wcpt_session_duration": 2700
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -422,7 +130,8 @@
   {
     "id": 2570,
     "meta": {
-      "_wcpt_session_time": 1572608700
+      "_wcpt_session_time": 1572608700,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -437,7 +146,8 @@
   {
     "id": 2566,
     "meta": {
-      "_wcpt_session_time": 1572607800
+      "_wcpt_session_time": 1572607800,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -452,7 +162,8 @@
   {
     "id": 2562,
     "meta": {
-      "_wcpt_session_time": 1572606000
+      "_wcpt_session_time": 1572606000,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -467,7 +178,8 @@
   {
     "id": 12112,
     "meta": {
-      "_wcpt_session_time": 1572616800
+      "_wcpt_session_time": 1572616800,
+      "_wcpt_session_duration": 2700
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -480,24 +192,10 @@
     }
   },
   {
-    "id": 12110,
-    "meta": {
-      "_wcpt_session_time": 1572687000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:30 am"
-    },
-    "session_track": [ 71 ],
-    "slug": "working-with-wordpress-and-external-apis",
-    "title": {
-      "rendered": "Working with WordPress and External APIs"
-    }
-  },
-  {
     "id": 12108,
     "meta": {
-      "_wcpt_session_time": 1572624900
+      "_wcpt_session_time": 1572624900,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -512,7 +210,8 @@
   {
     "id": 12106,
     "meta": {
-      "_wcpt_session_time": 1572616800
+      "_wcpt_session_time": 1572616800,
+      "_wcpt_session_duration": 1800
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -525,24 +224,10 @@
     }
   },
   {
-    "id": 2595,
-    "meta": {
-      "_wcpt_session_time": 1572617700
-    },
-    "session_date_time": {
-      "date": "November 1, 2019",
-      "time": "2:15 pm"
-    },
-    "session_track": [ 73 ],
-    "slug": "contributing-to-wordpress-with-a-rock-solid-talk",
-    "title": {
-      "rendered": "Contributing to WordPress with a Rock Solid Talk"
-    }
-  },
-  {
     "id": 2585,
     "meta": {
-      "_wcpt_session_time": 1572602400
+      "_wcpt_session_time": 1572602400,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -557,7 +242,8 @@
   {
     "id": 2575,
     "meta": {
-      "_wcpt_session_time": 1572606000
+      "_wcpt_session_time": 1572606000,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -572,7 +258,8 @@
   {
     "id": 12118,
     "meta": {
-      "_wcpt_session_time": 1572606900
+      "_wcpt_session_time": 1572606900,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -587,7 +274,8 @@
   {
     "id": 12116,
     "meta": {
-      "_wcpt_session_time": 1572618600
+      "_wcpt_session_time": 1572618600,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -600,24 +288,10 @@
     }
   },
   {
-    "id": 12114,
-    "meta": {
-      "_wcpt_session_time": 1572687000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:30 am"
-    },
-    "session_track": [ 72 ],
-    "slug": "feeling-fried-a-wordpressers-guide-to-preventing-burnout",
-    "title": {
-      "rendered": "Feeling Fried? A WordPresser&#8217;s Guide to Preventing Burnout"
-    }
-  },
-  {
     "id": 2591,
     "meta": {
-      "_wcpt_session_time": 1572615900
+      "_wcpt_session_time": 1572615900,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -632,7 +306,8 @@
   {
     "id": 12063,
     "meta": {
-      "_wcpt_session_time": 1572624900
+      "_wcpt_session_time": 1572624900,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -645,54 +320,10 @@
     }
   },
   {
-    "id": 12061,
-    "meta": {
-      "_wcpt_session_time": 1572687000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:30 am"
-    },
-    "session_track": [ 55 ],
-    "slug": "how-the-wordpress-community-can-embrace-next-generation-talk-panel",
-    "title": {
-      "rendered": "How the WordPress Community Can Embrace the Next Generation (Talk + Panel)"
-    }
-  },
-  {
-    "id": 12059,
-    "meta": {
-      "_wcpt_session_time": 1572690600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "10:30 am"
-    },
-    "session_track": [ 55 ],
-    "slug": "how-to-organize-events-for-youths-workshop",
-    "title": {
-      "rendered": "How to Organize Events for Youths (Discussion)"
-    }
-  },
-  {
-    "id": 12055,
-    "meta": {
-      "_wcpt_session_time": 1572694200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "11:30 am"
-    },
-    "session_track": [ 55 ],
-    "slug": "unconference",
-    "title": {
-      "rendered": "Unconference!"
-    }
-  },
-  {
     "id": 12053,
     "meta": {
-      "_wcpt_session_time": 1572613200
+      "_wcpt_session_time": 1572613200,
+      "_wcpt_session_duration": 6300
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -707,7 +338,8 @@
   {
     "id": 12050,
     "meta": {
-      "_wcpt_session_time": 1572621300
+      "_wcpt_session_time": 1572621300,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -720,24 +352,10 @@
     }
   },
   {
-    "id": 12001,
-    "meta": {
-      "_wcpt_session_time": 1572701400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 55 ],
-    "slug": "organizing-a-wordcamp-while-staying-sane",
-    "title": {
-      "rendered": "Organizing a WordCamp While Staying Sane"
-    }
-  },
-  {
     "id": 11997,
     "meta": {
-      "_wcpt_session_time": 1572602400
+      "_wcpt_session_time": 1572602400,
+      "_wcpt_session_duration": 7200
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -752,7 +370,8 @@
   {
     "id": 11938,
     "meta": {
-      "_wcpt_session_time": 1572605100
+      "_wcpt_session_time": 1572605100,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -767,7 +386,8 @@
   {
     "id": 11934,
     "meta": {
-      "_wcpt_session_time": 1572613200
+      "_wcpt_session_time": 1572613200,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -782,7 +402,8 @@
   {
     "id": 11932,
     "meta": {
-      "_wcpt_session_time": 1572613200
+      "_wcpt_session_time": 1572613200,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -797,7 +418,8 @@
   {
     "id": 2473,
     "meta": {
-      "_wcpt_session_time": 1572614100
+      "_wcpt_session_time": 1572614100,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -812,7 +434,8 @@
   {
     "id": 11926,
     "meta": {
-      "_wcpt_session_time": 1572619500
+      "_wcpt_session_time": 1572619500,
+      "_wcpt_session_duration": 1800
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -827,7 +450,8 @@
   {
     "id": 11838,
     "meta": {
-      "_wcpt_session_time": 1572602400
+      "_wcpt_session_time": 1572602400,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -842,7 +466,8 @@
   {
     "id": 11835,
     "meta": {
-      "_wcpt_session_time": 1572624900
+      "_wcpt_session_time": 1572624900,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -855,39 +480,10 @@
     }
   },
   {
-    "id": 11833,
-    "meta": {
-      "_wcpt_session_time": 1572690600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "10:30 am"
-    },
-    "session_track": [ 73 ],
-    "slug": "responsible-tracking-learning-from-your-users-without-being-creepy",
-    "title": {
-      "rendered": "Responsible Tracking: Learning from Your Users Without Being Creepy"
-    }
-  },
-  {
-    "id": 11829,
-    "meta": {
-      "_wcpt_session_time": 1572701400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 73 ],
-    "slug": "confidently-testing-wordpress",
-    "title": {
-      "rendered": "Confidently Testing WordPress"
-    }
-  },
-  {
     "id": 11827,
     "meta": {
-      "_wcpt_session_time": 1572621300
+      "_wcpt_session_time": 1572621300,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -902,7 +498,8 @@
   {
     "id": 11825,
     "meta": {
-      "_wcpt_session_time": 1572621300
+      "_wcpt_session_time": 1572621300,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -915,24 +512,10 @@
     }
   },
   {
-    "id": 11823,
-    "meta": {
-      "_wcpt_session_time": 1572701400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 72 ],
-    "slug": "how-to-disagree-on-the-internet",
-    "title": {
-      "rendered": "How to Disagree on the Internet"
-    }
-  },
-  {
     "id": 11821,
     "meta": {
-      "_wcpt_session_time": 1572602400
+      "_wcpt_session_time": 1572602400,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -947,7 +530,8 @@
   {
     "id": 11753,
     "meta": {
-      "_wcpt_session_time": 1572624900
+      "_wcpt_session_time": 1572624900,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -962,7 +546,8 @@
   {
     "id": 11710,
     "meta": {
-      "_wcpt_session_time": 1572613200
+      "_wcpt_session_time": 1572613200,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -977,7 +562,8 @@
   {
     "id": 11708,
     "meta": {
-      "_wcpt_session_time": 1572621300
+      "_wcpt_session_time": 1572621300,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -992,7 +578,8 @@
   {
     "id": 11706,
     "meta": {
-      "_wcpt_session_time": 1572603300
+      "_wcpt_session_time": 1572603300,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1007,7 +594,8 @@
   {
     "id": 11701,
     "meta": {
-      "_wcpt_session_time": 1572606000
+      "_wcpt_session_time": 1572606000,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1020,39 +608,10 @@
     }
   },
   {
-    "id": 11699,
-    "meta": {
-      "_wcpt_session_time": 1572694200
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "11:30 am"
-    },
-    "session_track": [ 71 ],
-    "slug": "from-developer-to-manager-how-to-survive",
-    "title": {
-      "rendered": "From Developer to Manager &#8212; How to Survive"
-    }
-  },
-  {
-    "id": 11697,
-    "meta": {
-      "_wcpt_session_time": 1572705000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "2:30 pm"
-    },
-    "session_track": [ 72 ],
-    "slug": "how-to-beat-technical-writers-block",
-    "title": {
-      "rendered": "How to Beat Technical Writer&#8217;s Block"
-    }
-  },
-  {
     "id": 11596,
     "meta": {
-      "_wcpt_session_time": 1572598800
+      "_wcpt_session_time": 1572598800,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1065,129 +624,10 @@
     }
   },
   {
-    "id": 11593,
-    "meta": {
-      "_wcpt_session_time": 1572613200
-    },
-    "session_date_time": {
-      "date": "November 1, 2019",
-      "time": "1:00 pm"
-    },
-    "session_track": [ 84 ],
-    "slug": "performing-a-live-a11y-audit",
-    "title": {
-      "rendered": "Making Your Website Work for Everyone: Accessibility and Inclusive Design"
-    }
-  },
-  {
-    "id": 11591,
-    "meta": {
-      "_wcpt_session_time": 1572701400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 83 ],
-    "slug": "structuring-modern-wordpress-sites-for-scale",
-    "title": {
-      "rendered": "Structuring Modern WordPress Sites for Scale"
-    }
-  },
-  {
-    "id": 11589,
-    "meta": {
-      "_wcpt_session_time": 1572690600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "10:30 am"
-    },
-    "session_track": [ 84 ],
-    "slug": "templates-plugins-blocks",
-    "title": {
-      "rendered": "Templates &#038; Plugins &#038; Blocks, Oh My! Designing the Theme that Thinks of Everything"
-    }
-  },
-  {
-    "id": 11587,
-    "meta": {
-      "_wcpt_session_time": 1572687000
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "9:30 am"
-    },
-    "session_track": [ 83 ],
-    "slug": "write-your-first-business-plan",
-    "title": {
-      "rendered": "How to Create Your First Business Plan"
-    }
-  },
-  {
-    "id": 11580,
-    "meta": {
-      "_wcpt_session_time": 1572792300
-    },
-    "session_date_time": {
-      "date": "November 3, 2019",
-      "time": "2:45 pm"
-    },
-    "session_track": [],
-    "slug": "afternoon-break-sunday",
-    "title": {
-      "rendered": "Afternoon Break &#8211; Sunday"
-    }
-  },
-  {
-    "id": 11578,
-    "meta": {
-      "_wcpt_session_time": 1572708600
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "3:30 pm"
-    },
-    "session_track": [ 55, 71, 72, 73, 83, 84 ],
-    "slug": "afternoon-break-saturday",
-    "title": {
-      "rendered": "Afternoon Break &#8211; Saturday"
-    }
-  },
-  {
-    "id": 11576,
-    "meta": {
-      "_wcpt_session_time": 1572619500
-    },
-    "session_date_time": {
-      "date": "November 1, 2019",
-      "time": "2:45 pm"
-    },
-    "session_track": [],
-    "slug": "afternoon-break-friday",
-    "title": {
-      "rendered": "Afternoon Break &#8211; Friday"
-    }
-  },
-  {
-    "id": 11571,
-    "meta": {
-      "_wcpt_session_time": 1572697800
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "12:30 pm"
-    },
-    "session_track": [ 55, 71, 72, 73, 83, 84 ],
-    "slug": "lunch-saturday",
-    "title": {
-      "rendered": "Lunch &#8211; Saturday"
-    }
-  },
-  {
     "id": 11569,
     "meta": {
-      "_wcpt_session_time": 1572609600
+      "_wcpt_session_time": 1572609600,
+      "_wcpt_session_duration": 3600
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1200,24 +640,10 @@
     }
   },
   {
-    "id": 11566,
-    "meta": {
-      "_wcpt_session_time": 1572701400
-    },
-    "session_date_time": {
-      "date": "November 2, 2019",
-      "time": "1:30 pm"
-    },
-    "session_track": [ 84 ],
-    "slug": "the-building-blocks-of-building-blocks",
-    "title": {
-      "rendered": "The Building Blocks of Building Blocks"
-    }
-  },
-  {
     "id": 11563,
     "meta": {
-      "_wcpt_session_time": 1572613200
+      "_wcpt_session_time": 1572613200,
+      "_wcpt_session_duration": 6300
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1232,7 +658,8 @@
   {
     "id": 11182,
     "meta": {
-      "_wcpt_session_time": 1572602400
+      "_wcpt_session_time": 1572602400,
+      "_wcpt_session_duration": 7200
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1247,7 +674,8 @@
   {
     "id": 11275,
     "meta": {
-      "_wcpt_session_time": 1572621300
+      "_wcpt_session_time": 1572621300,
+      "_wcpt_session_duration": 7200
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1262,7 +690,8 @@
   {
     "id": 11473,
     "meta": {
-      "_wcpt_session_time": 1572602400
+      "_wcpt_session_time": 1572602400,
+      "_wcpt_session_duration": 7200
     },
     "session_date_time": {
       "date": "November 1, 2019",
@@ -1277,7 +706,8 @@
   {
     "id": 2467,
     "meta": {
-      "_wcpt_session_time": 1572604200
+      "_wcpt_session_time": 1572604200,
+      "_wcpt_session_duration": 900
     },
     "session_date_time": {
       "date": "November 1, 2019",

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -21,7 +21,7 @@ describe( 'getCurrentSessions', () => {
 	} );
 
 	test( 'should return no sessions running at midnight, Jan 1st 2020', () => {
-		const time = Date.parse( '202-01-01T00:00:00.000Z' );
+		const time = Date.parse( '2020-01-01T00:00:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
 		const results = getCurrentSessions( { sessions, tracks } );
 		expect( results ).toHaveLength( 0 );
@@ -88,5 +88,14 @@ describe( 'getCurrentSessions', () => {
 		results.forEach( ( { now } ) => {
 			expect( now.slug ).toEqual( 'wordfest' );
 		} );
+	} );
+
+	test( 'should return "Session B" coming up next, nothing on now, at 10:45am Nov 2nd', () => {
+		const time = Date.parse( '2019-11-02T10:45:00.000Z' );
+		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
+		const results = getCurrentSessions( { sessions, tracks } );
+		expect( results ).toHaveLength( 1 );
+		expect( results[ 0 ].now ).toBeUndefined();
+		expect( results[ 0 ].next.slug ).toEqual( 'session-b' );
 	} );
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -43,25 +43,25 @@ describe( 'getCurrentSessions', () => {
 	} );
 
 	test( 'should return "Afternoon Break" as 6 sessions up next at 3:10pm', () => {
-		const time = Date.parse( '2019-11-02T15:10:00.000Z' );
+		const time = Date.parse( '2019-11-01T15:10:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `next` data.
 		expect( results.filter( ( { next } ) => !! next ) ).toHaveLength( 6 );
 	} );
 
-	test( 'should return just "Afternoon Break" as 1 session running at 3:30pm', () => {
-		const time = Date.parse( '2019-11-02T15:30:00.000Z' );
+	test( 'should return just "Afternoon Break" as 6 sessions running at 2:50pm', () => {
+		const time = Date.parse( '2019-11-01T14:50:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `now` data.
-		expect( results.filter( ( { now } ) => !! now ) ).toHaveLength( 1 );
+		expect( results.filter( ( { now } ) => !! now ) ).toHaveLength( 6 );
 	} );
 
-	// @todo Should return State of The Word, but doesn't.
+	// @todo Should return WordFest, but doesn't.
 	/* eslint-disable jest/no-disabled-tests */
-	test.skip( 'should return "State of The Word" as 1 session running at 4:10pm', () => {
-		const time = Date.parse( '2019-11-02T16:10:00.000Z' );
+	test.skip( 'should return "WordFest" as 1 session running at 7:10pm', () => {
+		const time = Date.parse( '2019-11-01T19:10:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `now` data.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -27,6 +27,15 @@ describe( 'getCurrentSessions', () => {
 		expect( results ).toHaveLength( 0 );
 	} );
 
+	// @todo Should return nothing upcoming, but doesn't.
+	/* eslint-disable jest/no-disabled-tests */
+	test( 'should return no sessions running at midnight, Jan 1st 2019', () => {
+		const time = Date.parse( '2019-01-01T00:00:00.000Z' );
+		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
+		const results = getCurrentSessions( { sessions, tracks } );
+		expect( results ).toHaveLength( 0 );
+	} );
+
 	test( 'should return 6 sessions running at 10:10am', () => {
 		const time = Date.parse( '2019-11-01T10:10:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -9,7 +9,7 @@ import { getCurrentSessions } from '../';
 import sessions from './__mock__/sessions';
 import tracks from './__mock__/session_track';
 
-// Note: Mocked session times are in UTC, on Nov 1st & 2nd, 2019.
+// Note: Mocked session times are in UTC, on Nov 1st, 2019.
 
 describe( 'getCurrentSessions', () => {
 	beforeAll( () => {
@@ -32,6 +32,13 @@ describe( 'getCurrentSessions', () => {
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `now` data.
 		expect( results.filter( ( { now } ) => !! now ) ).toHaveLength( 6 );
+		const titles = results.map( ( { now } ) => now.slug );
+		expect( titles[ 0 ] ).toEqual( 'grow-your-meetup' );
+		expect( titles[ 1 ] ).toEqual( 'open-source-open-process-open-web' );
+		expect( titles[ 2 ] ).toEqual( 'how-to-perform-a-quality-ux-audit-on-a-budget' );
+		expect( titles[ 3 ] ).toEqual( 'contributing-to-core-no-coding-necessary' );
+		expect( titles[ 4 ] ).toEqual( 'align-seo-efforts-with-your-target-market-and-todays-search-learn-how-to-perform-keyword-research-and-map-them-to-content' );
+		expect( titles[ 5 ] ).toEqual( 'automating-your-qa-with-visual-regression-testing' );
 	} );
 
 	test( 'should return 6 sessions up next at 10:10am', () => {
@@ -40,14 +47,24 @@ describe( 'getCurrentSessions', () => {
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `next` data.
 		expect( results.filter( ( { next } ) => !! next ) ).toHaveLength( 6 );
+		const titles = results.map( ( { next } ) => next.slug );
+		expect( titles[ 0 ] ).toEqual( 'lunch' );
+		expect( titles[ 1 ] ).toEqual( 'user-personas-as-an-inclusive-design-and-development-tool' );
+		expect( titles[ 2 ] ).toEqual( 'a-mom-a-lesbian-and-an-entrepreneur-walk-into-a-wordcamp' );
+		expect( titles[ 3 ] ).toEqual( 'using-wordpress-to-do_action' );
+		expect( titles[ 4 ] ).toEqual( 'lunch' );
+		expect( titles[ 5 ] ).toEqual( 'lunch' );
 	} );
 
-	test( 'should return "Afternoon Break" as 6 sessions up next at 3:10pm', () => {
-		const time = Date.parse( '2019-11-01T15:10:00.000Z' );
+	test( 'should return "Afternoon Break" as 6 sessions up next at 2:40pm', () => {
+		const time = Date.parse( '2019-11-01T14:40:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `next` data.
 		expect( results.filter( ( { next } ) => !! next ) ).toHaveLength( 6 );
+		results.forEach( ( { next } ) => {
+			expect( next.slug ).toEqual( 'afternoon-break-sponsored-by-cloudways' );
+		} );
 	} );
 
 	test( 'should return just "Afternoon Break" as 6 sessions running at 2:50pm', () => {
@@ -56,15 +73,19 @@ describe( 'getCurrentSessions', () => {
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `now` data.
 		expect( results.filter( ( { now } ) => !! now ) ).toHaveLength( 6 );
+		results.forEach( ( { now } ) => {
+			expect( now.slug ).toEqual( 'afternoon-break-sponsored-by-cloudways' );
+		} );
 	} );
 
-	// @todo Should return WordFest, but doesn't.
-	/* eslint-disable jest/no-disabled-tests */
-	test.skip( 'should return "WordFest" as 1 session running at 7:10pm', () => {
+	test( 'should return "WordFest" as 6 sessions running at 7:10pm', () => {
 		const time = Date.parse( '2019-11-01T19:10:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
 		const results = getCurrentSessions( { sessions, tracks } );
 		// filtering out just the tracks with `now` data.
-		expect( results.filter( ( { now } ) => !! now ) ).toHaveLength( 1 );
+		expect( results.filter( ( { now } ) => !! now ) ).toHaveLength( 6 );
+		results.forEach( ( { now } ) => {
+			expect( now.slug ).toEqual( 'wordfest' );
+		} );
 	} );
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -16,6 +16,7 @@ describe( 'getCurrentSessions', () => {
 		window.WordCampBlocks = {};
 		window.WordCampBlocks[ 'live-schedule' ] = {
 			nowOverride: false,
+			fallbackDuration: 3000,
 		};
 	} );
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -27,8 +27,6 @@ describe( 'getCurrentSessions', () => {
 		expect( results ).toHaveLength( 0 );
 	} );
 
-	// @todo Should return nothing upcoming, but doesn't.
-	/* eslint-disable jest/no-disabled-tests */
 	test( 'should return no sessions running at midnight, Jan 1st 2019', () => {
 		const time = Date.parse( '2019-01-01T00:00:00.000Z' );
 		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;


### PR DESCRIPTION
In #299, a new field was added for session duration. We can use this to accurately get the running sessions. If a session does not have a duration, we default to `WordCamp_Post_Types_Plugin::SESSION_DEFAULT_DURATION`, 50 minutes.

Currently, the Live Schedule block does not correctly display the last session of the day, because it uses the following session to gauge what is "now." Since we have duration now, the logic for sorting and selecting "current sessions" has been updated to fetch the session that starts before now, and ends after now.

The tests have also been updated to be a bit more accurate, and the test mock data has been trimmed down to one day of sessions.

### Screenshots

In this screenshot, the "afterparty" session is happening "now", with nothing after, so we hide the "Up Next" header.

<img width="677" alt="Screen Shot 2020-01-21 at 11 11 44 AM" src="https://user-images.githubusercontent.com/541093/72821671-d48ef900-3c3e-11ea-82c9-7bc6b2d4e9bc.png">

### How to test the changes in this Pull Request:

1. Check that the tests pass
2. Set up some sessions to be running "now", or add `'nowOverride' => strtotime( 'your time' ) * 1000,` to the live schedule controller (in `add_script_data`).
3. View the live schedule and check that it is showing the right sessions
