### PR TITLE
Refactor sponsor invoice update/notify system to avoid issues caused by `switch_to_blog`

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -496,7 +496,7 @@ function delete_index_row( $invoice_id ) {
  *
  * This runs as a cron job on every site, so it only needs to look for invoices that are from the current site.
  * (Previously it pulled all pending invoices from the index table, which caused weird issues like the email about
- * an invoice in Chicago coming from a WordCamp site in Germany.)
+ * an invoice in Chicago coming from a WordCamp site in Germany, translated in `de_DE`.)
  *
  * @return void
  */

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -14,21 +14,17 @@ const LATEST_DATABASE_VERSION = 3;
 
 if ( defined( 'DOING_AJAX' ) ) {
 	add_action( 'wp_ajax_wcbdsi_approve_invoice', __NAMESPACE__ . '\handle_approve_invoice_request'       );
-	add_action( 'save_post',                      __NAMESPACE__ . '\update_index_row',              10, 2 );
-} elseif ( defined( 'DOING_CRON' ) ) {
-	add_action( 'save_post', __NAMESPACE__ . '\update_index_row', 10, 2 );
 } elseif ( is_network_admin() ) {
 	add_action( 'network_admin_menu', __NAMESPACE__ . '\register_submenu_page' );
 	add_action( 'init',               __NAMESPACE__ . '\upgrade_database'      );
-} elseif ( is_admin() ) {
-	add_action( 'save_post',    __NAMESPACE__ . '\update_index_row', 11, 2 );   // See note in callback about priority.
-	add_action( 'trashed_post', __NAMESPACE__ . '\delete_index_row'        );
-	add_action( 'delete_post',  __NAMESPACE__ . '\delete_index_row'        );
 }
 
 add_action( 'plugins_loaded',                 __NAMESPACE__ . '\schedule_cron_events'  );
 add_action( 'wcbdsi_check_for_paid_invoices', __NAMESPACE__ . '\check_for_paid_invoices'       );
 add_action( 'send_invoice_pending_reminder',  __NAMESPACE__ . '\send_invoice_pending_reminder' );
