### PR TITLE
Speaker Feedback: Respect a `speaker_feedback` skip feature flag

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -19,13 +19,17 @@ define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 define( __NAMESPACE__ . '\OPTION_KEY', 'sft_feedback_page' );
 define( __NAMESPACE__ . '\QUERY_VAR', 'sft_feedback' );
 
-register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
-register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
-add_action( 'init', __NAMESPACE__ . '\add_page_endpoint' );
+// Only add actions to sites without the skip flag.
+if ( ! wcorg_skip_feature('speaker_feedback' ) ) {
+	register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
+	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 
-// Check if the page exists, and add it if not.
-add_action( 'init', __NAMESPACE__ . '\add_feedback_page' );
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\load' );
+	add_action( 'init', __NAMESPACE__ . '\add_page_endpoint' );
+
+	// Check if the page exists, and add it if not.
+	add_action( 'init', __NAMESPACE__ . '\add_feedback_page' );
+}
 
 /**
  * Include the rest of the plugin.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -19,8 +19,8 @@ define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
 define( __NAMESPACE__ . '\OPTION_KEY', 'sft_feedback_page' );
 define( __NAMESPACE__ . '\QUERY_VAR', 'sft_feedback' );
 
-// Only add actions to sites without the skip flag.
-if ( ! wcorg_skip_feature('speaker_feedback' ) ) {
+// Only add actions to sites without the skip flag, and only if WC Post Types exist.
+if ( ! wcorg_skip_feature('speaker_feedback' ) && class_exists( 'WordCamp_Post_Types_Plugin' ) ) {
 	register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -20,7 +20,7 @@ define( __NAMESPACE__ . '\OPTION_KEY', 'sft_feedback_page' );
 define( __NAMESPACE__ . '\QUERY_VAR', 'sft_feedback' );
 
 // Only add actions to sites without the skip flag, and only if WC Post Types exist.
-if ( ! wcorg_skip_feature('speaker_feedback' ) && class_exists( 'WordCamp_Post_Types_Plugin' ) ) {
+if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_Types_Plugin' ) ) {
 	register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 	register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
 


### PR DESCRIPTION
Prevent loading any feedback functionality on sites with this flag set. Not all sites need to have the speaker feedback forms, especially significantly older sites, so we can go through and set a skip flag on those WordCamps we decide are "too long ago." This also adds a check for the post types plugin, since if there are no sessions on a site, there's nothing to add the form to (and it prevents a notice when `EP_SESSIONS` is undefined).

See https://github.com/WordPress/wordcamp.org/pull/357#discussion_r377941023

### How to test the changes in this Pull Request:

1. Set a skip feature flag on a site in your test env, `wp wc-misc set-skip-feature-flag speaker_feedback [siteId]`
2. Network enable the plugin*
3. View that site's page listing, there should be no "Leave Feedback" page
4. View another site's page listing, there should be a "Leave Feedback" page
5. View a session's feedback form by visiting a `session-url/feedback`, it should work

You might need to flush rewrites on every site after a network-enable (will make another issue for that, if so).