### PR TITLE
Changes to the Meetup organizer application form and generic WordPress.org login required functionality

### DIFF
--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -122,6 +122,14 @@ function render_meetup_application_form( $countries ) {
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label>
+					Why do you want to start a WordPress Meetup in your city? And what are your immediate plans?
+					<span class="required-indicator">(required)</span>
+					<textarea name="q_reasons_plans" rows="5" required ></textarea>
+				</label>
+			</div>
+			<div class="PDF_questionDivide"></div>
+			<div class="PDF_question">
+				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
 					<input type="text" name="q_wporg_username" required/>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -105,21 +105,6 @@ function render_meetup_application_form( $countries ) {
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label>
-					How would you describe yourself?
-					<span class="required-indicator">(required)</span>
-
-					<select name="q_describe_yourself" required>
-						<option value=""></option>
-						<option>WordPress professional</option>
-						<option>Current WordPress user or developer</option>
-						<option>New to WordPress</option>
-						<option>I don't use WordPress</option>
-					</select>
-				</label>
-			</div>
-			<div class="PDF_questionDivide"></div>
-			<div class="PDF_question">
-				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
 					<input type="text" name="q_wporg_username" required/>
@@ -130,13 +115,6 @@ function render_meetup_application_form( $countries ) {
 				<label>
 					Your <a href="https://chat.wordpress.org" target="_blank">WordPress Slack</a> username
 					<input type="text" name="q_wp_slack_username"/>
-				</label>
-			</div>
-			<div class="PDF_questionDivide"></div>
-			<div class="PDF_question">
-				<label>
-					Anything you'd like to tell us about yourself, or what you hope to do with a meetup group?
-					<textarea name="q_additional_comments"></textarea>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -105,6 +105,14 @@ function render_meetup_application_form( $countries ) {
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label>
+					Could you introduce yourself and tell us more about your connection with WordPress?
+					<span class="required-indicator">(required)</span>
+					<textarea name="q_introduction" rows="5" required ></textarea>
+				</label>
+			</div>
+			<div class="PDF_questionDivide"></div>
+			<div class="PDF_question">
+				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
 					<input type="text" name="q_wporg_username" required/>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -157,6 +157,13 @@ function render_meetup_application_form( $countries ) {
 			</div>
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
+				<label>
+					Anything else you want us to know while we're looking over your application?
+					<textarea name="q_anything_else" rows="5"></textarea>
+				</label>
+			</div>
+			<div class="PDF_questionDivide"></div>
+			<div class="PDF_question">
 				<div class="submit-button">
 					<?php submit_button( 'Submit Application', 'primary', 'submit-application', false ); ?>
 				</div>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -9,17 +9,28 @@ defined( 'WPINC' ) || die();
  * @param array $countries
  */
 function render_meetup_application_form( $countries ) {
+	$prefilled = array(
+		'email'	=> '',
+		'name'	=> '',
+		'worg'	=> '',
+	);
 
-	?>
+	if ( is_user_logged_in() ) {
+		$current_user = wp_get_current_user();
+
+		$prefilled['email'] = $current_user->user_email;
+		$prefilled['name'] = $current_user->display_name;
+		$prefilled['worg'] = $current_user->user_login;
+	} ?>
 
 	<form id="meetup-application" method="post">
 		<div class="PDF_pageInner">
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label>
-					Please enter your full Name.
+					Please enter your full name.
 					<span class="required-indicator">(required)</span>
-					<input type="text" name="q_name" required/>
+					<input type="text" name="q_name" value="<?php echo esc_attr( $prefilled['name'] ) ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>
@@ -27,18 +38,18 @@ function render_meetup_application_form( $countries ) {
 				<label>
 					Please enter your email address.
 					<span class="required-indicator">(required)</span>
-					<input type="email" name="q_email" required/>
+					<input type="email" name="q_email" value="<?php echo esc_attr( $prefilled['email'] ) ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label> Please enter your mailing address (at least your city/state or city/country). </label>
 				<label>
-					Address Line 1
+					Address line 1
 					<input type="text" name="q_address_line_1">
 				</label>
 				<label>
-					Address Line 2
+					Address line 2
 					<input type="text" name="q_address_line_2">
 				</label>
 				<label>
@@ -145,7 +156,7 @@ function render_meetup_application_form( $countries ) {
 				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
-					<input type="text" name="q_wporg_username" required/>
+					<input type="text" name="q_wporg_username" value="<?php echo esc_attr( $prefilled['worg'] ) ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -113,6 +113,15 @@ function render_meetup_application_form( $countries ) {
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label>
+					Where we can find you online?
+					<span class="required-indicator">(required)</span>
+					<span class="label-description">Please add links to your websites, blogs and social media accounts.</span>
+					<textarea name="q_socialmedia" rows="5" required ></textarea>
+				</label>
+			</div>
+			<div class="PDF_questionDivide"></div>
+			<div class="PDF_question">
+				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
 					<input type="text" name="q_wporg_username" required/>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -130,6 +130,19 @@ function render_meetup_application_form( $countries ) {
 			<div class="PDF_questionDivide"></div>
 			<div class="PDF_question">
 				<label>
+					Have you talked with people in your community to check the level of interest?
+					<span class="required-indicator">(required)</span>
+					<select name="q_community_interest" required>
+						<option value=""></option>
+						<option>Nope, I have not</option>
+						<option>Yes, people are interested</option>
+						<option>I'm not sure about the level of interest</option>
+					</select>
+				</label>
+			</div>
+			<div class="PDF_questionDivide"></div>
+			<div class="PDF_question">
+				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
 					<input type="text" name="q_wporg_username" required/>

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -30,6 +30,29 @@ class Meetup_Application extends Event_Application {
 
 	const POST_TYPE = 'wp_meetup';
 
+	public function __construct() {
+		add_filter( 'forms_worg_login_required',	array( $this, 'forms_worg_login_required'		), 10 );
+	}
+
+	/**
+	 * Maybe require login before showing the application form
+	 */
+	public function forms_worg_login_required( $required ) {
+		// Check only central.wordcamp.org pages
+	  if ( is_main_site() ) {
+	    // Meetup organizer application
+	    if ( 3070672 === get_the_id() ) {
+	      return array(
+		      'start'   => '<form id="meetup-application"',
+		      'end'     => '</form>',
+		      'message' => sprintf( __( 'Before submitting your Meetup Organizer Application, please <a href="%s">log in to WordCamp.org</a> using your <strong>WordPress.org</strong>* account.', 'wordcamporg' ), wp_login_url( get_permalink() ) ),
+		    );
+	    }
+	  }
+
+	  return $required;
+	}
+
 	/**
 	 * User facing string of event type.
 	 *

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -138,6 +138,7 @@ class Meetup_Application extends Event_Application {
 			'q_country',
 			'q_mtp_loc',
 			'q_already_a_meetup',
+			'q_introduction',
 			'q_wporg_username',
 		);
 
@@ -177,6 +178,7 @@ class Meetup_Application extends Event_Application {
 			'q_mtp_loc'             => '',
 			'q_already_a_meetup'    => '',
 			'q_existing_meetup_url' => '',
+			'q_introduction'				=> '',
 			'q_wporg_username'      => '',
 			'q_wp_slack_username'   => '',
 		);

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -138,7 +138,6 @@ class Meetup_Application extends Event_Application {
 			'q_country',
 			'q_mtp_loc',
 			'q_already_a_meetup',
-			'q_describe_yourself',
 			'q_wporg_username',
 		);
 
@@ -178,10 +177,8 @@ class Meetup_Application extends Event_Application {
 			'q_mtp_loc'             => '',
 			'q_already_a_meetup'    => '',
 			'q_existing_meetup_url' => '',
-			'q_describe_yourself'   => '',
 			'q_wporg_username'      => '',
 			'q_wp_slack_username'   => '',
-			'q_additional_comments' => '',
 		);
 
 		return $values;
@@ -228,11 +225,9 @@ ADDRESS;
 		add_post_meta( $post_id, 'Address', $organizer_address );
 		add_post_meta( $post_id, 'Already a meetup', $data['q_already_a_meetup'] );
 		add_post_meta( $post_id, 'Meetup URL', $data['q_existing_meetup_url'] );
-		add_post_meta( $post_id, 'Organizer description', $data['q_describe_yourself'] );
 		add_post_meta( $post_id, 'Primary organizer WordPress.org username', $data['q_wporg_username'] );
 		add_post_meta( $post_id, 'Slack', $data['q_wp_slack_username'] );
 		add_post_meta( $post_id, 'Date Applied', time() );
-		add_post_meta( $post_id, 'Extra Comments', $data['q_additional_comments'] );
 		add_post_meta( $post_id, 'Meetup Location', $data['q_mtp_loc'] );
 
 		$status_log_id = add_post_meta(

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -187,6 +187,7 @@ class Meetup_Application extends Event_Application {
 			'q_community_interest'	=> '',
 			'q_wporg_username'      => '',
 			'q_wp_slack_username'   => '',
+			'q_anything_else'				=> '',
 		);
 
 		return $values;

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -139,6 +139,7 @@ class Meetup_Application extends Event_Application {
 			'q_mtp_loc',
 			'q_already_a_meetup',
 			'q_introduction',
+			'q_socialmedia',
 			'q_wporg_username',
 		);
 
@@ -179,6 +180,7 @@ class Meetup_Application extends Event_Application {
 			'q_already_a_meetup'    => '',
 			'q_existing_meetup_url' => '',
 			'q_introduction'				=> '',
+			'q_socialmedia'					=> '',
 			'q_wporg_username'      => '',
 			'q_wp_slack_username'   => '',
 		);

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -141,6 +141,7 @@ class Meetup_Application extends Event_Application {
 			'q_introduction',
 			'q_socialmedia',
 			'q_reasons_plans',
+			'q_community_interest',
 			'q_wporg_username',
 		);
 
@@ -183,6 +184,7 @@ class Meetup_Application extends Event_Application {
 			'q_introduction'				=> '',
 			'q_socialmedia'					=> '',
 			'q_reasons_plans'				=> '',
+			'q_community_interest'	=> '',
 			'q_wporg_username'      => '',
 			'q_wp_slack_username'   => '',
 		);

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -140,6 +140,7 @@ class Meetup_Application extends Event_Application {
 			'q_already_a_meetup',
 			'q_introduction',
 			'q_socialmedia',
+			'q_reasons_plans',
 			'q_wporg_username',
 		);
 
@@ -181,6 +182,7 @@ class Meetup_Application extends Event_Application {
 			'q_existing_meetup_url' => '',
 			'q_introduction'				=> '',
 			'q_socialmedia'					=> '',
+			'q_reasons_plans'				=> '',
 			'q_wporg_username'      => '',
 			'q_wp_slack_username'   => '',
 		);

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -22,7 +22,7 @@ class WordCamp_Forms_To_Drafts {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_filter( 'forms_worg_login_required',	array( $this, 'forms_worg_login_required'		), 10, 2 );
+		add_filter( 'forms_worg_login_required',	array( $this, 'forms_worg_login_required'		), 10		 );
 		add_action( 'template_redirect',        	array( $this, 'populate_form_based_on_user' ),  9    );
 		add_action( 'grunion_pre_message_sent',		array( $this, 'call_for_sponsors'           ), 10, 3 );
 		add_action( 'grunion_pre_message_sent',		array( $this, 'call_for_speakers'           ), 10, 3 );

--- a/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
@@ -26,9 +26,9 @@ function get_require_settings() {
 }
 
 function maybe_require_login() {
-  // if ( is_user_logged_in() ) {
-  //   return false;
-  // }
+  if ( is_user_logged_in() ) {
+    return false;
+  }
 
   $require = false;
   $require_settings = get_require_settings();

--- a/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
@@ -16,6 +16,7 @@ add_filter( 'the_content', __NAMESPACE__ . '\force_login_to_use_form', 15 );
 
 function get_require_settings() {
   return array(
+    // Meetup organizer application
     '3070672' => array(
       'start'   => '<form id="meetup-application"',
       'end'     => '</form>',
@@ -42,11 +43,10 @@ function maybe_require_login() {
 
   // Return settings for this spesific require case
   if ( isset( $require_settings[ $require ] ) ) {
-    return apply_filters( 'forms_worg_login_required', $require_settings[ $require ], $require );
+    $require = $require_settings[ $require ];
   }
 
-  // No setting for this require case, return no require adisory
-  return false;
+  return apply_filters( 'forms_worg_login_required', $require );
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
@@ -1,0 +1,106 @@
+<?php
+/*
+Plugin Name: WordCamp Forms WordPress.org login requirement
+Description:
+Version:     0.1
+Author:      WordCamp Central
+Author URI:  http://wordcamp.org
+*/
+
+namespace WordCamp\Forms_Worg_Login_Requirement;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'wp_print_styles', __NAMESPACE__ . '\print_front_end_styles' );
+add_filter( 'the_content', __NAMESPACE__ . '\force_login_to_use_form', 15 );
+
+function get_require_settings() {
+  return array(
+    '3070672' => array(
+      'start'   => '<form id="meetup-application"',
+      'end'     => '</form>',
+      'message' => sprintf( __( 'Before submitting your Meetup Organizer Application, please <a href="%s">log in to WordCamp.org</a> using your <strong>WordPress.org</strong>* account.', 'wordcamporg' ), wp_login_url( get_permalink() ) ),
+    ),
+  );
+}
+
+function maybe_require_login() {
+  // if ( is_user_logged_in() ) {
+  //   return false;
+  // }
+
+  $require = false;
+  $require_settings = get_require_settings();
+
+  // Check central.wordcamp.org pages
+  if ( is_main_site() ) {
+    // Meetup organizer application
+    if ( 3070672 === get_the_id() ) {
+      $require = '3070672';
+    }
+  }
+
+  // Return settings for this spesific require case
+  if ( isset( $require_settings[ $require ] ) ) {
+    return apply_filters( 'forms_worg_login_required', $require_settings[ $require ], $require );
+  }
+
+  // No setting for this require case, return no require adisory
+  return false;
+}
+
+/**
+ * Print CSS for the front-end
+ */
+function print_front_end_styles() {
+  if ( ! maybe_require_login() ) {
+    return;
+  } ?>
+
+  <style>
+    <?php require_once( __DIR__ . '/front-end.css' ); ?>
+  </style>
+
+<?php }
+
+/**
+ * Force user to login to use certain forms.
+ *
+ * @param string $content
+ *
+ * @return string
+ */
+function force_login_to_use_form( $content ) {
+  $require_settings = maybe_require_login();
+
+  if ( ! $require_settings ) {
+    return $content;
+  }
+
+  return inject_disabled_form_elements( $content, $require_settings['start'], $require_settings['end'], $require_settings['message'] );
+}
+
+/**
+ * Inject the HTML elements that are used to disable a form until the user logs in
+ *
+ * @param string $content
+ * @param string $please_login_message
+ *
+ * @return string
+ */
+function inject_disabled_form_elements( $content, $el_start, $el_end, $please_login_message ) {
+  $please_login_message = str_replace(
+    __( 'Please use your <strong>WordPress.org</strong>* account to log in.', 'wordcamporg' ),
+    $please_login_message,
+    wcorg_login_message( '', get_permalink() )
+  );
+
+  // Prevent wpautop() from converting tabs into empty paragraphs in #wcorg-login-message.
+  $please_login_message = trim( str_replace( "\t", '', $please_login_message ) );
+
+  $form_wrapper = '<div class="wcfd-disabled-form">' . $please_login_message . '<div class="wcfd-overlay"></div> '. $el_start;
+  $content      = str_replace( $el_start, $form_wrapper, $content );
+  $content      = str_replace( $el_end, $el_end . '</div>', $content );
+
+  return $content;
+}

--- a/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/forms-worg-login-requirement.php
@@ -26,27 +26,12 @@ function get_require_settings() {
 }
 
 function maybe_require_login() {
+  // Always false if user is already logged in
   if ( is_user_logged_in() ) {
     return false;
   }
 
-  $require = false;
-  $require_settings = get_require_settings();
-
-  // Check central.wordcamp.org pages
-  if ( is_main_site() ) {
-    // Meetup organizer application
-    if ( 3070672 === get_the_id() ) {
-      $require = '3070672';
-    }
-  }
-
-  // Return settings for this spesific require case
-  if ( isset( $require_settings[ $require ] ) ) {
-    $require = $require_settings[ $require ];
-  }
-
-  return apply_filters( 'forms_worg_login_required', $require );
+  return apply_filters( 'forms_worg_login_required', false );
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/front-end.css
+++ b/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/front-end.css
@@ -55,9 +55,3 @@
 body.page-slug-meetup-organizer-application .wcfd-disabled-form {
   width: 690px;
 }
-
-@media screen and ( min-width: 470px ) {
-  .wcfd-disabled-form #wcorg-login-message {
-    margin: 4em;
-  }
-}

--- a/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/front-end.css
+++ b/public_html/wp-content/plugins/wordcamp-forms-worg-login-requirement/front-end.css
@@ -1,0 +1,63 @@
+.wcfd-disabled-form {
+  position: relative;
+}
+
+  .wcfd-disabled-form #wcorg-login-message {
+    position: absolute;
+    z-index: 10;
+    margin: 2.4em;
+    padding: 1.8em;
+    background-color: #c62828;
+    border-radius: .25em;
+    margin-bottom: 2em;
+  }
+
+    .wcfd-disabled-form #wcorg-login-message p {
+      color: white !important /* !important to prevent theme from unintentionally overriding */;
+      font-size: 16px !important /* !important to prevent theme from unintentionally overriding */;
+    }
+
+      .wcfd-disabled-form #wcorg-login-message p:first-child {
+        font-size: 19px !important /* !important to prevent theme from unintentionally overriding */;
+      }
+
+      .wcfd-disabled-form #wcorg-login-message p:last-child {
+        margin-bottom: 0;
+      }
+
+      .wcfd-disabled-form #wcorg-login-message a {
+        color: white !important /* !important to prevent theme from unintentionally overriding */;
+        text-decoration: underline double white !important /* !important to prevent theme from unintentionally overriding */;
+        font-weight: normal;
+      }
+
+      .wcfd-disabled-form #wcorg-login-message a:hover,
+      .wcfd-disabled-form #wcorg-login-message a:focus,
+      .wcfd-disabled-form #wcorg-login-message a:active {
+        color: black !important /* !important to prevent theme from unintentionally overriding */;
+        text-decoration-color: white !important /* !important to prevent theme from unintentionally overriding */;
+        background: white !important;
+      }
+
+  .wcfd-overlay {
+    position: absolute;
+    z-index: 5;
+    width: 100%;
+    height: 100%;
+    background-color: black;
+    opacity: .5;
+  }
+
+  .wcfd-disabled-form div[id^="contact-form-"] {
+    padding: 1.8em;
+  }
+
+body.page-slug-meetup-organizer-application .wcfd-disabled-form {
+  width: 690px;
+}
+
+@media screen and ( min-width: 470px ) {
+  .wcfd-disabled-form #wcorg-login-message {
+    margin: 4em;
+  }
+}

--- a/public_html/wp-content/wp-cache-config.php
+++ b/public_html/wp-content/wp-cache-config.php
@@ -24,13 +24,13 @@ $wp_cache_no_cache_for_get     = 0;
 $wp_cache_disable_utf8         = 0;
 $cache_page_secret             = WP_CACHE_PAGE_SECRET;
 $cache_domain_mapping          = '1';
-$wp_cache_mobile_groups        = '';
-$wp_cache_mobile_prefixes      = 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-';
+$wp_cache_mobile_groups = '';
+$wp_cache_mobile_prefixes = 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-';
 $wp_cache_refresh_single_only  = 0;
 $wp_cache_mod_rewrite          = 0;
 $wp_cache_front_page_checks    = 0;
 $wp_supercache_304             = 0;
-$wp_cache_slash_check          = 1;
+$wp_cache_slash_check = 1;
 $wpsc_fix_164                  = 1;
 $wpsc_save_headers             = 0;
 $wp_cache_mfunc_enabled        = 0;
@@ -72,7 +72,7 @@ if ( '/' != substr( $cache_path, -1 ) ) {
 
 $wp_cache_mobile           = 0;
 $wp_cache_mobile_whitelist = 'Stand Alone/QNws';
-$wp_cache_mobile_browsers  = '2.0 MMP, 240x320, 400X240, AvantGo, BlackBerry, Blazer, Cellphone, Danger, DoCoMo, Elaine/3.0, EudoraWeb, Googlebot-Mobile, hiptop, IEMobile, KYOCERA/WX310K, LG/U990, MIDP-2., MMEF20, MOT-V, NetFront, Newt, Nintendo Wii, Nitro, Nokia, Opera Mini, Palm, PlayStation Portable, portalmmm, Proxinet, ProxiNet, SHARP-TQ-GX10, SHG-i900, Small, SonyEricsson, Symbian OS, SymbianOS, TS21i-10, UP.Browser, UP.Link, webOS, Windows CE, WinWAP, YahooSeeker/M1A1-R2D2, iPhone, iPod, iPad, Android, BlackBerry9530, LG-TU915 Obigo, LGE VX, webOS, Nokia5800';
+$wp_cache_mobile_browsers = '2.0 MMP, 240x320, 400X240, AvantGo, BlackBerry, Blazer, Cellphone, Danger, DoCoMo, Elaine/3.0, EudoraWeb, Googlebot-Mobile, hiptop, IEMobile, KYOCERA/WX310K, LG/U990, MIDP-2., MMEF20, MOT-V, NetFront, Newt, Nintendo Wii, Nitro, Nokia, Opera Mini, Palm, PlayStation Portable, portalmmm, Proxinet, ProxiNet, SHARP-TQ-GX10, SHG-i900, Small, SonyEricsson, Symbian OS, SymbianOS, TS21i-10, UP.Browser, UP.Link, webOS, Windows CE, WinWAP, YahooSeeker/M1A1-R2D2, iPhone, iPod, iPad, Android, BlackBerry9530, LG-TU915 Obigo, LGE VX, webOS, Nokia5800';
 
 $wp_cache_plugins_dir = WP_CONTENT_DIR . '/wp-super-cache-plugins';
 


### PR DESCRIPTION
This PR contains Meetup organizer application changes as per #321.

It also contains refactored WordPress.org login prompt. Code for that is based on functionality that was previously in `wordcamp-forms-to-drafts` plugin and bound only to the speaker submission form. PR introduces new plugin `wordcamp-forms-worg-login-requirement` that drives the same thing but all content behind a login is configured via filter. The plugin should be network activated in order to work.

Currently, this PR enables filters to speaker submission and meetup organizer application forms. For logged-in users, the prompt is never shown.

The only downside with the way how this plugin works is if `the_content` has multiple forms. Then things can break. But we can't detect reliably the forms otherwise than using `<form` tag if we don't make this with a javascript that has its own downsides.

Also slight style change on the prompt for better readability.

### Screenshots

**Old prompt**
![](https://i.imgur.com/a5Vy3CO.png)

**New prompt**
![](https://i.imgur.com/FL5WNrn.png)

### How to test the changes in this Pull Request:

1. Network activate the `WordCamp Forms WordPress.org login requirement` plugin
2. Go to https://central.wordcamp.test/meetup-organizer-application in private browsing and you should see a login prompt
3. Log-in to wordcamp.test
4. Now visit the meetup organizer application page again and form should be visible with few fields prefilled

To test the speaker submission form:

2. Create a new testing WordCamp site
3. Publish the call for speakers post
4. Visit the call for speakers post in private browsing and you should see a login prompt
5. Log-in to wordcamp.test
5. Now you should see the form

