### PR TITLE
Speaker Feedback: Add main feedback page

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/css/style.css
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/css/style.css
@@ -1,0 +1,19 @@
+.speaker-feedback__wrapper {
+	display: flex;
+}
+
+.speaker-feedback__field {
+	margin-bottom: 0;
+	padding-right: 1em;
+	flex: auto;
+	display: flex;
+	align-items: stretch;
+}
+
+.speaker-feedback__field select {
+	width: 100%;
+}
+
+.speaker-feedback__wrapper input[type="submit"] {
+	flex: initial;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/css/style.css
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/css/style.css
@@ -1,8 +1,8 @@
-.speaker-feedback__wrapper {
+.speaker-feedback-navigation .speaker-feedback__wrapper {
 	display: flex;
 }
 
-.speaker-feedback__field {
+.speaker-feedback-navigation .speaker-feedback__field {
 	margin-bottom: 0;
 	padding-right: 1em;
 	flex: auto;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -1,0 +1,16 @@
+/**
+ * Handle any frontend activity for the Speaker Feedback forms.
+ */
+( function() {
+	function onFormNavigate( event ) {
+		event.preventDefault();
+		const value = event.target[0].value;
+		// Use the fact that post IDs will redirect to the right page.
+		window.location = '/?p=' + value;
+	}
+
+	const form = document.getElementById( 'sft-navigation' );
+	if ( form ) {
+		form.addEventListener( 'submit', onFormNavigate, true );
+	}
+} )();

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\Form;
-use function WordCamp\SpeakerFeedback\get_views_path;
+use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };
 
 add_filter( 'the_content', __NAMESPACE__ . '\render' );
+add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
  * Short-circuit the content, and output the feedback form (or the session select).
@@ -16,4 +17,26 @@ function render( $content ) {
 	}
 
 	return $content;
+}
+
+/**
+ * Add stylesheet to the form page.
+ */
+function enqueue_assets() {
+	if ( is_page( get_option( 'feedback_page' ) ) ) {
+		wp_enqueue_style(
+			'speaker-feedback',
+			get_assets_url() . 'css/style.css',
+			array(),
+			filemtime( dirname( __DIR__ ) . '/assets/css/style.css' )
+		);
+
+		wp_enqueue_script(
+			'speaker-feedback',
+			get_assets_url() . 'js/script.js',
+			array(),
+			filemtime( dirname( __DIR__ ) . '/assets/js/script.js' ),
+			true
+		);
+	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Form;
+use function WordCamp\SpeakerFeedback\get_views_path;
+
+add_filter( 'the_content', __NAMESPACE__ . '\render' );
+
+/**
+ * Short-circuit the content, and output the feedback form (or the session select).
+ */
+function render( $content ) {
+	if ( is_page( get_option( 'feedback_page' ) ) ) {
+		ob_start();
+		require get_views_path() . 'form-select-sessions.php';
+		return ob_get_clean();
+	}
+
+	return $content;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\Form;
+use const WordCamp\SpeakerFeedback\OPTION_KEY;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };
 
 add_filter( 'the_content', __NAMESPACE__ . '\render' );
@@ -10,7 +11,7 @@ add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
  * Short-circuit the content, and output the feedback form (or the session select).
  */
 function render( $content ) {
-	if ( is_page( get_option( 'feedback_page' ) ) ) {
+	if ( is_page( get_option( OPTION_KEY ) ) ) {
 		ob_start();
 		require get_views_path() . 'form-select-sessions.php';
 		return ob_get_clean();
@@ -23,7 +24,7 @@ function render( $content ) {
  * Add stylesheet to the form page.
  */
 function enqueue_assets() {
-	if ( is_page( get_option( 'feedback_page' ) ) ) {
+	if ( is_page( get_option( OPTION_KEY ) ) ) {
 		wp_enqueue_style(
 			'speaker-feedback',
 			get_assets_url() . 'css/style.css',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
@@ -4,6 +4,7 @@ namespace WordCamp\SpeakerFeedback\Page;
 
 add_filter( 'pre_trash_post', __NAMESPACE__ . '\prevent_deletion', 10, 2 );
 add_filter( 'pre_delete_post', __NAMESPACE__ . '\prevent_deletion', 10, 3 );
+add_filter( 'display_post_states', __NAMESPACE__ . '\add_label_to_page', 10, 2 );
 
 /**
  * Prevent deletion of the Feedback page.
@@ -25,3 +26,20 @@ function prevent_deletion( $check, $post, $force_delete = false ) {
 	return $check;
 }
 
+/**
+ * Add label to the Feedback page, to indicate it's a "special" page.
+ *
+ * @param string[] $post_states An array of post display states.
+ * @param WP_Post  $post        The current post object.
+ *
+ * @return array The filtered list of post display states.
+ */
+function add_label_to_page( $post_states, $post ) {
+	$feedback_page = (int) get_option( 'feedback_page' );
+
+	if ( $feedback_page === $post->ID ) {
+		$post_states['sft-page'] = _x( 'Speaker Feedback', 'wordcamporg' );
+	}
+
+	return $post_states;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Page;
+
+add_filter( 'pre_trash_post', __NAMESPACE__ . '\prevent_deletion', 10, 2 );
+add_filter( 'pre_delete_post', __NAMESPACE__ . '\prevent_deletion', 10, 3 );
+
+/**
+ * Prevent deletion of the Feedback page.
+ *
+ * @param bool|null $check Whether to go forward with trashing/deletion.
+ * @param WP_Post   $post  Post object.
+ * @param bool      $force_delete Whether to bypass the trash, set when deactivating the plugin to clean up.
+ */
+function prevent_deletion( $check, $post, $force_delete = false ) {
+	if ( $force_delete ) {
+		return $check;
+	}
+
+	$feedback_page = (int) get_option( 'feedback_page' );
+	if ( $feedback_page === $post->ID ) {
+		return false;
+	}
+
+	return $check;
+}
+

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\Page;
+use const WordCamp\SpeakerFeedback\OPTION_KEY;
 
 add_filter( 'pre_trash_post', __NAMESPACE__ . '\prevent_deletion', 10, 2 );
 add_filter( 'pre_delete_post', __NAMESPACE__ . '\prevent_deletion', 10, 3 );
@@ -18,7 +19,7 @@ function prevent_deletion( $check, $post, $force_delete = false ) {
 		return $check;
 	}
 
-	$feedback_page = (int) get_option( 'feedback_page' );
+	$feedback_page = (int) get_option( OPTION_KEY );
 	if ( $feedback_page === $post->ID ) {
 		return false;
 	}
@@ -35,10 +36,10 @@ function prevent_deletion( $check, $post, $force_delete = false ) {
  * @return array The filtered list of post display states.
  */
 function add_label_to_page( $post_states, $post ) {
-	$feedback_page = (int) get_option( 'feedback_page' );
+	$feedback_page = (int) get_option( OPTION_KEY );
 
 	if ( $feedback_page === $post->ID ) {
-		$post_states['sft-page'] = _x( 'Speaker Feedback', 'wordcamporg' );
+		$post_states['sft-page'] = __( 'Speaker Feedback', 'wordcamporg' );
 	}
 
 	return $post_states;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/page.php
@@ -8,19 +8,21 @@ add_filter( 'pre_delete_post', __NAMESPACE__ . '\prevent_deletion', 10, 3 );
 add_filter( 'display_post_states', __NAMESPACE__ . '\add_label_to_page', 10, 2 );
 
 /**
- * Prevent deletion of the Feedback page.
+ * Prevent deletion of the Feedback page, unless force_delete is true.
  *
  * @param bool|null $check Whether to go forward with trashing/deletion.
  * @param WP_Post   $post  Post object.
  * @param bool      $force_delete Whether to bypass the trash, set when deactivating the plugin to clean up.
  */
 function prevent_deletion( $check, $post, $force_delete = false ) {
-	if ( $force_delete ) {
-		return $check;
-	}
-
 	$feedback_page = (int) get_option( OPTION_KEY );
 	if ( $feedback_page === $post->ID ) {
+		// Allow it, and delete the option if the page is force-deleted.
+		if ( $force_delete ) {
+			delete_option( OPTION_KEY );
+			return $check;
+		}
+
 		return false;
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -15,17 +15,22 @@ $session_args = array(
 $sessions = new \WP_Query( $session_args );
 
 if ( $sessions->have_posts() ) : ?>
-<form>
-	<select name="sft_session">
-		<?php while ( $sessions->have_posts() ) {
-			$sessions->the_post();
-			printf(
-				'<option value="%s">%s</option>',
-				esc_attr( get_the_ID() ),
-				wp_kses_post( get_the_title() )
-			);
-		} ?>
-	</select>
-	<input type="submit" value="<?php esc_attr_e( 'Give Feedback', 'wordcamporg' ); ?>" />
+<form id="sft-navigation" class="speaker-feedback">
+	<label for="sft-session"><?php esc_html_e( 'Select a session to leave feedback', 'wordcamporg' ); ?></label>
+	<div class="speaker-feedback__wrapper">
+		<div class="speaker-feedback__field">
+			<select name="sft_session" id="sft-session">
+				<?php while ( $sessions->have_posts() ) {
+					$sessions->the_post();
+					printf(
+						'<option value="%s">%s</option>',
+						esc_attr( get_the_ID() ),
+						wp_kses_post( get_the_title() )
+					);
+				} ?>
+			</select>
+		</div>
+		<input type="submit" value="<?php esc_attr_e( 'Give Feedback', 'wordcamporg' ); ?>" />
+	</div>
 </form>
 <?php endif;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -20,14 +20,14 @@ if ( $sessions->have_posts() ) : ?>
 	<div class="speaker-feedback__wrapper">
 		<div class="speaker-feedback__field">
 			<select name="sft_session" id="sft-session">
-				<?php while ( $sessions->have_posts() ) {
+				<?php while ( $sessions->have_posts() ) :
 					$sessions->the_post();
 					printf(
 						'<option value="%s">%s</option>',
 						esc_attr( get_the_ID() ),
 						wp_kses_post( get_the_title() )
 					);
-				} ?>
+				endwhile; ?>
 			</select>
 		</div>
 		<input type="submit" value="<?php esc_attr_e( 'Give Feedback', 'wordcamporg' ); ?>" />

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -15,7 +15,7 @@ $session_args = array(
 $sessions = new \WP_Query( $session_args );
 
 if ( $sessions->have_posts() ) : ?>
-<form id="sft-navigation" class="speaker-feedback">
+<form id="sft-navigation" class="speaker-feedback-navigation">
 	<label for="sft-session"><?php esc_html_e( 'Select a session to leave feedback', 'wordcamporg' ); ?></label>
 	<div class="speaker-feedback__wrapper">
 		<div class="speaker-feedback__field">

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\View;
+
+$session_args = array(
+	'post_type'      => 'wcb_session',
+	'posts_per_page' => -1,
+	'orderby'        => 'title',
+	'order'          => 'asc',
+	// get only sessions, no breaks.
+	'meta_key'       => '_wcpt_session_type',
+	'meta_value'     => 'session',
+);
+
+$sessions = new \WP_Query( $session_args );
+
+if ( $sessions->have_posts() ) : ?>
+<form>
+	<select name="sft_session">
+		<?php while ( $sessions->have_posts() ) {
+			$sessions->the_post();
+			printf(
+				'<option value="%s">%s</option>',
+				esc_attr( get_the_ID() ),
+				wp_kses_post( get_the_title() )
+			);
+		} ?>
+	</select>
+	<input type="submit" value="<?php esc_attr_e( 'Give Feedback', 'wordcamporg' ); ?>" />
+</form>
+<?php endif;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -78,3 +78,12 @@ function get_includes_path() {
 function get_views_path() {
 	return plugin_dir_path( __FILE__ ) . 'views/';
 }
+
+/**
+ * Shortcut to the assets URL.
+ *
+ * @return string
+ */
+function get_assets_url() {
+	return plugin_dir_url( __FILE__ ) . 'assets/';
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -22,6 +22,9 @@ register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
 
+// Check if the page exists, and add it if not.
+add_action( 'init', __NAMESPACE__ . '\add_feedback_page' );
+
 /**
  * Include the rest of the plugin.
  */
@@ -43,13 +46,26 @@ function activate() {
  * Create the Feedback page, save ID into an option.
  */
 function add_feedback_page() {
+	$page_id = get_option( OPTION_KEY );
+	if ( $page_id ) {
+		return;
+	}
+
+	$organizer_note = '<!-- wp:paragraph {"textColor":"white","customBackgroundColor":"#94240b"} -->';
+	$organizer_note .= '<p style="background-color:#94240b" class="has-text-color has-background has-white-color">';
+	$organizer_note .= __( 'This page is a placeholder for the Speaker Feedback form. The content here will not be shown on the site.', 'wordcamporg' );
+	$organizer_note .= '</p>';
+	$organizer_note .= '<!-- /wp:paragraph -->';
+
 	$page_id = wp_insert_post( array(
-		'post_title'  => __( 'Leave Feedback', 'wordcamporg' ),
+		'post_title'   => __( 'Leave Feedback', 'wordcamporg' ),
 		/* translators: Page slug for the feedback page. */
-		'post_name'   => __( 'feedback', 'wordcamporg' ),
-		'post_status' => 'publish',
-		'post_type'   => 'page',
+		'post_name'    => __( 'feedback', 'wordcamporg' ),
+		'post_content' => $organizer_note,
+		'post_status'  => 'publish',
+		'post_type'    => 'page',
 	) );
+
 	if ( $page_id > 0 ) {
 		update_option( OPTION_KEY, $page_id );
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -16,6 +16,7 @@ defined( 'WPINC' ) || die();
 
 define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
+define( __NAMESPACE__ . '\OPTION_KEY', 'sft_feedback_page' );
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
@@ -50,7 +51,7 @@ function add_feedback_page() {
 		'post_type'   => 'page',
 	) );
 	if ( $page_id > 0 ) {
-		update_option( 'feedback_page', $page_id );
+		update_option( OPTION_KEY, $page_id );
 	}
 }
 
@@ -58,7 +59,7 @@ function add_feedback_page() {
  * Remove the feedback page.
  */
 function deactivate() {
-	$page_id = get_option( 'feedback_page' );
+	$page_id = get_option( OPTION_KEY );
 	wp_delete_post( $page_id, true );
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -17,6 +17,8 @@ defined( 'WPINC' ) || die();
 define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 
+register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
+register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
 
 /**
@@ -25,4 +27,54 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
 function load() {
 	require_once PLUGIN_DIR . 'includes/class-feedback.php';
 	require_once PLUGIN_DIR . 'includes/comment.php';
+	require_once PLUGIN_DIR . 'includes/form.php';
+}
+
+/**
+ * Create main Feedback page.
+ */
+function activate() {
+	add_feedback_page();
+}
+
+/**
+ * Create the Feedback page, save ID into an option.
+ */
+function add_feedback_page() {
+	$page_id = wp_insert_post( array(
+		'post_title'  => __( 'Leave Feedback', 'wordcamporg' ),
+		/* translators: Page slug for the feedback page. */
+		'post_name'   => __( 'feedback', 'wordcamporg' ),
+		'post_status' => 'publish',
+		'post_type'   => 'page',
+	) );
+	if ( $page_id > 0 ) {
+		update_option( 'feedback_page', $page_id );
+	}
+}
+
+/**
+ * Remove the feedback page.
+ */
+function deactivate() {
+	$page_id = get_option( 'feedback_page' );
+	wp_delete_post( $page_id, true );
+}
+
+/**
+ * Shortcut to the includes directory.
+ *
+ * @return string
+ */
+function get_includes_path() {
+	return plugin_dir_path( __FILE__ ) . 'includes/';
+}
+
+/**
+ * Shortcut to the views directory.
+ *
+ * @return string
+ */
+function get_views_path() {
+	return plugin_dir_path( __FILE__ ) . 'views/';
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -28,6 +28,7 @@ function load() {
 	require_once PLUGIN_DIR . 'includes/class-feedback.php';
 	require_once PLUGIN_DIR . 'includes/comment.php';
 	require_once PLUGIN_DIR . 'includes/form.php';
+	require_once PLUGIN_DIR . 'includes/page.php';
 }
 
 /**


### PR DESCRIPTION
Fixes #336 — Add a page called "Leave Feedback" with a list of sessions. This will navigate to the session feedback form (TBD). The page is created on activation, and removed on deactivation, and it's otherwise not possible for most users to delete the page (it can be done through wp-cli).

### Screenshots

![Screen Shot 2020-02-06 at 6 41 01 PM](https://user-images.githubusercontent.com/541093/73988464-cd3f3f00-4910-11ea-9e49-ee05decc4ec2.png)

The page has a special label in the list table:

![Screen Shot 2020-02-06 at 7 21 17 PM](https://user-images.githubusercontent.com/541093/73990205-776d9580-4916-11ea-810d-c8878d2f1573.png)

### How to test the changes in this Pull Request:

1. The page is created on activation, so deactivate/reactivate the plugin
2. You should see a page called Leave Feedback, at site.wordcamp.org/feedback
3. This will list all sessions, and when "give feedback" is activated, navigate to that session page.
