### PR TITLE
Speaker Feedback: Submit feedback form to API

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -14,7 +14,6 @@
 		var rawData = new FormData( event.target );
 		var data = {
 			post: rawData.get( 'sft-post' ),
-			author: rawData.get( 'sft-author' ),
 			meta: {
 				rating: rawData.get( 'sft-rating' ),
 				q1: rawData.get( 'sft-question-1' ),
@@ -22,6 +21,14 @@
 				q3: rawData.get( 'sft-question-3' ),
 			},
 		};
+
+		var author = rawData.get( 'sft-author' );
+		if ( '0' !== author ) {
+			data.author = author;
+		} else {
+			data.author_name = rawData.get( 'sft-author-name' );
+			data.author_email = rawData.get( 'sft-author-email' );
+		}
 
 		var messageContainer = document.getElementById( 'speaker-feedback-notice' );
 		// Reset the notice before submission.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -23,11 +23,25 @@
 			},
 		};
 
+		var messageContainer = document.getElementById( 'speaker-feedback-notice' );
+		// Reset the notice before submission.
+		messageContainer.setAttribute( 'class', '' );
+		messageContainer.innerText = '';
+
 		wp.apiFetch( {
 			path: '/wordcamp-speaker-feedback/v1/feedback',
 			method: 'POST',
 			data: data,
-		} );
+		} )
+			.then( function() {
+				messageContainer.setAttribute( 'class', 'speaker-feedback__notice is-success' );
+				messageContainer.innerText = 'Feedback submitted.';
+				event.target.replaceWith( messageContainer );
+			} )
+			.catch( function( error ) {
+				messageContainer.setAttribute( 'class', 'speaker-feedback__notice is-error' );
+				messageContainer.innerText = error.message;
+			} );
 	}
 
 	var navForm = document.getElementById( 'sft-navigation' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -13,10 +13,14 @@
 		event.preventDefault();
 		var rawData = new FormData( event.target );
 		var data = {
-			rating: rawData.get( 'sft-rating' ),
-			q1: rawData.get( 'sft-question-1' ),
-			q2: rawData.get( 'sft-question-2' ),
-			q3: rawData.get( 'sft-question-3' ),
+			post: rawData.get( 'sft-post' ),
+			author: rawData.get( 'sft-author' ),
+			meta: {
+				rating: rawData.get( 'sft-rating' ),
+				q1: rawData.get( 'sft-question-1' ),
+				q2: rawData.get( 'sft-question-2' ),
+				q3: rawData.get( 'sft-question-3' ),
+			},
 		};
 
 		wp.apiFetch( {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -4,13 +4,35 @@
 ( function() {
 	function onFormNavigate( event ) {
 		event.preventDefault();
-		const value = event.target[ 0 ].value;
+		var value = event.target[ 0 ].value;
 		// Use the fact that post IDs will redirect to the right page.
 		window.location = '/?p=' + value + '&sft_feedback=1';
 	}
 
-	const form = document.getElementById( 'sft-navigation' );
-	if ( form ) {
-		form.addEventListener( 'submit', onFormNavigate, true );
+	function onFormSubmit( event ) {
+		event.preventDefault();
+		var rawData = new FormData( event.target );
+		var data = {
+			rating: rawData.get( 'sft-rating' ),
+			q1: rawData.get( 'sft-question-1' ),
+			q2: rawData.get( 'sft-question-2' ),
+			q3: rawData.get( 'sft-question-3' ),
+		};
+
+		wp.apiFetch( {
+			path: '/wordcamp-speaker-feedback/v1/feedback',
+			method: 'POST',
+			data: data,
+		} );
+	}
+
+	var navForm = document.getElementById( 'sft-navigation' );
+	if ( navForm ) {
+		navForm.addEventListener( 'submit', onFormNavigate, true );
+	}
+
+	var feedbackForm = document.getElementById( 'sft-feedback' );
+	if ( feedbackForm ) {
+		feedbackForm.addEventListener( 'submit', onFormSubmit, true );
 	}
 } )();

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -42,7 +42,7 @@
 		} )
 			.then( function() {
 				messageContainer.setAttribute( 'class', 'speaker-feedback__notice is-success' );
-				messageContainer.innerText = 'Feedback submitted.';
+				messageContainer.innerText = SpeakerFeedbackData.messages.submitSuccess;
 				event.target.replaceWith( messageContainer );
 			} )
 			.catch( function( error ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/_variables.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/_variables.scss
@@ -1,3 +1,11 @@
 // Colors.
 $star-default: #ccc;
 $star-selected: #f3940d;
+
+// Alert colors.
+$alert-yellow: #f0b849;
+$alert-red: #d94f4f;
+$alert-green: #4ab866;
+
+$blue-medium-500: #00a0d2;
+$blue-medium-100: #e5f5fa;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -126,7 +126,7 @@
 
 .speaker-feedback__notice {
 	display: flex;
-	margin: 5px 15px 1em;
+	margin: 5px 0 1em;
 	padding: 8px 12px;
 	background-color: $blue-medium-100;
 	border-left: 4px solid $blue-medium-500;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -12,6 +12,30 @@
 	}
 }
 
+.speaker-feedback__field-inline {
+	display: flex;
+	margin-bottom: 1em;
+	align-items: center;
+
+	label {
+		flex: 0 5rem;
+	}
+
+	input {
+		flex: 1;
+	}
+
+	@media (max-width: 480px) {
+		display: block;
+
+		label,
+		input {
+			display: block;
+			width: 100%;
+		}
+	}
+}
+
 /**
  * Session navigation page.
  */
@@ -47,6 +71,10 @@
 
 	&:focus-within {
 		outline: 1px dotted #666;
+	}
+
+	legend {
+		font-weight: 700;
 	}
 
 	svg {
@@ -103,6 +131,10 @@
 	background-color: $blue-medium-100;
 	border-left: 4px solid $blue-medium-500;
 	align-items: center;
+
+	p {
+		margin: 0;
+	}
 
 	&.is-success {
 		border-left-color: $alert-green;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -93,7 +93,30 @@
 }
 
 /**
- * Feedback list table.
+ * Post-submission Notices.
+ */
+
+.speaker-feedback__notice {
+	display: flex;
+	margin: 5px 15px 1em;
+	padding: 8px 12px;
+	background-color: $blue-medium-100;
+	border-left: 4px solid $blue-medium-500;
+	align-items: center;
+
+	&.is-success {
+		border-left-color: $alert-green;
+		background-color: lighten($alert-green, 45%);
+	}
+
+	&.is-error {
+		border-left-color: $alert-red;
+		background-color: lighten($alert-red, 35%);
+	}
+}
+
+/**
+ * WP Dashboard: Feedback list table.
  */
 
 .column-name {
@@ -117,7 +140,7 @@
 }
 
 /**
- * Question/answer display.
+ * WP Dashboard: Question/answer display.
  */
 
 .widefat td {
@@ -131,7 +154,7 @@
 }
 
 /**
- * Rating display.
+ * WP Dashboard: Rating display.
  */
 
 .speaker-feedback__meta-rating {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -283,7 +283,8 @@ function get_feedback_questions( $version = META_VERSION ) {
 	 * that contains the latest set of questions should match the integer assigned to the `META_VERSION` constant.
 	 *
 	 * If the questions below need to be modified, a new complete set should be added as a new case. The `META_VERSION`
-	 * constant in this file then needs to be updated to match the latest case number.
+	 * constant in this file then needs to be updated to match the latest case number. The submission form and JS
+	 * process will also need to be updated & tested.
 	 */
 	switch ( $version ) {
 		case 1:

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -124,7 +124,7 @@ function enqueue_assets() {
 		);
 
 		$data = array(
-			'messages'  => array(
+			'messages' => array(
 				'submitSuccess' => __( 'Feedback submitted.', 'wordcamporg' ),
 			),
 		);

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -107,7 +107,7 @@ function enqueue_assets() {
 		wp_enqueue_script(
 			'speaker-feedback',
 			get_assets_url() . 'js/script.js',
-			array(),
+			array( 'wp-api-fetch' ),
 			filemtime( dirname( __DIR__ ) . '/assets/js/script.js' ),
 			true
 		);

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -122,5 +122,20 @@ function enqueue_assets() {
 			filemtime( dirname( __DIR__ ) . '/assets/js/script.js' ),
 			true
 		);
+
+		$data = array(
+			'messages'  => array(
+				'submitSuccess' => __( 'Feedback submitted.', 'wordcamporg' ),
+			),
+		);
+
+		wp_add_inline_script(
+			'speaker-feedback',
+			sprintf(
+				'var SpeakerFeedbackData = JSON.parse( decodeURIComponent( \'%s\' ) );',
+				rawurlencode( wp_json_encode( $data ) )
+			),
+			'before'
+		);
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -118,7 +118,7 @@ function enqueue_assets() {
 		wp_enqueue_script(
 			'speaker-feedback',
 			get_assets_url() . 'js/script.js',
-			array( 'wp-api-fetch' ),
+			array( 'wp-api-fetch', 'jquery' ),
 			filemtime( dirname( __DIR__ ) . '/assets/js/script.js' ),
 			true
 		);

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/package.json
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/package.json
@@ -29,6 +29,7 @@
 			"window": true,
 			"document": true,
 			"wp": "readonly",
+			"jQuery": "readonly",
 			"SpeakerFeedbackData": "readonly"
 		},
 		"env": {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/package.json
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/package.json
@@ -28,7 +28,8 @@
 		"globals": {
 			"window": true,
 			"document": true,
-			"wp": "readonly"
+			"wp": "readonly",
+			"SpeakerFeedbackData": "readonly"
 		},
 		"env": {
 			"browser": true

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/package.json
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/package.json
@@ -12,30 +12,50 @@
 		"url": "https://github.com/WordPress/wordcamp.org/issues?q=label%3A%22%5BComponent%5D+Speaker+Feedback%22"
 	},
 	"devDependencies": {
+		"@wordpress/eslint-plugin": "4.0.0",
 		"@wordpress/scripts": "7.1.0",
 		"node-sass": "4.13.1"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
 	],
+	"eslintConfig": {
+		"extends": "plugin:@wordpress/eslint-plugin/es5",
+		"rules": {
+			"vars-on-top": "off",
+			"wrap-iife": "off"
+		},
+		"globals": {
+			"window": true,
+			"document": true,
+			"wp": "readonly"
+		},
+		"env": {
+			"browser": true
+		}
+	},
 	"eslintIgnore": [
 		"*.min.js"
 	],
 	"stylelint": {
-		"extends" : "stylelint-config-wordpress/scss",
-		"rules"   : {
+		"extends": "stylelint-config-wordpress/scss",
+		"rules": {
 			"max-line-length": 115,
-
-			"rule-empty-line-before" : [ "always-multi-line", {
-				"except" : [ "first-nested", "after-single-line-comment" ]
-			} ]
+			"rule-empty-line-before": [
+				"always-multi-line",
+				{
+					"except": [
+						"first-nested",
+						"after-single-line-comment"
+					]
+				}
+			]
 		}
 	},
 	"scripts": {
 		"start": "node-sass -wr assets/scss -o assets/build --source-map-embed",
 		"build": "node-sass assets/scss -o assets/build --output-style=compressed",
 		"lint:js": "wp-scripts lint-js assets/js/*.js",
-		"format:js": "wp-scripts format-js assets/js/*.js",
 		"lint:css": "wp-scripts lint-style 'assets/scss/*.scss'"
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -41,7 +41,7 @@ defined( 'WPINC' ) || die();
 			$user = wp_get_current_user();
 			echo wp_kses_post( sprintf(
 				__( 'You are leaving feedback as %s.', 'wordcamporg' ),
-				$user->display_name
+				'<strong>' . $user->display_name . '</strong>'
 			) ); ?></p>
 		</div>
 	<?php endif; ?>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -9,12 +9,48 @@ defined( 'WPINC' ) || die();
 ?>
 <hr />
 <form id="sft-feedback" class="speaker-feedback">
-	<h3><?php esc_html_e( 'Rate this talk', 'wordcamporg' ); ?></h3>
+
+	<h3><?php esc_html_e( 'Leave Feedback', 'wordcamporg' ); ?></h3>
+
+	<?php if ( ! is_user_logged_in() ) : ?>
+	<div class="speaker-feedback__field">
+		<div class="speaker-feedback__notice">
+			<p><?php echo wp_kses_post( sprintf(
+				__( '<a href="%s">Log in to your WordPress.org account,</a> or add your name & email to leave feedback.', 'wordcamporg' ),
+				wp_login_url( get_permalink() . 'feedback' )
+			) ); ?></p>
+		</div>
+
+		<div class="speaker-feedback__field-inline">
+			<label for="sft-author-name">
+				<?php esc_html_e( 'Name', 'wordcamporg' ); ?>
+			</label>
+			<input type="text" id="sft-author-name" name="sft-author-name" required />
+		</div>
+
+		<div class="speaker-feedback__field-inline">
+			<label for="sft-author-email">
+				<?php esc_html_e( 'Email', 'wordcamporg' ); ?>
+			</label>
+			<input type="email" id="sft-author-email" name="sft-author-email" required />
+		</div>
+	</div>
+	<?php else : ?>
+		<div class="speaker-feedback__notice">
+			<p><?php
+			$user = wp_get_current_user();
+			echo wp_kses_post( sprintf(
+				__( 'You are leaving feedback as %s.', 'wordcamporg' ),
+				$user->display_name
+			) ); ?></p>
+		</div>
+	<?php endif; ?>
 
 	<div id="speaker-feedback-notice" aria-live="polite" aria-relevant="additions text" aria-atomic="true"></div>
 
 	<div class="speaker-feedback__field">
-		<fieldset class="speaker-feedback__field-rating" aria-label="<?php esc_attr_e( 'Rate this talk', 'wordcamporg' ); ?>">
+		<fieldset class="speaker-feedback__field-rating">
+			<legend><?php esc_html_e( 'Rate this talk', 'wordcamporg' ); ?></legend>
 			<input
 				type="radio"
 				name="sft-rating"

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -49,7 +49,7 @@ defined( 'WPINC' ) || die();
 	<div id="speaker-feedback-notice" aria-live="polite" aria-relevant="additions text" aria-atomic="true"></div>
 
 	<div class="speaker-feedback__field">
-		<fieldset class="speaker-feedback__field-rating">
+		<fieldset class="speaker-feedback__field-rating" id="sft-rating">
 			<legend><?php echo esc_html( $rating_question ); ?></legend>
 			<input
 				type="radio"

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -15,32 +15,32 @@ defined( 'WPINC' ) || die();
 		<fieldset class="speaker-feedback__field-rating" aria-label="<?php esc_attr_e( 'Rate this talk', 'wordcamporg' ); ?>">
 			<input
 				type="radio"
-				name="feedback-rating"
+				name="sft-rating"
 				value="0"
 				checked
 				aria-label="<?php esc_attr_e( 'No stars', 'wordcamporg' ); ?>"
 			/>
-			<input type="radio" id="sft-rating-val-1" name="feedback-rating" value="1" />
+			<input type="radio" id="sft-rating-val-1" name="sft-rating" value="1" />
 			<label for="sft-rating-val-1">
 				<span class="screen-reader-text"><?php esc_html_e( '1 star', 'wordcamporg' ); ?></span>
 				<?php require get_assets_path() . 'svg/star.svg'; ?>
 			</label>
-			<input type="radio" id="sft-rating-val-2" name="feedback-rating" value="2" />
+			<input type="radio" id="sft-rating-val-2" name="sft-rating" value="2" />
 			<label for="sft-rating-val-2">
 				<span class="screen-reader-text"><?php esc_html_e( '2 stars', 'wordcamporg' ); ?></span>
 				<?php require get_assets_path() . 'svg/star.svg'; ?>
 			</label>
-			<input type="radio" id="sft-rating-val-3" name="feedback-rating" value="3" />
+			<input type="radio" id="sft-rating-val-3" name="sft-rating" value="3" />
 			<label for="sft-rating-val-3">
 				<span class="screen-reader-text"><?php esc_html_e( '3 stars', 'wordcamporg' ); ?></span>
 				<?php require get_assets_path() . 'svg/star.svg'; ?>
 			</label>
-			<input type="radio" id="sft-rating-val-4" name="feedback-rating" value="4" />
+			<input type="radio" id="sft-rating-val-4" name="sft-rating" value="4" />
 			<label for="sft-rating-val-4">
 				<span class="screen-reader-text"><?php esc_html_e( '4 stars', 'wordcamporg' ); ?></span>
 				<?php require get_assets_path() . 'svg/star.svg'; ?>
 			</label>
-			<input type="radio" id="sft-rating-val-5" name="feedback-rating" value="5" />
+			<input type="radio" id="sft-rating-val-5" name="sft-rating" value="5" />
 			<label for="sft-rating-val-5">
 				<span class="screen-reader-text"><?php esc_html_e( '5 stars', 'wordcamporg' ); ?></span>
 				<?php require get_assets_path() . 'svg/star.svg'; ?>
@@ -52,21 +52,21 @@ defined( 'WPINC' ) || die();
 		<label for="sft-question-1">
 			<?php esc_html_e( 'What’s one good thing you’d keep in this presentation?', 'wordcamporg' ); ?>
 		</label>
-		<textarea id="sft-question-1" required></textarea>
+		<textarea id="sft-question-1" name="sft-question-1" required></textarea>
 	</div>
 
 	<div class="speaker-feedback__field">
 		<label for="sft-question-2">
 			<?php esc_html_e( 'What’s one thing you’d tweak to improve the presentation?', 'wordcamporg' ); ?>
 		</label>
-		<textarea id="sft-question-2"></textarea>
+		<textarea id="sft-question-2" name="sft-question-2"></textarea>
 	</div>
 
 	<div class="speaker-feedback__field">
 		<label for="sft-question-3">
 			<?php esc_html_e( 'What’s one unhelpful thing you’d delete from the presentation?', 'wordcamporg' ); ?>
 		</label>
-		<textarea id="sft-question-3"></textarea>
+		<textarea id="sft-question-3" name="sft-question-3"></textarea>
 	</div>
 
 	<input type="submit" value="<?php esc_attr_e( 'Send Feedback', 'wordcamporg' ); ?>" />

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -50,7 +50,7 @@ defined( 'WPINC' ) || die();
 
 	<div class="speaker-feedback__field">
 		<fieldset class="speaker-feedback__field-rating">
-			<legend><?php esc_html_e( 'Rate this talk', 'wordcamporg' ); ?></legend>
+			<legend><?php echo esc_html( $rating_question ); ?></legend>
 			<input
 				type="radio"
 				name="sft-rating"
@@ -86,26 +86,18 @@ defined( 'WPINC' ) || die();
 		</fieldset>
 	</div>
 
+	<?php foreach ( $text_questions as list( $key, $question ) ) : ?>
 	<div class="speaker-feedback__field">
-		<label for="sft-question-1">
-			<?php esc_html_e( 'What’s one good thing you’d keep in this presentation?', 'wordcamporg' ); ?>
+		<label for="sft-<?php echo esc_attr( $key ); ?>">
+			<?php echo esc_html( $question ); ?>
 		</label>
-		<textarea id="sft-question-1" name="sft-question-1" required></textarea>
+		<textarea
+			id="sft-<?php echo esc_attr( $key ); ?>"
+			name="sft-<?php echo esc_attr( $key ); ?>"
+			<?php echo ( 'q1' === $key ) ? 'required' : ''; ?>
+		></textarea>
 	</div>
-
-	<div class="speaker-feedback__field">
-		<label for="sft-question-2">
-			<?php esc_html_e( 'What’s one thing you’d tweak to improve the presentation?', 'wordcamporg' ); ?>
-		</label>
-		<textarea id="sft-question-2" name="sft-question-2"></textarea>
-	</div>
-
-	<div class="speaker-feedback__field">
-		<label for="sft-question-3">
-			<?php esc_html_e( 'What’s one unhelpful thing you’d delete from the presentation?', 'wordcamporg' ); ?>
-		</label>
-		<textarea id="sft-question-3" name="sft-question-3"></textarea>
-	</div>
+	<?php endforeach; ?>
 
 	<input type="hidden" name="sft-author" value="<?php echo intval( get_current_user_id() ); ?>" />
 	<input type="hidden" name="sft-post" value="<?php echo intval( get_the_ID() ); ?>" />

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -69,5 +69,7 @@ defined( 'WPINC' ) || die();
 		<textarea id="sft-question-3" name="sft-question-3"></textarea>
 	</div>
 
+	<input type="hidden" name="sft-author" value="<?php echo intval( get_current_user_id() ); ?>" />
+	<input type="hidden" name="sft-post" value="<?php echo intval( get_the_ID() ); ?>" />
 	<input type="submit" value="<?php esc_attr_e( 'Send Feedback', 'wordcamporg' ); ?>" />
 </form>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -11,6 +11,8 @@ defined( 'WPINC' ) || die();
 <form id="sft-feedback" class="speaker-feedback">
 	<h3><?php esc_html_e( 'Rate this talk', 'wordcamporg' ); ?></h3>
 
+	<div id="speaker-feedback-notice" aria-live="polite" aria-relevant="additions text" aria-atomic="true"></div>
+
 	<div class="speaker-feedback__field">
 		<fieldset class="speaker-feedback__field-rating" aria-label="<?php esc_attr_e( 'Rate this talk', 'wordcamporg' ); ?>">
 			<input


### PR DESCRIPTION
Submit the feedback form to the API endpoint. Passes in author data (user ID if logged in, name/email if not), rating & questions as meta. Shows a success or failure notice after submission.

Fixes #334 

### Screenshots

Logged in:
![Screen Shot 2020-03-18 at 2 28 46 PM](https://user-images.githubusercontent.com/541093/76995153-d4049d00-6925-11ea-9133-b582d8c0f36f.png)

Logged out:
![Screen Shot 2020-03-18 at 2 24 03 PM](https://user-images.githubusercontent.com/541093/76995161-d6ff8d80-6925-11ea-812b-968da6abe8b5.png)

Success, replaces the form with message:
![Screen Shot 2020-03-16 at 5 54 43 PM](https://user-images.githubusercontent.com/541093/76995183-de269b80-6925-11ea-954d-d97dcfb50e16.png)

Error, message comes from API response:
![Screen Shot 2020-04-02 at 6 39 47 PM](https://user-images.githubusercontent.com/541093/78306707-0b706d80-7512-11ea-9b74-236e5fbd4f18.png)

### How to test the changes in this Pull Request:

1. Go to a feedback form, ex: `/session/[talk]/feedback`
2. Fill out the feedback form, submit it
3. The page should not redirect
4. Open network inspector, You should see a POST to `/wordcamp-speaker-feedback/v1/feedback`
5. A message should appear, success or failure
6. If success, you should also see a comment record in the Session Feedback in wp-admin (unapproved)
7. If failure, it should show you the error message, and let you re-try submission

You can trigger a failure message by not selecting a rating - the other inputs have browser validation 🙂 