### PR TITLE
CampTix: Add UI for changing attendee status

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -25,7 +25,7 @@ add_filter( 'camptix_shortcode_contents',                    __NAMESPACE__ . '\m
 // Attendees
 add_filter( 'camptix_name_order',                            __NAMESPACE__ . '\set_name_order'                      );
 add_action( 'camptix_form_edit_attendee_custom_error_flags', __NAMESPACE__ . '\disable_attendee_edits'              );
-add_action( 'transition_post_status',                        __NAMESPACE__ . '\log_publish_to_cancel',        10, 3 );
+add_action( 'publish_to_cancel',                             __NAMESPACE__ . '\log_publish_to_cancel',        10, 3 );
 add_filter( 'camptix_privacy_erase_attendee',                __NAMESPACE__ . '\retain_attendee_data',         10, 2 );
 add_action( 'admin_notices',                                 __NAMESPACE__ . '\admin_notice_attendee_privacy'       );
 add_filter( 'wp_privacy_personal_data_erasers',              __NAMESPACE__ . '\modify_erasers',                  99 );
@@ -497,19 +497,18 @@ function disable_attendee_edits( $attendee ) {
 /**
  * Log when published attendees are cancelled.
  *
- * @param string  $to
- * @param string  $from
  * @param WP_Post $post
  */
-function log_publish_to_cancel( $to, $from, $post ) {
+function log_publish_to_cancel( $post ) {
 	/** @var $camptix CampTix_Plugin */
 	global $camptix;
 
-	if ( 'tix_attendee' !== $post->post_type || $to === $from ) {
+	if ( 'tix_attendee' !== $post->post_type ) {
 		return;
 	}
 
-	if ( 'publish' === $from && 'cancel' === $to ) {
+	// Not a manual change, should be logged.
+	if ( 0 === wp_get_current_user_id() ) {
 		$camptix->log( 'Publish to cancel transition, possible bug.', $post->ID );
 	}
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -508,7 +508,7 @@ function log_publish_to_cancel( $post ) {
 	}
 
 	// Not a manual change, should be logged.
-	if ( 0 === wp_get_current_user_id() ) {
+	if ( 0 === get_current_user_id() ) {
 		$camptix->log( 'Publish to cancel transition, possible bug.', $post->ID );
 	}
 }

--- a/public_html/wp-content/plugins/camptix/admin.js
+++ b/public_html/wp-content/plugins/camptix/admin.js
@@ -538,6 +538,43 @@ window.camptix = window.camptix || { models: {}, views: {}, collections: {} };
 			return false;
 		});
 
+		// Edit post status on attendees.
+		if ( $( '#tix_attendee_submitdiv' ).length ) {
+			var $postStatusSelect = $('#post-status-select');
+			function updateText() {
+				// Update "Status:" to currently selected status.
+				$('#post-status-display').text(
+					// Remove any potential tags from post status text.
+					wp.sanitize.stripTagsAndEncodeText( $('option:selected', $postStatusSelect).text() )
+				);
+			}
+
+			// Post Status edit click.
+			$postStatusSelect.siblings('a.edit-post-status').click( function( event ) {
+				if ( $postStatusSelect.is( ':hidden' ) ) {
+					$postStatusSelect.slideDown( 'fast', function() {
+						$postStatusSelect.find('select').focus();
+					} );
+					$(this).hide();
+				}
+				event.preventDefault();
+			});
+
+			// Save the Post Status changes and hide the options.
+			$postStatusSelect.find('.save-post-status').click( function( event ) {
+				$postStatusSelect.slideUp( 'fast' ).siblings( 'a.edit-post-status' ).show().focus();
+				updateText();
+				event.preventDefault();
+			});
+
+			// Cancel Post Status editing and hide the options.
+			$postStatusSelect.find('.cancel-post-status').click( function( event ) {
+				$postStatusSelect.slideUp( 'fast' ).siblings( 'a.edit-post-status' ).show().focus();
+				$('#post_status').val( $('#hidden_post_status').val() );
+				updateText();
+				event.preventDefault();
+			});
+		}
 
 		/*
 		 * Track Attendance addon

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -3921,6 +3921,23 @@ class CampTix_Plugin {
 								<?php _e( 'Unknown status', 'wordcamporg' ); ?>
 							<?php endif; ?>
 						</span>
+						<a href="#post_status" class="edit-post-status hide-if-no-js" role="button" style="display: inline;">
+							<span aria-hidden="true"><?php esc_html_e( 'Edit', 'wordcamporg' ); ?></span>
+							<span class="screen-reader-text"><?php esc_html_e( 'Edit status', 'wordcamporg' ); ?></span>
+						</a>
+						<div id="post-status-select" class="hide-if-js" style="display: none;">
+							<input type="hidden" name="hidden_post_status" id="hidden_post_status" value="<?php echo esc_attr( $post->post_status ); ?>">
+							<label for="post_status" class="screen-reader-text"><?php esc_html_e( 'Set status', 'wordcamporg' ); ?></label>
+							<select name="post_status" id="post_status">
+								<option<?php selected( $post->post_status, 'publish' ); ?> value='publish'><?php _e( 'Published', 'wordcamporg' ); ?></option>
+								<option<?php selected( $post->post_status, 'draft' ); ?> value='draft'><?php _e( 'Draft', 'wordcamporg' ); ?></option>
+								<option<?php selected( $post->post_status, 'refund' ); ?> value='refund'><?php _e( 'Refunded', 'wordcamporg' ); ?></option>
+								<option<?php selected( $post->post_status, 'cancel' ); ?> value='cancel'><?php _e( 'Cancelled', 'wordcamporg' ); ?></option>
+								<option<?php selected( $post->post_status, 'failed' ); ?> value='failed'><?php _e( 'Failed', 'wordcamporg' ); ?></option>
+							</select>
+							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php esc_html_e( 'OK', 'wordcamporg' ); ?></a>
+							<a href="#post_status" class="cancel-post-status hide-if-no-js button-cancel"><?php esc_html_e( 'Cancel', 'wordcamporg' ); ?></a>
+						</div>
 					</div>
 
 					<?php

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -164,6 +164,9 @@ class CampTix_Plugin {
 
 		// Change updated messages
 		add_filter( 'post_updated_messages', array( $this, 'ticket_updated_messages' ) );
+		
+		// Add post statuses to bulk & quick edit.
+		add_action( 'admin_footer-edit.php', array( $this, 'append_post_status_bulk_edit' ) );
 
 		do_action( 'camptix_init' );
 	}
@@ -3997,6 +4000,25 @@ class CampTix_Plugin {
 				<div class="clear"></div>
 			</div>
 		</div><!-- #submitpost -->
+		<?php
+	}
+
+	/**
+	 * Adding custom post status to status dropdown in Bulk and Quick Edit.
+	 */
+	function append_post_status_bulk_edit() {
+		$screen = get_current_screen();
+		if ( $screen && 'edit-tix_attendee' !== $screen->id ) {
+			return;
+		}
+
+		?>
+		<script>
+			jQuery( document ).ready( function($) {
+				$( ".inline-edit-status select " ).append("<option value=\"<?php echo esc_attr( 'refund' ); ?>\"><?php echo esc_html_x( 'Refunded', 'post', 'wordcamporg' ); ?></option>" );
+				$( ".inline-edit-status select " ).append("<option value=\"<?php echo esc_attr( 'cancel' ); ?>\"><?php echo esc_html_x( 'Cancelled', 'post', 'wordcamporg' ); ?></option>" );
+			});
+		</script>
 		<?php
 	}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -3924,6 +3924,7 @@ class CampTix_Plugin {
 								<?php _e( 'Unknown status', 'wordcamporg' ); ?>
 							<?php endif; ?>
 						</span>
+						<?php if ( current_user_can( 'manage_sites' ) ) : ?>
 						<a href="#post_status" class="edit-post-status hide-if-no-js" role="button" style="display: inline;">
 							<span aria-hidden="true"><?php esc_html_e( 'Edit', 'wordcamporg' ); ?></span>
 							<span class="screen-reader-text"><?php esc_html_e( 'Edit status', 'wordcamporg' ); ?></span>
@@ -3947,6 +3948,7 @@ class CampTix_Plugin {
 							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php esc_html_e( 'OK', 'wordcamporg' ); ?></a>
 							<a href="#post_status" class="cancel-post-status hide-if-no-js button-cancel"><?php esc_html_e( 'Cancel', 'wordcamporg' ); ?></a>
 						</div>
+						<?php endif; ?>
 					</div>
 
 					<?php
@@ -4026,12 +4028,16 @@ class CampTix_Plugin {
 		?>
 		<script>
 			jQuery( document ).ready( function($) {
-				$( '.inline-edit-status select' ).empty();
-				<?php foreach ( $statuses as $slug => $label ) : ?>
-					$( '.inline-edit-status select' ).append( "<?php printf(
-						'<option value=\"%s\">%s</option>', esc_attr( $slug ), esc_html( $label )
-					); ?>" );
-				<?php endforeach; ?>
+				<?php if ( ! current_user_can( 'manage_sites' ) ) : ?>
+					$( '.inline-edit-status' ).remove();
+				<?php else: ?>
+					$( '.inline-edit-status select' ).empty();
+					<?php foreach ( $statuses as $slug => $label ) : ?>
+						$( '.inline-edit-status select' ).append( "<?php printf(
+							'<option value=\"%s\">%s</option>', esc_attr( $slug ), esc_html( $label )
+						); ?>" );
+					<?php endforeach; ?>
+				<?php endif; ?>
 			});
 		</script>
 		<?php

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -130,6 +130,9 @@ class CampTix_Plugin {
 		add_action( 'save_post', array( $this, 'save_attendee_post' ) );
 		add_action( 'save_post', array( $this, 'save_coupon_post' ) );
 
+		// Log attendee status changes.
+		add_action( 'transition_post_status', array( $this, 'log_attendee_status_change' ), 10, 3 );
+
 		// Handle query extras for attendees, tickets, etc.
 		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
 
@@ -5022,6 +5025,28 @@ class CampTix_Plugin {
 		}
 
 		$this->log( 'Saved coupon post with form data.', $post_id, $_POST );
+	}
+
+	/**
+	 * Log status changes in Attendees.
+	 */
+	function log_attendee_status_change( $new_status, $old_status, $post ) {
+		if ( $old_status === $new_status || 'tix_attendee' !== $post->post_type ) {
+			return;
+		}
+
+		$current_user = wp_get_current_user();
+		if ( 0 !== $current_user->ID ) {
+			$this->log(
+				sprintf(
+					'Attendee manually changed from %1$s to %2$s by %3$s.',
+					$old_status,
+					$new_status,
+					$current_user->user_login
+				),
+				$post->ID
+			);
+		}
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -3932,11 +3932,17 @@ class CampTix_Plugin {
 							<input type="hidden" name="hidden_post_status" id="hidden_post_status" value="<?php echo esc_attr( $post->post_status ); ?>">
 							<label for="post_status" class="screen-reader-text"><?php esc_html_e( 'Set status', 'wordcamporg' ); ?></label>
 							<select name="post_status" id="post_status">
-								<option<?php selected( $post->post_status, 'publish' ); ?> value='publish'><?php _e( 'Published', 'wordcamporg' ); ?></option>
-								<option<?php selected( $post->post_status, 'draft' ); ?> value='draft'><?php _e( 'Draft', 'wordcamporg' ); ?></option>
-								<option<?php selected( $post->post_status, 'refund' ); ?> value='refund'><?php _e( 'Refunded', 'wordcamporg' ); ?></option>
-								<option<?php selected( $post->post_status, 'cancel' ); ?> value='cancel'><?php _e( 'Cancelled', 'wordcamporg' ); ?></option>
-								<option<?php selected( $post->post_status, 'failed' ); ?> value='failed'><?php _e( 'Failed', 'wordcamporg' ); ?></option>
+								<?php if ( ! in_array( $post_status_object->name, array( 'publish', 'refund', 'cancel' ) ) ) : ?>
+									<option
+										<?php selected( $post->post_status, $post_status_object->name ); ?>
+										value="<?php echo esc_attr( $post_status_object->name ); ?>"
+									>
+										<?php echo esc_html( $post_status_object->label ); ?>
+									</option>
+								<?php endif; ?>
+								<option <?php selected( $post->post_status, 'publish' ); ?> value="publish"><?php _e( 'Published', 'wordcamporg' ); ?></option>
+								<option <?php selected( $post->post_status, 'refund' ); ?> value="refund"><?php _e( 'Refunded', 'wordcamporg' ); ?></option>
+								<option <?php selected( $post->post_status, 'cancel' ); ?> value="cancel"><?php _e( 'Cancelled', 'wordcamporg' ); ?></option>
 							</select>
 							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php esc_html_e( 'OK', 'wordcamporg' ); ?></a>
 							<a href="#post_status" class="cancel-post-status hide-if-no-js button-cancel"><?php esc_html_e( 'Cancel', 'wordcamporg' ); ?></a>
@@ -4011,12 +4017,21 @@ class CampTix_Plugin {
 		if ( $screen && 'edit-tix_attendee' !== $screen->id ) {
 			return;
 		}
+		$statuses = array(
+			'publish' => _x( 'Published', 'post', 'wordcamporg' ),
+			'refund'  => _x( 'Refunded', 'post', 'wordcamporg' ),
+			'cancel'  => _x( 'Cancelled', 'post', 'wordcamporg' ),
+		);
 
 		?>
 		<script>
 			jQuery( document ).ready( function($) {
-				$( ".inline-edit-status select " ).append("<option value=\"<?php echo esc_attr( 'refund' ); ?>\"><?php echo esc_html_x( 'Refunded', 'post', 'wordcamporg' ); ?></option>" );
-				$( ".inline-edit-status select " ).append("<option value=\"<?php echo esc_attr( 'cancel' ); ?>\"><?php echo esc_html_x( 'Cancelled', 'post', 'wordcamporg' ); ?></option>" );
+				$( '.inline-edit-status select' ).empty();
+				<?php foreach ( $statuses as $slug => $label ) : ?>
+					$( '.inline-edit-status select' ).append( "<?php printf(
+						'<option value=\"%s\">%s</option>', esc_attr( $slug ), esc_html( $label )
+					); ?>" );
+				<?php endforeach; ?>
 			});
 		</script>
 		<?php


### PR DESCRIPTION
Adds a status dropdown to the edit attendee screen, mirroring how core's post status works. This adds "publish", "draft", "refund", "cancel" and "failed" as possible statuses. It also updates bulk and quick edit on the list table to allow marking attendees cancelled or refunded in batches.

❓I'm not sure what the status list we want is, but I thought it might be useful to add all (except timeout) just in case we need to manually edit some attendees for … some reason? I can remove these if they feel too much like clutter.

### Screenshots

![Screen Shot 2020-03-13 at 6 09 40 PM](https://user-images.githubusercontent.com/541093/76662921-d8137200-6555-11ea-96ab-9e93af3f4ec1.png)

![Screen Shot 2020-03-13 at 6 10 19 PM](https://user-images.githubusercontent.com/541093/76662961-ec576f00-6555-11ea-877a-0e84190923a2.png)


### How to test the changes in this Pull Request:

1. Edit an attendee
2. You should be able to change the status
3. Save, it should correctly update
4. Back in the list table, quick edit and/or bulk edit some attendees
5. Refunded and cancelled should be options now
6. Saving correctly updates the attendees
