### PR TITLE
PWA: Disable Edit Flow script registration on the service worker request

### DIFF
--- a/public_html/wp-content/mu-plugins/service-worker-caching.php
+++ b/public_html/wp-content/mu-plugins/service-worker-caching.php
@@ -7,6 +7,8 @@ add_action( 'wp_front_service_worker', __NAMESPACE__ . '\register_caching_routes
 add_action( 'wp_front_service_worker', __NAMESPACE__ . '\set_navigation_caching_strategy' );
 add_filter( 'wccs_safelisted_namespaces', __NAMESPACE__ . '\safelist_manifest_api' );
 add_action( 'wp_print_footer_scripts', __NAMESPACE__ . '\disable_app_install_prompt' );
+add_action( 'wp_ajax_wp_service_worker', __NAMESPACE__ . '\prevent_editflow_script' );
+add_action( 'wp_ajax_nopriv_wp_service_worker', __NAMESPACE__ . '\prevent_editflow_script' );
 
 /**
  * Register caching routes with the frontend service worker.
@@ -154,4 +156,14 @@ function disable_app_install_prompt() {
 	} );
 	</script>
 	<?php
+}
+
+/**
+ * Prevent the edit-flow calendar script registration. It echos a script tag, which breaks the ajax-generated
+ * service-worker script.
+ */
+function prevent_editflow_script() {
+	if ( function_exists( 'EditFlow' ) ) {
+		remove_action( 'admin_enqueue_scripts', array( EditFlow()->calendar, 'enqueue_admin_scripts' ) );
+	}
 }


### PR DESCRIPTION
This prevents the Edit Flow calendar script from echoing a `<script>` tag, which causes a syntax error in the service worker script.

Currently, with Edit Flow and the PWA active, a visit to wp-admin will trigger this error in console:

```
Uncaught SyntaxError: Unexpected token '<'
```

This is because the service worker script looks like this:

```
<script type="text/javascript">var ef_week_first_day="1";</script>/* PWA v0.3.0-admin */

…
```

That script tag comes from Edit Flow, and is echo'd when `admin_enqueue_scripts` runs. I'm also submitting a PR to edit flow to fix this, but until then we can short-circuit it here by removing the action.

### How to test the changes in this Pull Request:

1. Activate both Edit Flow and the PWA, make sure the "Calendar" module is enabled in Edit Flow
1. View the service worker script: `[yoursite]/wp-admin/admin-ajax.php?action=wp_service_worker`
2. You should not see a script tag 🙂 
3. You might need to empty cache and refresh, since this is cached by the PWA itself
