### PR TITLE
Docker: Use a volume for the database storage

### DIFF
--- a/.docker/Dockerfile.php-fpm
+++ b/.docker/Dockerfile.php-fpm
@@ -6,6 +6,7 @@ RUN apt-get update \
         build-essential \
         git \
         less \
+        libicu-dev \
         libjpeg-dev \
         libpng-dev \
         libzip-dev \
@@ -22,12 +23,14 @@ RUN apt-get update \
         wget
 
 # Install additional PHP extensions.
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-configure gd --with-jpeg
 RUN docker-php-ext-install -j "$(nproc)" \
     gd \
+    intl \
     mysqli \
     opcache \
     zip
-RUN docker-php-ext-configure gd --with-jpeg
 
 # Add PHP configurations.
 COPY config/opcache-recommended.ini /usr/local/etc/php/conf.d/opcache-recommended.ini

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
             - "1080:1080"
         environment:
             - IS_LOCAL_DEV=1
+        networks:
+            - wordcamp-network
         depends_on:
             - wordcamp.db
         # todo configure entrypoint to work around annoying wp-cli allow-root problem -- https://github.com/wp-cli/wp-cli/issues/1838#issuecomment-434077907
@@ -31,11 +33,17 @@ services:
             dockerfile: Dockerfile.mysql
             # todo maybe rename `wordcamp.db` to something more correct.
         volumes:
-            - dbdata:/var/lib/mysql
+            - wordcampdb:/var/lib/mysql
             - .docker/bin:/var/scripts
         ports:
             # Uses port 3307 to avoid conflicts with possible host mysql (running on 3306).
             - "3307:3306"
+        networks:
+            - wordcamp-network
 
 volumes:
-    dbdata:
+    wordcampdb:
+
+networks:
+  wordcamp-network:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
             - "1080:1080"
         environment:
             - IS_LOCAL_DEV=1
+        depends_on:
+            - wordcamp.db
         # todo configure entrypoint to work around annoying wp-cli allow-root problem -- https://github.com/wp-cli/wp-cli/issues/1838#issuecomment-434077907
 
     # todo document why this is a separate container
@@ -29,8 +31,11 @@ services:
             dockerfile: Dockerfile.mysql
             # todo maybe rename `wordcamp.db` to something more correct.
         volumes:
-            - ".docker/database:/var/lib/mysql"
-            - ".docker/bin:/var/scripts"
+            - dbdata:/var/lib/mysql
+            - .docker/bin:/var/scripts
         ports:
-            # todo document that 3307 to avoid conflicts w/ host mysql server?
+            # Uses port 3307 to avoid conflicts with possible host mysql (running on 3306).
             - "3307:3306"
+
+volumes:
+    dbdata:

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -62,7 +62,7 @@ function register_block_categories( $default_categories ) {
 	return $default_categories;
 }
 
-add_filter( 'block_categories', __NAMESPACE__ . '\register_block_categories' );
+add_filter( 'block_categories_all', __NAMESPACE__ . '\register_block_categories' );
 
 /**
  * Register assets.


### PR DESCRIPTION
This is transparently managed by docker, not listed as a directory in the host filesystem. We don't need to expose the mysql internals, and this is still persistent. MySQL is still reachable by using the docker CLI.

_This is one of the changes I made when trying to get my local env working again, and while I'm not sure it's related, it does clean up the host filesystem._

⚠️  I imagine switching to this will probably blow away the existing database, so export or backup anything you want before doing so.