### PR TITLE
Speaker Feedback: Register API endpoints for feedback comments

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -33,6 +33,7 @@ require_once( $core_tests_directory . '/includes/functions.php' );
  */
 require_once( WP_PLUGIN_DIR . '/wordcamp-organizer-reminders/tests/bootstrap.php' );
 require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );
+require_once WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/tests/bootstrap.php';
 require_once WP_MU_PLUGIN_DIR . '/tests/bootstrap.php';
 
 /*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,5 +34,11 @@
 				./public_html/wp-content/plugins/wordcamp-remote-css/tests/
 			</directory>
 		</testsuite>
+
+		<testsuite name="WordCamp Speaker Feedback">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/
+			</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback;
+
+use WP_Error, WP_REST_Request, WP_REST_Response;
+use WP_REST_Comments_Controller;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+
+defined( 'WPINC' ) || die();
+
+
+class REST_Feedback_Controller extends WP_REST_Comments_Controller {
+	/**
+	 * REST_Feedback_Controller constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->namespace = 'wordcamp-speaker-feedback/v1';
+		$this->rest_base = 'feedback';
+	}
+
+	/**
+	 * Ensure a request has the correct parameters set for our feedback comment type.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Request
+	 */
+	protected function sanitize_request( $request ) {
+		$request['type'] = COMMENT_TYPE;
+
+		return $request;
+	}
+
+	/**
+	 * Retrieves a list of feedback items.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
+	 */
+	public function get_items( $request ) {
+		$request = $this->sanitize_request( $request );
+
+		return parent::get_items( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to read comments.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|bool True if the request has read access, error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$request = $this->sanitize_request( $request );
+
+		$default_comment_check = parent::get_item_permissions_check( $request );
+
+		if ( is_wp_error( $default_comment_check ) ) {
+			return $default_comment_check;
+		}
+
+		// TODO See #340.
+
+		return true;
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -208,6 +208,16 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 			);
 		}
 
+		if ( ! post_type_supports( get_post_type( $post ), 'wordcamp-speaker-feedback' ) ) {
+			return new WP_Error(
+				'rest_feedback_post_not_supported',
+				__( 'Sorry, this post type does not support feedback.', 'wordcamporg' ),
+				array(
+					'status' => 403,
+				)
+			);
+		}
+
 		if ( 'publish' !== $post->post_status ) {
 			return new WP_Error(
 				'rest_feedback_post_unavailable',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -4,12 +4,16 @@ namespace WordCamp\SpeakerFeedback;
 
 use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server;
 use WP_REST_Comments_Controller;
-use function WordCamp\SpeakerFeedback\Comment\{ add_feedback };
+use function WordCamp\SpeakerFeedback\Comment\add_feedback;
 use function WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta;
 
 defined( 'WPINC' ) || die();
 
-
+/**
+ * Class REST_Feedback_Controller
+ *
+ * @package WordCamp\SpeakerFeedback
+ */
 class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 	/**
 	 * REST_Feedback_Controller constructor.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -129,7 +129,7 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 			$error_code = $check_comment_lengths->get_error_code();
 			return new WP_Error(
 				$error_code,
-				__( 'Comment field exceeds maximum length allowed.' ),
+				__( 'Comment field exceeds maximum length allowed.', 'wordcamporg' ),
 				array(
 					'status' => 400,
 				)
@@ -164,7 +164,7 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		if ( false === $comment_id ) {
 			return new WP_Error(
 				'rest_feedback_creation_failed',
-				'Feedback submission failed.',
+				__( 'Feedback submission failed.', 'wordcamporg' ),
 				array(
 					'status' => 400,
 				)
@@ -190,7 +190,7 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		if ( empty( $request['post'] ) ) {
 			return new WP_Error(
 				'rest_feedback_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.' ),
+				__( 'Sorry, you are not allowed to create this comment without a post.', 'wordcamporg' ),
 				array(
 					'status' => 403,
 				)
@@ -201,7 +201,7 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		if ( ! $post ) {
 			return new WP_Error(
 				'rest_feedback_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.' ),
+				__( 'Sorry, you are not allowed to create this comment without a post.', 'wordcamporg' ),
 				array(
 					'status' => 403,
 				)
@@ -211,7 +211,7 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		if ( 'publish' !== $post->post_status ) {
 			return new WP_Error(
 				'rest_feedback_post_unavailable',
-				__( 'Sorry, you are not allowed to create a comment on this post.' ),
+				__( 'Sorry, you are not allowed to create a comment on this post.', 'wordcamporg' ),
 				array(
 					'status' => 403,
 				)

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -171,10 +171,10 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 			);
 		}
 
-		$response = __( 'Success!', 'wordcamporg' );
+		$response = array(); // At this point we have no reason to return details about the new feedback comment.
 		$response = rest_ensure_response( $response );
 
-		$response->set_status( 201 );
+		$response->set_status( 201 ); // This is a sufficient signal that the request was successful.
 
 		return $response;
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -101,12 +101,11 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 			return $allowed;
 		}
 
-		//$meta = validate_feedback_meta( $request['meta'] ?? array() );
-		$meta = array();
+		$meta = validate_feedback_meta( $request['meta'] ?? array() );
 
-		//if ( is_wp_error( $meta ) ) {
-		//	return $meta;
-		//}
+		if ( is_wp_error( $meta ) ) {
+			return $meta;
+		}
 
 		$comment_id = add_feedback( $prepared_feedback['comment_post_ID'], $feedback_author, $meta );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -2,9 +2,10 @@
 
 namespace WordCamp\SpeakerFeedback;
 
-use WP_Error, WP_REST_Request, WP_REST_Response;
+use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server;
 use WP_REST_Comments_Controller;
-use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+use function WordCamp\SpeakerFeedback\Comment\{ add_feedback };
+use function WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta;
 
 defined( 'WPINC' ) || die();
 
@@ -21,50 +22,128 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 	}
 
 	/**
-	 * Ensure a request has the correct parameters set for our feedback comment type.
+	 * Registers the routes for the objects of the controller.
 	 *
-	 * @param WP_REST_Request $request
+	 * Currently, the only route needed for feedback is `create`.
 	 *
-	 * @return WP_REST_Request
+	 * @return void
 	 */
-	protected function sanitize_request( $request ) {
-		$request['type'] = COMMENT_TYPE;
-
-		return $request;
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				),
+			)
+		);
 	}
 
 	/**
-	 * Retrieves a list of feedback items.
+	 * Creates a comment.
+	 *
+	 * Based off of WP_REST_Comments_Controller::create_item, but uses a specific custom comment type.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
 	 */
