### PR TITLE
Forms to Drafts: Fix login requirement on speaker application when using form block

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"workspaces": [
 		"public_html/wp-content/mu-plugins/blocks",
+		"public_html/wp-content/plugins/wordcamp-forms-to-drafts",
 		"public_html/wp-content/plugins/wordcamp-speaker-feedback"
 	],
 	"browserslist": [

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/front-end.css
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/front-end.css
@@ -7,7 +7,7 @@
 		z-index: 10;
 		margin: 2.4em;
 		padding: 1.8em;
-		background-color: #DC3232;
+		background-color: #c62828;
 		border-radius: .25em;
 		margin-bottom: 2em;
 	}
@@ -16,13 +16,22 @@
 			color: white !important /* !important to prevent theme from unintentionally overriding */;
 		}
 
+			.wcfd-disabled-form #wcorg-login-message p:first-child {
+				margin-top: 0;
+			}
+
 			.wcfd-disabled-form #wcorg-login-message p:last-child {
 				margin-bottom: 0;
 			}
 
 			.wcfd-disabled-form #wcorg-login-message a {
-				color: black !important /* !important to prevent theme from unintentionally overriding */;
-				font-weight: bold;
+				color: white;
+			}
+
+			.wcfd-disabled-form #wcorg-login-message a:hover,
+			.wcfd-disabled-form #wcorg-login-message a:focus,
+			.wcfd-disabled-form #wcorg-login-message a:active {
+				color: white;
 			}
 
 	.wcfd-overlay {

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/package.json
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "wordcamp-forms-to-drafts",
+	"version": "1.0.0",
+	"author": "WordCamp Team",
+	"license": "GPL-2.0-or-later",
+	"private": true,
+	"keywords": [],
+	"homepage": "https://github.com/WordPress/wordcamp.org/tree/production/public_html/wp-content/plugins/wordcamp-forms-to-drafts",
+	"repository": "git+https://github.com/WordPress/wordcamp.org.git",
+	"bugs": {
+		"url": "https://github.com/WordPress/wordcamp.org/issues?q=label%3A%22%5BComponent%5D%20WC-Post-Types%22"
+	},
+	"devDependencies": {
+		"@wordpress/scripts": "7.1.0",
+		"wicg-inert": "3.0.2"
+	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
+	"scripts": {
+		"start": "wp-scripts start src/inert.js",
+		"build": "wp-scripts build src/inert.js"
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/src/inert.js
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/src/inert.js
@@ -1,0 +1,1 @@
+import "wicg-inert";

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -23,7 +23,7 @@ class WordCamp_Forms_To_Drafts {
 	 */
 	public function __construct() {
 		add_action( 'wp_print_styles',          array( $this, 'print_front_end_styles'      )        );
-		add_filter( 'the_content',              array( $this, 'force_login_to_use_form'     ),  9    );
+		add_filter( 'the_content',              array( $this, 'force_login_to_use_form'     ),  8    );
 		add_action( 'template_redirect',        array( $this, 'populate_form_based_on_user' ),  9    );
 		add_action( 'grunion_pre_message_sent', array( $this, 'call_for_sponsors'           ), 10, 3 );
 		add_action( 'grunion_pre_message_sent', array( $this, 'call_for_speakers'           ), 10, 3 );
@@ -88,12 +88,19 @@ class WordCamp_Forms_To_Drafts {
 			wcorg_login_message( '', get_permalink() )
 		);
 
-		// Prevent wpautop() from converting tabs into empty paragraphs in #wcorg-login-message.
-		$please_login_message = trim( str_replace( "\t", '', $please_login_message ) );
+		$form_wrapper = sprintf(
+			'<div class="wcfd-disabled-form">%s<div class="wcfd-overlay"></div>',
+			// Prevent wpautop() from converting tabs into empty paragraphs in #wcorg-login-message.
+			trim( str_replace( "\t", '', $please_login_message ) )
+		);
 
-		$form_wrapper = '<div class="wcfd-disabled-form">' . $please_login_message . '<div class="wcfd-overlay"></div> [contact-form';
-		$content      = str_replace( '[contact-form',   $form_wrapper,           $content );
-		$content      = str_replace( '[/contact-form]', '[/contact-form]</div>', $content );
+		foreach ( array( '[contact-form', '<!-- wp:jetpack/contact-form' ) as $start ) {
+			$content = str_replace( $start, $form_wrapper . $start, $content );
+		}
+
+		foreach ( array( '[/contact-form]', '<!-- /wp:jetpack/contact-form -->' ) as $end ) {
+			$content = str_replace( $end, $end . '</div>', $content );
+		}
 
 		return $content;
 	}

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -89,7 +89,7 @@ class WordCamp_Forms_To_Drafts {
 		);
 
 		$form_wrapper = sprintf(
-			'<div class="wcfd-disabled-form">%s<div class="wcfd-overlay"></div>',
+			'<div class="wcfd-disabled-form">%s<div class="wcfd-overlay"></div><div inert>',
 			// Prevent wpautop() from converting tabs into empty paragraphs in #wcorg-login-message.
 			trim( str_replace( "\t", '', $please_login_message ) )
 		);
@@ -99,7 +99,7 @@ class WordCamp_Forms_To_Drafts {
 		}
 
 		foreach ( array( '[/contact-form]', '<!-- /wp:jetpack/contact-form -->' ) as $end ) {
-			$content = str_replace( $end, $end . '</div>', $content );
+			$content = str_replace( $end, $end . '</div></div>', $content );
 		}
 
 		return $content;

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -23,6 +23,7 @@ class WordCamp_Forms_To_Drafts {
 	 */
 	public function __construct() {
 		add_action( 'wp_print_styles',          array( $this, 'print_front_end_styles'      )        );
+		add_action( 'wp_enqueue_scripts',       array( $this, 'enqueue_inert_script'        )        );
 		add_filter( 'the_content',              array( $this, 'force_login_to_use_form'     ),  8    );
 		add_action( 'template_redirect',        array( $this, 'populate_form_based_on_user' ),  9    );
 		add_action( 'grunion_pre_message_sent', array( $this, 'call_for_sponsors'           ), 10, 3 );
@@ -44,6 +45,25 @@ class WordCamp_Forms_To_Drafts {
 		</style>
 
 		<?php
+	}
+
+	/**
+	 * Add the `inert` polyfill to disabled form pages.
+	 */
+	public function enqueue_inert_script() {
+		if ( ! $this->form_requires_login( $this->get_current_form_id() ) ) {
+			return;
+		}
+		$deps_path = __DIR__ . '/build/inert.asset.php';
+		$script_info = require $deps_path;
+
+		wp_enqueue_script(
+			'wicg-inert',
+			plugins_url( 'build/inert.js', __FILE__ ),
+			$script_info['dependencies'],
+			$script_info['version'],
+			true
+		);
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -11706,6 +11706,11 @@ which@1, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
+wicg-inert@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.0.2.tgz#46d8b01142c1bda8f6fa5d78e2754ba56f6f70be"
+  integrity sha512-L2eSi1fx1M+WLLUccwzAulgK5hZtllRDvYk3UB/fe1ZqdkZS6dz718o6xfe3JUtBEJJnqvI6NF8m1bAHlg3JUg==
+
 wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"


### PR DESCRIPTION
Add the block delimiters to the check for form content on a post, so that the login overlay will take effect on block-forms as well as the shortcode. This brings back the wp.org login gateway on the call for speakers form, which should prevent misattributed speakers & submission spam. Additionally this adds the `inert` attribute (+ [polyfill for browser support](https://github.com/WICG/inert)) to prevent keyboard users from being able to fill out & submit the form.

Fixes #332, Fixes #378 

### Screenshots

![Screen Shot 2020-03-05 at 5 36 21 PM](https://user-images.githubusercontent.com/541093/76033314-f3ed9700-5f09-11ea-8e00-e493d398ec67.png)

### How to test the changes in this Pull Request:

1. View the call for speakers form on a site, logged out
2. It should block you from editing the form
3. Log in, as a user that isn't an admin on the site
4. The form should pre-fill with your name, email, and username (Jetpack prevents this for users with `manage_options`, 🤷🏼‍♀️ )
