### PR TITLE
CampTix: Prevent calling CampTixStripe.form_handler multiple times

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.js
+++ b/public_html/wp-content/plugins/camptix/camptix.js
@@ -268,7 +268,11 @@ var CampTixStripe = new function() {
 	self.form = false;
 
 	self.init = function() {
-		self.form = jQuery( '#tix form' );
+		self.form = jQuery( '#tix_checkout_form' );
+		if ( ! self.form.length ) {
+			return;
+		}
+
 		self.form.on( 'submit', CampTixStripe.form_handler );
 
 		// On a failed attendee data request, we'll have the previous stripe token

--- a/public_html/wp-content/plugins/camptix/camptix.js
+++ b/public_html/wp-content/plugins/camptix/camptix.js
@@ -336,6 +336,8 @@ var CampTixStripe = new function() {
 	self.stripe_token_callback = function( token ) {
 		self.add_stripe_token_hidden_fields( token.id, token.receipt_email || token.email );
 
+		// Prevent calling form_handler multiple times.
+		self.form.off( 'submit', CampTixStripe.form_handler );
 		self.form.submit();
 	};
 

--- a/public_html/wp-content/plugins/camptix/camptix.js
+++ b/public_html/wp-content/plugins/camptix/camptix.js
@@ -289,6 +289,11 @@ var CampTixStripe = new function() {
 			return;
 		}
 
+		// Check if Stripe checkout is available (stripe's js is not added to free orders, etc).
+		if ( typeof StripeCheckout === 'undefined') {
+			return;
+		}
+
 		// If the form already has a Stripe token, bail.
 		var tokenised = self.form.find('input[name="tix_stripe_token"]');
 		if ( tokenised.length ) {

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5513,7 +5513,7 @@ class CampTix_Plugin {
 		?>
 		<div id="tix" class="tix-has-dynamic-receipts">
 			<?php do_action( 'camptix_notices' ); ?>
-			<form action="<?php echo esc_url( add_query_arg( 'tix_action', 'checkout' ), $this->get_tickets_url() ); ?>#tix" method="POST">
+			<form id="tix_checkout_form" action="<?php echo esc_url( add_query_arg( 'tix_action', 'checkout' ), $this->get_tickets_url() ); ?>#tix" method="POST">
 
 				<?php if ( $this->coupon ) : ?>
 					<input type="hidden" name="tix_coupon" value="<?php echo esc_attr( $this->coupon->post_title ); ?>" />


### PR DESCRIPTION
There have been reports of attendees who see a failed ticket purchase, but are later charged. These attendees usually have multiple tickets in wp-admin, the first successful, but later tickets failed with the error `token_already_used`. I believe this is due to the registration form submitting multiple times.

When checking out, we intercept the form submission to pop up the stripe modal & take card payment. Once the modal is submitted, the token is added to the form and the form is really-submitted. The intercept code still runs on this second submit. In most cases, the page should navigate off to checkout, but I think `form.submit()` is called again, attempting to charge again with the same token. Both requests to `tix_action=checkout` fly, the first ticket is charged and attendee created, then the second ticket attempts to charge but fails (due to single-use tokens), and the second ticket attendee is created but marked failed. It's this later request that the user is redirected to, making it seem like the entire purchase failed.

So the fix is to make sure we only call the `submit` callback when we intend to. This removes the `form_handler` callback before we programmatically submit the form. It also adds some checks to make sure we're only running when we have the right form, and when we have a stripe object.

### How to test the changes in this Pull Request:

Make sure checkout still works 👍  

I haven't been able to reproduce the actual issue locally, so I'm not sure how to test that this fixes it outside of "logically it should".