-	public function get_items( $request ) {
-		$request = $this->sanitize_request( $request );
+	public function create_item( $request ) {
+		if ( ! empty( $request['id'] ) ) {
+			return new WP_Error( 'rest_comment_exists', __( 'Cannot create existing feedback.', 'wordcamporg' ), array( 'status' => 400 ) );
+		}
 
-		return parent::get_items( $request );
+		$prepared_feedback = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $prepared_feedback ) ) {
+			return $prepared_feedback;
+		}
+
+		if ( ! isset( $prepared_feedback['comment_post_ID'] ) ) {
+			return new WP_Error( 'rest_comment_no_post', __( 'Feedback must be associated with a specific post.', 'wordcamporg' ), array( 'status' => 400 ) );
+		}
+
+		$feedback_author = null;
+		if ( ! empty( $prepared_feedback['user_id'] ) ) {
+			$feedback_author = absint( $prepared_feedback['user_id'] );
+		} elseif ( ! empty( $prepared_feedback['comment_author'] ) && ! empty( $prepared_feedback['comment_author_email'] ) ) {
+			$feedback_author = array(
+				'name'  => $prepared_feedback['comment_author'],
+				'email' => $prepared_feedback['comment_author_email'],
+			);
+		} else {
+			return new WP_Error( 'rest_comment_author_data_required', __( 'Submitting feedback requires valid author name and email values.', 'wordcamporg' ), array( 'status' => 400 ) );
+		}
+
+		$check_comment_lengths = wp_check_comment_data_max_lengths( $prepared_feedback );
+		if ( is_wp_error( $check_comment_lengths ) ) {
+			$error_code = $check_comment_lengths->get_error_code();
+			return new WP_Error( $error_code, __( 'Comment field exceeds maximum length allowed.' ), array( 'status' => 400 ) );
+		}
+
+		$allowed = wp_allow_comment( $prepared_feedback, true );
+
+		if ( is_wp_error( $allowed ) ) {
+			$error_code    = $allowed->get_error_code();
+			$error_message = $allowed->get_error_message();
+
+			if ( 'comment_duplicate' === $error_code ) {
+				return new WP_Error( $error_code, $error_message, array( 'status' => 409 ) );
+			}
+
+			if ( 'comment_flood' === $error_code ) {
+				return new WP_Error( $error_code, $error_message, array( 'status' => 400 ) );
+			}
+
+			return $allowed;
+		}
+
+		//$meta = validate_feedback_meta( $request['meta'] ?? array() );
+		$meta = array();
+
+		//if ( is_wp_error( $meta ) ) {
+		//	return $meta;
+		//}
+
+		$comment_id = add_feedback( $prepared_feedback['comment_post_ID'], $feedback_author, $meta );
+
+		if ( false === $comment_id ) {
+			return new WP_Error( 'feedback_creation_failed', 'Feedback submission failed.', array( 'status' => 400 ) );
+		}
+
+		$response = __( 'Success!', 'wordcamporg' );
+		$response = rest_ensure_response( $response );
+
+		$response->set_status( 201 );
+
+		return $response;
 	}
 
 	/**
-	 * Checks if a given request has access to read comments.
-	 *
-	 * @since 4.7.0
+	 * Checks if a given request has access to create a comment.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
-	 * @return WP_Error|bool True if the request has read access, error object otherwise.
+	 * @return WP_Error|bool True if the request has access to create items, error object otherwise.
 	 */
