### PR TITLE
CampTix Invoices: Check for post type before adding custom statuses

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/camptix-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/camptix-invoices.php
@@ -180,6 +180,10 @@ add_filter( 'display_post_states', 'ctx_display_custom_statuses' );
  * Adding custom post status to Bulk and Quick Edit boxes: Status dropdown
  */
 function ctx_append_post_status_bulk_edit() {
+	$screen = get_current_screen();
+	if ( $screen && 'tix_invoice' !== $screen->post_type ) {
+		return;
+	}
 
 	?>
 	<script>


### PR DESCRIPTION
This prevents the Invoice custom statuses from being injected into all other post type "quick edit" dropdowns. These options were added via JS on all `edit.php` pages, without a post-type check, which lead to confusing behavior (marking an attendee "Refunded" does not refund the ticket).

_I'm not really sure what these statuses are meant to do, so I didn't touch anything else._

### Screenshots

Before, even pages could be "refunded":

![Screen Shot 2020-03-02 at 3 39 32 PM](https://user-images.githubusercontent.com/541093/75715844-1bd7c300-5c9c-11ea-9790-6770ce567130.png)

After, "Refunded" & "Cancelled" should only show up on Invoices.

### How to test the changes in this Pull Request:

1. Try "quick edit" or bulk editing any post type
2. Only Invoices should show "Refunded" or "Cancelled" options
3. All other post type status lists should remain the same (enable/disable CampTix Invoices if unsure)
