### PR TITLE
Sponsors: Update the list of sponsors in email/page footers for 2020

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -676,7 +676,7 @@ function switch_email_template( $template_slug ) {
  * @return string
  */
 function get_global_sponsors_string( $sponsor_args = array() ) {
-	$sponsors = array( 'Jetpack', 'WooCommerce', 'Bluehost', 'GoDaddy', 'HubSpot', 'Liquid Web', 'GreenGeeks', 'DreamHost' );
+	$sponsors = array( 'Jetpack', 'WooCommerce', 'Bluehost', 'GoDaddy', 'Liquid Web', 'GreenGeeks' );
 
 	$sponsors = array_map(
 		function ( $string ) {


### PR DESCRIPTION
This reflects the list of participants in the 2020 global sponsors program that was announced on Feb 1st:

https://make.wordpress.org/community/2020/02/01/2020-global-sponsors/