### PR TITLE
Block Live Schedule: Display sessions with no tracks

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/session.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/components/session.js
@@ -29,7 +29,9 @@ export default function( { headingLevel = 3, session, track } ) {
 
 	return (
 		<div className={ `wordcamp-live-schedule__session type-${ type }` }>
-			<span className={ `wordcamp-live-schedule__session-track track-${ track.slug }` }>{ track.name }</span>
+			{ !! track.slug && (
+				<span className={ `wordcamp-live-schedule__session-track track-${ track.slug }` }>{ track.name }</span>
+			) }
 
 			<div className="wordcamp-live-schedule__session-details">
 				<Heading className="wordcamp-live-schedule__session-title">

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -55,13 +55,26 @@ export function getCurrentSessions( { sessions, tracks } ) {
 	const tzOffset = __experimentalGetSettings().timezone.offset * ( 60 * 60 * 1000 );
 	const nowTimestamp = window.WordCampBlocks[ 'live-schedule' ].nowOverride || Date.now();
 
-	return tracks.map( ( track ) => {
-		// Reverse the sorted array so that the first found index is the one that starts closest to "now". This is
-		// intended to catch sessions that don't set a duration, but are shorter than the default.
-		const sessionsInTrack = reverse( sortBy(
-			sessions.filter( ( session ) => session.session_track.includes( track.id ) ),
-			'meta._wcpt_session_time'
-		) );
+	const trackListWithSessions = tracks.length ?
+		tracks.map( ( track ) => {
+			// Reverse the sorted array so that the first found index is the one that starts closest to "now".
+			// This is intended to catch sessions that don't set a duration, but are shorter than the default.
+			const sessionsInTrack = reverse( sortBy(
+				sessions.filter( ( session ) => session.session_track.includes( track.id ) ),
+				'meta._wcpt_session_time'
+			) );
+			return {
+				track: track,
+				sessions: sessionsInTrack,
+			};
+		} ) :
+		// Fall back to one track with all sessions, if no tracks are found.
+		[ {
+			track: {}, // @todo Needs slug, name.
+			sessions: reverse( sortBy( sessions, 'meta._wcpt_session_time' ) ),
+		} ];
+
+	return trackListWithSessions.map( ( { track, sessions: sessionsInTrack } ) => {
 		if ( ! sessionsInTrack.length ) {
 			return {};
 		}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -70,7 +70,7 @@ export function getCurrentSessions( { sessions, tracks } ) {
 		} ) :
 		// Fall back to one track with all sessions, if no tracks are found.
 		[ {
-			track: {}, // @todo Needs slug, name.
+			track: {},
 			sessions: reverse( sortBy( sessions, 'meta._wcpt_session_time' ) ),
 		} ];
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions-no-tracks.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/__mock__/sessions-no-tracks.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": 1,
+    "meta": {
+      "_wcpt_session_time": 1588237200,
+      "_wcpt_session_duration": 3600
+    },
+    "session_date_time": {
+      "date": "April 30, 2020",
+      "time": "9:00 am"
+    },
+    "session_track": [],
+    "slug": "registration",
+    "title": {
+      "rendered": "Registration"
+    }
+  },
+  {
+    "id": 1,
+    "meta": {
+      "_wcpt_session_time": 1588240800,
+      "_wcpt_session_duration": 2700
+    },
+    "session_date_time": {
+      "date": "April 30, 2020",
+      "time": "10:00 am"
+    },
+    "session_track": [],
+    "slug": "building-a-good-block",
+    "title": {
+      "rendered": "Building a Good Block"
+    }
+  },
+  {
+    "id": 2,
+    "meta": {
+      "_wcpt_session_time": 1588243500,
+      "_wcpt_session_duration": 2700
+    },
+    "session_date_time": {
+      "date": "April 30, 2020",
+      "time": "11:00 am"
+    },
+    "session_track": [],
+    "slug": "project-management-intro",
+    "title": {
+      "rendered": "Project Management Intro"
+    }
+  },
+  {
+    "id": 3,
+    "meta": {
+      "_wcpt_session_time": 1588248000,
+      "_wcpt_session_duration": 3600
+    },
+    "session_date_time": {
+      "date": "April 30, 2020",
+      "time": "12:00 pm"
+    },
+    "session_track": [],
+    "slug": "lunch",
+    "title": {
+      "rendered": "Lunch"
+    }
+  }
+]

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/tests/index.test.js
@@ -7,6 +7,7 @@ import { getCurrentSessions } from '../';
  * Mock data from API
  */
 import sessions from './__mock__/sessions';
+import sessionsWithoutTracks from './__mock__/sessions-no-tracks';
 import tracks from './__mock__/session_track';
 
 // Note: Mocked session times are in UTC, on Nov 1st, 2019.
@@ -104,5 +105,14 @@ describe( 'getCurrentSessions', () => {
 		expect( results ).toHaveLength( 1 );
 		expect( results[ 0 ].now ).toBeUndefined();
 		expect( results[ 0 ].next.slug ).toEqual( 'session-b' );
+	} );
+
+	test( 'should return sessions even with no set tracks, at 10:30am April 30th', () => {
+		const time = Date.parse( '2020-04-30T10:30:00.000Z' );
+		window.WordCampBlocks[ 'live-schedule' ].nowOverride = time;
+		const results = getCurrentSessions( { sessions: sessionsWithoutTracks, tracks: [] } );
+		expect( results ).toHaveLength( 1 );
+		expect( results[ 0 ].now.slug ).toEqual( 'building-a-good-block' );
+		expect( results[ 0 ].next.slug ).toEqual( 'project-management-intro' );
 	} );
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/style.scss
@@ -12,9 +12,6 @@
 }
 
 .wordcamp-live-schedule__session-details {
-	margin-left: 1em;
-	width: 80%;
-
 	.wordcamp-live-schedule__session-title {
 		margin-top: 0;
 
@@ -26,6 +23,11 @@
 
 	span {
 		display: block;
+	}
+
+	.wordcamp-live-schedule__session-track + & {
+		margin-left: 1em;
+		width: 80%;
 	}
 }
 


### PR DESCRIPTION
The Live Schedule block uses tracks to display the currently running sessions, which does not work if a WordCamp has no tracks. In this case, we can assume it's a one track camp and show all sessions in one default track. 

Fixes #260.

### Screenshots

Since there is no track, we also hide the "track" cell in the display

<img width="676" alt="Screen Shot 2020-01-21 at 10 44 58 AM" src="https://user-images.githubusercontent.com/541093/72822993-030dd380-3c41-11ea-8820-8ab538aa1718.png">

### How to test the changes in this Pull Request:

1. Check that the tests pass
2. On a site with no tracks, add some sessions
3. Optionally use `'nowOverride' => strtotime( 'your time' ) * 1000`, in the live schedule controller (in add_script_data), to set a "now"
4. View the live schedule and check that it is showing the right sessions

⚠️  _Note_ that this won't work on a site with tracks, even if you don't assign them to sessions… that could be a future fix if it turns out to be a problem.