### PR TITLE
Add/schedule block scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
 	],
+	"eslintConfigComments": {
+		"whySeparate": "This needs to be a separate object from `eslintConfig` because eslint will refuse to run if there are any unknown properties in that object.",
+		"root": "Setting this to true is necessary to avoid merging WordCamp.org configs with any that exist in parent folders in the developer's environment. See https://github.com/eslint/eslint/commit/c99e9b621fe46b8535cf59fe489977dd36cb2a39."
+	},
+	"eslintConfig": {
+		"root": true
+	},
 	"eslintIgnore": [
 		"*.min.js"
 	]

--- a/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
+++ b/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
@@ -1,10 +1,17 @@
 /*
- * @todo
+ * @todo discuss these potential changes
  *
- * should use hasOwnProperty or Object.getOwnPropertyDescriptors(). the latter usually makes code more readable, but sometimes the former first better
+ * `arrow-parens` - skipping them when only have 1 arg remove unnecessary clutter, which helps readability
+ * `no-multiple-empty-lines` - somestimes 2 lines useful to separate sections of code, like `import`s at top of file from `export` of components
+ * `require-jsdoc` - not for `render` and lifecycle methods b/c it's obvious what they are
+ *
  * assignment and control structures/returns/etc should be separate by a blank line for readability.
  *      same for div and other block-level html elements
+ *
+ * should use hasOwnProperty or Object.getOwnPropertyDescriptors(). the latter usually makes code more readable, but sometimes the former first better
+ *
  * disable `no-console` b/c valid use case. if can make exception for `log` function without disabling, then do that. don't want console used for temporary debugging, but there are valid cases where you want to provide the user some insight into what went wrong
+ *
  */
 
 module.exports = {

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WordCamp\Blocks;
 
 defined( 'WPINC' ) || die();
@@ -22,9 +23,8 @@ function load_includes() {
 	$components_dir = PLUGIN_DIR . 'source/components/';
 	$hooks_dir      = PLUGIN_DIR . 'source/hooks/';
 
-	require_once $includes_dir . 'definitions.php';
-
 	// Utilities.
+	require_once $includes_dir . 'definitions.php';
 	require_once $includes_dir . 'content.php';
 
 	// Components.
@@ -38,6 +38,14 @@ function load_includes() {
 	require_once $blocks_dir . 'speakers/controller.php';
 	require_once $blocks_dir . 'sponsors/controller.php';
 	require_once $blocks_dir . 'live-schedule/controller.php';
+
+	$full_schedule_test_sites = array(
+		928, // 2017.testing
+	);
+
+	if ( 'development' === WORDCAMP_ENVIRONMENT || in_array( get_current_blog_id(), $full_schedule_test_sites, true ) ) {
+		require_once $blocks_dir . 'schedule/controller.php';
+	}
 
 	// Hooks.
 	require_once $hooks_dir . 'latest-posts/controller.php';

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -52,6 +52,7 @@
 	"scripts": {
 		"start": "wp-scripts start blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js live-posts=./source/hooks/latest-posts/front-end.js",
 		"build": "wp-scripts build blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js live-posts=./source/hooks/latest-posts/front-end.js",
+		"lint:js:comment": "echo 'Usage: `npm run lint:js source/blocks/schedule -- --fix`. The path has to be from the root `mu-plugins/blocks` folder.' ",
 		"lint:js": "wp-scripts lint-js",
 		"lint:css": "wp-scripts lint-style '**/*.scss'",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -12,6 +12,10 @@ import { BLOCKS } from './blocks/'; // Trailing slash required to differentiate 
 // This attaches to the hook itself.
 import './hooks/latest-posts';
 
+/*
+ * When a block isn't enabled on the current site, it won't be registered by it's `controller.php`.
+ * See also `blocks.php`.
+ */
 const enabledBlocks = BLOCKS.filter( ( block ) =>
 	window.WordCampBlocks.hasOwnProperty( block.NAME.replace( 'wordcamp/', '' ) )
 );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
@@ -3,6 +3,7 @@
  */
 import * as liveSchedule from './live-schedule';
 import * as organizers from './organizers';
+import * as schedule from './schedule';
 import * as sessions from './sessions';
 import * as speakers from './speakers';
 import * as sponsors from './sponsors';
@@ -10,6 +11,7 @@ import * as sponsors from './sponsors';
 export const BLOCKS = [
 	liveSchedule,
 	organizers,
+	schedule,
 	sessions,
 	speakers,
 	sponsors,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace WordCamp\Blocks\Schedule;
+
+defined( 'WPINC' ) || die();
+
+
+/**
+ * Register block types and enqueue scripts.
+ *
+ * @return void
+ */
+function init() {
+	register_block_type(
+		'wordcamp/schedule',
+		array(
+			'attributes'      => get_attributes_schema(),
+			'render_callback' => __NAMESPACE__ . '\render',
+			'editor_script'   => 'wordcamp-blocks',
+			'editor_style'    => 'wordcamp-blocks',
+			'style'           => 'wordcamp-blocks',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Render the block on the front end.
+ *
+ * @param array $attributes Block attributes.
+ *
+ * @return string
+ */
+function render( $attributes ) {
+	// @todo Render via JS instead?
+	return '';
+}
+
+/**
+ * Add data to be used by the JS scripts in the block editor.
+ *
+ * @param array $data
+ *
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['schedule'] = array(
+		'schema'  => get_attributes_schema(),
+		'options' => get_options(),
+	);
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );
+
+/**
+ * Get the schema for the block's attributes.
+ *
+ * @return array
+ */
+function get_attributes_schema() {
+	// todo need to update this when building inspector controls, to make them DRY
+	// this one will be different than others in that it wont have a 'mode', so need to make that not a shared attribute?
+		// or maybe leave it shared since most blocks use it, but explicitly remove it here?
+
+	return array(
+		'item_ids' => array(
+			'type'    => 'array',
+			'default' => array(),
+			'items'   => array(
+				'type' => 'integer',
+			),
+		),
+
+		'className' => array(
+			'type'    => 'string',
+			'default' => '',
+		),
+
+		'show_categories' => array(
+			'type'    => 'bool',
+			'default' => false,
+		),
+
+		'chosen_days' => array(
+			'type'    => 'array',
+			'default' => array(),
+			'items'   => array(
+				'type' => 'string',
+			),
+		),
+
+		'chosen_tracks' => array(
+			'type'    => 'array',
+			'default' => array(),
+			'items'   => array(
+				'type' => 'integer',
+			),
+		),
+	);
+}
+
+/**
+ * Get the label/value pairs for all options or a specific type.
+ *
+ * @param string $type
+ *
+ * @return array
+ */
+function get_options( $type = '' ) {
+	$options = array();
+
+	if ( $type ) {
+		return empty( $options[ $type ] ) ? array() : $options[ $type ];
+	}
+
+	return $options;
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/edit.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+/* eslint-disable-next-line */ /* todo tmp */
+import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { WC_BLOCKS_STORE } from '../../data';
+import { ScheduleGrid } from './schedule-grid';
+import InspectorControls from './inspector-controls';
+import { ICON } from './index';
+
+const blockData = window.WordCampBlocks.sessions || {};
+
+/**
+ * Top-level component for the editing UI for the block.
+ *
+ * @param {Object} props
+ * @param {Object} props.attributes
+ * @param {Object} props.entities
+ *
+ * @return {Element}
+ */
+function ScheduleEdit( { attributes, entities } ) {
+	return (
+		<Fragment>
+			<ScheduleGrid
+				icon={ ICON }
+				attributes={ attributes }
+				entities={ entities }
+			/>
+
+			<InspectorControls />
+		</Fragment>
+	);
+}
+
+const scheduleSelect = ( select ) => {
+	const { getEntities, getSiteSettings } = select( WC_BLOCKS_STORE );
+
+	const sessionArgs = {
+	};
+
+	const entities = {
+		sessions: getEntities( 'postType', 'wcb_session', sessionArgs ),
+		settings: getSiteSettings(),
+	};
+
+	return { blockData, entities };
+};
+
+export const Edit = withSelect( scheduleSelect )( ScheduleEdit );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/index.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { Edit } from './edit';
+
+export const NAME = 'wordcamp/schedule';
+export const LABEL = __( 'Schedule', 'wordcamporg' );
+export const ICON = 'schedule';
+
+const supports = {
+	align: [ 'wide', 'full' ],
+};
+
+export const SETTINGS = {
+	title: __( 'Schedule', 'wordcamporg' ),
+	description: __( 'Display your WordCamp\'s awesome schedule.', 'wordcamporg' ),
+	icon: ICON,
+	category: 'wordcamp',
+	supports: supports,
+	edit: Edit,
+	save: () => null,
+};

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -1,0 +1,116 @@
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { CheckboxControl, PanelBody, ToggleControl } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/*
+ * @todo
+ * make this dynamic
+ * add default schema and options, like speakers?
+ *
+ * commit w/ props mark, mel, corey. look for any others as well
+ */
+
+/**
+ * Render the inspector Controls for the Schedule block.
+ */
+export default class extends Component {
+	/**
+	 * Render the component.
+	 *
+	 * @return {Element}
+	 */
+	render() {
+		const { setAttributes } = this.props;
+		const show_categories = false;
+		const choose_days = true;
+		const choose_tracks = true;
+
+		return (
+			<InspectorControls>
+				<PanelBody title={ __( 'Display Settings', 'wordcamporg' ) } initialOpen={ true }>
+					<ToggleControl
+						label={ __( 'Show categories', 'wordcamporg' ) }
+						checked={ show_categories }
+						onChange={ ( value ) => setAttributes( { show_category: value } ) }
+					/>
+
+					<div className="wordcamp-schedule__control-container">
+						<fieldset>
+							<legend>
+								<ToggleControl
+									label={ __( 'Choose specific days', 'wordcamporg' ) }
+									checked={ choose_days }
+									onChange={ ( value ) => setAttributes( { choose_days: value } ) }
+								/>
+							</legend>
+
+							{ choose_days &&
+								<Fragment>
+									<CheckboxControl
+										label="Saturday, May 1st 2019"
+										checked={ true }
+										onChange={ ( isChecked ) => {
+											setAttributes( isChecked );
+										} }
+									/>
+
+									<CheckboxControl
+										label="Sunday, May 2nd 2019"
+										checked={ true }
+										onChange={ ( isChecked ) => {
+											setAttributes( isChecked );
+										} }
+									/>
+								</Fragment>
+							}
+						</fieldset>
+					</div>
+
+					<div className="wordcamp-schedule__control-container">
+						<fieldset>
+							<legend>
+								<ToggleControl
+									label={ __( 'Choose specific tracks', 'wordcamporg' ) }
+									checked={ choose_tracks }
+									onChange={ ( value ) => setAttributes( { show_tracks: value } ) }
+								/>
+							</legend>
+
+							{ choose_tracks &&
+								<Fragment>
+									<CheckboxControl
+										label="Auditorium"
+										checked={ true }
+										onChange={ ( isChecked ) => {
+											setAttributes( isChecked );
+										} }
+									/>
+
+									<CheckboxControl
+										label="Ballroom"
+										checked={ true }
+										onChange={ ( isChecked ) => {
+											setAttributes( isChecked );
+										} }
+									/>
+
+									<CheckboxControl
+										label="Balcony"
+										checked={ true }
+										onChange={ ( isChecked ) => {
+											setAttributes( isChecked );
+										} }
+									/>
+								</Fragment>
+							}
+						</fieldset>
+					</div>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { gmdate } from '@wordpress/date';
+import { Fragment } from '@wordpress/element';
+// eslint-disable-next-line
+import { _x } from '@wordpress/i18n';
+
+// todo remove all of the eslint-disable lines that were added for #356
+
+/**
+ * Internal dependencies
+ */
+import { NoContent } from '../../components/';
+
+/**
+ * Render the schedule for a specific day.
+ *
+ * @param {Object} props
+ * @param {string} props.date In a format acceptable by `wp.date.gmdate()`.
+ * @param {Array}  props.sessions
+ * @param {Array}  props.tracks
+ * @param {string} props.dateFormat
+ * @param {string} props.timeFormat
+ *
+ * @return {Element}
+ */
+/* eslint-disable-next-line */
+function ScheduleDay( { date, sessions, tracks, dateFormat, timeFormat } ) {
+	return (
+		<Fragment>
+			<h2 className="wordcamp-schedule__date">
+				{ gmdate( dateFormat, date ) }
+			</h2>
+			{ /* todo this needs to be editable, should also be a separate Heading block. so when inserting a schedule
+			 block, We can make the text editable, though, with a reasonable default. If they remove the text,
+			then we can automatically remove the corresponding h2 tag, to avoid leaving an artifact behind that
+			 affects margins/etc. */ }
+
+			<section id={ `wordcamp-schedule__day-${ gmdate( 'Y-m-d', date ) }` } className="wordcamp-schedule__day">
+				todo
+			</section>
+		</Fragment>
+	);
+}
+
+/**
+ * Render the schedule.
+ *
+ * @param {Object} props
+ * @param {Object} props.entities
+ *
+ * @return {Element}
+ */
+export function ScheduleGrid( { entities } ) {
+	const { sessions, settings } = entities;
+	const isLoading = ! Array.isArray( sessions );
+	const hasSessions = ! isLoading && sessions.length > 0;
+
+	if ( isLoading || ! hasSessions || ! settings ) {
+		return (
+			<NoContent loading={ isLoading } />
+		);
+	}
+
+	const { date_format, time_format } = settings;
+	const scheduleDays = [];
+	const date = '2020-01-01';
+
+	/* eslint-disable */
+	// for each day
+		scheduleDays.push(
+			<ScheduleDay
+				key={ date }
+				date={ date }
+				sessions={ [] }
+				tracks={ [] }
+				dateFormat={ date_format }
+				timeFormat={ time_format }
+			/>
+		);
+	/* eslint-enable */
+
+	return (
+		<div className="wordcamp-schedule">
+			{ scheduleDays }
+		</div>
+	);
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/style.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/style.scss
@@ -1,0 +1,1 @@
+/* this is just here to prevent eslint from complaining */


### PR DESCRIPTION
This is branched off of #104, to make reviewing easier. This one is just the scaffolding for the block, while 104 contains all the logic for the grid, etc.

With this one you should be able to add the block to a page, and see the date and "todo" in the place of the grid.