### PR TITLE
CampTix: Improve ticket form accessibility

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -84,7 +84,7 @@ class Accommodations_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
 				<?php echo esc_html( $this->question ); ?>
-				<span aria-hidden class="tix-required-star">*</span>
+				<span aria-hidden="true" class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -67,6 +67,51 @@ class Accommodations_Field extends CampTix_Addon {
 	}
 
 	/**
+	 * Render the field, used on both Registration and when editing an existing ticket.
+	 *
+	 * @param string $name
+	 * @param string $value
+	 */
+	public function render_field( $name, $value ) {
+		?>
+
+		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
+			<td class="tix-required tix-left">
+				<?php echo esc_html( $this->question ); ?>
+				<span aria-hidden="true" class="tix-required-star">*</span>
+			</td>
+
+			<td class="tix-right">
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
+					<label>
+						<input
+							name="<?php echo esc_attr( $name ); ?>"
+							type="radio"
+							value="yes"
+							<?php checked( 'yes', $value ); ?>
+							required
+						/>
+						<?php echo esc_html( $this->options['yes'] ); ?>
+					</label>
+					<br />
+					<label>
+						<input
+							name="<?php echo esc_attr( $name ); ?>"
+							type="radio"
+							value="no"
+							<?php checked( 'no', $value ); ?>
+							required
+						/>
+						<?php echo esc_html( $this->options['no'] ); ?>
+					</label>
+				</fieldset>
+			</td>
+		</tr>
+
+		<?php
+	}
+
+	/**
 	 * Render the new field for the registration form during checkout.
 	 *
 	 * @param array $form_data
@@ -79,30 +124,10 @@ class Accommodations_Field extends CampTix_Addon {
 			self::SLUG => '',
 		) );
 
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $this->question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-					<br />
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
+		$this->render_field(
+			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
+			$current_data[ self::SLUG ]
+		);
 	}
 
 	/**
@@ -205,28 +230,10 @@ class Accommodations_Field extends CampTix_Addon {
 			self::SLUG => 'no',
 		) );
 
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $this->question ); ?>
-				<span class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<label>
-					<input name="tix_ticket_info[<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['yes'] ); ?>
-				</label>
-				<br />
-				<label>
-					<input name="tix_ticket_info[<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['no'] ); ?>
-				</label>
-			</td>
-		</tr>
-
-		<?php
+		$this->render_field(
+			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
+			$current_data[ self::SLUG ]
+		);
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -84,19 +84,21 @@ class Accommodations_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
 				<?php echo esc_html( $this->question ); ?>
-				<span class="tix-required-star">*</span>
+				<span aria-hidden class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['yes'] ); ?>
-				</label>
-				<br />
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['no'] ); ?>
-				</label>
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html( $this->options['yes'] ); ?>
+					</label>
+					<br />
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html( $this->options['no'] ); ?>
+					</label>
+				</fieldset>
 			</td>
 		</tr>
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -65,6 +65,51 @@ class Allergy_Field extends CampTix_Addon {
 	}
 
 	/**
+	 * Render the field, used on both Registration and when editing an existing ticket.
+	 *
+	 * @param string $name
+	 * @param string $value
+	 */
+	public function render_field( $name, $value ) {
+		?>
+
+		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
+			<td class="tix-required tix-left">
+				<?php echo esc_html( $this->question ); ?>
+				<span aria-hidden="true" class="tix-required-star">*</span>
+			</td>
+
+			<td class="tix-right">
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
+					<label>
+						<input
+							name="<?php echo esc_attr( $name ); ?>"
+							type="radio"
+							value="yes"
+							<?php checked( 'yes', $value ); ?>
+							required
+						/>
+						<?php echo esc_html( $this->options['yes'] ); ?>
+					</label>
+					<br />
+					<label>
+						<input
+							name="<?php echo esc_attr( $name ); ?>"
+							type="radio"
+							value="no"
+							<?php checked( 'no', $value ); ?>
+							required
+						/>
+						<?php echo esc_html( $this->options['no'] ); ?>
+					</label>
+				</fieldset>
+			</td>
+		</tr>
+
+		<?php
+	}
+
+	/**
 	 * Render the new field for the registration form during checkout.
 	 *
 	 * @param array $form_data
@@ -77,30 +122,10 @@ class Allergy_Field extends CampTix_Addon {
 			self::SLUG => '',
 		) );
 
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $this->question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-					<br />
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
+		$this->render_field(
+			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
+			$current_data[ self::SLUG ]
+		);
 	}
 
 	/**
@@ -203,28 +228,10 @@ class Allergy_Field extends CampTix_Addon {
 			self::SLUG => 'no',
 		) );
 
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $this->question ); ?>
-				<span class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<label>
-					<input name="tix_ticket_info[<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['yes'] ); ?>
-				</label>
-				<br />
-				<label>
-					<input name="tix_ticket_info[<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['no'] ); ?>
-				</label>
-			</td>
-		</tr>
-
-		<?php
+		$this->render_field(
+			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
+			$current_data[ self::SLUG ]
+		);
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -82,7 +82,7 @@ class Allergy_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
 				<?php echo esc_html( $this->question ); ?>
-				<span aria-hidden class="tix-required-star">*</span>
+				<span aria-hidden="true" class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -82,19 +82,21 @@ class Allergy_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
 				<?php echo esc_html( $this->question ); ?>
-				<span class="tix-required-star">*</span>
+				<span aria-hidden class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['yes'] ); ?>
-				</label>
-				<br />
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['no'] ); ?>
-				</label>
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html( $this->options['yes'] ); ?>
+					</label>
+					<br />
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html( $this->options['no'] ); ?>
+					</label>
+				</fieldset>
 			</td>
 		</tr>
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
@@ -61,7 +61,7 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
 				<?php echo wp_kses_post( $question ); ?>
-				<span aria-hidden class="tix-required-star">*</span>
+				<span aria-hidden="true" class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
@@ -46,29 +46,31 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 
 		$current_data[ self::SLUG ] = wp_validate_boolean( $current_data[ self::SLUG ] );
 
+		$coc_url = $this->maybe_get_coc_url();
+		$question = __( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' );
+		if ( $coc_url ) {
+			$question = sprintf(
+				/* translators: %s placeholder is a URL */
+				__( 'Do you agree to follow the event <a href="%s" target="_blank">Code of Conduct</a>?', 'wordcamporg' ),
+				esc_url( $coc_url )
+			);
+		}
+
 		?>
 
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
-				<?php
-				if ( $coc_url = $this->maybe_get_coc_url() ) :
-					printf(
-						/* translators: %s placeholder is a URL */
-						wp_kses_post( __( 'Do you agree to follow the event <a href="%s" target="_blank">Code of Conduct</a>?', 'wordcamporg' ) ),
-						esc_url( $coc_url )
-					);
-				else :
-					esc_html_e( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' );
-				endif;
-				?>
-				<span class="tix-required-star">*</span>
+				<?php echo wp_kses_post( $question ); ?>
+				<span aria-hidden class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="checkbox" <?php checked( $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html_x( 'Yes', 'ticket registration option', 'wordcamporg' ); ?>
-				</label>
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( strip_tags( $question ) ); ?>">
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="checkbox" <?php checked( $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html_x( 'Yes', 'ticket registration option', 'wordcamporg' ); ?>
+					</label>
+				</fieldset>
 			</td>
 		</tr>
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
@@ -58,6 +58,51 @@ class Privacy_Field extends CampTix_Addon {
 	}
 
 	/**
+	 * Render the field, used on both Registration and when editing an existing ticket.
+	 *
+	 * @param string $name
+	 * @param string $value
+	 */
+	public function render_field( $name, $value ) {
+		?>
+
+		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
+			<td class="tix-left">
+				<?php echo wp_kses_post( $this->question ); ?>
+				<span aria-hidden="true" class="tix-required-star">*</span>
+			</td>
+
+			<td class="tix-right">
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->a11y_label ); ?>">
+					<label>
+						<input
+							name="<?php echo esc_attr( $name ); ?>"
+							type="radio"
+							value="yes"
+							<?php checked( 'yes', $value ); ?>
+							required
+						/>
+						<?php echo esc_html( $this->options['yes'] ); ?>
+					</label>
+					<br />
+					<label>
+						<input
+							name="<?php echo esc_attr( $name ); ?>"
+							type="radio"
+							value="no"
+							<?php checked( 'no', $value ); ?>
+							required
+						/>
+						<?php echo esc_html( $this->options['no'] ); ?>
+					</label>
+				</fieldset>
+			</td>
+		</tr>
+
+		<?php
+	}
+
+	/**
 	 * Render the new field for the registration form during checkout.
 	 *
 	 * @param array $form_data
@@ -70,30 +115,10 @@ class Privacy_Field extends CampTix_Addon {
 			self::SLUG => '',
 		) );
 
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-left">
-				<?php echo wp_kses_post( $this->question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->a11y_label ); ?>">
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-					<br />
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
+		$this->render_field(
+			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
+			$current_data[ self::SLUG ]
+		);
 	}
 
 	/**
@@ -198,28 +223,10 @@ class Privacy_Field extends CampTix_Addon {
 			self::SLUG => 'yes',
 		) );
 
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-left">
-				<?php echo wp_kses_post( $this->question ); ?>
-				<span class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<label>
-					<input name="tix_ticket_info[<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['yes'] ); ?>
-				</label>
-				<br />
-				<label>
-					<input name="tix_ticket_info[<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['no'] ); ?>
-				</label>
-			</td>
-		</tr>
-
-		<?php
+		$this->render_field(
+			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
+			$current_data[ self::SLUG ]
+		);
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
@@ -75,7 +75,7 @@ class Privacy_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-left">
 				<?php echo wp_kses_post( $this->question ); ?>
-				<span class="tix-required-star">*</span>
+				<span aria-hidden="true" class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
@@ -38,6 +38,7 @@ class Privacy_Field extends CampTix_Addon {
 				esc_url( get_privacy_policy_url() )
 			);
 		}
+		$this->a11y_label = __( 'Do you want to be listed on the public Attendees page?', 'wordcamporg' );
 
 		$this->options = array(
 			'yes' => _x( 'Yes', 'ticket registration option', 'wordcamporg' ),
@@ -78,15 +79,17 @@ class Privacy_Field extends CampTix_Addon {
 			</td>
 
 			<td class="tix-right">
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['yes'] ); ?>
-				</label>
-				<br />
-				<label>
-					<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
-					<?php echo esc_html( $this->options['no'] ); ?>
-				</label>
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->a11y_label ); ?>">
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="yes" <?php checked( 'yes', $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html( $this->options['yes'] ); ?>
+					</label>
+					<br />
+					<label>
+						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="radio" value="no" <?php checked( 'no', $current_data[ self::SLUG ] ); ?> required />
+						<?php echo esc_html( $this->options['no'] ); ?>
+					</label>
+				</fieldset>
 			</td>
 		</tr>
 

--- a/public_html/wp-content/plugins/camptix/addons/field-country.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-country.php
@@ -29,10 +29,15 @@ class CampTix_Addon_Country_Field extends CampTix_Addon {
 	 * Render the Country `select` field on the front-end.
 	 */
 	function question_field_country( $name, $user_value, $question, $required = false ) {
+		global $camptix;
 		$countries = wp_list_pluck( wcorg_get_countries(), 'name' );
 		?>
 
-		<select name="<?php echo esc_attr( $name ); ?>" <?php if ( $required ) echo 'required'; ?>>
+		<select
+			id="<?php echo esc_attr( $camptix->get_field_id( $name ) ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			<?php if ( $required ) echo 'required'; ?>
+		>
 			<?php foreach ( $countries as $country ) : ?>
 				<option value="<?php echo esc_attr( $country ); ?>" <?php selected( $country, $user_value ); ?>>
 					<?php echo esc_html( $country ); ?>

--- a/public_html/wp-content/plugins/camptix/addons/field-tshirt.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-tshirt.php
@@ -28,9 +28,14 @@ class CampTix_Addon_Tshirt_Field extends CampTix_Addon {
 	}
 
 	function question_field_tshirt( $name, $value, $question, $required = false ) {
+		global $camptix;
 		$values = get_post_meta( $question->ID, 'tix_values', true );
 		?>
-		<select name="<?php echo esc_attr( $name ); ?>" <?php if ( $required ) echo 'required'; ?>>
+		<select
+			id="<?php echo esc_attr( $camptix->get_field_id( $name ) ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			<?php if ( $required ) echo 'required'; ?>
+		>
 			<?php foreach ( (array) $values as $question_value ) : ?>
 				<option <?php selected( $question_value, $value ); ?> value="<?php echo esc_attr( $question_value ); ?>"><?php echo esc_html( $question_value ); ?></option>
 			<?php endforeach; ?>

--- a/public_html/wp-content/plugins/camptix/addons/field-url.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-url.php
@@ -27,8 +27,15 @@ class CampTix_Addon_URL_Field extends CampTix_Addon {
 	 * A url input for a question.
 	 */
 	function question_field_url( $name, $value, $question, $required = false ) {
+		global $camptix;
 		?>
-		<input name="<?php echo esc_attr( $name ); ?>" type="url" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) echo 'required'; ?> />
+		<input
+			id="<?php echo esc_attr( $camptix->get_field_id( $name ) ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			type="url"
+			value="<?php echo esc_attr( $value ); ?>"
+			<?php if ( $required ) echo 'required'; ?>
+		/>
 		<?php
 	}
 

--- a/public_html/wp-content/plugins/camptix/camptix.css
+++ b/public_html/wp-content/plugins/camptix/camptix.css
@@ -50,6 +50,12 @@
 	color: #DD0000;
 }
 
+.tix-screen-reader-fieldset {
+	margin: 0;
+	padding: 0;
+	border: none;
+}
+
 #tix {
 	padding-top: 20px;
 }

--- a/public_html/wp-content/plugins/camptix/camptix.css
+++ b/public_html/wp-content/plugins/camptix/camptix.css
@@ -161,6 +161,14 @@ body.admin-bar #tix {
 	vertical-align: middle;
 }
 
+.tix-tickets-list .tix-column-description {
+	font-weight: normal;
+}
+
+.tix-tickets-list .tix-ticket-title {
+	font-weight: bold;
+}
+
 .tix-submit {
 	text-align: right;
 }

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /*
  * Plugin Name: CampTix for WordCamp.org
  * Plugin URI:  http://wordcamp.org
@@ -4204,15 +4205,23 @@ class CampTix_Plugin {
 	}
 
 	/**
+	 * Sanitize the field name for use as an HTML ID attribute.
+	 */
+	function get_field_id( $name ) {
+		return sanitize_html_class( str_replace( array( '[', ']' ), array( '-', '' ), $name ) );
+	}
+
+	/**
 	 * A text input for a question.
 	 */
 	function question_field_text( $name, $value, $question, $required = false ) {
 		?>
 		<input
-				name="<?php echo esc_attr( $name ); ?>"
-				type="text"
-				value="<?php echo esc_attr( $value ); ?>"
-				<?php if ( $required ) echo 'required'; ?>
+			id="<?php echo esc_attr( $this->get_field_id( $name ) ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			type="text"
+			value="<?php echo esc_attr( $value ); ?>"
+			<?php if ( $required ) echo 'required'; ?>
 		/>
 		<?php
 	}
@@ -4223,7 +4232,11 @@ class CampTix_Plugin {
 	function question_field_select( $name, $user_value, $question, $required = false ) {
 		$values = get_post_meta( $question->ID, 'tix_values', true );
 		?>
-		<select name="<?php echo esc_attr( $name ); ?>" <?php if ( $required ) echo 'required'; ?>>
+		<select
+			id="<?php echo esc_attr( $this->get_field_id( $name ) ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			<?php if ( $required ) echo 'required'; ?>
+		>
 			<?php foreach ( (array) $values as $question_value ) : ?>
 				<option <?php selected( $question_value, $user_value ); ?> value="<?php echo esc_attr( $question_value ); ?>"><?php echo esc_html( $question_value ); ?></option>
 			<?php endforeach; ?>
@@ -4238,6 +4251,10 @@ class CampTix_Plugin {
 		$values = get_post_meta( $question->ID, 'tix_values', true );
 		$user_value_esc = array_map( 'esc_attr', (array) $user_value );
 		?>
+		<fieldset
+			class="tix-screen-reader-fieldset"
+			aria-label="<?php echo esc_attr( apply_filters( 'the_title', $question->post_title ) ); ?>"
+		>
 		<?php if ( $values ) : ?>
 			<?php foreach ( (array) $values as $question_value ) : ?>
 				<label>
@@ -4256,6 +4273,7 @@ class CampTix_Plugin {
 				<?php _e( 'Yes', 'wordcamporg' ); ?>
 			</label>
 		<?php endif; ?>
+		</fieldset>
 		<?php
 	}
 
@@ -4264,7 +4282,11 @@ class CampTix_Plugin {
 	 */
 	function question_field_textarea( $name, $value, $question, $required = false ) {
 		?>
-		<textarea name="<?php echo esc_attr( $name ); ?>" <?php if ( $required ) echo 'required'; ?>><?php echo esc_textarea( $value ); ?></textarea>
+		<textarea
+			id="<?php echo esc_attr( $this->get_field_id( $name ) ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+			<?php if ( $required ) echo 'required'; ?>
+		><?php echo esc_textarea( $value ); ?></textarea>
 		<?php
 	}
 
@@ -4274,12 +4296,17 @@ class CampTix_Plugin {
 	function question_field_radio( $name, $user_value, $question, $required = false ) {
 		$values = get_post_meta( $question->ID, 'tix_values', true );
 		?>
-		<?php foreach ( (array) $values as $question_value ) : ?>
-			<label>
-				<input <?php checked( $question_value, $user_value ); ?> name="<?php echo esc_attr( $name ); ?>" type="radio" value="<?php echo esc_attr( $question_value ); ?>" <?php if ( $required ) echo 'required'; ?> />
-				<?php echo esc_html( $question_value ); ?>
-			</label><br />
-		<?php endforeach; ?>
+		<fieldset
+			class="tix-screen-reader-fieldset"
+			aria-label="<?php echo esc_attr( apply_filters( 'the_title', $question->post_title ) ); ?>"
+		>
+			<?php foreach ( (array) $values as $question_value ) : ?>
+				<label>
+					<input <?php checked( $question_value, $user_value ); ?> name="<?php echo esc_attr( $name ); ?>" type="radio" value="<?php echo esc_attr( $question_value ); ?>" <?php if ( $required ) echo 'required'; ?> />
+					<?php echo esc_html( $question_value ); ?>
+				</label><br />
+			<?php endforeach; ?>
+		</fieldset>
 		<?php
 	}
 
@@ -5575,20 +5602,42 @@ class CampTix_Plugin {
 
 								<?php ob_start(); ?>
 								<tr class="tix-row-first-name">
-									<td class="tix-required tix-left"><?php _e( 'First Name', 'wordcamporg' ); ?> <span class="tix-required-star">*</span></td>
+									<td class="tix-required tix-left">
+										<label for="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][first_name]" ) ); ?>">
+											<?php _e( 'First Name', 'wordcamporg' ); ?>
+											<span aria-hidden class="tix-required-star">*</span>
+										</label>
+									</td>
 									<?php $value = isset( $this->form_data['tix_attendee_info'][$i]['first_name'] ) ? $this->form_data['tix_attendee_info'][$i]['first_name'] : apply_filters( 'camptix_attendee_info_default_value', '', 'first_name', $this->form_data, $ticket, $i ); ?>
 									<td class="tix-right">
-										<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][first_name]" type="text" value="<?php echo esc_attr( $value ); ?>" required />
+										<input
+											id="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][first_name]" ) ); ?>"
+											name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][first_name]"
+											type="text"
+											value="<?php echo esc_attr( $value ); ?>"
+											required
+										/>
 									</td>
 								</tr>
 								<?php $first = ob_get_clean(); ?>
 
 								<?php ob_start(); ?>
 								<tr class="tix-row-last-name">
-									<td class="tix-required tix-left"><?php _e( 'Last Name', 'wordcamporg' ); ?> <span class="tix-required-star">*</span></td>
+									<td class="tix-required tix-left">
+										<label for="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][last_name]" ) ); ?>">
+											<?php _e( 'Last Name', 'wordcamporg' ); ?>
+											<span aria-hidden class="tix-required-star">*</span>
+										</label>
+									</td>
 									<?php $value = isset( $this->form_data['tix_attendee_info'][$i]['last_name'] ) ? $this->form_data['tix_attendee_info'][$i]['last_name'] : apply_filters( 'camptix_attendee_info_default_value', '', 'last_name', $this->form_data, $ticket, $i ); ?>
 									<td class="tix-right">
