### PR TITLE
Post Types: Show drafted speakers attached to sessions

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -2069,6 +2069,7 @@ class WordCamp_Post_Types_Plugin {
 				if ( ! empty( $speakers_ids ) ) {
 					$speakers = get_posts( array(
 						'post_type'      => 'wcb_speaker',
+						'post_status'    => 'any',
 						'posts_per_page' => -1,
 						'post__in'       => $speakers_ids,
 					) );
@@ -2077,7 +2078,13 @@ class WordCamp_Post_Types_Plugin {
 				$output = array();
 
 				foreach ( $speakers as $speaker ) {
-					$output[] = sprintf( '<a href="%s">%s</a>', esc_url( get_edit_post_link( $speaker->ID ) ), esc_html( apply_filters( 'the_title', $speaker->post_title ) ) );
+					$is_draft = ( 'draft' === $speaker->post_status ) ? __( ' (draft)', 'wordcamporg' ) : '';
+					$output[] = sprintf(
+						'<a href="%1$s">%2$s%3$s</a>',
+						esc_url( get_edit_post_link( $speaker->ID ) ),
+						esc_html( apply_filters( 'the_title', $speaker->post_title ) ),
+						$is_draft
+					);
 				}
 
 				// Output is escaped when the string is built, so we can ignore the PHPCS error.

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -2069,7 +2069,7 @@ class WordCamp_Post_Types_Plugin {
 				if ( ! empty( $speakers_ids ) ) {
 					$speakers = get_posts( array(
 						'post_type'      => 'wcb_speaker',
-						'post_status'    => 'any',
+						'post_status'    => array( 'publish', 'draft' ),
 						'posts_per_page' => -1,
 						'post__in'       => $speakers_ids,
 					) );


### PR DESCRIPTION
Drafted speakers don't currently show up in the Sessions list table (speakers column), only published speakers. This can be confusing while you're setting up a site/schedule, since it seems like the speaker is not correctly attached to the session. This PR updates the query to show "any" speakers, with a "draft" label for unpublished speakers.

### Screenshots

![Screen Shot 2020-03-02 at 10 29 28 AM](https://user-images.githubusercontent.com/541093/75690383-bd491f80-5c70-11ea-9f2e-c78eec882e8b.png)

### How to test the changes in this Pull Request:

1. Set up some sessions & speakers, some should be drafts (or private, trash, etc)
2. View the sessions list table, `/wp-admin/edit.php?post_type=wcb_session`
3. Drafted speakers should appear in the Speakers column with ` (draft)` after their name
4. Privately published speakers will also show up here, but trashed should not.
