### PR TITLE
Add feedback form pages to each session

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -9,7 +9,10 @@ require_once 'inc/favorite-schedule-shortcode.php';
 require_once 'inc/privacy.php';
 require_once 'inc/deprecated.php';
 
-define( 'EP_SESSIONS', 8192 );
+// Bitwise mask for the sessions CPT, to add endpoints to the session pages. This should be a unique power of 2
+// greater than the core-defined ep_masks, but could potentially conflict with another plugin.
+// See https://developer.wordpress.org/reference/functions/add_rewrite_endpoint/.
+define( 'EP_SESSIONS', 16384 );
 
 class WordCamp_Post_Types_Plugin {
 	protected $wcpt_permalinks;

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -9,6 +9,8 @@ require_once 'inc/favorite-schedule-shortcode.php';
 require_once 'inc/privacy.php';
 require_once 'inc/deprecated.php';
 
+define( 'EP_SESSIONS', 8192 );
+
 class WordCamp_Post_Types_Plugin {
 	protected $wcpt_permalinks;
 
@@ -1732,6 +1734,7 @@ class WordCamp_Post_Types_Plugin {
 				'rewrite'         => array(
 					'slug'       => 'session',
 					'with_front' => false,
+					'ep_mask'    => EP_SESSIONS,
 				),
 				'supports'        => array( 'title', 'editor', 'excerpt', 'author', 'revisions', 'thumbnail', 'custom-fields' ),
 				'menu_position'   => 21,

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -6,7 +6,7 @@
 		event.preventDefault();
 		const value = event.target[0].value;
 		// Use the fact that post IDs will redirect to the right page.
-		window.location = '/?p=' + value;
+		window.location = '/?p=' + value + '&sft_feedback=1';
 	}
 
 	const form = document.getElementById( 'sft-navigation' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -8,9 +8,9 @@ add_filter( 'the_content', __NAMESPACE__ . '\render' );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
- * Check if the current page is the feedback form.
+ * Check if the current page should include the feedback form.
  */
-function is_feedback_page() {
+function has_feedback_form() {
 	global $wp_query;
 	return false !== $wp_query->get( QUERY_VAR, false );
 }
@@ -19,7 +19,7 @@ function is_feedback_page() {
  * Short-circuit the content, and output the feedback form (or the session select).
  */
 function render( $content ) {
-	if ( is_feedback_page() ) {
+	if ( has_feedback_form() ) {
 		ob_start();
 		require get_views_path() . 'form-feedback.php';
 		return $content . ob_get_clean();
@@ -36,7 +36,7 @@ function render( $content ) {
  * Add stylesheet to the form page.
  */
 function enqueue_assets() {
-	if ( is_feedback_page() || is_page( get_option( OPTION_KEY ) ) ) {
+	if ( has_feedback_form() || is_page( get_option( OPTION_KEY ) ) ) {
 		wp_enqueue_style(
 			'speaker-feedback',
 			get_assets_url() . 'css/style.css',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -1,17 +1,29 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\Form;
-use const WordCamp\SpeakerFeedback\OPTION_KEY;
+use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };
 
 add_filter( 'the_content', __NAMESPACE__ . '\render' );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
+ * Check if the current page is the feedback form.
+ */
+function is_feedback_page() {
+	global $wp_query;
+	return false !== $wp_query->get( QUERY_VAR, false );
+}
+
+/**
  * Short-circuit the content, and output the feedback form (or the session select).
  */
 function render( $content ) {
-	if ( is_page( get_option( OPTION_KEY ) ) ) {
+	if ( is_feedback_page() ) {
+		ob_start();
+		require get_views_path() . 'form-feedback.php';
+		return $content . ob_get_clean();
+	} elseif ( is_page( get_option( OPTION_KEY ) ) ) {
 		ob_start();
 		require get_views_path() . 'form-select-sessions.php';
 		return ob_get_clean();
@@ -24,7 +36,7 @@ function render( $content ) {
  * Add stylesheet to the form page.
  */
 function enqueue_assets() {
-	if ( is_page( get_option( OPTION_KEY ) ) ) {
+	if ( is_feedback_page() || is_page( get_option( OPTION_KEY ) ) ) {
 		wp_enqueue_style(
 			'speaker-feedback',
 			get_assets_url() . 'css/style.css',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\View;
+
+?>
+<hr />
+<form id="sft-feedback" class="speaker-feedback">
+	<h3><?php esc_html_e( 'Rate this talk', 'wordcamporg' ); ?></h3>
+	
+	<div>
+		star rating…
+	</div>
+	
+	<div class="speaker-feedback__field">
+		<label for="sft-question-1">
+			<?php esc_html_e( 'What’s one good thing you’d keep in this presentation?', 'wordcamporg' ); ?>
+		</label>
+		<textarea id="sft-question-1" required></textarea>
+	</div>
+
+	<div class="speaker-feedback__field">
+		<label for="sft-question-2">
+			<?php esc_html_e( 'What’s one thing you’d tweak to improve the presentation?', 'wordcamporg' ); ?>
+		</label>
+		<textarea id="sft-question-2"></textarea>
+	</div>
+
+	<div class="speaker-feedback__field">
+		<label for="sft-question-3">
+			<?php esc_html_e( 'What’s one unhelpful thing you’d delete from the presentation?', 'wordcamporg' ); ?>
+		</label>
+		<textarea id="sft-question-3"></textarea>
+	</div>
+
+	<input type="submit" value="<?php esc_attr_e( 'Send Feedback', 'wordcamporg' ); ?>" />
+</form>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -17,10 +17,12 @@ defined( 'WPINC' ) || die();
 define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 define( __NAMESPACE__ . '\OPTION_KEY', 'sft_feedback_page' );
+define( __NAMESPACE__ . '\QUERY_VAR', 'sft_feedback' );
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
+add_action( 'init', __NAMESPACE__ . '\add_page_endpoint' );
 
 // Check if the page exists, and add it if not.
 add_action( 'init', __NAMESPACE__ . '\add_feedback_page' );
@@ -40,6 +42,8 @@ function load() {
  */
 function activate() {
 	add_feedback_page();
+	add_page_endpoint();
+	flush_rewrite_rules();
 }
 
 /**
@@ -69,6 +73,14 @@ function add_feedback_page() {
 	if ( $page_id > 0 ) {
 		update_option( OPTION_KEY, $page_id );
 	}
+}
+
+/**
+ * Register a rewrite endpoint for the API.
+ */
+function add_page_endpoint() {
+	// Uses EP_SESSIONS mask to only add this endpoint to the session.
+	add_rewrite_endpoint( 'feedback', EP_SESSIONS, QUERY_VAR );
 }
 
 /**


### PR DESCRIPTION
See #334 — This PR adds a new endpoint for `[session]/feedback`, which will have the feedback form on it. This branches off #357, and updates the navigation action to redirect to these new pages.

I haven't styled anything yet, or done any submission work, but am looking for feedback on this approach & flow.

### Screenshots

<img width="456" alt="Screen Shot 2020-02-07 at 3 46 27 PM" src="https://user-images.githubusercontent.com/541093/74064611-07681980-49c1-11ea-98ee-964adca94b75.png">

### How to test the changes in this Pull Request:

1. Deactivate/Activate the plugin, or flush permalinks
2. Visit the `site.wordcamp.org/feedback` page from #357 
3. Pick a session, submit
4. It should redirect you to a session page with a form on it (URL is wonky right now, but the page loads correctly)

Alternately, visit the session feedback directly, by adding `feedback` to a session URL, ex:

```
https://site.wordcamp.test/session/session-name/feedback
```

You should see the feedback form.
