### PR TITLE
QBO: Make it ~possible~ easier to test in a local dev environment

### DIFF
--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -91,6 +91,11 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
     ```
 
 
+## Local Environment Customizations
+
+You may have a need to change a configuration or behavior in the local environment without modifying files that are tracked by version control. For this, you can add a file to the **mu-plugins** directory called **sandbox-functionality.php**. This file is ignored by git, so changes made to it will not affect the state of the working directory.
+
+
 ## Useful Docker Commands:
 
 Note: All of these commands are meant to be executed from project directory.

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -103,6 +103,7 @@ define( 'TWITTER_CONSUMER_KEY_WORDCAMP_CENTRAL',    '' );
 define( 'TWITTER_CONSUMER_SECRET_WORDCAMP_CENTRAL', '' );
 define( 'TWITTER_BEARER_TOKEN_WORDCAMP_CENTRAL',    '' );
 
+// These can't be empty, but no real values are needed here for local development.
 define( 'WORDCAMP_QBO_APP_TOKEN',       'localtoken' );
 define( 'WORDCAMP_QBO_CONSUMER_KEY',    'localkey' );
 define( 'WORDCAMP_QBO_CONSUMER_SECRET', 'localsecret' );

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -1,6 +1,6 @@
 <?php
 
-define( 'WORDCAMP_ENVIRONMENT', 'development' );
+define( 'WORDCAMP_ENVIRONMENT', 'local' );
 
 /*
  * Database

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -1,5 +1,18 @@
 <?php
+/**
+ * WordCamp.org configuration file.
+ */
 
+/**
+ * The environment in which the WordCamp codebase is currently running.
+ *
+ * There are a few different values that this might contain that have implications in the code:
+ *
+ * - `production`:  Used on the production server. Should not be used anywhere else.
+ * - `development`: The catchall value for non-production environments. Currently used on wporg sandboxes.
+ * - `local`:       The value used for local development environments, where the domain is wordcamp.test and some
+ *                  functionality that relies on remote connections may not be available.
+ */
 define( 'WORDCAMP_ENVIRONMENT', 'local' );
 
 /*

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -103,13 +103,13 @@ define( 'TWITTER_CONSUMER_KEY_WORDCAMP_CENTRAL',    '' );
 define( 'TWITTER_CONSUMER_SECRET_WORDCAMP_CENTRAL', '' );
 define( 'TWITTER_BEARER_TOKEN_WORDCAMP_CENTRAL',    '' );
 
-define( 'WORDCAMP_QBO_APP_TOKEN',       '' );
-define( 'WORDCAMP_QBO_CONSUMER_KEY',    '' );
-define( 'WORDCAMP_QBO_CONSUMER_SECRET', '' );
-define( 'WORDCAMP_QBO_HMAC_KEY',        '' );
+define( 'WORDCAMP_QBO_APP_TOKEN',       'localtoken' );
+define( 'WORDCAMP_QBO_CONSUMER_KEY',    'localkey' );
+define( 'WORDCAMP_QBO_CONSUMER_SECRET', 'localsecret' );
+define( 'WORDCAMP_QBO_HMAC_KEY',        'localhmac' );
 
-define( 'WORDCAMP_SANDBOX_QBO_CLIENT_ID',        '' );
-define( 'WORDCAMP_SANDBOX_QBO_CLIENT_SECRET',    '' );
+define( 'WORDCAMP_SANDBOX_QBO_CLIENT_ID',        "(Optional) your app's development client ID key goes here" );
+define( 'WORDCAMP_SANDBOX_QBO_CLIENT_SECRET',    "(Optional) your app's development client secret key goes here" );
 define( 'WORDCAMP_PRODUCTION_QBO_CLIENT_ID',     '' );
 define( 'WORDCAMP_PRODUCTION_QBO_CLIENT_SECRET', '' );
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ public_html/wp-content/languages/
 public_html/wp-content/mu-plugins/blocks/build
 public_html/wp-content/mu-plugins/includes/slack/
 public_html/wp-content/mu-plugins/vendor/
+public_html/wp-content/mu-plugins/sandbox-functionality.php
 public_html/wp-content/mu-plugins-private/
 public_html/wp-content/themes-private/
 public_html/wp-content/uploads/

--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -13,6 +13,9 @@ use function WordCamp\Logger\log;
  * Defaults to 'development' if the `WORDCAMP_ENVIRONMENT` constant isn't set or is empty. Other values may
  * have specific implications in the code.
  *
+ * See the definition of the `WORDCAMP_ENVIRONMENT` constant in the wp-config.php file for more info on the
+ * possible values.
+ *
  * @return string
  */
 function get_wordcamp_environment() {

--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -7,6 +7,23 @@ use function WordCamp\Logger\log;
  * Miscellaneous helper functions.
  */
 
+/**
+ * Get the current environment.
+ *
+ * Defaults to 'development' if the `WORDCAMP_ENVIRONMENT` constant isn't set or is empty. Other values may
+ * have specific implications in the code.
+ *
+ * @return string
+ */
+function get_wordcamp_environment() {
+	$environment = 'development';
+
+	if ( defined( 'WORDCAMP_ENVIRONMENT' ) && WORDCAMP_ENVIRONMENT ) {
+		$environment = WORDCAMP_ENVIRONMENT;
+	}
+
+	return $environment;
+}
 
 /**
  * Determine if a specific feature should be skipped on the current site

--- a/public_html/wp-content/mu-plugins/quickbooks/includes/admin.php
+++ b/public_html/wp-content/mu-plugins/quickbooks/includes/admin.php
@@ -96,7 +96,7 @@ function handle_form_post() {
 			exit();
 
 		case 'exchange':
-			// See \WordCamp\QuickBooks\Client::OAUTH_REDIRECT_URI.
+			// See \WordCamp\QuickBooks\Client::oauth_redirect_uri.
 
 			$client->maybe_exchange_code_for_token();
 

--- a/public_html/wp-content/mu-plugins/quickbooks/includes/client.php
+++ b/public_html/wp-content/mu-plugins/quickbooks/includes/client.php
@@ -23,9 +23,9 @@ class Client {
 	/**
 	 * The URI that QBO will redirect to after an OAuth user authorization.
 	 *
-	 * This is hardcoded here since it has to be hardcoded in the QBO app.
+	 * @var string
 	 */
-	const OAUTH_REDIRECT_URI = 'https://wordcamp.org/wp-admin/admin-post.php?action=wordcamp-qbo-oauth&cmd=exchange';
+	protected $oauth_redirect_uri;
 
 	/**
 	 * @var WP_Error|null
@@ -41,6 +41,14 @@ class Client {
 	 * Client constructor.
 	 */
 	public function __construct() {
+		/**
+		 * This value must match one of the Redirect URI values saved in the app.
+		 */
+		$this->oauth_redirect_uri = sprintf(
+			'https://wordcamp.%s/wp-admin/admin-post.php?action=wordcamp-qbo-oauth&cmd=exchange',
+			( 'local' === get_wordcamp_environment() ) ? 'test' : 'org'
+		);
+
 		$this->error = new WP_Error();
 
 		if ( ! class_exists( '\QuickBooksOnline\API\DataService\DataService' ) ) {
@@ -139,7 +147,7 @@ class Client {
 			'wordcamp_qbo_client_config',
 			array(
 				'auth_mode'    => 'oauth2',
-				'RedirectURI'  => self::OAUTH_REDIRECT_URI,
+				'RedirectURI'  => $this->oauth_redirect_uri,
 				'scope'        => 'com.intuit.quickbooks.accounting',
 				'ClientID'     => '',
 				'ClientSecret' => '',

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -4,23 +4,6 @@
  * Miscellaneous snippets that don't warrant their own file
  */
 
-/**
- * Get the current environment.
- *
- * Defaults to 'development' if the `WORDCAMP_ENVIRONMENT` constant isn't set or is empty.
- *
- * @return string
- */
-function get_wordcamp_environment() {
-	$environment = 'development';
-
-	if ( defined( 'WORDCAMP_ENVIRONMENT' ) && WORDCAMP_ENVIRONMENT ) {
-		$environment = WORDCAMP_ENVIRONMENT;
-	}
-
-	return $environment;
-}
-
 /*
  * Prevents 'index.php' from being prepended to permalink options.
  *

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -412,7 +412,10 @@ add_filter( 'wordcamp_qbo_client_options', function( $options ) {
 	}
 
 	$options['hmac_key'] = WORDCAMP_QBO_HMAC_KEY;
-	$options['api_base'] = 'https://central.wordcamp.org/wp-json/wordcamp-qbo/v1';
+	$options['api_base'] = sprintf(
+		'https://central.wordcamp.%s/wp-json/wordcamp-qbo/v1',
+		( 'local' === get_wordcamp_environment() ) ? 'test' : 'org'
+	);
 
 	return $options;
 });

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -4,6 +4,22 @@
  * Miscellaneous snippets that don't warrant their own file
  */
 
+/**
+ * Get the current environment.
+ *
+ * Defaults to 'development' if the `WORDCAMP_ENVIRONMENT` constant isn't set or is empty.
+ *
+ * @return string
+ */
+function get_wordcamp_environment() {
+	$environment = 'development';
+
+	if ( defined( 'WORDCAMP_ENVIRONMENT' ) && WORDCAMP_ENVIRONMENT ) {
+		$environment = WORDCAMP_ENVIRONMENT;
+	}
+
+	return $environment;
+}
 
 /*
  * Prevents 'index.php' from being prepended to permalink options.

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
@@ -4,7 +4,7 @@
  */
 
 // Local environments don't have the credentials to send to Slack.
-if ( 'development' === WORDCAMP_ENVIRONMENT && ( ! defined( 'WPORG_SANDBOXED' ) || ! WPORG_SANDBOXED ) ) {
+if ( 'local' === get_wordcamp_environment() ) {
 	return;
 }
 

--- a/public_html/wp-content/plugins/wordcamp-qbo-client/wordcamp-qbo-client.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo-client/wordcamp-qbo-client.php
@@ -307,7 +307,7 @@ class WordCamp_QBO_Client {
 			} elseif ( isset( $body->message ) ) {
 				$sent = $body->message;
 			} else {
-				$sent = 'Unknown error.';
+				$sent = print_r( array( $body ), true );
 			}
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-qbo-client/wordcamp-qbo-client.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo-client/wordcamp-qbo-client.php
@@ -307,7 +307,7 @@ class WordCamp_QBO_Client {
 			} elseif ( isset( $body->message ) ) {
 				$sent = $body->message;
 			} else {
-				$sent = print_r( array( $body ), true );
+				$sent = 'Unknown error.';
 			}
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-qbo-client/wordcamp-qbo-client.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo-client/wordcamp-qbo-client.php
@@ -250,7 +250,12 @@ class WordCamp_QBO_Client {
 				'Authorization' => self::_get_auth_header( 'post', $request_url, $body ),
 			),
 		);
-		$response     = wp_remote_post( $request_url, $request_args );
+
+		if ( 'local' === get_wordcamp_environment() ) {
+			$request_args['sslverify'] = false;
+		}
+
+		$response = wp_remote_post( $request_url, $request_args );
 
 		Logger\log( 'remote_request', compact( 'request_url', 'request_args', 'response' ) );
 
@@ -375,6 +380,10 @@ class WordCamp_QBO_Client {
 			),
 		);
 
+		if ( 'local' === get_wordcamp_environment() ) {
+			$args['sslverify'] = false;
+		}
+
 		return array(
 			'url'  => $request_url,
 			'args' => $args,
@@ -449,7 +458,11 @@ class WordCamp_QBO_Client {
 			),
 		);
 
-		$request_url = add_query_arg( $params, $request_url );  // has to be done after get_auth_header() is called so that the base url and params can be passed separately
+		if ( 'local' === get_wordcamp_environment() ) {
+			$args['sslverify'] = false;
+		}
+
+		$request_url = add_query_arg( $params, $request_url );  // has to be done after get_auth_header() is called so that the base url and params can be passed separately.
 
 		return array(
 			'url'  => $request_url,
@@ -507,7 +520,11 @@ class WordCamp_QBO_Client {
 			),
 		);
 
-		$request_url = add_query_arg( $params, $request_url );  // has to be done after get_auth_header() is called so that the base url and params can be passed separately
+		if ( 'local' === get_wordcamp_environment() ) {
+			$args['sslverify'] = false;
+		}
+
+		$request_url = add_query_arg( $params, $request_url );  // has to be done after get_auth_header() is called so that the base url and params can be passed separately.
 
 		return array(
 			'url'  => $request_url,


### PR DESCRIPTION
This adds a `local` value for the `WORDCAMP_ENVIRONMENT` constant, and makes various places in the code behave differently when this value is set. This makes it much easier to test interactions with the QBO API and between our own QBO client/server setup.

**To test**

This is specifically designed to work in the Docker environment, but you can probably make it work in other local environments if you change your `WORDCAMP_ENVIRONMENT` constant value to `local` (and maybe update other values in your **wp-config.php** file, see the changeset)

1. After you check out this branch, you may need to rebuild your Docker container to make sure it has the right values in **wp-config.php**.
1. Make sure you have a **sandbox-functionality.php** file in the **mu-plugins** directory.
1. Log in to [Intuit's developer site](https://developer.intuit.com) and go to the My Apps tab. "WordCamp Quickbooks" is the app we want. Go to the Keys & OAuth tab under Development.
1. Add this snippet to your **sandbox-functionality.php** file, using the Client ID and Client Secret from the Intuit app:
    ```php
	// QBO
	add_filter( 'wordcamp_qbo_client_config', function( $config = array() ) {
		$config = array_merge(
			$config,
			array(
				'ClientID'     => 'paste value here',
				'ClientSecret' => 'paste value here',
				'baseUrl'      => 'Development',
			)
		);
	
		return $config;
	}, 99 );
    ```
1. In another browser tab, go to the [Quickbooks settings page](https://wordcamp.test/wp-admin/network/settings.php?page=quickbooks) in the test WordCamp network admin. Click _Connect_ and go through the authentication flow. Choose "Sandbox WPCS" for the company. At the end, you should end up back on the Quickbooks settings page, and it should say "Connected to Sandbox WPCS. Expires in 3 months."
1. Now open a third browser tab and go to one of the other test WordCamp sites. Create a new sponsor invoice, and submit it.
1. Back on the browser tab with the network admin, go to the [Sponsor Invoices Dashboard](https://wordcamp.test/wp-admin/network/admin.php?page=sponsor-invoices-dashboard). You should see the invoice you just created.
1. Click the _Approve_ button on the invoice. This sends the invoice to QBO. You should get a green success notice.
1. Back on the Intuit developer browser tab, under the API Docs & Tools tab, click Sandbox. Then choose the Sandbox WPCS company. This will take you to a QBO dashboard.
1. Click the Invoices item under the Sales tab. You should see the invoice you just approved.