-	public function get_items_permissions_check( $request ) {
-		$request = $this->sanitize_request( $request );
-
-		$default_comment_check = parent::get_item_permissions_check( $request );
-
-		if ( is_wp_error( $default_comment_check ) ) {
-			return $default_comment_check;
+	public function create_item_permissions_check( $request ) {
+		if ( empty( $request['post'] ) ) {
+			return new WP_Error( 'rest_comment_invalid_post_id', __( 'Sorry, you are not allowed to create this comment without a post.' ), array( 'status' => 403 ) );
 		}
 
-		// TODO See #340.
+		$post = get_post( (int) $request['post'] );
+		if ( ! $post ) {
+			return new WP_Error( 'rest_comment_invalid_post_id', __( 'Sorry, you are not allowed to create this comment without a post.' ), array( 'status' => 403 ) );
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return new WP_Error( 'rest_comment_draft_post', __( 'Sorry, you are not allowed to create a comment on this post.' ), array( 'status' => 403 ) );
+		}
+
+		// TODO nonce check, other permissions?
 
 		return true;
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -141,14 +141,31 @@ function validate_feedback_meta( $meta ) {
 	if ( ! empty( $missing_fields ) ) {
 		return new WP_Error(
 			'feedback_missing_meta',
-			__( 'Please fill in all required fields.', 'wordcamporg' )
+			__( 'Please fill in all required fields.', 'wordcamporg' ),
+			array(
+				'missing_fields' => array_keys( $missing_fields ),
+			)
 		);
+	}
+
+	$integer_fields = array_keys( wp_list_pluck( $fields, 'type' ), 'integer', true );
+
+	foreach ( $integer_fields as $key ) {
+		if ( isset( $meta[ $key ] ) && ! is_numeric( $meta[ $key ] ) ) {
+			return new WP_Error(
+				'feedback_meta_not_numeric',
+				__( 'Feedback submission contains invalid data.', 'wordcamporg' ),
+				array(
+					'meta_key' => $key,
+				)
+			);
+		}
 	}
 
 	$string_fields = array_keys( wp_list_pluck( $fields, 'type' ), 'string', true );
 
 	foreach ( $string_fields as $key ) {
-		if ( mb_strlen( $meta[ $key ] ) > META_MAX_LENGTH ) {
+		if ( isset( $meta[ $key ] ) && mb_strlen( $meta[ $key ] ) > META_MAX_LENGTH ) {
 			return new WP_Error(
 				'feedback_meta_too_long',
 				__( 'Feedback submission is too long.', 'wordcamporg' ),

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -140,7 +140,7 @@ function validate_feedback_meta( $meta ) {
 
 	if ( ! empty( $missing_fields ) ) {
 		return new WP_Error(
-			'feedback_missing_meta',
+			'feedback_meta_missing_field',
 			__( 'Please fill in all required fields.', 'wordcamporg' ),
 			array(
 				'missing_fields' => array_keys( $missing_fields ),
@@ -167,7 +167,7 @@ function validate_feedback_meta( $meta ) {
 	foreach ( $string_fields as $key ) {
 		if ( isset( $meta[ $key ] ) && mb_strlen( $meta[ $key ] ) > META_MAX_LENGTH ) {
 			return new WP_Error(
-				'feedback_meta_too_long',
+				'feedback_meta_string_too_long',
 				__( 'Feedback submission is too long.', 'wordcamporg' ),
 				array(
 					'meta_key' => $key,

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -148,10 +148,13 @@ function validate_feedback_meta( $meta ) {
 	$string_fields = array_keys( wp_list_pluck( $fields, 'type' ), 'string', true );
 
 	foreach ( $string_fields as $key ) {
-		if ( mb_strlen( $meta[ $key ], '8bit' ) > META_MAX_LENGTH ) {
+		if ( mb_strlen( $meta[ $key ] ) > META_MAX_LENGTH ) {
 			return new WP_Error(
 				'feedback_meta_too_long',
-				__( 'Feedback submission is too long.', 'wordcamporg' )
+				__( 'Feedback submission is too long.', 'wordcamporg' ),
+				array(
+					'meta_key' => $key,
+				)
 			);
 		}
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\CommentMeta;
+
+use WP_Error;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+
+defined( 'WPINC' ) || die();
+
+const META_VERSION    = 1;
+const META_MAX_LENGTH = 5000;
+
+add_filter( 'get_object_subtype_comment', __NAMESPACE__ . '\add_comment_subtype', 10, 2 );
+add_action( 'init',                       __NAMESPACE__ . '\register_meta_fields' );
+
+/**
+ * Filter: Register a subtype for feedback comments.
+ *
+ * Unlike for posts, Core does not recognize subtypes for comment objects out-of-the-box.
+ *
+ * @param string $object_subtype
+ * @param int    $object_id
+ *
+ * @return string
+ */
+function add_comment_subtype( $object_subtype, $object_id ) {
+	$comment = get_comment( $object_id );
+
+	if ( COMMENT_TYPE === $comment->comment_type ) {
+		$object_subtype = $comment->comment_type;
+	}
+
+	return $object_subtype;
+}
+
+/**
+ * Register meta fields for the feedback comment subtype.
+ *
+ * This allows for automatic sanitization of meta values when storing and retrieving.
+ *
+ * Note that Core doesn't normally support subtypes for the comment object, even though it kind of
+ * supports comment types. See `add_comment_subtype` in this file.
+ *
+ * @return void
+ */
+function register_meta_fields() {
+	$fields = get_feedback_meta_field_schema();
+
+	foreach ( $fields as $key => $schema ) {
+		$schema['object_subtype'] = COMMENT_TYPE;
+
+		register_meta( 'comment', $key, $schema );
+	}
+}
+
+/**
+ * Define the properties of the feedback meta fields.
+ *
+ * @param string $key Optional. A specific key to get the schema for.
+ *
+ * @return array
+ */
+function get_feedback_meta_field_schema( $key = '' ) {
+	$schema = array(
+		'version' => array(
+			'description'       => 'The version of the feedback questions.',
+			'type'              => 'integer',
+			'single'            => true,
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => false,
+			'default'           => META_VERSION,
+			'required'          => true,
+		),
+		'rating'  => array(
+			'description'       => 'The rating. A number between 1 and 5.',
+			'type'              => 'integer',
+			'single'            => true,
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => false,
+			'default'           => 0,
+			'required'          => true,
+		),
+		'q1'      => array(
+			'description'       => 'The answer to the first feedback question.',
+			'type'              => 'string',
+			'single'            => true,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => false,
+			'default'           => '',
+			'required'          => false,
+		),
+		'q2'      => array(
+			'description'       => 'The answer to the second feedback question.',
+			'type'              => 'string',
+			'single'            => true,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => false,
+			'default'           => '',
+			'required'          => false,
+		),
+		'q3'      => array(
+			'description'       => 'The answer to the third feedback question.',
+			'type'              => 'string',
+			'single'            => true,
+			'sanitize_callback' => 'sanitize_text_field',
+			'show_in_rest'      => false,
+			'default'           => '',
+			'required'          => false,
+		),
+	);
+
+	if ( $key ) {
+		return $schema[ $key ] ?? array();
+	}
+
+	return $schema;
+}
+
+/**
+ * Check that an array of meta values has all required keys and contains valid data.
+ *
+ * @param array $meta
+ *
+ * @return array|WP_Error
+ */
+function validate_feedback_meta( $meta ) {
+	$fields = get_feedback_meta_field_schema();
+
+	$required_fields = array_filter(
+		wp_list_pluck( $fields, 'required' ),
+		function( $is_required ) {
+			return $is_required;
+		}
+	);
+
+	$missing_fields = array_diff_key( $required_fields, $meta );
+
+	if ( ! empty( $missing_fields ) ) {
+		return new WP_Error(
+			'feedback_missing_meta',
+			__( 'Please fill in all required fields.', 'wordcamporg' )
+		);
+	}
+
+	$string_fields = array_keys( wp_list_pluck( $fields, 'type' ), 'string', true );
+
+	foreach ( $string_fields as $key ) {
+		if ( mb_strlen( $meta[ $key ], '8bit' ) > META_MAX_LENGTH ) {
+			return new WP_Error(
+				'feedback_meta_too_long',
+				__( 'Feedback submission is too long.', 'wordcamporg' )
+			);
+		}
+	}
+
+	$meta['version'] = META_VERSION;
+
+	return $meta;
+}
+
+/**
+ *
+ *
+ * @param int $version
+ *
+ * @return array
+ */
+function get_feedback_questions( $version = META_VERSION ) {
+	/**
+	 * Versioned questions. The array key for each set of questions is the version number.
+	 *
+	 * If the questions below need to be modified, a new complete set should be added as an additional item in the
+	 * array, with a new version key. The `META_VERSION` constant in this file then needs to be updated to match the
+	 * latest key in the array.
+	 */
+	$questions = array(
+		1 => array(
+			'rating' => __( 'Rate this talk', 'wordcamporg' ),
+			'q1'     => __( "What's one good thing you'd keep in this presentation?", 'wordcamporg' ),
+			'q2'     => __( "What's one thing you'd tweak to improve the presentation?", 'wordcamporg' ),
+			'q3'     => __( "What's one unhelpful thing you'd delete from the presentation?", 'wordcamporg' ),
+		),
+	);
+
+	return $questions[ $version ] ?? array();
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -7,8 +7,7 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
-const META_VERSION    = 1;
-const META_MAX_LENGTH = 5000;
+const META_VERSION = 1;
 
 add_filter( 'get_object_subtype_comment', __NAMESPACE__ . '\add_comment_subtype', 10, 2 );
 add_action( 'init',                       __NAMESPACE__ . '\register_meta_fields' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -124,8 +124,11 @@ function get_feedback_meta_field_schema( $key = '' ) {
  * @return array|WP_Error
  */
 function validate_feedback_meta( $meta ) {
-	$fields = get_feedback_meta_field_schema();
+	if ( ! isset( $meta['version'] ) ) {
+		$meta['version'] = META_VERSION;
+	}
 
+	$fields          = get_feedback_meta_field_schema();
 	$required_fields = array_filter(
 		wp_list_pluck( $fields, 'required' ),
 		function( $is_required ) {
@@ -152,8 +155,6 @@ function validate_feedback_meta( $meta ) {
 			);
 		}
 	}
-
-	$meta['version'] = META_VERSION;
 
 	return $meta;
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -91,7 +91,7 @@ function get_feedback_meta_field_schema( $key = '' ) {
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => false,
 			'default'           => '',
-			'required'          => false,
+			'required'          => true,
 			'attributes'        => array(
 				'maxlength' => 5000,
 			),

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -10,6 +10,48 @@ defined( 'WPINC' ) || die();
 const COMMENT_TYPE = 'wc-speaker-feedback'; // Per the database schema, this must be <= 20 characters.
 
 /**
+ * Check if a comment is a feedback comment.
+ *
+ * @param WP_Comment|Feedback|string|int $comment A comment/feedback object or a comment ID.
+ *
+ * @return bool
+ */
+function is_feedback( $comment ) {
+	if ( is_string( $comment ) || is_int( $comment ) ) {
+		$comment = get_comment( $comment );
+	}
+
+	if ( $comment instanceof Feedback ) {
+		return true;
+	} elseif ( COMMENT_TYPE === $comment->comment_type ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Get a single feedback comment as a Feedback object.
+ *
+ * @param WP_Comment|Feedback|string|int $comment A comment/feedback object or a comment ID.
+ *
+ * @return Feedback|null A Feedback object, or null if the input is not a feedback comment.
+ */
+function get_feedback_comment( $comment ) {
+	if ( $comment instanceof Feedback ) {
+		return $comment;
+	}
+
+	$comment = get_comment( $comment );
+
+	if ( ! is_feedback( $comment ) ) {
+		return null;
+	}
+
+	return new Feedback( $comment );
+}
+
+/**
  * Add a new feedback submission.
  *
  * @param int       $post_id         The ID of the post to attach the feedback to.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -58,7 +58,7 @@ function get_feedback_comment( $comment ) {
  * @param array|int $feedback_author Either an array containing 'name' and 'email' values, or a user ID.
  * @param array     $feedback_meta   An associative array of key => value pairs.
  *
- * @return false|int
+ * @return int|bool Comment ID on success. `false` on failure.
  */
 function add_feedback( $post_id, $feedback_author, array $feedback_meta ) {
 	$args = array(
@@ -87,10 +87,10 @@ function add_feedback( $post_id, $feedback_author, array $feedback_meta ) {
  * The only parts of a feedback submission that we'd perhaps want to update after submission are the feedback rating
  * and questions that are stored in comment meta.
  *
- * @param int   $comment_id    The ID of the comment to update.
- * @param array $feedback_meta An associative array of key => value pairs.
+ * @param string|int $comment_id    The ID of the comment to update.
+ * @param array      $feedback_meta An associative array of key => value pairs.
  *
- * @return int
+ * @return int This will always return `0` because the comment itself does not get updated, only comment meta.
  */
 function update_feedback( $comment_id, array $feedback_meta ) {
 	$args = array(
@@ -98,7 +98,6 @@ function update_feedback( $comment_id, array $feedback_meta ) {
 		'comment_meta' => $feedback_meta,
 	);
 
-	// This will always return `0` because the comment itself does not get updated, only comment meta.
 	return wp_update_comment( $args );
 }
 
@@ -140,7 +139,7 @@ function get_feedback( array $status = array( 'hold', 'approve' ), array $post__
 /**
  * Trash a feedback submission.
  *
- * @param int $comment_id The ID of the comment to delete.
+ * @param string|int $comment_id The ID of the comment to delete.
  *
  * @return bool
  */

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -132,12 +132,9 @@ function get_feedback( array $status = array( 'hold', 'approve' ), array $post__
 	// This makes loading meta values for comments much faster.
 	wp_queue_comments_for_comment_meta_lazyload( $comments );
 
-	return array_map(
-		function( WP_Comment $comment ) {
-			return new Feedback( $comment );
-		},
-		$comments
-	);
+	$comments = array_map( __NAMESPACE__ . '\get_feedback_comment', $comments );
+
+	return $comments;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -7,7 +7,7 @@ use WordCamp\SpeakerFeedback\Feedback;
 
 defined( 'WPINC' ) || die();
 
-const COMMENT_TYPE = 'wordcamp-speaker-feedback';
+const COMMENT_TYPE = 'wc-speaker-feedback'; // Per the database schema, this must be <= 20 characters.
 
 /**
  * Add a new feedback submission.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WordCamp\SpeakerFeedback;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugins that we'll need to be active for the tests.
+ */
+function manually_load_plugin() {
+	require_once WP_MU_PLUGIN_DIR . '/3-helpers-misc.php';
+
+	// Initialize the plugin.
+	require_once dirname( __DIR__ )  . '/wordcamp-speaker-feedback.php';
+
+	SpeakerFeedback\load();
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -6,7 +6,7 @@ use WP_UnitTestCase;
 use WP_Post, WP_User;
 use WP_REST_Request, WP_REST_Response;
 use WordCamp\SpeakerFeedback\REST_Feedback_Controller;
-use const WordCamp\SpeakerFeedback\CommentMeta\{ META_VERSION };
+use function WordCamp\SpeakerFeedback\Comment\get_feedback;
 
 defined( 'WPINC' ) || die();
 
@@ -37,6 +37,11 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	protected $valid_meta;
 
 	/**
+	 * @var WP_REST_Request
+	 */
+	protected $request;
+
+	/**
 	 * Test_SpeakerFeedback_REST_Feedback_Controller constructor.
 	 *
 	 * @param null   $name
@@ -55,32 +60,96 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		$this->user = self::factory()->user->create_and_get();
 
 		$this->valid_meta = array(
-			'version' => META_VERSION,
-			'rating'  => 1,
-			'q1'      => 'asdf 1',
-			'q2'      => 'asdf 2',
-			'q3'      => 'asdf 3',
+			'rating' => 1,
+			'q1'     => 'asdf 1',
+			'q2'     => 'asdf 2',
+			'q3'     => 'asdf 3',
 		);
+
+		tests_add_filter( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->request = new WP_REST_Request( 'POST', '/wordcamp-speaker-feedback/v1/feedback' );
+	}
+
+	/**
+	 * Reset after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wpdb;
+
+		$ids = $wpdb->get_col( "SELECT comment_ID FROM {$wpdb->prefix}comments" );
+
+		// This ensures that only comments created during a given test exist in the database and cache during the test.
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}comments" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}commentmeta" );
+		clean_comment_cache( $ids );
 	}
 
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item()
 	 */
-	public function test_create_item() {
-		$request = new WP_REST_Request( 'POST', '/wordcamp-speaker-feedback/v1/feedback' );
-
+	public function test_create_item_user_id() {
 		$params = array(
 			'post'   => $this->session_post->ID,
 			'author' => $this->user->ID,
 			'meta'   => $this->valid_meta,
 		);
 
-		$request->set_body_params( $params );
+		$this->request->set_body_params( $params );
 
-		$response = $this->controller->create_item( $request );
+		$response = $this->controller->create_item( $this->request );
 
 		$this->assertTrue( $response instanceof WP_REST_Response );
 		$this->assertEquals( 201, $response->get_status() );
 		$this->assertEquals( 'Success!', $response->get_data() );
+		$this->assertEquals( 1, count( get_feedback() ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item()
+	 */
+	public function test_create_item_user_array() {
+		$params = array(
+			'post'         => $this->session_post->ID,
+			'author_name'  => 'Foo',
+			'author_email' => 'bar@example.org',
+			'meta'         => $this->valid_meta,
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = $this->controller->create_item( $this->request );
+
+		$this->assertTrue( $response instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 'Success!', $response->get_data() );
+		$this->assertEquals( 1, count( get_feedback() ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item()
+	 */
+	public function test_create_item_no_user() {
+		$params = array(
+			'post' => $this->session_post->ID,
+			'meta' => $this->valid_meta,
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = $this->controller->create_item( $this->request );
+
+		$this->assertTrue( is_wp_error( $response ) );
+		$this->assertEquals( 'rest_comment_author_data_required', $response->get_error_code() );
+		$this->assertEquals( 0, count( get_feedback() ) );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -111,7 +111,6 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 
 		$this->assertTrue( $response instanceof WP_REST_Response );
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( 'Success!', $response->get_data() );
 		$this->assertCount( 1, get_feedback() );
 	}
 
@@ -132,7 +131,6 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 
 		$this->assertTrue( $response instanceof WP_REST_Response );
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( 'Success!', $response->get_data() );
 		$this->assertCount( 1, get_feedback() );
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_UnitTestCase;
+use WP_Post, WP_User;
+use WP_REST_Request, WP_REST_Response;
+use WordCamp\SpeakerFeedback\REST_Feedback_Controller;
+use const WordCamp\SpeakerFeedback\CommentMeta\{ META_VERSION };
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_Comment
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
+	/**
+	 * @var REST_Feedback_Controller
+	 */
+	protected $controller;
+
+	/**
+	 * @var WP_Post
+	 */
+	protected $session_post;
+
+	/**
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * @var array
+	 */
+	protected $valid_meta;
+
+	/**
+	 * Test_SpeakerFeedback_REST_Feedback_Controller constructor.
+	 *
+	 * @param null   $name
+	 * @param array  $data
+	 * @param string $data_name
+	 */
+	public function __construct( $name = null, array $data = array(), $data_name = '' ) {
+		parent::__construct( $name, $data, $data_name );
+
+		$this->controller = new REST_Feedback_Controller();
+
+		$this->session_post = self::factory()->post->create_and_get( array(
+			'post_type' => 'wcb_session',
+		) );
+
+		$this->user = self::factory()->user->create_and_get();
+
+		$this->valid_meta = array(
+			'version' => META_VERSION,
+			'rating'  => 1,
+			'q1'      => 'asdf 1',
+			'q2'      => 'asdf 2',
+			'q3'      => 'asdf 3',
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item()
+	 */
+	public function test_create_item() {
+		$request = new WP_REST_Request( 'POST', '/wordcamp-speaker-feedback/v1/feedback' );
+
+		$params = array(
+			'post'   => $this->session_post->ID,
+			'author' => $this->user->ID,
+			'meta'   => $this->valid_meta,
+		);
+
+		$request->set_body_params( $params );
+
+		$response = $this->controller->create_item( $request );
+
+		$this->assertTrue( $response instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 'Success!', $response->get_data() );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -52,6 +52,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		self::$session_post = $factory->post->create_and_get( array(
 			'post_type' => 'wcb_session',
 		) );
+		add_post_type_support( 'wcb_session', 'wordcamp-speaker-feedback' );
 
 		self::$user = $factory->user->create_and_get( array(
 			'role' => 'subscriber',
@@ -191,8 +192,29 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item_permissions_check()
 	 */
+	public function test_create_item_permissions_check_not_supported() {
+		$post = self::factory()->post->create_and_get();
+
+		$params = array(
+			'post'   => $post->ID,
+			'author' => self::$user->ID,
+			'meta'   => self::$valid_meta,
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->create_item_permissions_check( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_post_not_supported', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item_permissions_check()
+	 */
 	public function test_create_item_permissions_check_not_published() {
 		$post = self::factory()->post->create_and_get( array(
+			'post_type'   => 'wcb_session',
 			'post_status' => 'draft',
 		) );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -3,8 +3,8 @@
 namespace WordCamp\SpeakerFeedback\Tests;
 
 use WP_UnitTestCase;
-use const WordCamp\SpeakerFeedback\CommentMeta\{ META_MAX_LENGTH, META_VERSION };
-use function WordCamp\SpeakerFeedback\CommentMeta\{ validate_feedback_meta };
+use const WordCamp\SpeakerFeedback\CommentMeta\{ META_VERSION };
+use function WordCamp\SpeakerFeedback\CommentMeta\{ get_feedback_meta_field_schema, validate_feedback_meta };
 
 defined( 'WPINC' ) || die();
 
@@ -109,7 +109,9 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_too_long() {
-		$too_long_answer = array_fill( 0, META_MAX_LENGTH + 1, 'a' );
+		$schema = get_feedback_meta_field_schema( 'q1' );
+
+		$too_long_answer = array_fill( 0, $schema['attributes']['maxlength'] + 1, 'a' );
 		$too_long_answer = implode( '', $too_long_answer );
 
 		$invalid_meta       = self::$valid_meta;
@@ -125,7 +127,9 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_multibyte_not_too_long() {
-		$almost_long_answer = array_fill( 0, META_MAX_LENGTH, '💩' );
+		$schema = get_feedback_meta_field_schema( 'q1' );
+
+		$almost_long_answer = array_fill( 0, $schema['attributes']['maxlength'], '💩' );
 		$almost_long_answer = implode( '', $almost_long_answer );
 
 		$alternate_valid_meta       = self::$valid_meta;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_UnitTestCase;
+use const WordCamp\SpeakerFeedback\CommentMeta\{ META_MAX_LENGTH, META_VERSION };
+use function WordCamp\SpeakerFeedback\CommentMeta\{ validate_feedback_meta };
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_CommentMeta
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
+	/**
+	 * @var array
+	 */
+	protected $valid_meta;
+
+	/**
+	 * Test_SpeakerFeedback_CommentMeta constructor.
+	 *
+	 * Setup the only needs to happen once, rather than before each test.
+	 *
+	 * @param null   $name
+	 * @param array  $data
+	 * @param string $data_name
+	 */
+	public function __construct( $name = null, array $data = array(), $data_name = '' ) {
+		parent::__construct( $name, $data, $data_name );
+
+		$this->valid_meta = array(
+			'version' => META_VERSION,
+			'rating'  => 1,
+			'q1'      => 'asdf 1',
+			'q2'      => 'asdf 2',
+			'q3'      => 'asdf 3',
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
+	public function test_validate_feedback_meta_all_valid() {
+		$result = validate_feedback_meta( $this->valid_meta );
+
+		$this->assertEqualSetsWithIndex( $this->valid_meta, $result );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
+	public function test_validate_feedback_meta_missing_key() {
+		$invalid_meta = $this->valid_meta;
+		unset( $invalid_meta['rating'] );
+
+		$result = validate_feedback_meta( $invalid_meta );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( 'feedback_missing_meta', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
+	public function test_validate_feedback_meta_too_long() {
+		$too_long_answer = array_fill( 0, META_MAX_LENGTH + 1, 'a' );
+		$too_long_answer = implode( '', $too_long_answer );
+
+		$invalid_meta       = $this->valid_meta;
+		$invalid_meta['q1'] = $too_long_answer;
+
+		$result = validate_feedback_meta( $invalid_meta );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( 'feedback_meta_too_long', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
+	public function test_validate_feedback_meta_multibyte_not_too_long() {
+		$almost_long_answer = array_fill( 0, META_MAX_LENGTH, '💩' );
+		$almost_long_answer = implode( '', $almost_long_answer );
+
+		$alternate_valid_meta       = $this->valid_meta;
+		$alternate_valid_meta['q1'] = $almost_long_answer;
+
+		$result = validate_feedback_meta( $alternate_valid_meta );
+
+		$this->assertEqualSetsWithIndex( $alternate_valid_meta, $result );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -50,8 +50,8 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 
 		$result = validate_feedback_meta( $invalid_meta );
 
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'feedback_missing_meta', $result->get_error_code() );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'feedback_meta_missing_field', $result->get_error_code() );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 
 		$result = validate_feedback_meta( $invalid_meta );
 
-		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertWPError( $result );
 		$this->assertEquals( 'feedback_meta_not_numeric', $result->get_error_code() );
 	}
 
@@ -79,8 +79,8 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 
 		$result = validate_feedback_meta( $invalid_meta );
 
-		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertEquals( 'feedback_meta_too_long', $result->get_error_code() );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'feedback_meta_string_too_long', $result->get_error_code() );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -65,6 +65,19 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
+	public function test_validate_feedback_meta_not_numeric() {
+		$invalid_meta           = $this->valid_meta;
+		$invalid_meta['rating'] = 'spork';
+
+		$result = validate_feedback_meta( $invalid_meta );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEquals( 'feedback_meta_not_numeric', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
 	public function test_validate_feedback_meta_too_long() {
 		$too_long_answer = array_fill( 0, META_MAX_LENGTH + 1, 'a' );
 		$too_long_answer = implode( '', $too_long_answer );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -17,21 +17,13 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	/**
 	 * @var array
 	 */
-	protected $valid_meta;
+	protected static $valid_meta;
 
 	/**
-	 * Test_SpeakerFeedback_CommentMeta constructor.
-	 *
-	 * Setup the only needs to happen once, rather than before each test.
-	 *
-	 * @param null   $name
-	 * @param array  $data
-	 * @param string $data_name
+	 * Set up shared fixtures for these tests.
 	 */
-	public function __construct( $name = null, array $data = array(), $data_name = '' ) {
-		parent::__construct( $name, $data, $data_name );
-
-		$this->valid_meta = array(
+	public static function wpSetUpBeforeClass() {
+		self::$valid_meta = array(
 			'version' => META_VERSION,
 			'rating'  => 1,
 			'q1'      => 'asdf 1',
@@ -44,16 +36,16 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_all_valid() {
-		$result = validate_feedback_meta( $this->valid_meta );
+		$result = validate_feedback_meta( self::$valid_meta );
 
-		$this->assertEqualSetsWithIndex( $this->valid_meta, $result );
+		$this->assertEqualSetsWithIndex( self::$valid_meta, $result );
 	}
 
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_missing_key() {
-		$invalid_meta = $this->valid_meta;
+		$invalid_meta = self::$valid_meta;
 		unset( $invalid_meta['rating'] );
 
 		$result = validate_feedback_meta( $invalid_meta );
@@ -66,7 +58,7 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_not_numeric() {
-		$invalid_meta           = $this->valid_meta;
+		$invalid_meta           = self::$valid_meta;
 		$invalid_meta['rating'] = 'spork';
 
 		$result = validate_feedback_meta( $invalid_meta );
@@ -82,7 +74,7 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 		$too_long_answer = array_fill( 0, META_MAX_LENGTH + 1, 'a' );
 		$too_long_answer = implode( '', $too_long_answer );
 
-		$invalid_meta       = $this->valid_meta;
+		$invalid_meta       = self::$valid_meta;
 		$invalid_meta['q1'] = $too_long_answer;
 
 		$result = validate_feedback_meta( $invalid_meta );
@@ -98,7 +90,7 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 		$almost_long_answer = array_fill( 0, META_MAX_LENGTH, '💩' );
 		$almost_long_answer = implode( '', $almost_long_answer );
 
-		$alternate_valid_meta       = $this->valid_meta;
+		$alternate_valid_meta       = self::$valid_meta;
 		$alternate_valid_meta['q1'] = $almost_long_answer;
 
 		$result = validate_feedback_meta( $alternate_valid_meta );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -56,11 +56,16 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 * Reset after each test.
 	 */
 	public function tearDown() {
+		parent::tearDown();
+
 		global $wpdb;
 
-		// This ensures that only comments created during a given test exist in the database during the test.
+		$ids = $wpdb->get_col( "SELECT comment_ID FROM {$wpdb->prefix}comments" );
+
+		// This ensures that only comments created during a given test exist in the database and cache during the test.
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}comments" );
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}commentmeta" );
+		clean_comment_cache( $ids );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -199,8 +199,8 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 		$all_comments = get_comments();
 		$feedback     = get_feedback();
 
-		$this->assertEquals( 6, count( $all_comments ) );
-		$this->assertEquals( 3, count( $feedback ) );
+		$this->assertCount( 6, $all_comments );
+		$this->assertCount( 3, $feedback );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -3,7 +3,7 @@
 namespace WordCamp\SpeakerFeedback\Tests;
 
 use WP_Post, WP_User;
-use WP_UnitTestCase;
+use WP_UnitTestCase, WP_UnitTest_Factory;
 use WordCamp\SpeakerFeedback\Feedback;
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use function WordCamp\SpeakerFeedback\Comment\{
@@ -26,38 +26,32 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	/**
 	 * @var WP_Post
 	 */
-	protected $session_post;
+	protected static $session_post;
 
 	/**
 	 * @var WP_User
 	 */
-	protected $user;
+	protected static $user;
 
 	/**
-	 * Test_SpeakerFeedback_Comment constructor.
+	 * Set up shared fixtures for these tests.
 	 *
-	 * Setup the only needs to happen once, rather than before each test.
-	 *
-	 * @param null   $name
-	 * @param array  $data
-	 * @param string $data_name
+	 * @param WP_UnitTest_Factory $factory
 	 */
-	public function __construct( $name = null, array $data = array(), $data_name = '' ) {
-		parent::__construct( $name, $data, $data_name );
-
-		$this->session_post = self::factory()->post->create_and_get( array(
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$session_post = $factory->post->create_and_get( array(
 			'post_type' => 'wcb_session',
 		) );
 
-		$this->user = self::factory()->user->create_and_get();
+		self::$user = $factory->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
 	}
 
 	/**
 	 * Reset after each test.
 	 */
 	public function tearDown() {
-		parent::tearDown();
-
 		global $wpdb;
 
 		$ids = $wpdb->get_col( "SELECT comment_ID FROM {$wpdb->prefix}comments" );
@@ -66,6 +60,8 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}comments" );
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}commentmeta" );
 		clean_comment_cache( $ids );
+
+		parent::tearDown();
 	}
 
 	/**
@@ -119,8 +115,8 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 */
 	public function test_add_feedback_user_id() {
 		$comment_id = add_feedback(
-			$this->session_post->ID,
-			$this->user->ID,
+			self::$session_post->ID,
+			self::$user->ID,
 			array()
 		);
 
@@ -137,7 +133,7 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 */
 	public function test_add_feedback_user_array() {
 		$comment_id = add_feedback(
-			$this->session_post->ID,
+			self::$session_post->ID,
 			array(
 				'name'  => 'Foo',
 				'email' => 'bar@example.org',
@@ -155,7 +151,7 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 */
 	public function test_add_feedback_no_user() {
 		$comment_id = add_feedback(
-			$this->session_post->ID,
+			self::$session_post->ID,
 			array(),
 			array()
 		);
@@ -168,8 +164,8 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 */
 	public function test_update_feedback() {
 		$comment_id = add_feedback(
-			$this->session_post->ID,
-			$this->user->ID,
+			self::$session_post->ID,
+			self::$user->ID,
 			array(
 				'rating' => 1,
 			)
@@ -212,8 +208,8 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 */
 	public function test_delete_feedback() {
 		$comment_id = add_feedback(
-			$this->session_post->ID,
-			$this->user->ID,
+			self::$session_post->ID,
+			self::$user->ID,
 			array()
 		);
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_Post, WP_User;
+use WP_UnitTestCase;
+use WordCamp\SpeakerFeedback\Feedback;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+use function WordCamp\SpeakerFeedback\Comment\{
+	add_feedback,
+	update_feedback,
+	get_feedback,
+	delete_feedback,
+	is_feedback,
+	get_feedback_comment,
+};
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_Comment
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
+	/**
+	 * @var WP_Post
+	 */
+	protected $session_post;
+
+	/**
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * Test_SpeakerFeedback_Comment constructor.
+	 *
+	 * Setup the only needs to happen once, rather than before each test.
+	 *
+	 * @param null   $name
+	 * @param array  $data
+	 * @param string $data_name
+	 */
+	public function __construct( $name = null, array $data = array(), $data_name = '' ) {
+		parent::__construct( $name, $data, $data_name );
+
+		$this->session_post = self::factory()->post->create_and_get( array(
+			'post_type' => 'wcb_session',
+		) );
+
+		$this->user = self::factory()->user->create_and_get();
+	}
+
+	/**
+	 * Reset after each test.
+	 */
+	public function tearDown() {
+		global $wpdb;
+
+		// This ensures that only comments created during a given test exist in the database during the test.
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}comments" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}commentmeta" );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\is_feedback()
+	 */
+	public function test_is_feedback() {
+		$comment_object = self::factory()->comment->create_and_get( array(
+			'comment_type' => COMMENT_TYPE,
+		) );
+
+		$this->assertTrue( is_feedback( $comment_object ) );
+		$this->assertTrue( is_feedback( $comment_object->comment_ID ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\is_feedback()
+	 */
+	public function test_is_not_feedback() {
+		$comment_object = self::factory()->comment->create_and_get();
+
+		$this->assertFalse( is_feedback( $comment_object ) );
+		$this->assertFalse( is_feedback( $comment_object->comment_ID ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\get_feedback_comment()
+	 */
+	public function test_get_feedback_comment() {
+		$comment = self::factory()->comment->create_and_get( array(
+			'comment_type' => COMMENT_TYPE,
+		) );
+
+		$feedback = get_feedback_comment( $comment );
+
+		$this->assertTrue( $feedback instanceof Feedback );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\get_feedback_comment()
+	 */
+	public function test_get_feedback_comment_invalid() {
+		$comment = self::factory()->comment->create_and_get();
+
+		$feedback = get_feedback_comment( $comment );
+
+		$this->assertNull( $feedback );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\add_feedback()
+	 */
+	public function test_add_feedback_user_id() {
+		$comment_id = add_feedback(
+			$this->session_post->ID,
+			$this->user->ID,
+			array()
+		);
+
+		$comment = get_comment( $comment_id );
+
+		$this->assertTrue( is_feedback( $comment ) );
+
+		// Feedback default status is `hold`/`0`.
+		$this->assertEquals( 0, $comment->comment_approved );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\add_feedback()
+	 */
+	public function test_add_feedback_user_array() {
+		$comment_id = add_feedback(
+			$this->session_post->ID,
+			array(
+				'name'  => 'Foo',
+				'email' => 'bar@example.org',
+			),
+			array()
+		);
+
+		$comment = get_comment( $comment_id );
+
+		$this->assertTrue( is_feedback( $comment ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\add_feedback()
+	 */
+	public function test_add_feedback_no_user() {
+		$comment_id = add_feedback(
+			$this->session_post->ID,
+			array(),
+			array()
+		);
+
+		$this->assertFalse( $comment_id );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\update_feedback()
+	 */
+	public function test_update_feedback() {
+		$comment_id = add_feedback(
+			$this->session_post->ID,
+			$this->user->ID,
+			array(
+				'rating' => 1,
+			)
+		);
+
+		$feedback = get_feedback_comment( $comment_id );
+
+		$this->assertEquals( 1, $feedback->rating );
+
+		$new_meta = array(
+			'rating' => 5,
+		);
+
+		update_feedback( $comment_id, $new_meta );
+
+		$this->assertEquals( 5, $feedback->rating );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\get_feedback()
+	 */
+	public function test_get_feedback_exclude_other_comments() {
+		self::factory()->comment->create_many( 3 );
+		self::factory()->comment->create_many(
+			3,
+			array(
+				'comment_type' => COMMENT_TYPE,
+			)
+		);
+
+		$all_comments = get_comments();
+		$feedback     = get_feedback();
+
+		$this->assertEquals( 6, count( $all_comments ) );
+		$this->assertEquals( 3, count( $feedback ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Comment\delete_feedback()
+	 */
+	public function test_delete_feedback() {
+		$comment_id = add_feedback(
+			$this->session_post->ID,
+			$this->user->ID,
+			array()
+		);
+
+		$deleted = delete_feedback( $comment_id );
+
+		$this->assertTrue( $deleted );
+		$this->assertEquals( 'trash', get_comment( $comment_id )->comment_approved );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -29,7 +29,7 @@ if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_
 	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
-	add_action( 'init', __NAMESPACE__ . '\add_support' );
+	add_action( 'init', __NAMESPACE__ . '\add_support', 99 );
 	add_action( 'init', __NAMESPACE__ . '\add_page_endpoint' );
 	add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes', 100 );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -12,6 +12,8 @@
 
 namespace WordCamp\SpeakerFeedback;
 
+use WordCamp\SpeakerFeedback\{ REST_Feedback_Controller };
+
 defined( 'WPINC' ) || die();
 
 define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
@@ -26,6 +28,7 @@ if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
 	add_action( 'init', __NAMESPACE__ . '\add_page_endpoint' );
+	add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes', 100 );
 
 	// Check if the page exists, and add it if not.
 	add_action( 'init', __NAMESPACE__ . '\add_feedback_page' );
@@ -33,9 +36,12 @@ if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_
 
 /**
  * Include the rest of the plugin.
+ *
+ * @return void
  */
 function load() {
 	require_once PLUGIN_DIR . 'includes/class-feedback.php';
+	require_once PLUGIN_DIR . 'includes/class-rest-feedback-controller.php';
 	require_once PLUGIN_DIR . 'includes/comment.php';
 	require_once PLUGIN_DIR . 'includes/form.php';
 	require_once PLUGIN_DIR . 'includes/page.php';
@@ -129,4 +135,14 @@ function get_assets_path() {
  */
 function get_assets_url() {
 	return plugin_dir_url( __FILE__ ) . 'assets/';
+}
+
+/**
+ * Initialize REST API endpoints.
+ *
+ * @return void
+ */
+function register_rest_routes() {
+	$controller = new REST_Feedback_Controller();
+	$controller->register_routes();
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -43,6 +43,7 @@ function load() {
 	require_once PLUGIN_DIR . 'includes/class-feedback.php';
 	require_once PLUGIN_DIR . 'includes/class-rest-feedback-controller.php';
 	require_once PLUGIN_DIR . 'includes/comment.php';
+	require_once PLUGIN_DIR . 'includes/comment-meta.php';
 	require_once PLUGIN_DIR . 'includes/form.php';
 	require_once PLUGIN_DIR . 'includes/page.php';
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -21,12 +21,15 @@ define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 define( __NAMESPACE__ . '\OPTION_KEY', 'sft_feedback_page' );
 define( __NAMESPACE__ . '\QUERY_VAR', 'sft_feedback' );
 
+const SUPPORTED_POST_TYPES = array( 'wcb_session' );
+
 // Only add actions to sites without the skip flag, and only if WC Post Types exist.
 if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_Types_Plugin' ) ) {
 	register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
+	add_action( 'init', __NAMESPACE__ . '\add_support' );
 	add_action( 'init', __NAMESPACE__ . '\add_page_endpoint' );
 	add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes', 100 );
 
@@ -55,6 +58,20 @@ function activate() {
 	add_feedback_page();
 	add_page_endpoint();
 	flush_rewrite_rules();
+}
+
+/**
+ * Add post type support for supported post types. Only for the types that are supported though.
+ *
+ * This makes it easy to check if a particular post type can have feedback comments using Core functionality, rather
+ * than having to import a namespaced constant or function.
+ *
+ * @return void
+ */
+function add_support() {
+	foreach ( SUPPORTED_POST_TYPES as $post_type ) {
+		add_post_type_support( $post_type, 'wordcamp-speaker-feedback' );
+	}
 }
 
 /**


### PR DESCRIPTION
Extends the `WP_REST_Comments_Controller` class to create a new custom endpoint for creating feedback comments.

We can't use the standard Comments endpoint, because it won't allow creation of comments with a custom type or without anything in the content field.

This also introduces schema and functions for the comment meta values that we'll be using to store feedback content, as well as sets up this plugin for phpunit testing.

Fixes #337, Refs #340 

**To test:**

1. Run all the phpunit tests and make sure all are passing.
1. It's easiest to use a tool like [Insomnia](https://insomnia.rest/) to craft payloads to send to the endpoint. The endpoint URL will be `[your-test-site].wordcamp.org/wp-json/wordcamp-speaker-feedback/v1/feedback`
1. The parameters required for a successful payload are:
    * `post` (the ID of the post to attach the feedback comment to)
    * `author` (the numeric ID of a user)
    * `meta[rating]` (an integer representation of 1 to 5 stars)
    * `meta[q1]` (a string less than 5000 characters)
1. You can use `author_name` and `author_email` (string values) in lieu of `author`.
1. You can also include `meta[q2]` and `meta[q3]` parameters, but these are not currently required fields.
1. The response to a successful request to the endpoint should be a `201` status. For an unsuccessful request, it'll be a JSON object with an error code and message. Try to get some of each! Try multiple invalid fields in one request!
1. It would probably also be good to check that the comments and their meta are actually being created in the database upon successful request.