### PR TITLE
Payments: Add Refunded status for Sponsor Invoices

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -92,6 +92,10 @@ function render_submenu_page() {
 		case 'uncollectible':
 			$section_explanation = 'These invoices have been marked as uncollectible. They were not paid, and we don\'t expect payment.';
 			break;
+
+		case 'refunded':
+			$section_explanation = 'These invoices have been refunded.';
+			break;
 	}
 
 	require_once( dirname( __DIR__ ) . '/views/sponsor-invoices/page-sponsor-invoices.php' );
@@ -103,7 +107,7 @@ function render_submenu_page() {
  * @return string
  */
 function get_current_section() {
-	$sections        = array( 'submitted', 'approved', 'paid', 'uncollectible' );
+	$sections        = array( 'submitted', 'approved', 'paid', 'uncollectible', 'refunded' );
 	$current_section = 'submitted';
 
 	if ( isset( $_GET['section'] ) && in_array( $_GET['section'], $sections, true ) ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -109,6 +109,14 @@ function get_custom_statuses() {
 				'wordcamporg'
 			),
 		),
+		'wcbsi_refunded'      => array(
+			'label'       => esc_html__( 'Refunded', 'wordcamporg' ),
+			'label_count' => _nx_noop(
+				'Refunded <span class="count">(%s)</span>',
+				'Refunded <span class="count">(%s)</span>',
+				'wordcamporg'
+			),
+		),
 	);
 }
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -522,27 +522,43 @@ function add_row_action( $actions, $post ) {
 		return $actions;
 	}
 
-	if ( 'wcbsi_uncollectible' === $post->post_status ) {
-		return $actions;
-	}
-
 	$post_type_object = get_post_type_object( $post->post_type );
 
-	$url = add_query_arg(
-		array(
-			'action' => 'wcbsi_update',
-			'status' => 'uncollectible',
-		),
-		admin_url( sprintf( $post_type_object->_edit_link, $post->ID ) )
-	);
+	if ( 'wcbsi_uncollectible' !== $post->post_status ) {
+		$url = add_query_arg(
+			array(
+				'action' => 'wcbsi_update',
+				'status' => 'uncollectible',
+			),
+			admin_url( sprintf( $post_type_object->_edit_link, $post->ID ) )
+		);
 
-	$actions['wcbsi_uncollectible'] = sprintf(
-		'<a href="%1$s" aria-label="%2$s">%3$s</a>',
-		wp_nonce_url( $url, 'wcbsi_update-post_' . $post->ID ),
-		/* translators: %s: Post title. */
-		esc_attr( sprintf( __( 'Mark invoice &#8220;%s&#8221; uncollectible', 'wordcamporg' ), $post->post_title ) ),
-		__( 'Uncollectible', 'wordcamporg' )
-	);
+		$actions['wcbsi_uncollectible'] = sprintf(
+			'<a href="%1$s" aria-label="%2$s">%3$s</a>',
+			wp_nonce_url( $url, 'wcbsi_update-post_' . $post->ID ),
+			/* translators: %s: Post title. */
+			esc_attr( sprintf( __( 'Mark invoice &#8220;%s&#8221; uncollectible', 'wordcamporg' ), $post->post_title ) ),
+			__( 'Uncollectible', 'wordcamporg' )
+		);
+	}
+
+	if ( 'wcbsi_paid' === $post->post_status ) {
+		$url = add_query_arg(
+			array(
+				'action' => 'wcbsi_update',
+				'status' => 'refunded',
+			),
+			admin_url( sprintf( $post_type_object->_edit_link, $post->ID ) )
+		);
+
+		$actions['wcbsi_refunded'] = sprintf(
+			'<a href="%1$s" aria-label="%2$s">%3$s</a>',
+			wp_nonce_url( $url, 'wcbsi_update-post_' . $post->ID ),
+			/* translators: %s: Post title. */
+			esc_attr( sprintf( __( 'Mark invoice &#8220;%s&#8221; refunded', 'wordcamporg' ), $post->post_title ) ),
+			__( 'Refunded', 'wordcamporg' )
+		);
+	}
 
 	return $actions;
 }
