### PR TITLE
WCPT: Add virtual event information to WordCamps

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/admin.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/admin.css
@@ -12,6 +12,11 @@ span.swag-needed-icon {
     width: 100%;
 }
 
+#post-body [id^="wcpt_"] input[type="checkbox"],
+#post-body [id^="wcpt_"] input[type="radio"] {
+    margin: 0 0 0 5px;
+}
+
 body.wp-admin.post-type-wordcamp .postbox textarea,
 body.wp-admin.post-type-wp_meetup .postbox textarea {
     resize: both;

--- a/public_html/wp-content/plugins/wcpt/css/applications/admin.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/admin.css
@@ -2,6 +2,10 @@ span.swag-needed-icon {
     color: goldenrod;
 }
 
+.wcpt-field label {
+    font-weight: 600;
+}
+
 #post-body textarea {
     width: 50%;
     height: 150px;
@@ -12,8 +16,8 @@ span.swag-needed-icon {
     width: 100%;
 }
 
-#post-body [id^="wcpt_"] input[type="checkbox"],
-#post-body [id^="wcpt_"] input[type="radio"] {
+#post-body .wcpt-field input[type="checkbox"],
+#post-body .wcpt-field input[type="radio"] {
     margin: 0 0 0 5px;
 }
 

--- a/public_html/wp-content/plugins/wcpt/css/applications/admin.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/admin.css
@@ -8,17 +8,14 @@ span.swag-needed-icon {
 
 #post-body textarea {
     width: 50%;
+    min-width: 20rem;
     height: 150px;
 }
 
 #post-body #wcpt_notes textarea {
     resize: both;
     width: 100%;
-}
-
-#post-body .wcpt-field input[type="checkbox"],
-#post-body .wcpt-field input[type="radio"] {
-    margin: 0 0 0 5px;
+    min-width: 0;
 }
 
 body.wp-admin.post-type-wordcamp .postbox textarea,
@@ -26,8 +23,18 @@ body.wp-admin.post-type-wp_meetup .postbox textarea {
     resize: both;
 }
 
-#post-body input[type=text] {
+#post-body .wcpt-field input[type="checkbox"],
+#post-body .wcpt-field input[type="radio"] {
+    margin: 0 0 0 5px;
+}
+
+#post-body .wcpt-field input[type=text] {
     width: 50%;
+    min-width: 20rem;
+}
+
+#post-body .field__type-select-streaming input[type=text] {
+    width: 18rem;
 }
 
 .postbox-container .select2-container {

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -34,7 +34,7 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 			self.initializeMentorPicker( $mentorUserName );
 		}
 
-		$virtualEventCheckbox.change( self.togglePhysicalAddrRequire );
+		$virtualEventCheckbox.change( self.togglePhysicalVenueFields );
 		$virtualEventCheckbox.trigger( 'change' );
 	};
 
@@ -43,12 +43,16 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 	 *
 	 * @param {object} event
 	 */
-	self.togglePhysicalAddrRequire = function( event ) {
-		var $label = $( '#wcpt_physical_address' ).closest( '.inside' ).find( '.description' );
+	self.togglePhysicalVenueFields = function( event ) {
+		var $container = $( event.target ).closest( '.inside' ).parent();
+		var $items = $container
+			.find( '.inside' )
+			.not( '.field__wcpt_virtual_event_only,.field__wcpt_streaming_account_to_use' );
+		console.log( $items );
 		if ( $( event.target ).is( ':checked' ) ) {
-			$label.hide();
+			$items.hide();
 		} else {
-			$label.show();
+			$items.show();
 		}
 	}
 

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -12,7 +12,8 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 		var createSiteCheckbox = $( '#wcpt_create-site-in-network' ),
 			$mentorUserName = $( '#wcpt_mentor_wordpress_org_user_name' ),
 			hasContributor = $( '#wcpt_contributor_day' ),
-			$virtualEventCheckbox = $( '#wcpt_virtual_event_only' );
+			$virtualEventCheckbox = $( '#wcpt_virtual_event_only' ),
+			$streamingSelection = $( '.field__type-select-streaming' );
 
 		// Sponsor region
 		createSiteCheckbox.change( self.toggleSponsorRegionRequired );
@@ -36,6 +37,15 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 
 		$virtualEventCheckbox.change( self.togglePhysicalVenueFields );
 		$virtualEventCheckbox.trigger( 'change' );
+		
+		$streamingSelection.find( 'select' ).change( function( event ) {
+			if ( 'other' === $( event.target ).val() ) {
+				$streamingSelection.find( 'input' ).show();
+			} else {
+				$streamingSelection.find( 'input' ).val( '' ).hide();
+			}
+		} );
+		$streamingSelection.find( 'select' ).trigger( 'change' );
 	};
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -58,7 +58,6 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 		var $items = $container
 			.find( '.inside' )
 			.not( '.field__wcpt_virtual_event_only,.field__wcpt_streaming_account_to_use' );
