### PR TITLE
Virtual Embeds: Add blocks for virtual events

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"workspaces": [
 		"public_html/wp-content/mu-plugins/blocks",
+		"public_html/wp-content/mu-plugins/virtual-embeds",
 		"public_html/wp-content/plugins/wordcamp-forms-to-drafts",
 		"public_html/wp-content/plugins/wordcamp-speaker-feedback"
 	],

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -18,6 +18,7 @@ function wcorg_include_individual_mu_plugins() {
 	require_once( __DIR__ . '/blocks/blocks.php' );
 	require_once __DIR__ . '/quickbooks/quickbooks.php';
 	require_once __DIR__ . '/theme-templates/bootstrap.php';
+	require_once __DIR__ . '/virtual-embeds/virtual-embeds.php';
 
 	if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 		require_once __DIR__ . '/vendor/autoload.php';

--- a/public_html/wp-content/mu-plugins/virtual-embeds/.prettierrc.js
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/.prettierrc.js
@@ -1,0 +1,7 @@
+// Import the default config for core compatibility, but enable us to add some overrides as needed.
+const defaultConfig = require( '@wordpress/scripts/config/.prettierrc.js' );
+
+module.exports = {
+	...defaultConfig,
+	printWidth: 115,
+};

--- a/public_html/wp-content/mu-plugins/virtual-embeds/package.json
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "virtual-embeds",
+	"version": "1.0.0",
+	"description": "Embeds for virtual events on WordCamp.org",
+	"author": "WordCamp Team",
+	"license": "GPL-2.0-or-later",
+	"private": true,
+	"keywords": [],
+	"homepage": "https://github.com/WordPress/wordcamp.org/tree/production/public_html/wp-content/mu-plugins/virtual-embeds",
+	"repository": "git+https://github.com/WordPress/wordcamp.org.git",
+	"devDependencies": {
+		"@wordpress/eslint-plugin": "4.0.0",
+		"@wordpress/scripts": "7.1.0"
+	},
+	"eslintConfig": {
+		"extends": "plugin:@wordpress/eslint-plugin/recommended-with-formatting",
+		"rules": {
+			"object-shorthand": [ "error", "consistent-as-needed" ]
+		}
+	},
+	"scripts": {
+		"start": "wp-scripts start",
+		"build": "wp-scripts build",
+		"lint:js": "wp-scripts lint-js",
+		"format:js": "wp-scripts format-js",
+		"lint:pkg-json": "wp-scripts lint-pkg-json"
+	}
+}

--- a/public_html/wp-content/mu-plugins/virtual-embeds/src/components/edit-placeholder.js
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/src/components/edit-placeholder.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { Placeholder, TextControl } from '@wordpress/components';
+
+export default function( { className, help, icon, instructions, label, onChange, value } ) {
+	return (
+		<Placeholder className={ className } icon={ icon } label={ label } instructions={ instructions }>
+			<TextControl label={ label } hideLabelFromVision value={ value } onChange={ onChange } help={ help } />
+		</Placeholder>
+	);
+}

