### PR TITLE
Speaker Feedback: Add base plugin file and comment type functions

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback;
+
+use WP_Comment;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Feedback
+ *
+ * A wrapper for WP_Comment that allows access to comment meta in a similar way to WP_Post.
+ *
+ * @package WordCamp\SpeakerFeedback
+ */
+class Feedback {
+	/**
+	 * @var WP_Comment|null
+	 */
+	protected $wp_comment = null;
+
+	/**
+	 * Feedback constructor.
+	 *
+	 * @param WP_Comment $wp_comment
+	 */
+	public function __construct( WP_Comment $wp_comment ) {
+		$this->wp_comment = $wp_comment;
+	}
+
+	/**
+	 * Enable getting props directly from the WP_Comment instance and comment meta.
+	 *
+	 * @param string $name
+	 *
+	 * @return mixed
+	 */
+	public function __get( $name ) {
+		if ( property_exists( $this->wp_comment, $name ) ) {
+			return $this->wp_comment->$name;
+		} else {
+			return get_comment_meta( $this->wp_comment->comment_ID, $name, true );
+		}
+	}
+
+	/**
+	 * Enable calling methods directly from the WP_Comment instance.
+	 *
+	 * @param string $name
+	 * @param array  $arguments
+	 *
+	 * @return mixed
+	 */
+	public function __call( $name, $arguments ) {
+		return call_user_func_array( array( $this->wp_comment, $name ), $arguments );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -91,3 +91,14 @@ function get_feedback( array $status = array( 'hold', 'approve' ), array $post__
 
 	return $feedback;
 }
+
+/**
+ * Trash a feedback submission.
+ *
+ * @param int $comment_id The ID of the comment to delete.
+ *
+ * @return bool
+ */
+function delete_feedback( $comment_id ) {
+	return wp_delete_comment( $comment_id );
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -7,7 +7,7 @@ use WordCamp\SpeakerFeedback\Feedback;
 
 defined( 'WPINC' ) || die();
 
-const COMMENT_TYPE = 'speaker-feedback';
+const COMMENT_TYPE = 'wordcamp-speaker-feedback';
 
 /**
  * Add a new feedback submission.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -11,9 +11,9 @@ const COMMENT_TYPE = 'speaker-feedback';
 /**
  * Add a new feedback submission.
  *
- * @param int           $post_id
- * @param array|WP_User $feedback_author
- * @param array         $feedback_meta
+ * @param int       $post_id         The ID of the post to attach the feedback to.
+ * @param array|int $feedback_author Either an array containing 'name' and 'email' values, or a user ID.
+ * @param array     $feedback_meta   An associative array of key => value pairs.
  *
  * @return false|int
  */
@@ -44,8 +44,8 @@ function add_feedback( $post_id, $feedback_author, array $feedback_meta ) {
  * The only parts of a feedback submission that we'd perhaps want to update after submission are the feedback rating
  * and questions that are stored in comment meta.
  *
- * @param int   $comment_id
- * @param array $feedback_meta
+ * @param int   $comment_id    The ID of the comment to update.
+ * @param array $feedback_meta An associative array of key => value pairs.
  *
  * @return int
  */
@@ -62,9 +62,9 @@ function update_feedback( $comment_id, array $feedback_meta ) {
 /**
  * Retrieve a list of feedback submissions.
  *
- * @param array $status
- * @param array $post__in
- * @param array $meta_query
+ * @param array $status     An array of statuses to include in the results.
+ * @param array $post__in   An array of post IDs whose feedback comments should be included.
+ * @param array $meta_query A valid `WP_Meta_Query` array.
  *
  * @return array A collection of WP_Comment objects.
  */

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -70,8 +70,10 @@ function update_feedback( $comment_id, array $feedback_meta ) {
  */
 function get_feedback( array $status = array( 'hold', 'approve' ), array $post__in = array(), array $meta_query = array() ) {
 	$args = array(
-		'status' => $status,
-		'type'   => COMMENT_TYPE,
+		'status'  => $status,
+		'type'    => COMMENT_TYPE,
+		'orderby' => 'comment_date',
+		'order'   => 'asc',
 	);
 
 	if ( ! empty( $post__in ) ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -25,8 +25,8 @@ function add_feedback( $post_id, $feedback_author, array $feedback_meta ) {
 		'comment_meta'     => $feedback_meta,
 	);
 
-	if ( $feedback_author instanceof WP_User ) {
-		$args['user_id'] = $feedback_author->ID;
+	if ( is_int( $feedback_author ) ) {
+		$args['user_id'] = $feedback_author;
 	} elseif ( isset( $feedback_author['name'], $feedback_author['email'] ) ) {
 		$args['comment_author']       = $feedback_author['name'];
 		$args['comment_author_email'] = $feedback_author['email'];

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Comment;
+
+use WP_User;
+
+defined( 'WPINC' ) || die();
+
+const COMMENT_TYPE = 'speaker-feedback';
+
+/**
+ * Add a new feedback submission.
+ *
+ * @param int           $post_id
+ * @param array|WP_User $feedback_author
+ * @param array         $feedback_meta
+ *
+ * @return false|int
+ */
+function add_feedback( $post_id, $feedback_author, array $feedback_meta ) {
+	$args = array(
+		'comment_approved' => 0, // "hold".
+		'comment_post_ID'  => $post_id,
+		'comment_type'     => COMMENT_TYPE,
+		'comment_meta'     => $feedback_meta,
+	);
+
+	if ( $feedback_author instanceof WP_User ) {
+		$args['user_id'] = $feedback_author->ID;
+	} elseif ( isset( $feedback_author['name'], $feedback_author['email'] ) ) {
+		$args['comment_author']       = $feedback_author['name'];
+		$args['comment_author_email'] = $feedback_author['email'];
+	} else {
+		// No author, bail.
+		return false;
+	}
+
+	return wp_insert_comment( $args );
+}
+
+/**
+ * Update an existing feedback submission.
+ *
+ * The only parts of a feedback submission that we'd perhaps want to update after submission are the feedback rating
+ * and questions that are stored in comment meta.
+ *
+ * @param int   $comment_id
+ * @param array $feedback_meta
+ *
+ * @return int
+ */
+function update_feedback( $comment_id, array $feedback_meta ) {
+	$args = array(
+		'comment_ID'   => $comment_id,
+		'comment_meta' => $feedback_meta,
+	);
+
+	return wp_update_comment( $args );
+}
+
+/**
+ * Retrieve a list of feedback submissions.
+ *
+ * @param array $status
+ * @param array $post__in
+ * @param array $meta_query
+ *
+ * @return array A collection of WP_Comment objects.
+ */
+function get_feedback( array $status = array( 'hold', 'approve' ), array $post__in = array(), array $meta_query = array() ) {
+	$args = array(
+		'status' => $status,
+		'type'   => COMMENT_TYPE,
+	);
+
+	if ( ! empty( $post__in ) ) {
+		$args['post__in'] = $post__in;
+	}
+
+	if ( ! empty( $meta_query ) ) {
+		$args['meta_query'] = $meta_query;
+	}
+
+	$feedback = get_comments( $args );
+
+	// This makes loading meta values for comments much faster.
+	wp_queue_comments_for_comment_meta_lazyload( $feedback );
+
+	return $feedback;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -2,8 +2,6 @@
 
 namespace WordCamp\SpeakerFeedback\Comment;
 
-use WP_User;
-
 defined( 'WPINC' ) || die();
 
 const COMMENT_TYPE = 'speaker-feedback';

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -55,6 +55,7 @@ function update_feedback( $comment_id, array $feedback_meta ) {
 		'comment_meta' => $feedback_meta,
 	);
 
+	// This will always return `0` because the comment itself does not get updated, only comment meta.
 	return wp_update_comment( $args );
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -2,6 +2,9 @@
 
 namespace WordCamp\SpeakerFeedback\Comment;
 
+use WP_Comment;
+use WordCamp\SpeakerFeedback\Feedback;
+
 defined( 'WPINC' ) || die();
 
 const COMMENT_TYPE = 'speaker-feedback';
@@ -82,12 +85,17 @@ function get_feedback( array $status = array( 'hold', 'approve' ), array $post__
 		$args['meta_query'] = $meta_query;
 	}
 
-	$feedback = get_comments( $args );
+	$comments = get_comments( $args );
 
 	// This makes loading meta values for comments much faster.
-	wp_queue_comments_for_comment_meta_lazyload( $feedback );
+	wp_queue_comments_for_comment_meta_lazyload( $comments );
 
-	return $feedback;
+	return array_map(
+		function( WP_Comment $comment ) {
+			return new Feedback( $comment );
+		},
+		$comments
+	);
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name:     WordCamp Speaker Feedback
+ * Plugin URI:      https://wordcamp.org
+ * Description:     Tools to provide feedback to speakers at WordCamp events.
+ * Author:          WordCamp.org
+ * Author URI:      https://wordcamp.org
+ * Version:         1
+ *
+ * @package         WordCamp\SpeakerFeedback
+ */
+
+namespace WordCamp\SpeakerFeedback;
+
+defined( 'WPINC' ) || die();
+
+define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
+define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
+
+

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -17,4 +17,11 @@ defined( 'WPINC' ) || die();
 define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
 
+/**
+ * Include the rest of the plugin.
+ */
+function load() {
+	require_once PLUGIN_DIR . 'includes/comment.php';
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -23,5 +23,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
  * Include the rest of the plugin.
  */
 function load() {
+	require_once PLUGIN_DIR . 'includes/class-feedback.php';
 	require_once PLUGIN_DIR . 'includes/comment.php';
 }


### PR DESCRIPTION
Gotta start somewhere.

This scaffolds the main plugin file and creates CRUD functions for managing comments of our custom type.

There isn't a function for the "D" in "CRUD" because `wp_delete_comment` is sufficient, and needs no wrapper method.

Fixes #338 

**To test**

1. Activate the plugin on a site in your local dev environment
1. Use `wp shell` to try running the CRUD functions:
  * `\WordCamp\SpeakerFeedback\Comment\get_feedback()` (do this one first to see that there aren't any submissions yet, then again after adding a submission)
  * `\WordCamp\SpeakerFeedback\Comment\add_feedback( {post ID}, array( 'name' => 'Foo', 'email' => 'foo@example.org' ), array( 'bar' => 'baz' ) )`
  * `\WordCamp\SpeakerFeedback\Comment\update_feedback( {comment ID}, array( 'bar' => 'bop', 'fizz' => 'bang' ) )`
  * `\WordCamp\SpeakerFeedback\Comment\delete_feedback( {comment ID} )`
1. To check that comment meta is getting added/updated, try accessing them as properties on the returned comment objects:
  * `$test = \WordCamp\SpeakerFeedback\Comment\get_feedback()`
  * `$test[0]->bar`