### PR TITLE
Miscellaneous: Add CampTix Invoices to list of plugins site owners can activate

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -576,6 +576,7 @@ function wcorg_let_admins_activate_some_plugins( $required_capabilities, $reques
 	$target_plugin    = $args[0] ?? null;
 	$optional_plugins = array(
 		'campt-indian-payment-gateway/campt-indian-payment-gateway.php',
+		'camptix-invoices/camptix-invoices.php',
 		'camptix-mailchimp/camptix-mailchimp.php',
 		'camptix-mercadopago/camptix-mercadopago.php',
 		'camptix-pagseguro/camptix-pagseguro.php',


### PR DESCRIPTION
Fixes [meta#2992](https://meta.trac.wordpress.org/ticket/2992)

We've been activating this for anyone who asks, AFAIK we consider this out of beta, so let's let people activate it. (really, I was in this file for the PWA fix, and decided to add this— if it's not ready for everyone, this PR can be closed or left on hold)

### How to test the changes in this Pull Request:

1. Log in as a normal admin
2. View plugins on a site
3. You should be able to activate the CampTix Invoices plugin