### PR TITLE
CampTix: Add "Remote" ticket type

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -40,7 +40,7 @@ class Accommodations_Field extends CampTix_Addon {
 
 		// Registration field
 		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 12, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
+		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ), 11 );
 		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
@@ -148,6 +148,11 @@ class Accommodations_Field extends CampTix_Addon {
 		/* @var CampTix_Plugin $camptix */
 		global $camptix;
 
+		$skip_question = apply_filters( 'camptix_accommodations_should_skip', false );
+		if ( $skip_question ) {
+			return $data;
+		}
+
 		if ( ! isset( $data[ self::SLUG ] ) || empty( $data[ self::SLUG ] ) ) {
 			$camptix->error_flags['required_fields'] = true;
 		} else {
@@ -166,7 +171,7 @@ class Accommodations_Field extends CampTix_Addon {
 	 * @return WP_Post
 	 */
 	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = $data[ self::SLUG ];
+		$attendee->{ self::SLUG } = isset( $data[ self::SLUG ] ) ? $data[ self::SLUG ] : 'no';
 
 		return $attendee;
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -71,18 +71,24 @@ class Accommodations_Field extends CampTix_Addon {
 	 *
 	 * @param string $name
 	 * @param string $value
+	 * @param int    $ticket_id
 	 */
-	public function render_field( $name, $value ) {
+	public function render_field( $name, $value, $ticket_id ) {
+		if ( apply_filters( 'camptix_accommodations_should_skip', false ) ) {
+			return;
+		}
+
+		$question = apply_filters( 'camptix_accommodations_question_text', $this->question, $ticket_id );
 		?>
 
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
-				<?php echo esc_html( $this->question ); ?>
+				<?php echo esc_html( $question ); ?>
 				<span aria-hidden="true" class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $question ); ?>">
 					<label>
 						<input
 							name="<?php echo esc_attr( $name ); ?>"
@@ -126,7 +132,8 @@ class Accommodations_Field extends CampTix_Addon {
 
 		$this->render_field(
 			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
-			$current_data[ self::SLUG ]
+			$current_data[ self::SLUG ],
+			$current_data['ticket_id']
 		);
 	}
 
@@ -213,7 +220,7 @@ class Accommodations_Field extends CampTix_Addon {
 	 * @return bool|int
 	 */
 	public function validate_save_ticket_info_field( $data, $attendee ) {
-		$value = ( 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
+		$value = ( isset( $data[ self::SLUG ] ) && 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
 
 		$this->maybe_send_notification_email( $value, $attendee );
 
@@ -230,7 +237,8 @@ class Accommodations_Field extends CampTix_Addon {
 
 		$this->render_field(
 			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
-			$current_data[ self::SLUG ]
+			$current_data[ self::SLUG ],
+			$current_data['ticket_id']
 		);
 	}
 
@@ -247,7 +255,8 @@ class Accommodations_Field extends CampTix_Addon {
 		if ( $value && isset( $this->options[ $value ] ) ) {
 			$value = $this->options[ $value ];
 		}
-		$new_row = array( $this->question, esc_html( $value ) );
+		$question = apply_filters( 'camptix_accommodations_question_text', $this->question, $post->tix_ticket_id );
+		$new_row = array( $question, esc_html( $value ) );
 
 		add_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -38,7 +38,7 @@ class Allergy_Field extends CampTix_Addon {
 
 		// Registration field
 		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 11, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
+		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ), 11 );
 		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
@@ -146,6 +146,11 @@ class Allergy_Field extends CampTix_Addon {
 		/* @var CampTix_Plugin $camptix */
 		global $camptix;
 
+		$skip_question = apply_filters( 'camptix_allergy_should_skip', false );
+		if ( $skip_question ) {
+			return $data;
+		}
+
 		if ( ! isset( $data[ self::SLUG ] ) || empty( $data[ self::SLUG ] ) ) {
 			$camptix->error_flags['required_fields'] = true;
 		} else {
@@ -164,7 +169,7 @@ class Allergy_Field extends CampTix_Addon {
 	 * @return WP_Post
 	 */
 	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = $data[ self::SLUG ];
+		$attendee->{ self::SLUG } = isset( $data[ self::SLUG ] ) ? $data[ self::SLUG ] : 'no';
 
 		return $attendee;
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -69,18 +69,24 @@ class Allergy_Field extends CampTix_Addon {
 	 *
 	 * @param string $name
 	 * @param string $value
+	 * @param int    $ticket_id
 	 */
-	public function render_field( $name, $value ) {
+	public function render_field( $name, $value, $ticket_id ) {
+		if ( apply_filters( 'camptix_allergy_should_skip', false ) ) {
+			return;
+		}
+
+		$question = apply_filters( 'camptix_allergy_question_text', $this->question, $ticket_id );
 		?>
 
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left">
-				<?php echo esc_html( $this->question ); ?>
+				<?php echo esc_html( $question ); ?>
 				<span aria-hidden="true" class="tix-required-star">*</span>
 			</td>
 
 			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->question ); ?>">
+				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $question ); ?>">
 					<label>
 						<input
 							name="<?php echo esc_attr( $name ); ?>"
@@ -124,7 +130,8 @@ class Allergy_Field extends CampTix_Addon {
 
 		$this->render_field(
 			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
-			$current_data[ self::SLUG ]
+			$current_data[ self::SLUG ],
+			$current_data['ticket_id']
 		);
 	}
 
@@ -211,7 +218,7 @@ class Allergy_Field extends CampTix_Addon {
 	 * @return bool|int
 	 */
 	public function validate_save_ticket_info_field( $data, $attendee ) {
-		$value = ( 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
+		$value = ( isset( $data[ self::SLUG ] ) && 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
 
 		$this->maybe_send_notification_email( $value, $attendee );
 
@@ -228,7 +235,8 @@ class Allergy_Field extends CampTix_Addon {
 
 		$this->render_field(
 			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
-			$current_data[ self::SLUG ]
+			$current_data[ self::SLUG ],
+			$current_data['ticket_id']
 		);
 	}
 
@@ -245,7 +253,8 @@ class Allergy_Field extends CampTix_Addon {
 		if ( $value && isset( $this->options[ $value ] ) ) {
 			$value = $this->options[ $value ];
 		}
-		$new_row = array( $this->question, esc_html( $value ) );
+		$question = apply_filters( 'camptix_allergy_question_text', $this->question, $post->tix_ticket_id );
+		$new_row = array( $question, esc_html( $value ) );
 
 		add_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -9,6 +9,8 @@ const SLUG = 'remote';
 add_filter( 'camptix_ticket_types', __NAMESPACE__ . '\add_type' );
 add_filter( 'camptix_metabox_questions_default_fields_list', __NAMESPACE__ . '\modify_default_fields_list' );
 add_filter( 'camptix_accommodations_question_text', __NAMESPACE__ . '\accommodations_question_text', 10, 2 );
+add_filter( 'camptix_attendee_form_after_questions', __NAMESPACE__ . '\set_allergy_filter', 10, 2 );
+add_filter( 'camptix_form_edit_attendee_after_questions', __NAMESPACE__ . '\set_allergy_filter', 10 );
 
 /**
  * Add this type to the available ticket types.
@@ -46,3 +48,28 @@ function accommodations_question_text( $question, $ticket_id ) {
 	}
 	return $question;
 }
+
+/**
+ * Set a boolean filter on the "Allergy" question, to skip the question if it's remote.
+ *
+ * @param array    $form_data
+ * @param int|null $i
+ */
+function set_allergy_filter( $form_data, $i = null ) {
+	if ( ! is_null( $i ) ) {
+		$form_data = ( isset( $form_data['tix_attendee_info'][ $i ] ) ) ? $form_data['tix_attendee_info'][ $i ] : array();
+	}
+
+	if ( ! isset( $form_data['ticket_id'] ) ) {
+		return;
+	}
+
+	if ( SLUG === get_type_slug( $form_data['ticket_id'] ) ) {
+		remove_filter( 'camptix_allergy_should_skip', '__return_false' );
+		add_filter( 'camptix_allergy_should_skip', '__return_true' );
+	} else {
+		remove_filter( 'camptix_allergy_should_skip', '__return_true' );
+		add_filter( 'camptix_allergy_should_skip', '__return_false' );
+	}
+}
+

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -8,6 +8,7 @@ const SLUG = 'remote';
 
 add_filter( 'camptix_ticket_types', __NAMESPACE__ . '\add_type' );
 add_filter( 'camptix_metabox_questions_default_fields_list', __NAMESPACE__ . '\modify_default_fields_list' );
+add_filter( 'camptix_accommodations_question_text', __NAMESPACE__ . '\accommodations_question_text', 10, 2 );
 
 /**
  * Add this type to the available ticket types.
@@ -31,4 +32,17 @@ function modify_default_fields_list( $default_fields ) {
 		return __( 'Top three fields: First name, last name, e-mail address.<br />Bottom three fields: Attendee list opt-out, accessibility needs, Code of Conduct agreement.', 'wordcamporg' );
 	}
 	return $default_fields;
+}
+
+/**
+ * Modify the accommodations question.
+ *
+ * @param string $question
+ * @return string
+ */
+function accommodations_question_text( $question, $ticket_id ) {
+	if ( SLUG === get_type_slug( $ticket_id ) ) {
+		return __( 'Do you have any accessibility needs, such as a sign language interpreter, to participate in WordCamp?', 'wordcamporg' );
+	}
+	return $question;
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -47,7 +47,7 @@ function modify_default_fields_list( $default_fields ) {
  */
 function accommodations_question_text( $question, $ticket_id ) {
 	if ( SLUG === get_type_slug( $ticket_id ) ) {
-		return __( 'Do you have any accessibility needs, such as a sign language interpreter, to participate in WordCamp?', 'wordcamporg' );
+		return __( 'Do you have any accessibility needs, such as a sign language interpreter or live captioning, to participate in WordCamp?', 'wordcamporg' );
 	}
 	return $question;
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WordCamp\CampTix_Tweaks\Ticket_Types\Remote;
+use function WordCamp\CampTix_Tweaks\Ticket_Types\get_type_slug;
+defined( 'WPINC' ) || die();
+
+const SLUG = 'remote';
+
+add_filter( 'camptix_ticket_types', __NAMESPACE__ . '\add_type' );
+add_filter( 'camptix_metabox_questions_default_fields_list', __NAMESPACE__ . '\modify_default_fields_list' );
+
+/**
+ * Add this type to the available ticket types.
+ */
+function add_type( $types ) {
+	$types[] = array(
+		'slug' => SLUG,
+		'name' => __( 'Remote/Livestream', 'wordcamporg' ),
+	);
+	return $types;
+}
+
+/**
+ * Modify the list of default questions on the ticket registration form.
+ *
+ * @param string $default_fields
+ * @return string
+ */
+function modify_default_fields_list( $default_fields ) {
+	if ( SLUG === get_type_slug( get_the_ID() ) ) {
+		return __( 'Top three fields: First name, last name, e-mail address.<br />Bottom three fields: Attendee list opt-out, accessibility needs, Code of Conduct agreement.', 'wordcamporg' );
+	}
+	return $default_fields;
+}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -9,8 +9,10 @@ const SLUG = 'remote';
 add_filter( 'camptix_ticket_types', __NAMESPACE__ . '\add_type' );
 add_filter( 'camptix_metabox_questions_default_fields_list', __NAMESPACE__ . '\modify_default_fields_list' );
 add_filter( 'camptix_accommodations_question_text', __NAMESPACE__ . '\accommodations_question_text', 10, 2 );
-add_filter( 'camptix_attendee_form_after_questions', __NAMESPACE__ . '\set_allergy_filter', 10, 2 );
-add_filter( 'camptix_form_edit_attendee_after_questions', __NAMESPACE__ . '\set_allergy_filter', 10 );
+
+add_action( 'camptix_attendee_form_after_questions', __NAMESPACE__ . '\set_allergy_filter', 10, 2 );
+add_action( 'camptix_form_edit_attendee_after_questions', __NAMESPACE__ . '\set_allergy_filter', 10 );
+add_filter( 'camptix_checkout_attendee_info', __NAMESPACE__ . '\set_allergy_filter', 10 );
 
 /**
  * Add this type to the available ticket types.
@@ -50,10 +52,13 @@ function accommodations_question_text( $question, $ticket_id ) {
 }
 
 /**
- * Set a boolean filter on the "Allergy" question, to skip the question if it's remote.
+ * Set a boolean filter on the "Allergy" question, to skip the question if it's remote. This will also skip the
+ * validation step when creating an attendee record.
  *
  * @param array    $form_data
  * @param int|null $i
+ * @return array The form data, used by `camptix_checkout_attendee_info` hook. Should be unchanged, only used
+ *               to set the skip filter.
  */
 function set_allergy_filter( $form_data, $i = null ) {
 	if ( ! is_null( $i ) ) {
@@ -61,7 +66,7 @@ function set_allergy_filter( $form_data, $i = null ) {
 	}
 
 	if ( ! isset( $form_data['ticket_id'] ) ) {
-		return;
+		return $form_data;
 	}
 
 	if ( SLUG === get_type_slug( $form_data['ticket_id'] ) ) {
@@ -71,5 +76,7 @@ function set_allergy_filter( $form_data, $i = null ) {
 		remove_filter( 'camptix_allergy_should_skip', '__return_true' );
 		add_filter( 'camptix_allergy_should_skip', '__return_false' );
 	}
+
+	return $form_data;
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -21,6 +21,7 @@ function add_type( $types ) {
 	$types[] = array(
 		'slug' => SLUG,
 		'name' => __( 'Remote/Livestream', 'wordcamporg' ),
+		'description' => __( 'Remote attendee, ex: watching on livestream, from home.', 'wordcamporg' ),
 	);
 	return $types;
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -18,7 +18,7 @@ add_filter( 'camptix_checkout_attendee_info', __NAMESPACE__ . '\set_allergy_filt
  * Add this type to the available ticket types.
  */
 function add_type( $types ) {
-	$types[] = array(
+	$types[ SLUG ] = array(
 		'slug' => SLUG,
 		'name' => __( 'Remote/Livestream', 'wordcamporg' ),
 		'description' => __( 'Remote attendee, ex: watching on livestream, from home.', 'wordcamporg' ),

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -56,8 +56,8 @@ function accommodations_question_text( $question, $ticket_id ) {
  * Set a boolean filter on the "Allergy" question, to skip the question if it's remote. This will also skip the
  * validation step when creating an attendee record.
  *
- * @param array    $form_data
- * @param int|null $i
+ * @param array    $form_data All data about the current form, including all tickets data.
+ * @param int|null $i         Index for the current ticket.
  * @return array The form data, used by `camptix_checkout_attendee_info` hook. Should be unchanged, only used
  *               to set the skip filter.
  */

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/remote.php
@@ -20,8 +20,8 @@ add_filter( 'camptix_checkout_attendee_info', __NAMESPACE__ . '\set_allergy_filt
 function add_type( $types ) {
 	$types[ SLUG ] = array(
 		'slug' => SLUG,
-		'name' => __( 'Remote/Livestream', 'wordcamporg' ),
-		'description' => __( 'Remote attendee, ex: watching on livestream, from home.', 'wordcamporg' ),
+		'name' => __( 'Livestream', 'wordcamporg' ),
+		'description' => __( 'Attendee watching livestream from home.', 'wordcamporg' ),
 	);
 	return $types;
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -44,6 +44,7 @@ function get_types() {
 			array(
 				'slug' => 'default',
 				'name' => __( 'Default', 'wordcamporg' ),
+				'description' => __( 'Default, in-person attendee.', 'wordcamporg' ),
 			),
 		)
 	);
@@ -98,12 +99,17 @@ function metabox_ticket_type() {
 	global $camptix;
 	$purchased = $camptix->get_purchased_tickets_count( get_the_ID() );
 	$selected = get_type_slug( get_the_ID() );
+	$types = get_types();
 	?>
 	<p>
-		<?php esc_attr_e( '[Some explanation of what the types are…] The type of ticket will determine how we set up the required questions.', 'wordcamporg' ); ?>
+		<?php esc_html_e( 'The type of ticket will determine how we set up the required questions. This cannot be changed once someone buys a ticket.', 'wordcamporg' ); ?>
 	</p>
 	<p>
-		<?php esc_attr_e( 'This cannot be changed once someone buys a ticket.', 'wordcamporg' ); ?>
+		<ul>
+		<?php foreach ( $types as $type ) : ?>
+			<li><strong><?php echo esc_html( $type['name'] ); ?>:</strong> <?php echo esc_html( $type['description'] ); ?></li>
+		<?php endforeach; ?>
+		</ul>
 	</p>
 	<p>
 		<label for="<?php echo esc_attr( META_KEY ); ?>"><?php esc_attr_e( 'Type:', 'wordcamporg' ); ?></label>
@@ -112,7 +118,7 @@ function metabox_ticket_type() {
 			name="<?php echo esc_attr( META_KEY ); ?>"
 			<?php echo ( $purchased <= 0 ) ? '' : 'disabled="disabled"'; ?>
 		>
-			<?php foreach ( get_types() as $type ) : ?>
+			<?php foreach ( $types as $type ) : ?>
 				<option value="<?php echo esc_attr( $type['slug'] ); ?>" <?php selected( $selected, $type['slug'] ); ?>>
 					<?php echo esc_html( $type['name'] ); ?>
 				</option>
@@ -122,7 +128,7 @@ function metabox_ticket_type() {
 
 	<?php if ( $purchased > 0 ) : ?>
 	<p>
-		<?php esc_attr_e( 'You can not change the type because one or more tickets have already been purchased.', 'wordcamporg' ); ?>
+		<?php esc_html_e( 'You can not change the type because one or more tickets have already been purchased.', 'wordcamporg' ); ?>
 	</p>
 	<?php endif; ?>
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -41,7 +41,7 @@ function get_types() {
 	return apply_filters(
 		'camptix_ticket_types',
 		array(
-			array(
+			'default' => array(
 				'slug' => 'default',
 				'name' => __( 'Default', 'wordcamporg' ),
 				'description' => __( 'Default, in-person attendee.', 'wordcamporg' ),
@@ -54,9 +54,9 @@ function get_types() {
  * Match the given value to an existing type slug, return the slug, or "default" if not a match.
  */
 function get_slug_from_value( $value ) {
-	$match = wp_list_pluck( wp_list_filter( get_types(), array( 'slug' => $value ) ), 'slug' );
-	if ( count( $match ) > 0 ) {
-		return current( $match );
+	$types = get_types();
+	if ( isset( $types[ $value ] ) ) {
+		return $value;
 	}
 	return 'default';
 }
@@ -67,12 +67,17 @@ function get_slug_from_value( $value ) {
  * @return array
  */
 function get_type( $ticket_id ) {
+	$types = get_types();
 	$type = get_post_meta( $ticket_id, META_KEY, true );
 	if ( ! $type ) {
 		$type = 'default';
 	}
-	$match = wp_list_filter( get_types(), array( 'slug' => $type ) );
-	return current( $match );
+
+	if ( isset( $types[ $type ] ) ) {
+		return $types[ $type ];
+	}
+
+	return $types[ 'default' ];
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -53,7 +53,7 @@ function get_types() {
  * Match the given value to an existing type slug, return the slug, or "default" if not a match.
  */
 function get_slug_from_value( $value ) {
-	$match = wp_list_pluck( wp_list_filter( s(), array( 'slug' => $value ) ), 'slug' );
+	$match = wp_list_pluck( wp_list_filter( get_types(), array( 'slug' => $value ) ), 'slug' );
 	if ( count( $match ) > 0 ) {
 		return current( $match );
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -27,6 +27,9 @@ function camptix_init() {
 
 	add_action( 'camptix_add_meta_boxes', __NAMESPACE__ . '\add_types_meta_box' );
 	add_action( 'save_post', __NAMESPACE__ . '\save_post' );
+
+	add_filter( 'manage_edit-tix_ticket_columns', __NAMESPACE__ . '\manage_columns_filter', 9 );
+	add_action( 'manage_tix_ticket_posts_custom_column', __NAMESPACE__ . '\manage_columns_output', 10, 2 );
 }
 
 /**
@@ -152,5 +155,28 @@ function save_post( $post_id ) {
 
 	if ( isset( $_POST['tix_type'] ) ) {
 		update_post_meta( $post_id, META_KEY, $_POST['tix_type'] );
+	}
+}
+
+/**
+ * Manage columns filter for ticket post type.
+ *
+ * @param array $columns
+ */
+function manage_columns_filter( $columns ) {
+	$columns[ META_KEY ] = __( 'Type', 'wordcamporg' );
+	return $columns;
+}
+
+/**
+ * Manage columns action for ticket post type.
+ *
+ * @param string $column
+ * @param int    $post_id
+ */
+function manage_columns_output( $column, $post_id ) {
+	if ( META_KEY === $column ) {
+		$selected = get_type( $post_id );
+		echo esc_html( $selected['name'] );
 	}
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -165,7 +165,8 @@ function save_post( $post_id ) {
 	check_admin_referer( $nonce_action );
 
 	if ( isset( $_POST['tix_type'] ) ) {
-		update_post_meta( $post_id, META_KEY, $_POST['tix_type'] );
+		$value = filter_input( INPUT_POST, 'tix_type', FILTER_SANITIZE_STRING );
+		update_post_meta( $post_id, META_KEY, $value );
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Add a fixed set of ticket types to every site, globally defined.
+ */
+
+namespace WordCamp\CampTix_Tweaks\Ticket_Types;
+defined( 'WPINC' ) || die();
+
+const META_KEY = 'tix_type';
+
+require_once __DIR__ . '/remote.php';
+
+add_action( 'camptix_init', __NAMESPACE__ . '\camptix_init' );
+
+/**
+ * Hook into WordPress and Camptix.
+ */
+function camptix_init() {
+	register_post_meta(
+		'tix_ticket',
+		META_KEY,
+		array(
+			'single'            => true,
+			'sanitize_callback' => __NAMESPACE__ . '\get_slug_from_value',
+		)
+	);
+
+	add_action( 'camptix_add_meta_boxes', __NAMESPACE__ . '\add_types_meta_box' );
+	add_action( 'save_post', __NAMESPACE__ . '\save_post' );
+}
+
+/**
+ * Get the list of ticket types.
+ *
+ * @return array[] List of associative arrays representing ticket-types.
+ */
+function get_types() {
+	return apply_filters(
+		'camptix_ticket_types',
+		array(
+			array(
+				'slug' => 'default',
+				'name' => __( 'Default', 'wordcamporg' ),
+			),
+		)
+	);
+}
+
+/**
+ * Match the given value to an existing type slug, return the slug, or "default" if not a match.
+ */
+function get_slug_from_value( $value ) {
+	$match = wp_list_pluck( wp_list_filter( s(), array( 'slug' => $value ) ), 'slug' );
+	if ( count( $match ) > 0 ) {
+		return current( $match );
+	}
+	return 'default';
+}
+
+/**
+ * Get the type of a given ticket.
+ *
+ * @return array
+ */
+function get_type( $ticket_id ) {
+	$type = get_post_meta( $ticket_id, META_KEY, true );
+	if ( ! $type ) {
+		$type = 'default';
+	}
+	$match = wp_list_filter( get_types(), array( 'slug' => $type ) );
+	return current( $match );
+}
+
+/**
+ * Get the slug for the type of a given ticket.
+ *
+ * @return string
+ */
+function get_type_slug( $ticket_id ) {
+	$type = get_type( $ticket_id );
+	return isset( $type['slug'] ) ? $type['slug'] : 'default';
+}
+
+/**
+ * Add the Ticket Types metabox to ticket editor.
+ */
+function add_types_meta_box() {
+	\add_meta_box( 'tix_ticket_types', __( 'Ticket Type', 'wordcamporg' ), __NAMESPACE__ . '\metabox_ticket_type', 'tix_ticket', 'normal', 'high' );
+}
+
+/**
+ * Metabox callback for ticket type.
+ */
+function metabox_ticket_type() {
+	global $camptix;
+	$purchased = $camptix->get_purchased_tickets_count( get_the_ID() );
+	$selected = get_type_slug( get_the_ID() );
+	?>
+	<p>
+		<?php esc_attr_e( '[Some explanation of what the types are…] The type of ticket will determine how we set up the required questions.', 'wordcamporg' ); ?>
+	</p>
+	<p>
+		<?php esc_attr_e( 'This cannot be changed once someone buys a ticket.', 'wordcamporg' ); ?>
+	</p>
+	<p>
+		<label for="<?php echo esc_attr( META_KEY ); ?>"><?php esc_attr_e( 'Type:', 'wordcamporg' ); ?></label>
+		<select
+			id="<?php echo esc_attr( META_KEY ); ?>"
+			name="<?php echo esc_attr( META_KEY ); ?>"
+			<?php echo ( $purchased <= 0 ) ? '' : 'disabled="disabled"'; ?>
+		>
+			<?php foreach ( get_types() as $type ) : ?>
+				<option value="<?php echo esc_attr( $type['slug'] ); ?>" <?php selected( $selected, $type['slug'] ); ?>>
+					<?php echo esc_html( $type['name'] ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+	</p>
+
+	<?php if ( $purchased > 0 ) : ?>
+	<p>
+		<?php esc_attr_e( 'You can not change the type because one or more tickets have already been purchased.', 'wordcamporg' ); ?>
+	</p>
+	<?php endif; ?>
+
+	<div class="clear"></div>
+	<?php
+}
+
+/**
+ * Callback on `save_post`, used to set our type meta.
+ *
+ * @param int $post_id
+ */
+function save_post( $post_id ) {
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	if ( wp_is_post_revision( $post_id ) || 'tix_ticket' !== get_post_type( $post_id ) ) {
+		return;
+	}
+
+	// Stuff here is submittable via POST only.
+	if ( ! isset( $_POST['action'] ) || 'editpost' != $_POST['action'] ) {
+		return;
+	}
+
+	// Security check.
+	$nonce_action = 'update-post_' . $post_id;
+	check_admin_referer( $nonce_action );
+
+	if ( isset( $_POST['tix_type'] ) ) {
+		update_post_meta( $post_id, META_KEY, $_POST['tix_type'] );
+	}
+}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -576,6 +576,11 @@ function load_custom_addons() {
 	// Spam prevention
 	require_once( __DIR__ . '/addons/spam-prevention.php' );
 
+	// Ticket types
+	if ( 'production' !== get_wordcamp_environment() ) {
+		require_once( __DIR__ . '/addons/ticket-types/ticket-types.php' );
+	}
+
 	// Payment options.
 	if (
 		in_array( filter_input( INPUT_GET, 'tix_action' ), array( 'attendee_info', 'checkout' ), true ) &&

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5606,6 +5606,7 @@ class CampTix_Plugin {
 						<?php
 							$ticket = $this->tickets[$ticket_id];
 							$questions = $this->get_sorted_questions( $ticket->ID );
+							$this->form_data['tix_attendee_info'][ $i ]['ticket_id'] = intval( $ticket->ID );
 						?>
 						<input type="hidden" name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][ticket_id]" value="<?php echo intval( $ticket->ID ); ?>" />
 						<table class="tix_tickets_table tix-attendee-form">
@@ -6036,6 +6037,9 @@ class CampTix_Plugin {
 			$ticket_info = $new_ticket_info;
 			$answers     = $new_answers;
 		}
+
+		// Add ticket ID to the ticket info array.
+		$ticket_info['ticket_id'] = $ticket_id;
 		?>
 		<div id="tix">
 			<?php do_action( 'camptix_notices' ); ?>


### PR DESCRIPTION
Set up a "Ticket Type", which pulls from a global list of types (set up in code) and can conditionally alter the registration process. Types are set up as a safelist of slug+name, and the type is saved in ticket post meta. This also updates the allergy & accommodations questions, by adding filters to skip rendering the question and/or reword the question text. Other ticket types are possible in the future, by filtering `camptix_ticket_types` & similarly working with CampTix filters.

Fixes #385 

👩🏼‍💻 _Dev notes…_

I went through 2 architecture iterations before landing here— intentionally not using the `CampTix_Addon` class & instead sticking to plain namespacing so that the ticket-type files can easily access the `get_type*` functions. This way, we can add another file to `ticket-types`, ex `workshop.php`, and just like `remote.php` set it up to filter `camptix_ticket_types`. I tried to make minimal changes to CampTix itself & the hardcoded questions. Overall this works pretty well but I'd still be interested in any feedback.

📝 **I could use copy advice!**

You can see these strings "in context" in the screenshots below, but I'd appreciate better phrasing or even re-worked ideas.

- **Ticket type name:** I went with "Default" & "Remote/Livestream"
- **Describing what the ticket types are:** 
    ```
    The type of ticket will determine how we set up the required questions. This
    cannot be changed once someone buys a ticket.

    Default: Default, in-person attendee.
    Remote/Livestream: Remote attendee, ex: watching on livestream, from home.
    ```
- **Reworded a11y question:** "Do you have any accessibility needs, such as a sign language interpreter, to participate in WordCamp?" — this is still hard-coded, but there was a request that it be re-worded to be more remote-friendly, so I removed the "wheelchair access" bit.

### Screenshots

Creating a new ticket type allows for picking a type
![c-default-dd](https://user-images.githubusercontent.com/541093/76461424-3dc8f800-63b6-11ea-9a52-c37401a2a671.png)

Once a ticket is purchased, this is disabled
![Screen Shot 2020-03-11 at 4 35 21 PM](https://user-images.githubusercontent.com/541093/76461458-51745e80-63b6-11ea-9002-68fc12fa6f6e.png)

The ticket type is added to the ticket list table
![c-ticket-list](https://user-images.githubusercontent.com/541093/76460461-6a7c1000-63b4-11ea-8494-07f49f297140.png)

In the ticket form, we don't ask the allergy question, and the accommodations question is updated.
![c-remote-ticket-form](https://user-images.githubusercontent.com/541093/76460463-6b14a680-63b4-11ea-8e69-0303184ffe10.png)

### How to test the changes in this Pull Request:

1. Create a ticket, pick "Remote" for the type
2. It should work, and be labelled "remote" in the list table in wp-admin
3. Go through buying a remote ticket
4. The allergy question should not be in the form
5. The a11y question should not say anything about physical access
6. Selecting yes for the a11y question should still trigger the email
7. Buy a non-remote ticket
8. Allergy & a11y questions are both present
9. Selecting yes for the allergy question should still trigger the email