-										<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][last_name]" type="text" value="<?php echo esc_attr( $value ); ?>" required />
+										<input
+											id="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][last_name]" ) ); ?>"
+											name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][last_name]"
+											type="text"
+											value="<?php echo esc_attr( $value ); ?>"
+											required
+										/>
 									</td>
 								</tr>
 								<?php $last = ob_get_clean(); ?>
@@ -5598,10 +5647,22 @@ class CampTix_Plugin {
 								<?php do_action( 'camptix_attendee_form_additional_info', $this->form_data, $i, $this->tickets_selected_count ); ?>
 
 								<tr class="tix-row-email">
-									<td class="tix-required tix-left"><?php _e( 'E-mail', 'wordcamporg' ); ?> <span class="tix-required-star">*</span></td>
+									<td class="tix-required tix-left">
+										<label for="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][email]" ) ); ?>">
+											<?php _e( 'E-mail', 'wordcamporg' ); ?>
+											<span aria-hidden class="tix-required-star">*</span>
+										</label>
+									</td>
 									<?php $value = isset( $this->form_data['tix_attendee_info'][$i]['email'] ) ? $this->form_data['tix_attendee_info'][$i]['email'] : apply_filters( 'camptix_attendee_info_default_value', '', 'email', $this->form_data, $ticket, $i ); ?>
 									<td class="tix-right">