+add_action( 'save_post',                      __NAMESPACE__ . '\update_index_row', 11, 2 ); // See note in callback about priority.
+add_action( 'trashed_post',                   __NAMESPACE__ . '\delete_index_row'        );
+add_action( 'delete_post',                    __NAMESPACE__ . '\delete_index_row'        );
 
 /**
  * Schedule cron jobs.

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -8,7 +8,7 @@ use WordCamp_QBO_Client;
 use WordCamp_Budgets;
 use const WordCamp\Budgets\Sponsor_Invoices\POST_TYPE;
 
-defined( 'WPINC' ) or die();
+defined( 'WPINC' ) || die();
 
 const LATEST_DATABASE_VERSION = 3;
 
@@ -443,7 +443,7 @@ function update_index_row( $invoice_id, $invoice ) {
 		return;
 	}
 
-	// Drafts, etc aren't displayed in the list table, so there's no reason to index them
+	// Drafts, etc aren't displayed in the list table, so there's no reason to index them.
 	$ignored_statuses = array( 'auto-draft', 'draft', 'trash' );
 
 	if ( in_array( $invoice->post_status, $ignored_statuses, true ) ) {
@@ -462,7 +462,7 @@ function update_index_row( $invoice_id, $invoice ) {
 		'sponsor_name'   => substr( get_sponsor_name( $invoice_id ), 0, 75 ),
 		'description'    => get_post_meta( $invoice_id, '_wcbsi_description', true ),
 		'currency'       => get_post_meta( $invoice_id, '_wcbsi_currency',    true ),
-		'due_date'       => 0,  // todo remove this field from index
+		'due_date'       => 0,  // todo remove this field from index.
 		'amount'         => get_post_meta( $invoice_id, '_wcbsi_amount',      true ),
 	);
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -598,7 +598,8 @@ function send_invoice_pending_reminder_mail( $invoice_id, $organizer_mail ) {
 			'From: WordCamp Central <support@wordcamp.org>',
 			'Content-Type: text/html; charset=UTF-8',
 			'Sender: wordpress@' . strtolower( $_SERVER['SERVER_NAME'] ),
-			sprintf( "CC: %s", $organizer_mail ), // CC to lead organizer in case post author is not active anymore.
+			sprintf( 'CC: %s', $organizer_mail ), // CC to lead organizer in case post author is not active anymore.
+			'BCC: ' . EMAIL_DEVELOPER_NOTIFICATIONS, // Temporary, to test that these notifications are working.
 		)
 	);
 }
@@ -628,6 +629,7 @@ function send_invoice_defaulted_notification( $invoice_id ) {
 			'From: WordCamp Central <support@wordcamp.org>',
 			'Content-Type: text/html; charset=UTF-8',
 			'Sender: wordpress@' . strtolower( $_SERVER['SERVER_NAME'] ),
+			'BCC: ' . EMAIL_DEVELOPER_NOTIFICATIONS, // Temporary, to test that these notifications are working.
 		)
 	);
 }

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -280,7 +280,7 @@ function check_for_paid_invoices() {
 	) );
 
 	// Batch requests in order to avoid request size limits imposed by QuickBooks, nginx, etc.
-	$qbo_invoice_ids = wp_list_pluck( $sent_invoices, 'qbo_invoice_id' );
+	$qbo_invoice_ids = wp_list_pluck( $sent_invoices, '_wcbsi_qbo_invoice_id' );
 	$qbo_invoice_ids = array_chunk( $qbo_invoice_ids, 20 );
 
 	$paid_invoices = array();
@@ -307,7 +307,7 @@ function check_for_paid_invoices() {
  */
 function mark_invoices_as_paid( $sent_invoices, $paid_invoices ) {
 	foreach ( $sent_invoices as $invoice ) {
-		if ( in_array( (int) $invoice->qbo_invoice_id, $paid_invoices, true ) ) {
+		if ( in_array( (int) $invoice->_wcbsi_qbo_invoice_id, $paid_invoices, true ) ) {
 			update_invoice_status( $invoice->ID, 'paid' );
 			notify_organizer_status_changed( $invoice->ID, 'paid' );
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -576,11 +576,11 @@ function send_invoice_pending_reminder_mail( $invoice_id, $organizer_mail ) {
 		'',
 		sprintf(
 			__(
-				"Howdy organizers,
+				'Howdy organizers,
 				<br>
-				It looks like the invoice <a href='%s'>%s</a> is still unpaid. If you still expect the sponsor to pay this invoice, please contact them to find out when we should expect payment. If this invoice needs to be cancelled, please email support@wordcamp.org.
+				It looks like the invoice <a href="%1$s">%2$s</a> is still unpaid. If you still expect the sponsor to pay this invoice, please contact them to find out when we should expect payment. If this invoice needs to be cancelled, please email support@wordcamp.org.
 				<br>
-				Thanks for all your hard work on WordCamp.",
+				Thanks for all your hard work on WordCamp.',
 				'wordcamporg'
 			),
 			$edit_link,
@@ -592,7 +592,7 @@ function send_invoice_pending_reminder_mail( $invoice_id, $organizer_mail ) {
 
 	wp_mail(
 		array( $author->user_email ),
-		sprintf( __( "Pending invoice: %s" ,'wordcamporg' ), $invoice->post_title ),
+		sprintf( __( 'Pending invoice: %s', 'wordcamporg' ), $invoice->post_title ),
 		$reminder_body,
 		array(
 			'From: WordCamp Central <support@wordcamp.org>',
@@ -622,8 +622,8 @@ function send_invoice_defaulted_notification( $invoice_id ) {
 	);
 
 	wp_mail(
-		array( "support@wordcamp.org" ),
-		"Sponsor Invoice pending for too long",
+		array( 'support@wordcamp.org' ),
+		'Sponsor Invoice pending for too long',
 		$notification_body,
 		array(
 			'From: WordCamp Central <support@wordcamp.org>',


### PR DESCRIPTION
Removes `switch_to_blog` wherever possible in the ecosystem of functions that processes and notifies about changes to sponsor invoices.

**To do:**

* [ ] ~Maybe make email message strings translatable that currently aren't~ This PR is complicated enough, we can do this later.
* [x] Add more temporary logging or email to devs for tracking/troubleshooting

Fixes #358 

**To test:**

1. Follow all the testing steps in #371 to create two or three invoices and check that they have all been sent over to the QBO sandbox. When you click the "Approve" button on an invoice in the network Invoices dashboard, you should be able to refresh the screen and see that it has moved from the "Submitted" tab to the "Sent" tab. Then also in the Sponsor Invoices list table over on the test site, you should see that the status of the invoice changes as well. (Success here indicates that both the post status and the entry in the index table are being updated correctly)
1. In the QBO sandbox company dashboard, on the Invoices screen, choose one of the invoices that you just created and click the button to "Receive payment"
1. Open up MailCatcher so you can see email notifications being sent from the test environment.
1. In order to test the cron job that checks for paid invoices, you can use wp-cli to immediately trigger a scheduled event. So first, test that running the cron job on a different site from the one where the invoices are does _not_ mark anything as paid:
    `wp --allow-root --url=https://wrongsite.wordcamp.test cron event run wcbdsi_check_for_paid_invoices`
1. Then go to the site that does have the sponsor invoices:
    `wp --allow-root --url=https://rightsite.wordcamp.test cron event run wcbdsi_check_for_paid_invoices`
1. The invoice that received payment should move from "Sent" to "Paid" in the network Invoices dashboard, and the status of the invoice post in the test site should also update to Paid. MailCatcher should have an email about the invoice being paid. Note that this email notification is not translatable, so it will be in `en_US`.
1. In order to test the pending invoice reminder email cron job, you'll need to add a temporary hack to the code. In the `send_invoice_pending_reminder()` function, comment out lines 551 through 561, so it will send for all pending invoices, even though you just created them today, and also not mark them as defaulted in the case that your test WordCamp start date is already in the past.
1. Change the locale to something other than `en_US` (to test whether this email notification, which is translatable, is sent using the correct locale).
1. As with the above tests for finding paid invoices, try first on the wrong site to make sure no reminder emails are sent, and then from the correct site to make sure the emails _are_ sent, and in the correct locale:
    `wp --allow-root --url=https://wrongsite.wordcamp.test cron event run send_invoice_pending_reminder`
    `wp --allow-root --url=https://rightsite.wordcamp.test cron event run send_invoice_pending_reminder`
1. When finished, don't forget to remove the temporary hack 😄 