@@ -570,16 +586,17 @@ function handle_status_action( $post_id ) {
 		return;
 	}
 
-	if ( 'uncollectible' === $status ) {
+	if ( in_array( $status, array( 'uncollectible', 'refunded' ) ) ) {
 		// Remove filters that intercept the `wp_update_post` process.
 		remove_filter( 'wp_insert_post_data', __NAMESPACE__ . '\set_invoice_status', 10 );
 		remove_filter( 'save_post', __NAMESPACE__ . '\save_invoice', 10 );
 		wp_update_post( array(
 			'ID'          => $post_id,
-			'post_status' => 'wcbsi_uncollectible',
+			'post_status' => 'wcbsi_' . $status,
 		) );
 		$sendback = wp_get_referer();
-		wp_safe_redirect( add_query_arg( 'wcbsi_updated', 1, $sendback ) );
+		$code = ( 'uncollectible' === $status ) ? 1 : 2;
+		wp_safe_redirect( add_query_arg( 'wcbsi_updated', $code, $sendback ) );
 		exit();
 	}
 }
@@ -592,7 +609,11 @@ function handle_status_action( $post_id ) {
 function action_success_message() {
 	if ( isset( $_GET['wcbsi_updated'] ) ) : ?>
 	<div id="message" class="updated notice-success notice is-dismissible">
-		<p><?php esc_html_e( 'Invoice marked uncollectible.', 'wordcamporg' ); ?></p>
+		<?php if ( '1' === $_GET['wcbsi_updated'] ) : ?>
+			<p><?php esc_html_e( 'Invoice marked uncollectible.', 'wordcamporg' ); ?></p>
+		<?php elseif ( '2' === $_GET['wcbsi_updated'] ) : ?>
+			<p><?php esc_html_e( 'Invoice marked refunded.', 'wordcamporg' ); ?></p>
+		<?php endif; ?>
 	</div>
 	<?php endif;
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/views/sponsor-invoice/metabox-status.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/sponsor-invoice/metabox-status.php
@@ -40,6 +40,8 @@ defined( 'WPINC' ) or die();
 						<?php _e( 'Paid', 'wordcamporg' ); ?>
 					<?php elseif ( 'wcbsi_uncollectible' == $post->post_status ) : ?>
 						<?php _e( 'Uncollectible', 'wordcamporg' ); ?>
+					<?php elseif ( 'wcbsi_refunded' == $post->post_status ) : ?>
+						<?php _e( 'Refunded', 'wordcamporg' ); ?>
 					<?php endif; ?>
 				</span>
 


### PR DESCRIPTION
Add a new status for Sponsor Invoices to track which invoices have been refunded. This can be applied to an invoice in the list table, by clicking the new action "Refunded", which is only available on paid invoices. It also adds a Refunded tab to the network Sponsor Invoices dashboard to show all refunded invoices.

Fixes #392 

### Screenshots

Actions in list table, Refunded is only available on paid invoices, Uncollectible is available on everything but already marked "uncollectible": (all actions shown for example)
![Screen Shot 2020-03-17 at 5 33 26 PM](https://user-images.githubusercontent.com/541093/76904255-0060e080-6876-11ea-99f0-3913e57f1c87.png)

Network dashboard tab:
![Screen Shot 2020-03-17 at 5 33 58 PM](https://user-images.githubusercontent.com/541093/76904240-fa6aff80-6875-11ea-9c4d-4d857746dd2a.png)

### How to test the changes in this Pull Request:

1. Add some test invoices to your dev environment
2. Mark them paid (I used CLI for this to skip submission)
3. Mark them refunded using the UI
4. The invoice should be correctly updated, and show as refunded both in the list table and in the edit screen.
5. The network dashboard should show this invoice in the refunded tab.
