### PR TITLE
Blocks: Update packages, fix deprecations & new configurations

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
+++ b/public_html/wp-content/mu-plugins/blocks/.eslintrc.js
@@ -8,7 +8,7 @@
  */
 
 module.exports = {
-	extends : 'plugin:@wordpress/eslint-plugin/recommended',
+	extends : 'plugin:@wordpress/eslint-plugin/recommended-with-formatting',
 
 	globals : {
 		wp : true,

--- a/public_html/wp-content/mu-plugins/blocks/.prettierrc.js
+++ b/public_html/wp-content/mu-plugins/blocks/.prettierrc.js
@@ -1,0 +1,7 @@
+// Import the default config for core compatibility, but enable us to add some overrides as needed.
+const defaultConfig = require( '@wordpress/scripts/config/.prettierrc.js' );
+
+module.exports = {
+	...defaultConfig,
+	printWidth: 115,
+};

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -53,6 +53,7 @@
 		"start": "wp-scripts start blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js live-posts=./source/hooks/latest-posts/front-end.js",
 		"build": "wp-scripts build blocks=./source/blocks.js live-schedule=./source/blocks/live-schedule/front-end.js live-posts=./source/hooks/latest-posts/front-end.js",
 		"lint:js": "wp-scripts lint-js",
+		"format:js": "wp-scripts format-js",
 		"lint:css": "wp-scripts lint-style '**/*.scss'",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"test": "wp-scripts test-unit-js"

--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -17,19 +17,19 @@
 		"rememo": "3.0.0"
 	},
 	"devDependencies": {
-		"@wordpress/api-fetch": "3.8.0",
-		"@wordpress/components": "8.4.0",
-		"@wordpress/date": "3.7.0",
-		"@wordpress/element": "2.9.0",
-		"@wordpress/eslint-plugin": "3.2.0",
-		"@wordpress/scripts": "6.0.0",
-		"@wordpress/url": "2.9.0",
-		"css-loader": "3.2.1",
-		"mini-css-extract-plugin": "0.8.0",
-		"node-sass": "4.13.0",
+		"@wordpress/api-fetch": "3.11.0",
+		"@wordpress/components": "9.2.0",
+		"@wordpress/date": "3.8.0",
+		"@wordpress/element": "2.11.0",
+		"@wordpress/eslint-plugin": "4.0.0",
+		"@wordpress/scripts": "7.1.0",
+		"@wordpress/url": "2.11.0",
+		"css-loader": "3.4.2",
+		"mini-css-extract-plugin": "0.9.0",
+		"node-sass": "4.13.1",
 		"prop-types": "15.7.2",
-		"sass-loader": "8.0.0",
-		"webpack-cli": "3.3.10"
+		"sass-loader": "8.0.2",
+		"webpack-cli": "3.3.11"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/live-schedule/data/index.js
@@ -53,8 +53,8 @@ function fetchFromAPI() {
 export function getCurrentSessions( { sessions, tracks } ) {
 	const nowTimestamp = window.WordCampBlocks[ 'live-schedule' ].nowOverride || Date.now();
 
-	const trackListWithSessions = tracks.length ?
-		tracks.map( ( track ) => {
+	const trackListWithSessions = tracks.length
+		? tracks.map( ( track ) => {
 			// Reverse the sorted array so that the first found index is the one that starts closest to "now".
 			// This is intended to catch sessions that don't set a duration, but are shorter than the default.
 			const sessionsInTrack = reverse( sortBy(
@@ -65,9 +65,9 @@ export function getCurrentSessions( { sessions, tracks } ) {
 				track: track,
 				sessions: sessionsInTrack,
 			};
-		} ) :
+		} )
 		// Fall back to one track with all sessions, if no tracks are found.
-		[ {
+		: [ {
 			track: {},
 			sessions: reverse( sortBy( sessions, 'meta._wcpt_session_time' ) ),
 		} ];

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
@@ -73,7 +73,6 @@ class Edit extends Component {
 						<div className="wordcamp__edit-mode-option">
 							<Button
 								isSecondary
-								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );
 								} }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/edit.js
@@ -72,7 +72,7 @@ class Edit extends Component {
 					>
 						<div className="wordcamp__edit-mode-option">
 							<Button
-								isDefault
+								isSecondary
 								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
@@ -74,7 +74,7 @@ class Edit extends Component {
 					>
 						<div className="wordcamp__edit-mode-option">
 							<Button
-								isDefault
+								isSecondary
 								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/edit.js
@@ -75,7 +75,6 @@ class Edit extends Component {
 						<div className="wordcamp__edit-mode-option">
 							<Button
 								isSecondary
-								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );
 								} }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/inspector-controls.js
@@ -78,25 +78,25 @@ export default class extends Component {
 					/>
 					<ToggleControl
 						label={ __( 'Details', 'wordcamporg' ) }
-						help={ show_meta ?
-							__( 'Date, time, and track are visible.', 'wordcamporg' ) :
-							__( 'Date, time, and track are hidden.', 'wordcamporg' ) }
+						help={ show_meta
+							? __( 'Date, time, and track are visible.', 'wordcamporg' )
+							: __( 'Date, time, and track are hidden.', 'wordcamporg' ) }
 						checked={ show_meta === undefined ? false : show_meta }
 						onChange={ ( value ) => setAttributes( { show_meta: value } ) }
 					/>
 					<ToggleControl
 						label={ __( 'Categories', 'wordcamporg' ) }
-						help={ show_category ?
-							__( 'Session categories are visible.', 'wordcamporg' ) :
-							__( 'Session categories are hidden.', 'wordcamporg' ) }
+						help={ show_category
+							? __( 'Session categories are visible.', 'wordcamporg' )
+							: __( 'Session categories are hidden.', 'wordcamporg' ) }
 						checked={ show_category === undefined ? false : show_category }
 						onChange={ ( value ) => setAttributes( { show_category: value } ) }
 					/>
 					<ToggleControl
 						label={ __( 'Speakers', 'wordcamporg' ) }
-						help={ show_speaker ?
-							__( 'Session speakers are visible.', 'wordcamporg' ) :
-							__( 'Session speakers are hidden.', 'wordcamporg' ) }
+						help={ show_speaker
+							? __( 'Session speakers are visible.', 'wordcamporg' )
+							: __( 'Session speakers are hidden.', 'wordcamporg' ) }
 						checked={ show_speaker === undefined ? false : show_speaker }
 						onChange={ ( value ) => setAttributes( { show_speaker: value } ) }
 					/>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/edit.js
@@ -73,7 +73,6 @@ class Edit extends Component {
 						<div className="wordcamp__edit-mode-option">
 							<Button
 								isSecondary
-								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );
 								} }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/edit.js
@@ -72,7 +72,7 @@ class Edit extends Component {
 					>
 						<div className="wordcamp__edit-mode-option">
 							<Button
-								isDefault
+								isSecondary
 								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/inspector-controls.js
@@ -87,9 +87,9 @@ export default class extends Component {
 					/>
 					<ToggleControl
 						label={ __( 'Session Information', 'wordcamporg' ) }
-						help={ show_session ?
-							__( "Speaker's session name, time, and track are visible.", 'wordcamporg' ) :
-							__( "Speaker's session name, time, and track are hidden.", 'wordcamporg' ) }
+						help={ show_session
+							? __( "Speaker's session name, time, and track are visible.", 'wordcamporg' )
+							: __( "Speaker's session name, time, and track are hidden.", 'wordcamporg' ) }
 						checked={ show_session }
 						onChange={ ( value ) => setAttributes( { show_session: value } ) }
 					/>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
@@ -57,8 +57,8 @@ function SpeakerSessions( { speaker, tracks } ) {
 							{ session.title.rendered.trim() || __( '(Untitled)', 'wordcamporg' ) }
 						</a>
 						<span className="wordcamp-speakers__session-info">
-							{ session.session_track.length && Array.isArray( tracks ) ?
-								arrayTokenReplace(
+							{ session.session_track.length && Array.isArray( tracks )
+								? arrayTokenReplace(
 									/* translators: 1: A date; 2: A time; 3: A location; */
 									tokenSplit( __( '%1$s at %2$s in %3$s', 'wordcamporg' ) ),
 									[
@@ -72,8 +72,8 @@ function SpeakerSessions( { speaker, tracks } ) {
 											'name'
 										),
 									]
-								) :
-								arrayTokenReplace(
+								)
+								: arrayTokenReplace(
 									/* translators: 1: A date; 2: A time; */
 									tokenSplit( __( '%1$s at %2$s', 'wordcamporg' ) ),
 									[ session.session_date_time.date, session.session_date_time.time ]

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
@@ -73,7 +73,6 @@ class Edit extends Component {
 						<div className="wordcamp__edit-mode-option">
 							<Button
 								isSecondary
-								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );
 								} }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/edit.js
@@ -72,7 +72,7 @@ class Edit extends Component {
 					>
 						<div className="wordcamp__edit-mode-option">
 							<Button
-								isDefault
+								isSecondary
 								isLarge
 								onClick={ () => {
 									setAttributes( { mode: 'all' } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/inspector-controls.js
@@ -63,9 +63,9 @@ export default class extends Component {
 				<PanelBody title={ __( 'Content Settings', 'wordcamporg' ) } initialOpen={ true }>
 					<ToggleControl
 						label={ __( 'Name', 'wordcamporg' ) }
-						help={ show_name ?
-							__( 'Sponsor name is visible.', 'wordcamporg' ) :
-							__( 'Sponsor name is hidden.', 'wordcamporg' ) }
+						help={ show_name
+							? __( 'Sponsor name is visible.', 'wordcamporg' )
+							: __( 'Sponsor name is hidden.', 'wordcamporg' ) }
 						checked={ show_name }
 						onChange={ ( value ) => setAttributes( { show_name: value } ) }
 					/>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls/image-size-control.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls/image-size-control.js
@@ -68,7 +68,6 @@ class ImageSizeControl extends Component {
 								return (
 									<Button
 										key={ slug }
-										isLarge
 										isPrimary={ isCurrent }
 										aria-label={ name }
 										aria-pressed={ isCurrent }
@@ -83,8 +82,6 @@ class ImageSizeControl extends Component {
 
 					<Button
 						className="wordcamp-image__size-button-reset"
-						isLarge
-						isDefault
 						onClick={ () => this.onChange( Number( initialPosition ) ) }
 					>
 						{ __( 'Reset', 'wordcamporg' ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/inspector-controls/index.js
@@ -65,9 +65,9 @@ class ImageInspectorPanel extends Component {
 			>
 				<ToggleControl
 					label={ __( 'Show images', 'wordcamporg' ) }
-					help={ show ?
-						__( 'Images are visible.', 'wordcamporg' ) :
-						__( 'Images are hidden.', 'wordcamporg' ) }
+					help={ show
+						? __( 'Images are visible.', 'wordcamporg' )
+						: __( 'Images are hidden.', 'wordcamporg' ) }
 					checked={ show }
 					onChange={ onChangeShow }
 				/>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -190,7 +190,7 @@ export class ItemSelect extends Component {
 					<Button
 						className="wordcamp-item-select__button"
 						isLarge
-						isDefault
+						isSecondary
 						onClick={ () => onChange( this.getNewAttributes() ) }
 					>
 						{ submitLabel || __( 'Select', 'wordcamporg' ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -189,7 +189,6 @@ export class ItemSelect extends Component {
 					/>
 					<Button
 						className="wordcamp-item-select__button"
-						isLarge
 						isSecondary
 						onClick={ () => onChange( this.getNewAttributes() ) }
 					>

--- a/public_html/wp-content/mu-plugins/blocks/source/data/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/data/index.js
@@ -56,9 +56,9 @@ export const filterEntities = ( entities, args ) => {
 					return false;
 				}
 
-				const compareValue = isArray( entity[ fieldName ] ) ?
-					entity[ fieldName ] :
-					[ entity[ fieldName ] ];
+				const compareValue = isArray( entity[ fieldName ] )
+					? entity[ fieldName ]
+					: [ entity[ fieldName ] ];
 
 				return intersection( fieldValue, compareValue ).length > 0;
 			} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,6 +1472,28 @@
     "@emotion/utils" "0.11.2"
     "@emotion/weak-memoize" "0.2.4"
 
+"@emotion/cache@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.27.tgz#7895db204e2c1a991ae33d51262a3a44f6737303"
+  integrity sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==
+  dependencies:
+    "@emotion/sheet" "0.9.4"
+    "@emotion/stylis" "0.8.5"
+    "@emotion/utils" "0.11.3"
+    "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/core@^10.0.22":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
+  integrity sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
 "@emotion/core@^10.0.9":
   version "10.0.22"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.22.tgz#2ac7bcf9b99a1979ab5b0a876fbf37ab0688b177"
@@ -1493,15 +1515,55 @@
     "@emotion/utils" "0.11.2"
     babel-plugin-emotion "^10.0.22"
 
+"@emotion/css@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
+  integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
+  dependencies:
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+    babel-plugin-emotion "^10.0.27"
+
 "@emotion/hash@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
   integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
 
+"@emotion/hash@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
+  integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
+
+"@emotion/is-prop-valid@0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz#4757646f0a58e9dec614c47c838e7147d88c263c"
+  integrity sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/memoize@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
   integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/native@^10.0.22":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/native/-/native-10.0.27.tgz#67c2c0ceeeed873c849c611d9a6497a006d43a8f"
+  integrity sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==
+  dependencies:
+    "@emotion/primitives-core" "10.0.27"
+
+"@emotion/primitives-core@10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/primitives-core/-/primitives-core-10.0.27.tgz#7a5fae07fe06a046ced597f5c0048f22d5c45842"
+  integrity sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==
+  dependencies:
+    css-to-react-native "^2.2.1"
 
 "@emotion/serialize@^0.11.12", "@emotion/serialize@^0.11.14":
   version "0.11.14"
@@ -1514,30 +1576,84 @@
     "@emotion/utils" "0.11.2"
     csstype "^2.5.7"
 
+"@emotion/serialize@^0.11.15":
+  version "0.11.15"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.15.tgz#9a0f5873fb458d87d4f23e034413c12ed60a705a"
+  integrity sha512-YE+qnrmGwyR+XB5j7Bi+0GT1JWsdcjM/d4POu+TXkcnrRs4RFCCsi3d/Ebf+wSStHqAlTT2+dfd+b9N9EO2KBg==
+  dependencies:
+    "@emotion/hash" "0.7.4"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/unitless" "0.7.5"
+    "@emotion/utils" "0.11.3"
+    csstype "^2.5.7"
+
 "@emotion/sheet@0.9.3":
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.3.tgz#689f135ecf87d3c650ed0c4f5ddcbe579883564a"
   integrity sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==
+
+"@emotion/sheet@0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
+  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/styled-base@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.27.tgz#d9efa307ae4e938fcc4d0596b40b7e8bc10f7c7c"
+  integrity sha512-ufHM/HhE3nr309hJG9jxuFt71r6aHn7p+bwXduFxcwPFEfBIqvmZUMtZ9YxIsY61PVwK3bp4G1XhaCzy9smVvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/is-prop-valid" "0.8.6"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/styled@^10.0.23":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
+  integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
+  dependencies:
+    "@emotion/styled-base" "^10.0.27"
+    babel-plugin-emotion "^10.0.27"
 
 "@emotion/stylis@0.8.4":
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
   integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
 
+"@emotion/stylis@0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
 "@emotion/unitless@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
+
+"@emotion/unitless@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@emotion/utils@0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.2.tgz#713056bfdffb396b0a14f1c8f18e7b4d0d200183"
   integrity sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==
 
+"@emotion/utils@0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
+  integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
 "@emotion/weak-memoize@0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
+
+"@emotion/weak-memoize@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -1752,6 +1868,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
+
+"@popperjs/core@^2.0.5":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.6.tgz#5a39ac118811ca844155b0ad5190b8c24f35e533"
+  integrity sha512-zj7Gw8QC4jmR92eKUvtrZUEpl2ypRbq+qlE4pwf9n2hnUO9BOAcWUs4/Ht+gNIbFt98xtqhLvccdCfD469MzpQ==
 
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
@@ -2179,7 +2300,7 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@wordpress/a11y@^2.5.1":
+"@wordpress/a11y@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-2.7.0.tgz#eaf4bdaf8fc32fbbd2e97619abc765abaa6fba7a"
   integrity sha512-slmpj1Dyb8oGkDRkmfkvR/KOvRMTvRFuc/yMk7omuNspj4MsLimKhpQnu16NycelC6IGg+Rzp/6ziYIAMi/1sw==
@@ -2187,21 +2308,21 @@
     "@babel/runtime" "^7.8.3"
     "@wordpress/dom-ready" "^2.7.0"
 
-"@wordpress/api-fetch@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-3.8.0.tgz#69594d2e9a50b9611f1208c420b92e40e08d32cb"
-  integrity sha512-8dB7gToTCqYHLq4tc+jscwPOOEtaltkbIlGRi5rHkODP1XPHknA93fcN1/FAZhTIJsqlXfWXdrMWvQheRJK/lw==
+"@wordpress/api-fetch@3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz#795e14b58d13f53284bfdf5ff875d0dbdbc8f53c"
+  integrity sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==
   dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@wordpress/i18n" "^3.7.0"
-    "@wordpress/url" "^2.9.0"
+    "@babel/runtime" "^7.8.3"
+    "@wordpress/i18n" "^3.9.0"
+    "@wordpress/url" "^2.11.0"
 
 "@wordpress/babel-plugin-import-jsx-pragma@^2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.5.0.tgz#d140f902be16f9bef38abafd2a05e040e8aed29e"
   integrity sha512-fvb9+BBi5ns95pTKj2R/YoGbIbA2oBb2YNxRr0pSmeuURFqzeaQIzE+lFnkLCkWVp3DCkXQ1x92+5aWqOqfqzg==
 
-"@wordpress/babel-preset-default@^4.10.0", "@wordpress/babel-preset-default@^4.7.0":
+"@wordpress/babel-preset-default@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@wordpress/babel-preset-default/-/babel-preset-default-4.10.0.tgz#84b490c660ad0b1377c7e1fea5c1ed08c45656d4"
   integrity sha512-fVwtjumi0iIvaD2iTw/X2zK7dQnl0bwUy3L7mBU0M5WkUQ6C4wd6ukA+HRGSH8QKqqxm4ZL1OQnpshJfgioxfw==
@@ -2224,37 +2345,47 @@
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-2.6.0.tgz#00074a1cb1ba979ba7ac5afc4e322bc8447035d1"
   integrity sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA==
 
-"@wordpress/components@8.4.0":
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-8.4.0.tgz#ba58c2f736f838020ec8ad471bd37bb6450a4bec"
-  integrity sha512-Fr2L8b8RxUC6hPiN2pMVKGaeB25RA+g4ENpA32LzmuEGd0ITBXtZfFUv3+5FMcUe4y9KFQZbXxBRElBf4xA+SQ==
+"@wordpress/components@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-9.2.0.tgz#c6416a53d3772b5533ab8206dd737a73d0b39324"
+  integrity sha512-8KETp5Dafq1uYaQc3D9EWqPG/pM8ffGyqwCGr7n+Gc9v86v7ctIWNz2iJvjY1Pw7Sr/AlezhstOVE5z8sHMZag==
   dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@wordpress/a11y" "^2.5.1"
-    "@wordpress/compose" "^3.8.0"
-    "@wordpress/deprecated" "^2.6.1"
-    "@wordpress/dom" "^2.6.0"
-    "@wordpress/element" "^2.9.0"
-    "@wordpress/hooks" "^2.6.0"
-    "@wordpress/i18n" "^3.7.0"
-    "@wordpress/is-shallow-equal" "^1.6.1"
-    "@wordpress/keycodes" "^2.7.0"
-    "@wordpress/rich-text" "^3.8.0"
+    "@babel/runtime" "^7.8.3"
+    "@emotion/core" "^10.0.22"
+    "@emotion/css" "^10.0.22"
+    "@emotion/native" "^10.0.22"
+    "@emotion/styled" "^10.0.23"
+    "@wordpress/a11y" "^2.7.0"
+    "@wordpress/compose" "^3.11.0"
+    "@wordpress/deprecated" "^2.7.0"
+    "@wordpress/dom" "^2.8.0"
+    "@wordpress/element" "^2.11.0"
+    "@wordpress/hooks" "^2.7.0"
+    "@wordpress/i18n" "^3.9.0"
+    "@wordpress/icons" "^1.1.0"
+    "@wordpress/is-shallow-equal" "^1.8.0"
+    "@wordpress/keycodes" "^2.9.0"
+    "@wordpress/primitives" "^1.1.0"
+    "@wordpress/rich-text" "^3.12.0"
+    "@wordpress/warning" "^1.0.0"
     classnames "^2.2.5"
     clipboard "^2.0.1"
     dom-scroll-into-view "^1.2.1"
+    downshift "^4.0.5"
+    gradient-parser "^0.1.5"
     lodash "^4.17.15"
     memize "^1.0.5"
     moment "^2.22.1"
-    mousetrap "^1.6.2"
     re-resizable "^6.0.0"
     react-dates "^17.1.1"
+    react-resize-aware "^3.0.0"
     react-spring "^8.0.20"
+    reakit "^1.0.0-beta.12"
     rememo "^3.0.0"
     tinycolor2 "^1.4.1"
     uuid "^3.3.2"
 
-"@wordpress/compose@^3.11.0", "@wordpress/compose@^3.8.0":
+"@wordpress/compose@^3.11.0":
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-3.11.0.tgz#ffc130fa391559295c5c1d14955ddd46918b1beb"
   integrity sha512-CNbLn9NtG2A0X71wjEux126uEHpWp3v546FtSgMoWlq73z3LEEBDoEeS2glIPAbIK6e1X2UibsKrn5Tn651tlg==
@@ -2285,16 +2416,16 @@
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
 
-"@wordpress/date@3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.7.0.tgz#ea3b3b626248d75e1cba69f24d9bd337b38182ae"
-  integrity sha512-UQ8E150xJqc3ykVqFNGvWmEpIsPJLifvoANTRg8ySuho59E8pNUZo1t5y68nBsTqpwcXuqfhA9JbvqusH1us8Q==
+"@wordpress/date@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.8.0.tgz#beeedf0eaa995756f341b3e72c7fa9ee6e0002c0"
+  integrity sha512-P0P02h7AdBtdZLeNhmfyPoWh8rBpWpHaOdvTHdZm3kUpu9+mSDfTsGvmvS35+TR766MwDRHioR7SD8nL8+jNQQ==
   dependencies:
-    "@babel/runtime" "^7.4.4"
+    "@babel/runtime" "^7.8.3"
     moment "^2.22.1"
     moment-timezone "^0.5.16"
 
-"@wordpress/dependency-extraction-webpack-plugin@^2.1.0", "@wordpress/dependency-extraction-webpack-plugin@^2.2.0":
+"@wordpress/dependency-extraction-webpack-plugin@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.2.0.tgz#a524ef1f4362d596190b9d65932e2a59c9896719"
   integrity sha512-74zJPfSohTfcNtNG/Y0VmE/ow1sG6wCEl7A7xN3VdhMRFUOfpfGV2XifBA9UjDoxY/IAbf80WDqiuA7MzcDMKw==
@@ -2303,7 +2434,7 @@
     webpack "^4.8.3"
     webpack-sources "^1.3.0"
 
-"@wordpress/deprecated@^2.6.1", "@wordpress/deprecated@^2.7.0":
+"@wordpress/deprecated@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-2.7.0.tgz#9e9702795b468e79f7d7aa7fe98af6cd256bf636"
   integrity sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==
@@ -2318,7 +2449,7 @@
   dependencies:
     "@babel/runtime" "^7.8.3"
 
-"@wordpress/dom@^2.6.0":
+"@wordpress/dom@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-2.8.0.tgz#7f7a41a390bedcb7b28a2fb576330f067d6d96ac"
   integrity sha512-JpTvlC7Z16xTI0st/3SL8dBA3uFnQnJTOF6CRjfMi8OcDX2f/pkGsnuHljXKByXGsXNoVh5CV58NNciNgfLsDg==
@@ -2326,18 +2457,7 @@
     "@babel/runtime" "^7.8.3"
     lodash "^4.17.15"
 
-"@wordpress/element@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.9.0.tgz#5f374d6ea7ec18d4064b57e3e790f10354e29732"
-  integrity sha512-IohEi9EkT+jnZof35l5PxDAHaBZXOcZzFS14B4cBt1eKFjbd5C54b8lHbifaL8b82S26ggMdA44sEoXVutdC0g==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@wordpress/escape-html" "^1.6.0"
-    lodash "^4.17.15"
-    react "^16.9.0"
-    react-dom "^16.9.0"
-
-"@wordpress/element@^2.11.0", "@wordpress/element@^2.9.0":
+"@wordpress/element@2.11.0", "@wordpress/element@^2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.11.0.tgz#7bd6bad7bc90cca88746cb333d0c79c870e2064b"
   integrity sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==
@@ -2348,44 +2468,14 @@
     react "^16.9.0"
     react-dom "^16.9.0"
 
-"@wordpress/escape-html@^1.6.0", "@wordpress/escape-html@^1.7.0":
+"@wordpress/escape-html@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.7.0.tgz#8f3e1798a23c16deac7bd0e416f11b90f3f31e89"
   integrity sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==
   dependencies:
     "@babel/runtime" "^7.8.3"
 
-"@wordpress/eslint-plugin@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/eslint-plugin/-/eslint-plugin-3.2.0.tgz#e3958c0b8e9a5421ed0d88a5c92040d230b3a0da"
-  integrity sha512-T406kigwx6GQMo3r1rH6dPT3/XQdq0hOMLrxTQVu/zMQXbifOvgNYW/7EEwMF1cF04jmkEr1mbOrXkfZ3cFLng==
-  dependencies:
-    babel-eslint "^10.0.2"
-    eslint-plugin-jest "^22.15.1"
-    eslint-plugin-jsdoc "^15.8.0"
-    eslint-plugin-jsx-a11y "^6.2.3"
-    eslint-plugin-react "^7.14.3"
-    eslint-plugin-react-hooks "^1.6.1"
-    globals "^12.0.0"
-    requireindex "^1.2.0"
-
-"@wordpress/eslint-plugin@^3.2.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/eslint-plugin/-/eslint-plugin-3.4.1.tgz#ccf1adeec8ecc9e22f0a6d47d812976bab509ca5"
-  integrity sha512-ZH88rJDMiSpzf7fYYSe5FncUJYxN4iIGG6vtIE/McTX23huKdgd0A1qAQY9d9tegVftMz6ERMa2W9E+nbzldvw==
-  dependencies:
-    babel-eslint "^10.0.3"
-    eslint-config-prettier "^6.10.0"
-    eslint-plugin-jest "^22.15.1"
-    eslint-plugin-jsdoc "^15.8.0"
-    eslint-plugin-jsx-a11y "^6.2.3"
-    eslint-plugin-prettier "^3.1.2"
-    eslint-plugin-react "^7.14.3"
-    eslint-plugin-react-hooks "^1.6.1"
-    globals "^12.0.0"
-    requireindex "^1.2.0"
-
-"@wordpress/eslint-plugin@^4.0.0":
+"@wordpress/eslint-plugin@4.0.0", "@wordpress/eslint-plugin@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/eslint-plugin/-/eslint-plugin-4.0.0.tgz#cb44c51ecba03e220c9c6547fab1d4f34b172e55"
   integrity sha512-8BCMGeLbvzikPv4HHpLwFCbC/aVY/jKcayi/ZfBcCs8rGZEt/r8zVsXskQRxA1EInL2UTBdBx1H7XhjOA/HZgQ==
@@ -2402,14 +2492,14 @@
     prettier "npm:wp-prettier@1.19.1"
     requireindex "^1.2.0"
 
-"@wordpress/hooks@^2.6.0", "@wordpress/hooks@^2.7.0":
+"@wordpress/hooks@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.7.0.tgz#34f8b612c1804a2332ab4c6906bf1695545f6a97"
   integrity sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==
   dependencies:
     "@babel/runtime" "^7.8.3"
 
-"@wordpress/i18n@^3.7.0", "@wordpress/i18n@^3.9.0":
+"@wordpress/i18n@^3.9.0":
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.9.0.tgz#a81e23a32f0957f0bb2922f6cdb79a40a45a2b87"
   integrity sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==
@@ -2421,7 +2511,16 @@
     sprintf-js "^1.1.1"
     tannin "^1.1.0"
 
-"@wordpress/is-shallow-equal@^1.6.1", "@wordpress/is-shallow-equal@^1.8.0":
+"@wordpress/icons@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-1.1.0.tgz#d76ad05a097f133f1055a71752dadaf53794d50d"
+  integrity sha512-JPSWz1qOj7pWhAd3pQaHIRrgVDaePv7w6nPX5Uy3LFny+RfBXMNDh+tBGEQvC5iAAhBhDvJyekiDc63tbdnO4g==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    "@wordpress/element" "^2.11.0"
+    "@wordpress/primitives" "^1.1.0"
+
+"@wordpress/is-shallow-equal@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz#905f31599df92201e4d7601a42a45d430eb666f2"
   integrity sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==
@@ -2437,7 +2536,7 @@
     jest-matcher-utils "^24.7.0"
     lodash "^4.17.15"
 
-"@wordpress/jest-preset-default@^5.2.0", "@wordpress/jest-preset-default@^5.4.0":
+"@wordpress/jest-preset-default@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@wordpress/jest-preset-default/-/jest-preset-default-5.4.0.tgz#8b0020f31cf0e6580339ed909ac6270ca7168d76"
   integrity sha512-+7zlgPB57jxlVHQ2Vg0bbYYcJozc+YbBocHZ2ZQlQC5IUXHJ2IZDPGb6kUAWGCNXy/1MzFIMEa0znjxG5zc1Fg==
@@ -2449,7 +2548,7 @@
     enzyme-adapter-react-16 "^1.10.0"
     enzyme-to-json "^3.3.5"
 
-"@wordpress/keycodes@^2.7.0", "@wordpress/keycodes@^2.9.0":
+"@wordpress/keycodes@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-2.9.0.tgz#896f8cfe6520d732aeb75ef4f6a8e67173df8c62"
   integrity sha512-m9SO9eYbzuGv5kNZLimL2O7khDddb+uNAkCJC7juD9K/a+l2LiXSLJRm6gAmnBdrGP8UrTudR0oLaPZLcKXYZA==
@@ -2458,10 +2557,19 @@
     "@wordpress/i18n" "^3.9.0"
     lodash "^4.17.15"
 
-"@wordpress/npm-package-json-lint-config@^2.1.0", "@wordpress/npm-package-json-lint-config@^2.2.0":
+"@wordpress/npm-package-json-lint-config@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-2.2.0.tgz#b085acc6b9467079c2615f67d168cb164265d0f2"
   integrity sha512-8Td9vWekCwZCPfWkVWKQllim/F/m0uN1cma3KkBsKxi0liftj/iXpDBDH6wDxsv8z1Gbwq+H9a4D6w7Ob8SqtQ==
+
+"@wordpress/primitives@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-1.1.0.tgz#08d562f16266dfd5c63f81f15a5b2030a2d0b9c4"
+  integrity sha512-qENxMXnGASutHqbQzbGOj/66B1LQwSBBLGtL9/Tjze+X9e04tUfdJCGroAgaEKmpDFJO39sL26UhW/f8rKz7cw==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    "@wordpress/element" "^2.11.0"
+    classnames "^2.2.5"
 
 "@wordpress/priority-queue@^1.5.0":
   version "1.5.0"
@@ -2480,7 +2588,7 @@
     lodash "^4.17.15"
     rungen "^0.3.2"
 
-"@wordpress/rich-text@^3.8.0":
+"@wordpress/rich-text@^3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-3.12.0.tgz#94bf59acaaa00a125c35dba724bf707dc22f0fec"
   integrity sha512-HKNseU4XW4UiK58uPMSzOPHa+/zwY1NnsXqQByamahz/Gy4KX8mB1den842ATObdm46GfJOXPwofbEglX/W2hg==
@@ -2497,44 +2605,6 @@
     lodash "^4.17.15"
     memize "^1.0.5"
     rememo "^3.0.0"
-
-"@wordpress/scripts@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/scripts/-/scripts-6.0.0.tgz#4f900d92f7b20d2219a0a27635559d47307aa447"
-  integrity sha512-EYNiRT9QZWygelQ175IzkO4c25D0G9tyoIRkzEoz8xi/9ui1kOEAwdS401R5dMRHHWSEkMLM2qJ/ZHnCeVwvhw==
-  dependencies:
-    "@wordpress/babel-preset-default" "^4.7.0"
-    "@wordpress/dependency-extraction-webpack-plugin" "^2.1.0"
-    "@wordpress/eslint-plugin" "^3.2.0"
-    "@wordpress/jest-preset-default" "^5.2.0"
-    "@wordpress/npm-package-json-lint-config" "^2.1.0"
-    babel-jest "^24.7.1"
-    babel-loader "^8.0.6"
-    chalk "^2.4.2"
-    check-node-version "^3.1.1"
-    command-exists "^1.2.8"
-    cross-spawn "^5.1.0"
-    decompress-zip "^0.2.2"
-    eslint "^6.1.0"
-    jest "^24.7.1"
-    jest-puppeteer "^4.3.0"
-    js-yaml "^3.13.1"
-    lodash "^4.17.15"
-    minimist "^1.2.0"
-    npm-package-json-lint "^4.0.3"
-    puppeteer "^2.0.0"
-    read-pkg-up "^1.0.1"
-    request "^2.88.0"
-    resolve-bin "^0.4.0"
-    source-map-loader "^0.2.4"
-    sprintf-js "^1.1.1"
-    stylelint "^9.10.1"
-    stylelint-config-wordpress "^13.1.0"
-    thread-loader "^2.1.2"
-    webpack "^4.41.0"
-    webpack-bundle-analyzer "^3.3.2"
-    webpack-cli "^3.1.2"
-    webpack-livereload-plugin "^2.2.0"
 
 "@wordpress/scripts@7.1.0":
   version "7.1.0"
@@ -2581,15 +2651,7 @@
     webpack-cli "^3.1.2"
     webpack-livereload-plugin "^2.2.0"
 
-"@wordpress/url@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.9.0.tgz#302f3e8db59a0bec74b2cbade7a0d3527e89c934"
-  integrity sha512-ntrXO42/NElNHIrezoYPjWrXNyNYqyHzvvtBVSMLwwwMf7836t/C7GACuk56O3PwQEmSikMNStHQnNCwmyeaag==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    qs "^6.5.2"
-
-"@wordpress/url@^2.9.0":
+"@wordpress/url@2.11.0", "@wordpress/url@^2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.11.0.tgz#b4abc0b1107ce243d106b4b7feeae22390966256"
   integrity sha512-x7vac1Up64lxX7j69f1OYMcC61gADnz4iFYocJCPPioPjkp3OX1sTPIwBOARw/T/EzwRLSFJsyfEcxr7hJhCSw==
@@ -2998,7 +3060,7 @@ axobject-query@^2.0.2:
     "@babel/runtime" "^7.7.4"
     "@babel/runtime-corejs3" "^7.7.4"
 
-babel-eslint@^10.0.2, babel-eslint@^10.0.3:
+babel-eslint@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
   integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
@@ -3010,7 +3072,7 @@ babel-eslint@^10.0.2, babel-eslint@^10.0.3:
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
 
-babel-jest@^24.7.1, babel-jest@^24.9.0:
+babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
   integrity sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
@@ -3049,6 +3111,22 @@ babel-plugin-emotion@^10.0.22:
     "@emotion/hash" "0.7.3"
     "@emotion/memoize" "0.7.3"
     "@emotion/serialize" "^0.11.14"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-emotion@^10.0.27:
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.27.tgz#59001cf5de847c1d61f2079cd906a90a00d3184f"
+  integrity sha512-SUNYcT4FqhOqvwv0z1oeYhqgheU8qrceLojuHyX17ngo7WtWqN5I9l3IGHzf21Xraj465CVzF4IvOlAF+3ed0A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.4"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/serialize" "^0.11.15"
     babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
@@ -3191,6 +3269,11 @@ body-parser@1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+body-scroll-lock@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.6.4.tgz#567abc60ef4d656a79156781771398ef40462e94"
+  integrity sha512-NP08WsovlmxEoZP9pdlqrE+AhNaivlTrz9a0FF37BQsnOrpN48eNqivKkE7SYpM9N+YIPjsdVzfLAUQDBm6OQw==
+
 body@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/body/-/body-5.1.0.tgz#e4ba0ce410a46936323367609ecb4e6553125069"
@@ -3328,13 +3411,13 @@ browserslist@^4.6.0, browserslist@^4.8.0, browserslist@^4.8.2:
     node-releases "^1.1.42"
 
 browserslist@^4.8.3, browserslist@^4.8.5:
-  version "4.8.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
-  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
+  version "4.8.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.7.tgz#ec8301ff415e6a42c949d0e66b405eb539c532d0"
+  integrity sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==
   dependencies:
-    caniuse-lite "^1.0.30001023"
-    electron-to-chromium "^1.3.341"
-    node-releases "^1.1.47"
+    caniuse-lite "^1.0.30001027"
+    electron-to-chromium "^1.3.349"
+    node-releases "^1.1.49"
 
 bser@2.1.1:
   version "2.1.1"
@@ -3484,12 +3567,17 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
+
 caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001015:
   version "1.0.30001015"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz#15a7ddf66aba786a71d99626bc8f2b91c6f0f5f0"
   integrity sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==
 
-caniuse-lite@^1.0.30001023:
+caniuse-lite@^1.0.30001027:
   version "1.0.30001027"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz#283e2ef17d94889cc216a22c6f85303d78ca852d"
   integrity sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==
@@ -3827,6 +3915,11 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
+compute-scroll-into-view@^1.0.9:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.13.tgz#be1b1663b0e3f56cd5f7713082549f562a3477e2"
+  integrity sha512-o+w9w7A98aAFi/GjK8cxSV+CdASuPa2rR5UWs3+yHkJzWqaKoBEufFNWYaXInCSmUfDCVhesG+v9MTWqOjsxFg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4051,10 +4144,15 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-css-loader@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.2.1.tgz#62849b45a414b7bde0bfba17325a026471040eae"
-  integrity sha512-q40kYdcBNzMvkIImCL2O+wk8dh+RGwPPV9Dfz3n7XtOYPXqe2Z6VgtvoxjkLHz02gmhepG9sOAJOUlx+3hHsBg==
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
+css-loader@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.2.tgz#d3fdb3358b43f233b78501c5ed7b1c6da6133202"
+  integrity sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==
   dependencies:
     camelcase "^5.3.1"
     cssesc "^3.0.0"
@@ -4093,6 +4191,15 @@ css-select@~1.2.0:
     css-what "2.1"
     domutils "1.5.1"
     nth-check "~1.0.1"
+
+css-to-react-native@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -4470,6 +4577,16 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+downshift@^4.0.5:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-4.1.0.tgz#a16c67ea965fd7c310c5f7872276e109a4de1704"
+  integrity sha512-GODZOZC65a8n8YD/S/87hR2t5PJfqZ7+lwEBJsNi/AJnhImfle+CFD/ZPde4l+nB8QNHfn0GbE1W9djEFOj1yQ==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    compute-scroll-into-view "^1.0.9"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -4508,10 +4625,10 @@ electron-to-chromium@^1.3.322:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz#a6f7e1c79025c2b05838e8e344f6e89eb83213a8"
   integrity sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==
 
-electron-to-chromium@^1.3.341:
-  version "1.3.346"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.346.tgz#b08becbfbd64a42061195afd3a4923d0416c5d46"
-  integrity sha512-Yy4jF5hJd57BWmGPt0KjaXc25AmWZeQK75kdr4zIzksWVtiT6DwaNtvTb9dt+LkQKwUpvBfCyyPsXXtbY/5GYw==
+electron-to-chromium@^1.3.349:
+  version "1.3.349"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz#663f26a69d348a462df47b4d7ab162a2f29bbcb7"
+  integrity sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q==
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -5787,6 +5904,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
+gradient-parser@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/gradient-parser/-/gradient-parser-0.1.5.tgz#0c7e2179559e5ce7d8d71f4423af937100b2248c"
+  integrity sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw=
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -6979,7 +7101,7 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest@^24.7.1, jest@^24.9.0:
+jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
@@ -7695,10 +7817,10 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mini-css-extract-plugin@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz#81d41ec4fe58c713a96ad7c723cdb2d0bd4d70e1"
-  integrity sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==
+mini-css-extract-plugin@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz#47f2cf07aa165ab35733b1fc97d4c46c0564339e"
+  integrity sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==
   dependencies:
     loader-utils "^1.1.0"
     normalize-url "1.9.1"
@@ -8024,35 +8146,12 @@ node-releases@^1.1.42:
   dependencies:
     semver "^6.3.0"
 
-node-releases@^1.1.47:
-  version "1.1.48"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.48.tgz#7f647f0c453a0495bcd64cbd4778c26035c2f03a"
-  integrity sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==
+node-releases@^1.1.49:
+  version "1.1.49"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.49.tgz#67ba5a3fac2319262675ef864ed56798bb33b93e"
+  integrity sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==
   dependencies:
     semver "^6.3.0"
-
-node-sass@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
-  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash "^4.17.15"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.13.2"
-    node-gyp "^3.8.0"
-    npmlog "^4.0.0"
-    request "^2.88.0"
-    sass-graph "^2.2.4"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
 
 node-sass@4.13.1:
   version "4.13.1"
@@ -9263,6 +9362,11 @@ react-portal@^4.1.5:
   dependencies:
     prop-types "^15.5.8"
 
+react-resize-aware@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.0.0.tgz#fee9e1c61ac5bb2dd87c59e03703070d01601269"
+  integrity sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q==
+
 react-select@3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
@@ -9428,6 +9532,26 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+reakit-system@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/reakit-system/-/reakit-system-0.9.0.tgz#678fecdd688fabbd3395e74d2447750241857fad"
+  integrity sha512-uxhjpxpI3XHAj3OhkDeyyulG3hNgEJ6KtEZbwRXiCv9DOKIe0zwN8qTAXRIKXtP4pu5PyETBh3XEZoxiv4FAww==
+
+reakit-utils@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.9.0.tgz#e17a877702af422dc13d6fae95a7a4f4bc7788db"
+  integrity sha512-qVsGLmsFZv1+A5B/k1xEhFYD8U9fkl8ssvE3D5zIM33V0oIFvVClDTm8Iv96dpB1cod1kolLDKva6FkNxXP+bw==
+
+reakit@^1.0.0-beta.12:
+  version "1.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.0.0-beta.16.tgz#dccfcd84e1dd5bf9ce5888ec7fdda1d93b3ba131"
+  integrity sha512-zytLIb7Ai2b6Yi0/C8lSPSvl/9HI7M8ntO1ty7aoJ9XCKxhFi4Oq1rwF6ja/242cBH7uqspRfhagBhgJniOr8A==
+  dependencies:
+    "@popperjs/core" "^2.0.5"
+    body-scroll-lock "^2.6.4"
+    reakit-system "^0.9.0"
+    reakit-utils "^0.9.0"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -9894,15 +10018,15 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sass-loader@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.0.tgz#e7b07a3e357f965e6b03dd45b016b0a9746af797"
-  integrity sha512-+qeMu563PN7rPdit2+n5uuYVR0SSVwm0JsOUsaJXzgYcClWSlmX0iHDnmeOobPkf5kUglVot3QS6SyLyaQoJ4w==
+sass-loader@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
+  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
   dependencies:
     clone-deep "^4.0.1"
     loader-utils "^1.2.3"
     neo-async "^2.6.1"
-    schema-utils "^2.1.0"
+    schema-utils "^2.6.1"
     semver "^6.3.0"
 
 sax@^1.2.4, sax@~1.2.4:
@@ -9927,7 +10051,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.1.0, schema-utils@^2.5.0:
+schema-utils@^2.5.0, schema-utils@^2.6.1:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.4.tgz#a27efbf6e4e78689d91872ee3ccfa57d7bdd0f53"
   integrity sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==
@@ -11437,7 +11561,24 @@ webpack-bundle-analyzer@^3.3.2:
     opener "^1.5.1"
     ws "^6.0.0"
 
-webpack-cli@3.3.10, webpack-cli@^3.1.2:
+webpack-cli@3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.11.tgz#3bf21889bf597b5d82c38f215135a411edfdc631"
+  integrity sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==
+  dependencies:
+    chalk "2.4.2"
+    cross-spawn "6.0.5"
+    enhanced-resolve "4.1.0"
+    findup-sync "3.0.0"
+    global-modules "2.0.0"
+    import-local "2.0.0"
+    interpret "1.2.0"
+    loader-utils "1.2.3"
+    supports-color "6.1.0"
+    v8-compile-cache "2.0.3"
+    yargs "13.2.4"
+
+webpack-cli@^3.1.2:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
   integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==


### PR DESCRIPTION
Update the `@wordpress/*` packages, which includes some configuration changes and component prop deprecations. Remove deprecated `isDefault` prop from `<Button />`. Update eslint config to use `@wordpress/eslint-plugin/recommended-with-formatting`, which uses eslint for formatting rules instead of prettier. This prevents the prettier ruleset from running before we're ready to use it. Lastly, this adds the prettier config & format command, so we can test out whether we want to adopt the auto-formatting features.

### How to test the changes in this Pull Request:

1. Run `yarn` to update local packages
2. Building, testing, etc should all work
3. Linters should pass
4. Try running `yarn workspace wordcamp-blocks run format:js` to test out the prettier commands