--- a/public_html/wp-content/mu-plugins/virtual-embeds/src/crowdcast.js
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/src/crowdcast.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import EditPlaceholder from './components/edit-placeholder.js';
+
+export const name = 'wordcamp/crowdcast-embed';
+
+export const settings = {
+	title: __( 'CrowdCast', 'wordcamporg' ),
+	icon: 'format-video',
+	category: 'embed',
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
+	attributes: {
+		channel: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit: ( { attributes, setAttributes } ) => (
+		<EditPlaceholder
+			className="wc-block__crowdcast-embed"
+			icon="format-video"
+			label={ __( 'CrowdCast Event', 'wordcamporg' ) }
+			instructions={ __( 'Enter the channel name to embed a stream on your site.', 'wordcamporg' ) }
+			value={ attributes.channel }
+			onChange={ ( newValue ) => setAttributes( { channel: newValue } ) }
+		/>
+	),
+	// Block is rendered dynamically to inject the iframe, no need to save anything.
+	save: () => null,
+};

--- a/public_html/wp-content/mu-plugins/virtual-embeds/src/index.js
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/src/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import * as crowdcast from './crowdcast';
+import * as streamtext from './streamtext';
+
+[ crowdcast, streamtext ].forEach( ( block ) => {
+	const { name, settings } = block;
+	registerBlockType( name, settings );
+} );

--- a/public_html/wp-content/mu-plugins/virtual-embeds/src/streamtext.js
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/src/streamtext.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import EditPlaceholder from './components/edit-placeholder.js';
+
+export const name = 'wordcamp/streamtext-embed';
+
+export const settings = {
+	title: __( 'StreamText', 'wordcamporg' ),
+	icon: 'text',
+	category: 'embed',
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
+	attributes: {
+		channel: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit: ( { attributes, setAttributes } ) => (
+		<EditPlaceholder
+			className="wc-block__streamtext-embed"
+			icon="text"
+			label={ __( 'StreamText Event', 'wordcamporg' ) }
+			instructions={ __( 'Enter the event name to embed the captions on your site.', 'wordcamporg' ) }
+			value={ attributes.channel }
+			onChange={ ( newValue ) => setAttributes( { channel: newValue } ) }
+		/>
+	),
+	// Save the block to the streamtext shortcode.
+	save: ( props ) => {
+		const { channel = '', align } = props.attributes;
+
+		const classes = [];
+		if ( align ) {
+			classes.push( `align${ align }` );
+		}
+
+		return (
+			<div className={ classes.join( ' ' ) }>{ channel ? '[streamtext event="' + channel + '"]' : '' }</div>
+		);
+	},
+};

--- a/public_html/wp-content/mu-plugins/virtual-embeds/style.css
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/style.css
@@ -1,0 +1,4 @@
+.wc-block__crowdcast-embed .components-base-control,
+.wc-block__streamtext-embed .components-base-control {
+	width: 100%;
+}

--- a/public_html/wp-content/mu-plugins/virtual-embeds/virtual-embeds.php
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/virtual-embeds.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Embeds for virtual events on WordCamp.org:
+ *  - CrowdCast block to embed iframe
+ *  - StreamText block which saves as the streamtext shortcode
+ */
+
+namespace WordCamp\Virtual_Embeds;
+
+defined( 'WPINC' ) || die();
+
+define( __NAMESPACE__ . '\PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
+define( __NAMESPACE__ . '\PLUGIN_URL', \plugins_url( '/', __FILE__ ) );
+
+/**
+ * Register assets.
+ *
+ * @return void
+ */
+function register_assets() {
+	$script_info = require PLUGIN_DIR . 'build/index.asset.php';
+
+	wp_register_script(
+		'virtual-embeds',
+		PLUGIN_URL . 'build/index.js',
+		$script_info['dependencies'],
+		$script_info['version'],
+		false
+	);
+
+	wp_register_style(
+		'virtual-embeds',
+		PLUGIN_URL . 'style.css',
+		array(),
+		$script_info['version']
+	);
+
+	wp_set_script_translations( 'virtual-embeds', 'wordcamporg' );
+
+	register_block_type(
+		'wordcamp/crowdcast-embed',
+		array(
+			'editor_script'   => 'virtual-embeds',
+			'editor_style'    => 'virtual-embeds',
+			'render_callback' => __NAMESPACE__ . '\render_crowdcast_block',
+		)
+	);
+
+	register_block_type(
+		'wordcamp/streamtext-embed',
+		array(
+			'editor_script' => 'virtual-embeds',
+			'editor_style'  => 'virtual-embeds',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
+
+/**
+ * Render the CrowdCast embed on the front end.
+ *
+ * @param array $attributes Block attributes.
+ * @return string
+ */
+function render_crowdcast_block( $attributes ) {
+	if ( ! isset( $attributes['channel'] ) ) {
+		return '';
+	}
+
+	$channel = sanitize_text_field( $attributes['channel'] );
+	$url     = sprintf( 'https://www.crowdcast.io/e/%s?navlinks=false&embed=true', $channel );
+	$embed   = '<iframe width="100%" height="800" frameborder="0" marginheight="0" marginwidth="0" allowtransparency="true" src="' . esc_url( $url ) . '" style="border: 1px solid #EEE;border-radius:3px" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" allow="microphone; camera;"></iframe>';
+
+	$classes = '';
+	if ( isset( $attributes['align'] ) && $attributes['align'] ) {
+		$classes .= 'align' . sanitize_html_class( $attributes['align'] );
+	}
+
+	return '<div class="wp-block-wordcamp-crowdcast-embed ' . $classes . '">' . $embed . '</div>';
+}


### PR DESCRIPTION
Adds a CrowdCast block to embed the crowdcast channel iframe, and a StreamText block to embed a caption stream (uses the streamtext shortcode behind the scenes). You need the channel/event name for each service, and it renders a very simple embed (no configuration supported). It does support wide & full width.

### Screenshots

![Screen Shot 2020-03-26 at 1 10 41 PM](https://user-images.githubusercontent.com/541093/77675370-3cc1ca00-6f63-11ea-9630-cd59a7781905.png)

### How to test the changes in this Pull Request:

1. After checking out the branch, run `yarn` to install the workspace
2. Run `yarn workspace virtual-embeds build` to build the files
3. Add CrowdCast and/or StreamText blocks to a page
4. Add valid events (ex, `IHaveADream` for an active streamtext event, `wordcamp-san-antonio-2020-mktg` for a crowdcast)
5. It should save & correctly show up on the page
6. Try adding malformed or empty events, it shouldn't break
