### PR TITLE
Subroles: Omit user caps that have been added via usermeta values

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 define( 'WP_PLUGIN_DIR', __DIR__ . '/public_html/wp-content/plugins' );
+define( 'WP_MU_PLUGIN_DIR', __DIR__ . '/public_html/wp-content/mu-plugins' );
 
 $core_tests_directory = getenv( 'WP_TESTS_DIR' );
 
@@ -32,6 +33,7 @@ require_once( $core_tests_directory . '/includes/functions.php' );
  */
 require_once( WP_PLUGIN_DIR . '/wordcamp-organizer-reminders/tests/bootstrap.php' );
 require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );
+require_once WP_MU_PLUGIN_DIR . '/tests/bootstrap.php';
 
 /*
  * This has to be the last plugin bootstrapper, because it includes the Core test bootstrapper, which would

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,12 @@
 	</php>
 
 	<testsuites>
+		<testsuite name="WordCamp MU Plugins">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/mu-plugins/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="CampTix">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/plugins/camptix/tests/

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WordCamp\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugins that we'll need to be active for the tests
+ */
+function manually_load_plugins() {
+	// Needed for checking subrole capabilities. The ID is 1 because there's only one site in the test instance.
+	define( 'BLOG_ID_CURRENT_SITE', 1 );
+
+	require_once dirname( __DIR__ ) . '/wcorg-subroles.php';
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/mu-plugins/tests/test-wcorg-subroles.php
+++ b/public_html/wp-content/mu-plugins/tests/test-wcorg-subroles.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+use WordCamp\SubRoles;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_Omit_UserMeta_Caps
+ *
+ * @group wordcamp-mu-plugins
+ *
+ * @package WordCamp\Tests
+ */
+class Test_Omit_UserMeta_Caps extends WP_UnitTestCase {
+	/**
+	 * @covers WordCamp\SubRoles\omit_usermeta_caps()
+	 */
+	public function test_user_with_additional_caps_cannot() {
+		$user = self::factory()->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
+
+		$user->add_cap( 'wordcamp_wrangle_wordcamps' );
+		$usermeta = get_user_meta( $user->ID, 'wptests_capabilities', true );
+
+		$this->assertTrue( $user->has_cap( 'read' ) );
+		$this->assertFalse( $user->has_cap( 'wordcamp_wrangle_wordcamps' ) );
+		$this->assertTrue( array_key_exists( 'wordcamp_wrangle_wordcamps', $usermeta ) );
+	}
+
+	/**
+	 * @covers WordCamp\SubRoles\omit_usermeta_caps()
+	 */
+	public function test_user_with_subrole_can() {
+		$user = self::factory()->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
+
+		global $wcorg_subroles;
+		$wcorg_subroles = array(
+			$user->ID => array( 'wordcamp_wrangler' ),
+		);
+
+		$this->assertTrue( $user->has_cap( 'read' ) );
+		$this->assertTrue( $user->has_cap( 'wordcamp_wrangle_wordcamps' ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wcorg-subroles.php
+++ b/public_html/wp-content/mu-plugins/wcorg-subroles.php
@@ -189,10 +189,11 @@ add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_subrole_caps', 10, 4 );
  *
  * See `additional_capabilities_display` filter.
  *
- * @param bool[]   $allcaps
- * @param string[] $caps
- * @param array    $args
- * @param WP_User  $user
+ * @param bool[]   $allcaps Array of key/value pairs where keys represent a capability name and boolean values
+ *                          represent whether the user has that capability.
+ * @param string[] $caps    Unused. Required primitive capabilities for the requested capability.
+ * @param array    $args    Unused. Arguments that accompany the requested capability check.
+ * @param WP_User  $user    The user object.
  *
  * @return bool[]
  */

--- a/public_html/wp-content/mu-plugins/wcorg-subroles.php
+++ b/public_html/wp-content/mu-plugins/wcorg-subroles.php
@@ -183,7 +183,7 @@ function map_subrole_caps( $primitive_caps, $meta_cap, $user_id, $args ) {
 add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_subrole_caps', 10, 4 );
 
 /**
- * Remove capabilities that are "additional" i.e. stored in user meta.
+ * Ignore capabilities that are "additional" i.e. stored in user meta.
  *
  * Additional capabilities should only be granted via `map_meta_cap`, not via values stored in the user meta table.
  *


### PR DESCRIPTION
On WordCamp.org we grant additional capabilities to users via the `map_meta_cap` filter and a hard-coded list of users/caps. This way the granting/revoking of capabilities has an audit log in the form of revision history.

When a `WP_User` object is instantiated, it populates a `caps` property from a user meta value that is blog-specific. Normally this value only contains the user's role, but it can also store additional capabilities if they are added via `add_cap`. These additional capabilities are then merged with additions from `map_meta_cap` when evaluating something like `current_user_can`.

Possibly related: https://core.trac.wordpress.org/ticket/10201

This adds a filter that omits capabilities that have been incorporated from user meta when evaluating `has_cap`, so that only the `map_meta_cap` filter can add caps.