### PR TITLE
Sessions: Save & display date using the correct timezone

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -6,7 +6,6 @@ import { findLastIndex, reverse, sortBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __experimentalGetSettings } from '@wordpress/date';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -52,7 +51,6 @@ function fetchFromAPI() {
  * @return {Array} A list of objects, `{track, now, next}`.
  */
 export function getCurrentSessions( { sessions, tracks } ) {
-	const tzOffset = __experimentalGetSettings().timezone.offset * ( 60 * 60 * 1000 );
 	const nowTimestamp = window.WordCampBlocks[ 'live-schedule' ].nowOverride || Date.now();
 
 	const trackListWithSessions = tracks.length ?
@@ -82,7 +80,7 @@ export function getCurrentSessions( { sessions, tracks } ) {
 		// Check if we're more than a day out from the earliest session (so that we don't show "up next" before
 		// the WordCamp starts).
 		const firstSession = sessionsInTrack[ sessionsInTrack.length - 1 ];
-		const firstSessionTimestamp = ( firstSession.meta._wcpt_session_time * 1000 ) - tzOffset;
+		const firstSessionTimestamp = firstSession.meta._wcpt_session_time * 1000;
 		const dayInMiliseconds = 24 * 60 * 60 * 1000;
 		if ( nowTimestamp < ( firstSessionTimestamp - dayInMiliseconds ) ) {
 			return {};
@@ -90,7 +88,7 @@ export function getCurrentSessions( { sessions, tracks } ) {
 
 		const index = sessionsInTrack.findIndex( ( { meta } ) => {
 			const duration = ( meta._wcpt_session_duration || window.WordCampBlocks[ 'live-schedule' ].fallbackDuration ) * 1000;
-			const startTimestamp = ( meta._wcpt_session_time * 1000 ) - tzOffset;
+			const startTimestamp = meta._wcpt_session_time * 1000;
 			const endTimestamp = startTimestamp + duration;
 
 			// Start time before now, end time after now.
@@ -103,7 +101,7 @@ export function getCurrentSessions( { sessions, tracks } ) {
 			// If nothing is found for "now", see if anything is coming up next by looking for the earliest thing
 			// that's later than now.
 			nextIndex = findLastIndex( sessionsInTrack, ( { meta } ) => {
-				const startTimestamp = ( meta._wcpt_session_time * 1000 ) - tzOffset;
+				const startTimestamp = meta._wcpt_session_time * 1000;
 				return ( startTimestamp > nowTimestamp );
 			} );
 		}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -81,8 +81,8 @@ setup_postdata( $session );
 						printf(
 							/* translators: 1: A date; 2: A time; 3: A location; */
 							esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
-							esc_html( date_i18n( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-							esc_html( date_i18n( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
+							esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
+							esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
 							sprintf(
 								'<span class="wordcamp-sessions__track slug-%s">%s</span>',
 								esc_attr( $tracks[0]->slug ),
@@ -94,8 +94,8 @@ setup_postdata( $session );
 						printf(
 							/* translators: 1: A date; 2: A time; */
 							esc_html__( '%1$s at %2$s', 'wordcamporg' ),
-							esc_html( date_i18n( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-							esc_html( date_i18n( get_option( 'time_format' ), $session->_wcpt_session_time ) )
+							esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
+							esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) )
 						);
 					endif; ?>
 				</div>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
@@ -70,8 +70,8 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 									printf(
 										/* translators: 1: A date; 2: A time; 3: A location; */
 										esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
-										esc_html( date_i18n( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-										esc_html( date_i18n( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
+										esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
+										esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
 										esc_html( $tracks[0]->name )
 									);
 								?>
@@ -81,8 +81,8 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 									printf(
 										/* translators: 1: A date; 2: A time; */
 										esc_html__( '%1$s at %2$s', 'wordcamporg' ),
-										esc_html( date_i18n( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-										esc_html( date_i18n( get_option( 'time_format' ), $session->_wcpt_session_time ) )
+										esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
+										esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) )
 									);
 								?>
 							<?php endif; ?>

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -236,7 +236,7 @@ function generate_plaintext_fav_sessions( $sessions_rev, $fav_sessions_lookup ) 
 			}
 
 			// Line format: Time of session | Session title [by Speaker] | Track name(s).
-			$sessions_text .= date( get_option( 'time_format' ), $timestamp );
+			$sessions_text .= wp_date( get_option( 'time_format' ), $timestamp );
 			$sessions_text .= ' | ';
 			$sessions_text .= $session_title;
 			if ( count( $speakers_names ) > 0 ) {
@@ -265,7 +265,7 @@ function get_sessions_dates( $sessions, $date_format ) {
 
 	$session_dates = array_map(
 		function( $timestamp ) use ( $date_format ) {
-			return date( $date_format, $timestamp );
+			return wp_date( $date_format, $timestamp );
 		},
 		$session_timestamps
 	);
@@ -341,7 +341,7 @@ function generate_email_body( $wordcamp_name, $fav_sessions_lookup ) {
 		$sessions_for_current_day = array_filter(
 			$sessions_reversed,
 			function( $date_ ) use ( $current_day, $date_format ) {
-				return date( $date_format, $date_ ) === $current_day;
+				return wp_date( $date_format, $date_ ) === $current_day;
 			},
 			ARRAY_FILTER_USE_KEY
 		);

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -110,8 +110,8 @@ function register_additional_rest_fields() {
 				);
 
 				if ( $raw ) {
-					$return['date'] = date_i18n( get_option( 'date_format' ), $raw );
-					$return['time'] = date_i18n( get_option( 'time_format' ), $raw );
+					$return['date'] = wp_date( get_option( 'date_format' ), $raw );
+					$return['time'] = wp_date( get_option( 'time_format' ), $raw );
 				}
 
 				return $return;

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -29,11 +29,28 @@ function expose_public_post_meta() {
 	$default_integer = wp_parse_args( array( 'type' => 'integer' ), $meta_defaults );
 
 	// Session.
-	register_post_meta( 'wcb_session', '_wcpt_session_time',     $default_integer );
 	register_post_meta( 'wcb_session', '_wcpt_session_duration', $default_integer );
 	register_post_meta( 'wcb_session', '_wcpt_session_type', $meta_defaults );
 	register_post_meta( 'wcb_session', '_wcpt_session_slides', $meta_defaults );
 	register_post_meta( 'wcb_session', '_wcpt_session_video', $meta_defaults );
+
+	register_post_meta(
+		'wcb_session',
+		'_wcpt_session_time',
+		array(
+			'show_in_rest' => array(
+				'prepare_callback' => function( $value, $request, $args ) {
+					if ( $request->get_param( 'wc_session_utc' ) ) {
+						$datetime = date_create( wp_date( 'Y-m-d\TH:i:s\Z', $value ) );
+						return $datetime->getTimestamp();
+					}
+					return (int) $value;
+				},
+			),
+			'single'       => true,
+			'type'         => 'integer',
+		)
+	);
 
 	// Sponsor.
 	register_post_meta( 'wcb_sponsor', '_wcpt_sponsor_website', $meta_defaults );
@@ -247,6 +264,13 @@ function add_meta_collection_params( $query_params, $post_type ) {
 	$query_params['wc_meta_value'] = array(
 		'description' => __( 'Limit result set to posts with a specific meta value. Use in conjunction with the wc_meta_key parameter.', 'wordcamporg' ),
 		'type'        => 'string',
+	);
+
+	// Add a parameter for the faux-UTC time.
+	$query_params['wc_session_utc'] = array(
+		'description' => __( 'Toggle the legacy timestamp.', 'wordcamporg' ),
+		'type'        => 'boolean',
+		'default'     => false,
 	);
 
 	return $query_params;

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1269,8 +1269,8 @@ class WordCamp_Post_Types_Plugin {
 			$session_time        = ( isset( $wordcamp_start_date ) ) ? $wordcamp_start_date : 0;
 		}
 
-		$session_date     = ( $session_time ) ? wp_date( 'Y-m-d', $session_time ) : date( 'Y-m-d' );
-		$session_hours    = ( $session_time ) ? wp_date( 'g', $session_time )     : date( 'g' );
+		$session_date     = ( $session_time ) ? wp_date( 'Y-m-d', $session_time ) : wp_date( 'Y-m-d' );
+		$session_hours    = ( $session_time ) ? wp_date( 'g', $session_time )     : wp_date( 'g' );
 		$session_minutes  = ( $session_time ) ? wp_date( 'i', $session_time )     : '00';
 		$session_meridiem = ( $session_time ) ? wp_date( 'a', $session_time )     : 'am';
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1521,14 +1521,19 @@ class WordCamp_Post_Types_Plugin {
 
 		if ( isset( $_POST['wcpt-meta-session-info'] ) && wp_verify_nonce( $_POST['wcpt-meta-session-info'], 'edit-session-info' ) ) {
 			// Update session time.
-			$session_time = strtotime( sprintf(
-				'%s %d:%02d %s',
-				sanitize_text_field( $_POST['wcpt-session-date'] ),
-				absint( $_POST['wcpt-session-hour'] ),
-				absint( $_POST['wcpt-session-minutes'] ),
-				'am' === $_POST['wcpt-session-meridiem'] ? 'am' : 'pm'
-			) );
-			update_post_meta( $post_id, '_wcpt_session_time', $session_time );
+			$session_time = date_create(
+				sprintf(
+					'%s %d:%02d %s',
+					sanitize_text_field( $_POST['wcpt-session-date'] ),
+					absint( $_POST['wcpt-session-hour'] ),
+					absint( $_POST['wcpt-session-minutes'] ),
+					'am' === $_POST['wcpt-session-meridiem'] ? 'am' : 'pm'
+				),
+				wp_timezone()
+			);
+			if ( $session_time ) {
+				update_post_meta( $post_id, '_wcpt_session_time', $session_time->getTimestamp() );
+			}
 
 			$duration = absint(
 				( $_POST['wcpt-session-duration-hours']   * HOUR_IN_SECONDS ) +

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -509,8 +509,8 @@ class WordCamp_Post_Types_Plugin {
 			$global_session      = count( $columns ) === $colspan ? ' global-session' : '';
 			$global_session_slug = $global_session ? ' ' . sanitize_html_class( sanitize_title_with_dashes( $session->post_title ) ) : '';
 
-			$html .= sprintf( '<tr class="%s">', sanitize_html_class( 'wcpt-time-' . date( $time_format, $time ) ) . $global_session . $global_session_slug );
-			$html .= sprintf( '<td class="wcpt-time">%s</td>', str_replace( ' ', '&nbsp;', esc_html( date( $time_format, $time ) ) ) );
+			$html .= sprintf( '<tr class="%s">', sanitize_html_class( 'wcpt-time-' . wp_date( $time_format, $time ) ) . $global_session . $global_session_slug );
+			$html .= sprintf( '<td class="wcpt-time">%s</td>', str_replace( ' ', '&nbsp;', esc_html( wp_date( $time_format, $time ) ) ) );
 			$html .= $columns_html;
 			$html .= '</tr>';
 		}
@@ -1269,10 +1269,10 @@ class WordCamp_Post_Types_Plugin {
 			$session_time        = ( isset( $wordcamp_start_date ) ) ? $wordcamp_start_date : 0;
 		}
 
-		$session_date     = ( $session_time ) ? date( 'Y-m-d', $session_time ) : date( 'Y-m-d' );
-		$session_hours    = ( $session_time ) ? date( 'g', $session_time )     : date( 'g' );
-		$session_minutes  = ( $session_time ) ? date( 'i', $session_time )     : '00';
-		$session_meridiem = ( $session_time ) ? date( 'a', $session_time )     : 'am';
+		$session_date     = ( $session_time ) ? wp_date( 'Y-m-d', $session_time ) : date( 'Y-m-d' );
+		$session_hours    = ( $session_time ) ? wp_date( 'g', $session_time )     : date( 'g' );
+		$session_minutes  = ( $session_time ) ? wp_date( 'i', $session_time )     : '00';
+		$session_meridiem = ( $session_time ) ? wp_date( 'a', $session_time )     : 'am';
 
 		$session_duration         = $post->_wcpt_session_duration ?? self::SESSION_DEFAULT_DURATION;
 		$session_duration_hours   = floor( $session_duration / HOUR_IN_SECONDS );
@@ -2076,7 +2076,7 @@ class WordCamp_Post_Types_Plugin {
 
 			case 'wcb_session_time':
 				$session_time = absint( get_post_meta( get_the_ID(), '_wcpt_session_time', true ) );
-				$session_time = ( $session_time ) ? date( get_option( 'time_format' ), $session_time ) : '&mdash;';
+				$session_time = ( $session_time ) ? wp_date( get_option( 'time_format' ), $session_time ) : '&mdash;';
 				echo esc_html( $session_time );
 				break;
 


### PR DESCRIPTION
This PR updates session date (`_wcpt_session_time`) displays to output a timezone-aware date. It also replaces `strtotime` with `date_create` when saving the timestamp, to generate the correct timestamp value. Lastly, it removes the (now unnecessary) timezone computation from the Live Schedule block.

Fixes #226 

This will need to be merged right before running the session time fixer script (see https://github.com/WordPress/wordcamp.org/issues/226#issuecomment-577916924), but this means sites will display the wrong time until all are fixed. On the other hand, waiting until after will have the sites that get fixed displaying incorrectly as the script runs.  Thoughts❓

Edit: I think the script will take about 10-15min to run, so it's not a large window either way.

### How to test the changes in this Pull Request:

1. Set a timezone on your site, if not done already
2. Add/edit some sessions with times
3. Check that the right value is saved:
    - `wp post meta get <id> _wcpt_session_time`
    - Go to `https://www.unixtimeconverter.io/[value]`
    - It should show you the timestamp value in UTC & your timezone, unless you set the site timezone to UTC+0, the UTC version _should not_ be the session time
4. Check that the date displays correctly…
    - in the datepicker for the session
    - in the session list table
    - in the schedule shortcode
    - anywhere else a human-readable date is output
5. Check that the live schedule is calculating correctly (see #324 for LS test instructions)