-										<input class="tix-field-email" name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][email]" type="email" value="<?php echo esc_attr( $value ); ?>" required />
+										<input
+											id="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][email]" ) ); ?>"
+											class="tix-field-email"
+											name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][email]"
+											type="email"
+											value="<?php echo esc_attr( $value ); ?>"
+											required
+										/>
 										<?php $tix_receipt_email = isset( $this->form_data['tix_receipt_email'] ) ? $this->form_data['tix_receipt_email'] : 1; ?>
 
 										<?php if ( $this->tickets_selected_count > 1 ) : ?>
@@ -5633,8 +5694,10 @@ class CampTix_Plugin {
 
 										<tr class="<?php echo esc_attr( $class_name ); ?>">
 											<td class="<?php if ( $required ) echo 'tix-required'; ?> tix-left">
-												<?php echo make_clickable( esc_html( apply_filters( 'the_title', $question->post_title ) ) ); ?>
-												<?php if ( $required ) echo ' <span class="tix-required-star">*</span>'; ?>
+												<label for="<?php echo in_array( $type, array( 'radio', 'checkbox' ) ) ? '' : $this->get_field_id( $name ); ?>">
+													<?php echo make_clickable( esc_html( apply_filters( 'the_title', $question->post_title ) ) ); ?>
+													<?php if ( $required ) echo ' <span aria-hidden class="tix-required-star">*</span>'; ?>
+												</label>
 											</td>
 											<td class="tix-right">
 												<?php do_action( "camptix_question_field_{$type}", $name, $value, $question, $required ); ?>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5310,7 +5310,7 @@ class CampTix_Plugin {
 					<input type="hidden" name="tix_reservation_token" value="<?php echo esc_attr( $this->reservation['token'] ); ?>" />
 				<?php endif; ?>
 
-				<table class="tix_tickets_table">
+				<table class="tix_tickets_table tix-tickets-list">
 					<thead>
 						<tr>
 							<th scope="col" class="tix-column-description"><?php _e( 'Description', 'wordcamporg' ); ?></th>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5589,7 +5589,10 @@ class CampTix_Plugin {
 									</small>
 								<?php endif; ?>
 							</td>
-							<td><strong><?php echo esc_html( $this->append_currency( $total ) ); ?></strong></td>
+							<td>
+								<span class="screen-reader-text"><?php esc_html_e( 'Total:', 'wordcamporg' ); ?></span>
+								<strong><?php echo esc_html( $this->append_currency( $total ) ); ?></strong>
+							</td>
 						</tr>
 					</tbody>
 				</table>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5313,12 +5313,12 @@ class CampTix_Plugin {
 				<table class="tix_tickets_table">
 					<thead>
 						<tr>
-							<th class="tix-column-description"><?php _e( 'Description', 'wordcamporg' ); ?></th>
-							<th class="tix-column-price"><?php _e( 'Price', 'wordcamporg' ); ?></th>
+							<th scope="col" class="tix-column-description"><?php _e( 'Description', 'wordcamporg' ); ?></th>
+							<th scope="col" class="tix-column-price"><?php _e( 'Price', 'wordcamporg' ); ?></th>
 							<?php if ( apply_filters( 'camptix_show_remaining_tickets', true ) ) : ?>
-								<th class="tix-column-remaining"><?php _e( 'Remaining', 'wordcamporg' ); ?></th>
+								<th scope="col" class="tix-column-remaining"><?php _e( 'Remaining', 'wordcamporg' ); ?></th>
 							<?php endif; ?>
-							<th class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_quantity_row_classes', array( 'tix-column-quantity' ) ) ) ); ?>">
+							<th scope="col" class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_quantity_row_classes', array( 'tix-column-quantity' ) ) ) ); ?>">
 								<?php _e( 'Quantity', 'wordcamporg' ); ?>
 							</th>
 						</tr>
@@ -5347,16 +5347,18 @@ class CampTix_Plugin {
 							}
 							?>
 							<tr class="tix-ticket-<?php echo absint( $ticket->ID ); ?>">
-								<td class="tix-column-description">
-									<strong class="tix-ticket-title"><?php echo wp_kses_post( $ticket->post_title ); ?></strong>
+								<th class="tix-column-description" scope="row">
+									<label for="tix-qty-<?php echo absint( $ticket->ID ); ?>" class="tix-ticket-title">
+										<?php echo wp_kses_post( $ticket->post_title ); ?>
+									</label>
 									<?php if ( $ticket->post_excerpt ) : ?>
 										<br /><span class="tix-ticket-excerpt"><?php echo wp_kses_post( $ticket->post_excerpt ); ?></span>
 									<?php endif; ?>
 									<?php if ( $ticket->tix_coupon_applied ) : ?>
 										<br /><small class="tix-discount"><?php echo esc_html( $ticket->tix_discounted_text ); ?></small>
 									<?php endif; ?>
-								</td>
-								<td class="tix-column-price" style="vertical-align: middle;">
+								</th>
+								<td class="tix-column-price">
 									<?php if ( $price > 0 ) : ?>
 										<?php echo esc_html( $this->append_currency( $price ) ); ?>
 									<?php else : ?>
@@ -5364,10 +5366,12 @@ class CampTix_Plugin {
 									<?php endif; ?>
 								</td>
 								<?php if ( apply_filters( 'camptix_show_remaining_tickets', true ) ) : ?>
-									<td class="tix-column-remaining" style="vertical-align: middle;"><?php echo esc_html( apply_filters( 'camptix_form_start_tix_remaining', $ticket->tix_remaining, $ticket ) ); ?></td>
+									<td class="tix-column-remaining">
+										<?php echo esc_html( apply_filters( 'camptix_form_start_tix_remaining', $ticket->tix_remaining, $ticket ) ); ?>
+									</td>
 								<?php endif; ?>
-								<td class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_quantity_row_classes', array( 'tix-column-quantity' ) ) ) ); ?>" style="vertical-align: middle;">
-									<select name="tix_tickets_selected[<?php echo esc_attr( $ticket->ID ); ?>]">
+								<td class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_quantity_row_classes', array( 'tix-column-quantity' ) ) ) ); ?>">
+									<select id="tix-qty-<?php echo absint( $ticket->ID ); ?>" name="tix_tickets_selected[<?php echo esc_attr( $ticket->ID ); ?>]">
 										<?php foreach ( range( 0, $max ) as $value ) : ?>
 											<option <?php selected( $selected, $value ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $value ); ?></option>
 										<?php endforeach; ?>
@@ -5404,7 +5408,13 @@ class CampTix_Plugin {
 											<?php _e( 'Click here to enter a coupon code', 'wordcamporg' ); ?>
 										</a>
 										<div id="tix-coupon-container" style="display: none;">
-											<input type="text" id="tix-coupon-input" name="tix_coupon" value="" />
+											<input
+												type="text"
+												id="tix-coupon-input"
+												name="tix_coupon"
+												value=""
+												aria-label="<?php esc_attr_e( 'Coupon Code', 'wordcamporg' ); ?>"
+											/>
 											<input type="submit" name="tix_coupon_submit" value="<?php esc_attr_e( 'Apply Coupon', 'wordcamporg' ); ?>" />
 										</div>
 										<script>
@@ -5425,7 +5435,12 @@ class CampTix_Plugin {
 				</table>
 
 				<p>
-					<input type="submit" value="<?php esc_attr_e( 'Register &rarr;', 'wordcamporg' ); ?>" style="float: right; cursor: pointer;" class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_register_button_classes', array() ) ) ); ?>" />
+					<input
+						type="submit"
+						value="<?php esc_attr_e( 'Register &rarr;', 'wordcamporg' ); ?>"
+						style="float: right; cursor: pointer;"
+						class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_register_button_classes', array() ) ) ); ?>"
+					/>
 					<br class="tix-clear" />
 				</p>
 				</form>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5620,7 +5620,7 @@ class CampTix_Plugin {
 									<td class="tix-required tix-left">
 										<label for="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][first_name]" ) ); ?>">
 											<?php _e( 'First Name', 'wordcamporg' ); ?>
-											<span aria-hidden class="tix-required-star">*</span>
+											<span aria-hidden="true" class="tix-required-star">*</span>
 										</label>
 									</td>
 									<?php $value = isset( $this->form_data['tix_attendee_info'][$i]['first_name'] ) ? $this->form_data['tix_attendee_info'][$i]['first_name'] : apply_filters( 'camptix_attendee_info_default_value', '', 'first_name', $this->form_data, $ticket, $i ); ?>
@@ -5641,7 +5641,7 @@ class CampTix_Plugin {
 									<td class="tix-required tix-left">
 										<label for="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][last_name]" ) ); ?>">
 											<?php _e( 'Last Name', 'wordcamporg' ); ?>
-											<span aria-hidden class="tix-required-star">*</span>
+											<span aria-hidden="true" class="tix-required-star">*</span>
 										</label>
 									</td>
 									<?php $value = isset( $this->form_data['tix_attendee_info'][$i]['last_name'] ) ? $this->form_data['tix_attendee_info'][$i]['last_name'] : apply_filters( 'camptix_attendee_info_default_value', '', 'last_name', $this->form_data, $ticket, $i ); ?>
@@ -5665,7 +5665,7 @@ class CampTix_Plugin {
 									<td class="tix-required tix-left">
 										<label for="<?php echo esc_attr( $this->get_field_id( "tix_attendee_info[$i][email]" ) ); ?>">
 											<?php _e( 'E-mail', 'wordcamporg' ); ?>
-											<span aria-hidden class="tix-required-star">*</span>
+											<span aria-hidden="true" class="tix-required-star">*</span>
 										</label>
 									</td>
 									<?php $value = isset( $this->form_data['tix_attendee_info'][$i]['email'] ) ? $this->form_data['tix_attendee_info'][$i]['email'] : apply_filters( 'camptix_attendee_info_default_value', '', 'email', $this->form_data, $ticket, $i ); ?>
@@ -5711,7 +5711,7 @@ class CampTix_Plugin {
 											<td class="<?php if ( $required ) echo 'tix-required'; ?> tix-left">
 												<label for="<?php echo in_array( $type, array( 'radio', 'checkbox' ) ) ? '' : $this->get_field_id( $name ); ?>">
 													<?php echo make_clickable( esc_html( apply_filters( 'the_title', $question->post_title ) ) ); ?>
-													<?php if ( $required ) echo ' <span aria-hidden class="tix-required-star">*</span>'; ?>
+													<?php if ( $required ) echo ' <span aria-hidden="true" class="tix-required-star">*</span>'; ?>
 												</label>
 											</td>
 											<td class="tix-right">

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6048,19 +6048,55 @@ class CampTix_Plugin {
 							</th>
 						</tr>
 						<tr>
-							<td class="tix-required tix-left"><?php _e( 'First Name', 'wordcamporg' ); ?> <span class="tix-required-star">*</span></td>
-							<td class="tix-right"><input name="tix_ticket_info[first_name]" type="text" value="<?php echo esc_attr( $ticket_info['first_name'] ); ?>" /></td>
+							<td class="tix-required tix-left">
+								<label for="tix_ticket_info-first_name">
+									<?php _e( 'First Name', 'wordcamporg' ); ?>
+									<span aria-hidden="true" class="tix-required-star">*</span>
+								</label>
+							</td>
+							<td class="tix-right">
+								<input
+									id="tix_ticket_info-first_name"
+									name="tix_ticket_info[first_name]"
+									type="text"
+									value="<?php echo esc_attr( $ticket_info['first_name'] ); ?>"
+								/>
+							</td>
 						</tr>
 						<tr>
-							<td class="tix-required tix-left"><?php _e( 'Last Name', 'wordcamporg' ); ?> <span class="tix-required-star">*</span></td>
-							<td class="tix-right"><input name="tix_ticket_info[last_name]" type="text" value="<?php echo esc_attr( $ticket_info['last_name'] ); ?>" /></td>
+							<td class="tix-required tix-left">
+								<label for="tix_ticket_info-last_name">
+									<?php _e( 'Last Name', 'wordcamporg' ); ?>
+									<span aria-hidden="true" class="tix-required-star">*</span>
+								</label>
+							</td>
+							<td class="tix-right">
+								<input
+									id="tix_ticket_info-last_name"
+									name="tix_ticket_info[last_name]"
+									type="text"
+									value="<?php echo esc_attr( $ticket_info['last_name'] ); ?>"
+								/>
+							</td>
 						</tr>
 
 						<?php do_action( 'camptix_form_edit_attendee_additional_info', $attendee ); ?>
 
 						<tr>
-							<td class="tix-required tix-left"><?php _e( 'E-mail', 'wordcamporg' ); ?> <span class="tix-required-star">*</span></td>
-							<td class="tix-right"><input name="tix_ticket_info[email]" type="text" value="<?php echo esc_attr( $ticket_info['email'] ); ?>" /></td>
+							<td class="tix-required tix-left">
+								<label for="tix_ticket_info-email">
+									<?php _e( 'E-mail', 'wordcamporg' ); ?>
+									<span aria-hidden="true" class="tix-required-star">*</span>
+								</label>
+							</td>
+							<td class="tix-right">
+								<input
+									id="tix_ticket_info-email"
+									name="tix_ticket_info[email]"
+									type="text"
+									value="<?php echo esc_attr( $ticket_info['email'] ); ?>"
+								/>
+							</td>
 						</tr>
 
 						<?php do_action( 'camptix_form_edit_attendee_before_questions', $ticket_info ); ?>
@@ -6078,8 +6114,11 @@ class CampTix_Plugin {
 
 								<tr class="<?php echo esc_attr( $class_name ); ?>">
 									<td class="<?php if ( $required ) echo 'tix-required'; ?> tix-left">
-										<?php echo esc_html( apply_filters( 'the_title', $question->post_title ) ); ?>
-										<?php if ( $required ) echo ' <span class="tix-required-star">*</span>'; ?></td>
+										<label for="<?php echo in_array( $type, array( 'radio', 'checkbox' ) ) ? '' : $this->get_field_id( $name ); ?>">
+											<?php echo esc_html( apply_filters( 'the_title', $question->post_title ) ); ?>
+											<?php if ( $required ) echo ' <span aria-hidden="true" class="tix-required-star">*</span>'; ?>
+										</label>
+									</td>
 									<td class="tix-right">
 										<?php do_action( "camptix_question_field_{$type}", $name, $value, $question ); ?>
 									</td>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5532,10 +5532,10 @@ class CampTix_Plugin {
 				<table class="tix_tickets_table tix-order-summary">
 					<thead>
 						<tr>
-							<th class="tix-column-description"><?php _e( 'Description', 'wordcamporg' ); ?></th>
-							<th class="tix-column-per-ticket"><?php _e( 'Per Ticket', 'wordcamporg' ); ?></th>
-							<th class="tix-column-quantity"><?php _e( 'Quantity', 'wordcamporg' ); ?></th>
-							<th class="tix-column-price"><?php _e( 'Price', 'wordcamporg' ); ?></th>
+							<th scope="col" class="tix-column-description"><?php _e( 'Description', 'wordcamporg' ); ?></th>
+							<th scope="col" class="tix-column-per-ticket"><?php _e( 'Per Ticket', 'wordcamporg' ); ?></th>
+							<th scope="col" class="tix-column-quantity"><?php _e( 'Quantity', 'wordcamporg' ); ?></th>
+							<th scope="col" class="tix-column-price"><?php _e( 'Price', 'wordcamporg' ); ?></th>
 						</tr>
 					</thead>
 					<tbody>


### PR DESCRIPTION
Fixes multiple instances of unlabelled inputs in the registration flow for screen reader users. Add headings & table structure hints to the available ticket table, and label for the quantity dropdown. Add & attach labels to the registration form inputs, including addons & custom fields. Wrap the checkboxes & radios into `fieldset`s, using [hidden labels](https://codepen.io/stevef/post/fielsdet-and-legend-semantics) to attach the question text.

Fixes https://meta.trac.wordpress.org/ticket/1591

### Screenshots

There should be no visual changes.

### How to test the changes in this Pull Request:

1. Go through the ticket buying process using a screen reader
2. Every input you hit should have an audible label

(alternately you can use dev tools to check the accessible name of each input)