-		console.log( $items );
 		if ( $( event.target ).is( ':checked' ) ) {
 			$items.hide();
 		} else {

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -11,7 +11,8 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 	self.initialize = function() {
 		var createSiteCheckbox = $( '#wcpt_create-site-in-network' ),
 			$mentorUserName = $( '#wcpt_mentor_wordpress_org_user_name' ),
-			hasContributor = $( '#wcpt_contributor_day' );
+			hasContributor = $( '#wcpt_contributor_day' ),
+			$virtualEventCheckbox = $( '#wcpt_virtual_event_only' );
 
 		// Sponsor region
 		createSiteCheckbox.change( self.toggleSponsorRegionRequired );
@@ -32,7 +33,24 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 		if ( $mentorUserName.length && ! $mentorUserName.is( '[readonly]' ) ) {
 			self.initializeMentorPicker( $mentorUserName );
 		}
+
+		$virtualEventCheckbox.change( self.togglePhysicalAddrRequire );
+		$virtualEventCheckbox.trigger( 'change' );
 	};
+
+	/**
+	 * Toggle the "required" label on the physical address field.
+	 *
+	 * @param {object} event
+	 */
+	self.togglePhysicalAddrRequire = function( event ) {
+		var $label = $( '#wcpt_physical_address' ).closest( '.inside' ).find( '.description' );
+		if ( $( event.target ).is( ':checked' ) ) {
+			$label.hide();
+		} else {
+			$label.show();
+		}
+	}
 
 	/**
 	 * Toggle whether the Sponsor Region field is required or not.
@@ -51,11 +69,11 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 		}
 	};
 
-    /**
+	/**
 	 * Insert a Mentor picker after the Mentor username field.
 	 *
-     * @param $el jQuery object for the Mentor username field.
-     */
+	 * @param $el jQuery object for the Mentor username field.
+	 */
 	self.initializeMentorPicker = function( $el ) {
 		if ( 'undefined' === typeof window.wordCampPostType.Mentors.data ) {
 			return;
@@ -118,11 +136,11 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 
 	};
 
-    /**
+	/**
 	 * Update the Mentor fields with the data for the mentor chosen in the picker.
 	 *
-     * @param $option jQuery object for the selected option element.
-     */
+	 * @param $option jQuery object for the selected option element.
+	 */
 	self.updateMentor = function( $option ) {
 		var l10n            = window.wordCampPostType.Mentors.l10n,
 			$mentorUserName = $( '#wcpt_mentor_wordpress_org_user_name' ),
@@ -131,9 +149,9 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 
 		// Confirm before changing Mentor field contents
 		if ( $option.val() && confirm( l10n.confirm ) ) {
-            $mentorUserName.val( $option.val() );
-            $mentorName.val( $option.data('name') );
-            $mentorEmail.val( $option.data('email') );
+			$mentorUserName.val( $option.val() );
+			$mentorName.val( $option.data('name') );
+			$mentorEmail.val( $option.data('email') );
 		}
 	};
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -730,7 +730,7 @@ abstract class Event_Admin {
 								// Quick filter on dates.
 								$date = get_post_meta( $post_id, $key, true );
 								if ( $date ) {
-									$date = date( 'Y-m-d', $date );
+									$date = gmdate( 'Y-m-d', $date );
 								}
 
 								?>

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -541,10 +541,21 @@ abstract class Event_Admin {
 
 				case 'select-streaming':
 					$allowed_values = array_keys( self::get_streaming_services() );
+					$key_other = wcpt_key_to_str( $key, 'wcpt_' ) . '-other';
 					if ( in_array( $values[ $key ], $allowed_values ) ) {
 						update_post_meta( $post_id, $key, $values[ $key ] );
+
+						if ( ! empty( $_POST[ $key_other ] ) ) {
+							update_post_meta(
+								$post_id,
+								$key_other,
+								sanitize_text_field( $_POST[ $key_other ] )
+							);
+						}
 					} else {
-						delete_post_meta( $post_id, $key );
+						// The value isn't in the allowed values (anymore?) so we should save it as "other".
+						update_post_meta( $post_id, $key, 'other' );
+						update_post_meta( $post_id, $key_other, $values[ $key ] );
 					}
 					break;
 
@@ -843,6 +854,17 @@ abstract class Event_Admin {
 										</option>
 									<?php endforeach; ?>
 								</select>
+
+								<label class="screen-reader-text" for="<?php echo esc_attr( $object_name ); ?>-other">
+									Other streaming account:
+								</label>
+								<input
+									type="text"
+									placeholder="Other streaming service"
+									id="<?php echo esc_attr( $object_name ); ?>-other"
+									name="<?php echo esc_attr( $object_name ); ?>-other"
+									value="<?php echo esc_attr( get_post_meta( $post_id, $object_name . '-other', true ) ); ?>"
+								/>
 
 								<?php
 								break;

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -687,9 +687,16 @@ abstract class Event_Admin {
 				<?php if ( 'checkbox' == $value ) : ?>
 
 					<p>
-						<strong><?php echo esc_html( $key ); ?></strong>:
-						<input type="checkbox" name="<?php echo esc_attr( $object_name ); ?>"
-							   id="<?php echo esc_attr( $object_name ); ?>" <?php checked( get_post_meta( $post_id, $key, true ) ); ?><?php echo esc_attr( $readonly ); ?> />
+						<label>
+							<strong><?php echo esc_html( $key ); ?></strong>:
+							<input
+								type="checkbox"
+								name="<?php echo esc_attr( $object_name ); ?>"
+								id="<?php echo esc_attr( $object_name ); ?>"
+								<?php checked( get_post_meta( $post_id, $key, true ) ); ?>
+								<?php echo esc_attr( $readonly ); ?>
+							/>
+						</label>
 					</p>
 
 				<?php else : ?>

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -417,7 +417,7 @@ abstract class Event_Admin {
 			'wcpt-admin',
 			plugins_url( 'css/applications/admin.css', __DIR__ ),
 			array(),
-			WCPT_VERSION
+			filemtime( plugin_dir_path( dirname( __FILE__ ) ) . '/css/applications/admin.css' )
 		);
 
 		wp_enqueue_style( 'jquery-ui' );

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -706,9 +706,15 @@ abstract class Event_Admin {
 		foreach ( $meta_keys as $key => $value ) :
 			$object_name = wcpt_key_to_str( $key, 'wcpt_' );
 			$readonly    = in_array( $key, $protected_fields ) ? ' readonly="readonly"' : '';
+			$classes = array(
+				'inside',
+				'wcpt-field',
+				'field__' . $object_name,
+				'field__type-' . $value,
+			);
 			?>
 
-			<div class="inside">
+			<div class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 				<?php if ( 'checkbox' == $value ) : ?>
 
 					<p>
@@ -727,16 +733,13 @@ abstract class Event_Admin {
 				<?php else : ?>
 
 					<p>
-						<strong><?php echo esc_html( $key ); ?></strong>
+						<label for="<?php echo esc_attr( $object_name ); ?>"><?php echo esc_html( $key ); ?></label>
 						<?php if ( in_array( $key, $required_fields, true ) ) : ?>
 							<span class="description"><?php esc_html_e( '(required)', 'wordcamporg' ); ?></span>
 						<?php endif; ?>
 					</p>
 
 					<p>
-						<label class="screen-reader-text"
-							   for="<?php echo esc_attr( $object_name ); ?>"><?php echo esc_html( $key ); ?></label>
-
 						<?php
 						switch ( $value ) :
 							case 'text':

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -756,7 +756,7 @@ abstract class Event_Admin {
 							case 'text':
 								?>
 
-								<input type="text" size="36" name="<?php echo esc_attr( $object_name ); ?>"
+								<input type="text" name="<?php echo esc_attr( $object_name ); ?>"
 									   id="<?php echo esc_attr( $object_name ); ?>"
 									   value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"<?php echo esc_attr( $readonly ); ?> />
 
@@ -765,10 +765,15 @@ abstract class Event_Admin {
 							case 'number':
 								?>
 
-								<input type="number" size="16" name="<?php echo esc_attr( $object_name ); ?>"
-									   id="<?php echo esc_attr( $object_name ); ?>"
-									   value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"
-									   step="any" min="0"<?php echo esc_attr( $readonly ); ?> />
+								<input
+									type="number"
+									name="<?php echo esc_attr( $object_name ); ?>"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"
+									step="any"
+									min="0"
+									<?php echo esc_attr( $readonly ); ?>
+								/>
 
 								<?php
 								break;
@@ -781,17 +786,25 @@ abstract class Event_Admin {
 
 								?>
 
-								<input type="text" size="36" class="date-field" name="<?php echo esc_attr( $object_name ); ?>"
-									   id="<?php echo esc_attr( $object_name ); ?>"
-									   value="<?php echo esc_attr( $date ); ?>"<?php echo esc_attr( $readonly ); ?> />
+								<input
+									type="text"
+									class="date-field"
+									name="<?php echo esc_attr( $object_name ); ?>"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									value="<?php echo esc_attr( $date ); ?>"
+									<?php echo esc_attr( $readonly ); ?>
+								/>
 
 								<?php
 								break;
 							case 'textarea':
 								?>
 
-								<textarea rows="4" cols="23" name="<?php echo esc_attr( $object_name ); ?>"
-										  id="<?php echo esc_attr( $object_name ); ?>"<?php echo esc_attr( $readonly ); ?>><?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?></textarea>
+								<textarea
+									name="<?php echo esc_attr( $object_name ); ?>"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									<?php echo esc_attr( $readonly ); ?>
+								><?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?></textarea>
 
 								<?php
 								break;
@@ -803,17 +816,26 @@ abstract class Event_Admin {
 								if ( $readonly ) :
 									$value = get_post_meta( $post_id, $key, true );
 									?>
-								<select name="<?php echo esc_attr( $object_name ); ?>"
-										id="<?php echo esc_attr( $object_name ); ?>"<?php echo esc_attr( $readonly ); ?>>
+								<select
+									name="<?php echo esc_attr( $object_name ); ?>"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									<?php echo esc_attr( $readonly ); ?>
+								>
 									<option value="<?php echo esc_attr( $value ); ?>" selected>
 										<?php echo ( $value ) ? esc_html( $currencies[ $value ] . ' (' . $value . ')' ) : ''; ?>
 									</option>
 								</select>
 							<?php else : ?>
-								<select name="<?php echo esc_attr( $object_name ); ?>"
-										id="<?php echo esc_attr( $object_name ); ?>" class="select-currency">
+								<select
+									name="<?php echo esc_attr( $object_name ); ?>"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									class="select-currency"
+								>
 									<?php foreach ( $currencies as $symbol => $name ) : ?>
-										<option value="<?php echo esc_attr( $symbol ); ?>"<?php selected( $symbol, get_post_meta( $post_id, $key, true ) ); ?>>
+										<option
+											value="<?php echo esc_attr( $symbol ); ?>"
+											<?php selected( $symbol, get_post_meta( $post_id, $key, true ) ); ?>
+										>
 											<?php echo ( $symbol ) ? esc_html( $name . ' (' . $symbol . ')' ) : ''; ?>
 										</option>
 									<?php endforeach; ?>

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -144,6 +144,22 @@ abstract class Event_Admin {
 	abstract public function column_headers( $columns );
 
 	/**
+	 * Get a list of streaming services.
+	 *
+	 * The individual event types can override this if different event types need different streaming accounts,
+	 * but these are the default accounts available.
+	 *
+	 * @return array
+	 */
+	public static function get_streaming_services() {
+		return array(
+			'crowdcast-wc-1' => 'Crowdcast WordCamp 1',
+			'crowdcast-wc-2' => 'Crowdcast WordCamp 2',
+			'other' => 'Other',
+		);
+	}
+
+	/**
 	 * Add status metabox
 	 */
 	public function add_status_metabox() {
@@ -523,6 +539,15 @@ abstract class Event_Admin {
 					update_post_meta( $post_id, $key, $new_value );
 					break;
 
+				case 'select-streaming':
+					$allowed_values = array_keys( self::get_streaming_services() );
+					if ( in_array( $values[ $key ], $allowed_values ) ) {
+						update_post_meta( $post_id, $key, $values[ $key ] );
+					} else {
+						delete_post_meta( $post_id, $key );
+					}
+					break;
+
 				default:
 					do_action( 'wcpt_metabox_save', $key, $value, $post_id );
 					break;
@@ -797,6 +822,26 @@ abstract class Event_Admin {
 										'show_option_none' => 'None',
 									)
 								);
+								break;
+							case 'select-streaming':
+								$selected = get_post_meta( $post_id, $key, true );
+								$options = self::get_streaming_services();
+								?>
+
+								<select
+									name="<?php echo esc_attr( $object_name ); ?>"
+									id="<?php echo esc_attr( $object_name ); ?>"
+									<?php echo esc_attr( $readonly ); ?>
+								>
+									<option value="">None, not streaming</option>
+									<?php foreach ( $options as $val => $label ) : ?>
+										<option value="<?php echo esc_attr( $val ); ?>" <?php selected( $selected, $val ); ?>>
+											<?php echo esc_html( $label ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+
+								<?php
 								break;
 							default:
 								do_action( 'wcpt_metabox_value', $key, $value, $object_name );

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -383,7 +383,7 @@ abstract class Event_Admin {
 			'wcpt-admin',
 			WCPT_URL . 'javascript/wcpt-wordcamp/admin.js',
 			array( 'jquery', 'jquery-ui-datepicker' ),
-			WCPT_VERSION,
+			filemtime( plugin_dir_path( dirname( __FILE__ ) ) . '/javascript/wcpt-wordcamp/admin.js' ),
 			true
 		);
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -726,7 +726,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			$message = sprintf(
 				"<%s|WordCamp $city> has been scheduled for a start date of %s. :tada: :community: :wordpress:\n\n%s",
 				$wordcamp_url,
-				date( 'F j, Y', $start_date ),
+				gmdate( 'F j, Y', $start_date ),
 				$wordcamp_url
 			);
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -342,6 +342,8 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 
 				case 'venue':
 					$retval = array(
+						'Virtual event only'         => 'checkbox',
+						'Streaming account to use'   => 'select-streaming',
 						'Venue Name'                 => 'text',
 						'Physical Address'           => 'textarea',
 						'Maximum Capacity'           => 'text',
@@ -440,6 +442,8 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Mentor Name'                      => 'text',
 						'Mentor E-mail Address'            => 'text',
 
+						'Virtual event only'               => 'checkbox',
+						'Streaming account to use'         => 'select-streaming',
 						'Venue Name'                       => 'text',
 						'Physical Address'                 => 'textarea',
 						'Maximum Capacity'                 => 'text',


### PR DESCRIPTION
Adds two new meta values to WordCamp post types: a checkbox for if this is only a virtual event, and a dropdown for a streaming service account to be used. The streaming accounts are hardcoded, but as a function on the Event class to allow the possibility that meetups might use this, and that WordCamps or Meetups might use different accounts. Lastly, this removes the "required" label on physical address, if the event is online-only.

Fixes #398 

### Screenshots

<img width="540" alt="Screen Shot 2020-03-23 at 2 26 59 PM" src="https://user-images.githubusercontent.com/541093/77350137-70f27c00-6d12-11ea-8efd-89905a10f3c6.png">

### How to test the changes in this Pull Request:

1. Edit a WordCamp on central
2. There should be these new options in the Venue metabox
3. Saving these fields should work
