### PR TITLE
Camptix Notify: Add `attendee_id` shortcodde for email

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -370,6 +370,12 @@ class CampTix_Plugin {
 		add_shortcode( 'last_name', array( $this, 'notify_shortcode_last_name' ) );
 		add_shortcode( 'email', array( $this, 'notify_shortcode_email' ) );
 		add_shortcode( 'ticket_url', array( $this, 'notify_shortcode_ticket_url' ) );
+		add_shortcode(
+			'attendee_id',
+			function() {
+				return $this->tmp( 'attendee_id' );
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #327 — Add `[attendee_id]` shortcode, available in the email content when sending email to ticket buyers. This outputs the attendee ID, an unique identifier for every attendee record.

### How to test the changes in this Pull Request:

1. Go to Camptix -> Tools -> Notify
2. You should see `[attendee_id]` as an option below the inputs
3. Create an email with the `[attendee_id]` shortcode, send it
4. If you're on the docker env, mailcatcher catches all email at http://127.0.0.1:1080/
5. Check the sent email has the correct ID for each person
