### PR TITLE
Speaker Feedback: Check submissions for spam, duplicates

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -257,12 +257,7 @@ function enqueue_assets() {
  * @return bool
  */
 function user_can_edit_request( $post ) {
-	$editable_status = false;
-
-	if ( $post instanceof WP_Post ) {
-		$editable_status = in_array( $post->post_status, array( 'auto-draft', 'draft', 'wcb-incomplete' ), true );
-	}
-
+	$editable_status = in_array( $post->post_status, array( 'auto-draft', 'draft', 'wcb-incomplete' ), true );
 	return current_user_can( 'manage_network' ) || $editable_status;
 }
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -257,7 +257,12 @@ function enqueue_assets() {
  * @return bool
  */
 function user_can_edit_request( $post ) {
-	$editable_status = in_array( $post->post_status, array( 'auto-draft', 'draft', 'wcb-incomplete' ), true );
+	$editable_status = false;
+
+	if ( $post instanceof WP_Post ) {
+		$editable_status = in_array( $post->post_status, array( 'auto-draft', 'draft', 'wcb-incomplete' ), true );
+	}
+
 	return current_user_can( 'manage_network' ) || $editable_status;
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -164,7 +164,10 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		if ( 'discard' === $spam_check ) {
 			return new WP_Error(
 				'rest_feedback_spam_discarded',
-				__( 'Feedback submission has been discarded as spam.', 'wordcamporg' )
+				__( 'Feedback submission has been discarded as spam.', 'wordcamporg' ),
+				array(
+					'status' => 403,
+				)
 			);
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -55,6 +55,10 @@ function register_meta_fields() {
 /**
  * Define the properties of the feedback meta fields.
  *
+ * Note that if another `type` of field is added besides string or integer, the
+ * WordCamp\SpeakerFeedback\REST_Feedback_Controller::duplicate_check() method will
+ * need to be updated.
+ *
  * @param string $key Optional. A specific key to get the schema for.
  *
  * @return array

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -127,36 +127,31 @@ function get_feedback_comment( $comment ) {
 /**
  * Add a new feedback submission.
  *
- * @param int       $post_id         The ID of the post to attach the feedback to.
- * @param array|int $feedback_author Either an array containing 'name' and 'email' values, or a user ID.
- * @param array     $feedback_meta   An associative array of key => value pairs.
- * @param bool      $is_spam         True if the comment is suspected to be spam.
+ * @param array $comment_data
  *
  * @return int|bool Comment ID on success. `false` on failure.
  */
-function add_feedback( $post_id, $feedback_author, array $feedback_meta, $is_spam = false ) {
-	$args = array(
-		'comment_approved' => 0, // "hold".
-		'comment_post_ID'  => $post_id,
-		'comment_type'     => COMMENT_TYPE,
-		'comment_meta'     => $feedback_meta,
+function add_feedback( array $comment_data ) {
+	$required_keys = array(
+		'comment_author',
+		'comment_author_email',
+		'comment_post_ID',
+		'comment_meta',
 	);
 
-	if ( true === $is_spam ) {
-		$args['comment_approved'] = 'spam';
-	}
+	$missing_keys = array_diff_key( array_fill_keys( $required_keys, '' ), $comment_data );
 
-	if ( is_int( $feedback_author ) ) {
-		$args['user_id'] = $feedback_author;
-	} elseif ( isset( $feedback_author['name'], $feedback_author['email'] ) ) {
-		$args['comment_author']       = $feedback_author['name'];
-		$args['comment_author_email'] = $feedback_author['email'];
-	} else {
-		// No author, bail.
+	if ( ! empty( $missing_keys ) ) {
 		return false;
 	}
 
-	return wp_insert_comment( $args );
+	$comment_data['comment_type'] = COMMENT_TYPE;
+
+	if ( ! isset( $comment_data['comment_approved'] ) ) {
+		$comment_data['comment_approved'] = 0; // "hold".
+	}
+
+	return wp_insert_comment( $comment_data );
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -130,16 +130,21 @@ function get_feedback_comment( $comment ) {
  * @param int       $post_id         The ID of the post to attach the feedback to.
  * @param array|int $feedback_author Either an array containing 'name' and 'email' values, or a user ID.
  * @param array     $feedback_meta   An associative array of key => value pairs.
+ * @param bool      $is_spam         True if the comment is suspected to be spam.
  *
  * @return int|bool Comment ID on success. `false` on failure.
  */
-function add_feedback( $post_id, $feedback_author, array $feedback_meta ) {
+function add_feedback( $post_id, $feedback_author, array $feedback_meta, $is_spam = false ) {
 	$args = array(
 		'comment_approved' => 0, // "hold".
 		'comment_post_ID'  => $post_id,
 		'comment_type'     => COMMENT_TYPE,
 		'comment_meta'     => $feedback_meta,
 	);
+
+	if ( true === $is_spam ) {
+		$args['comment_approved'] = 'spam';
+	}
 
 	if ( is_int( $feedback_author ) ) {
 		$args['user_id'] = $feedback_author;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
@@ -5,6 +5,7 @@ namespace WordCamp\SpeakerFeedback\Spam;
 use WP_Error;
 use Grunion_Contact_Form_Plugin;
 use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_meta_field_schema;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
@@ -84,7 +85,12 @@ function is_akismet_spam( array $comment_data ) {
 
 	$grunion = Grunion_Contact_Form_Plugin::init();
 
-	$prepared_data = $grunion->prepare_for_akismet( $comment_data );
+	$prepared_data                 = $grunion->prepare_for_akismet( $comment_data );
+	$prepared_data['comment_type'] = COMMENT_TYPE;
+
+	if ( 'production' !== get_wordcamp_environment() ) {
+		$prepared_data['is_test'] = true;
+	}
 
 	return $grunion->is_spam_akismet( false, $prepared_data );
 }
@@ -100,7 +106,7 @@ function is_akismet_spam( array $comment_data ) {
  * @return string
  */
 function get_consolidated_meta_string( array $meta ) {
-	$schema = array_keys( get_feedback_meta_field_schema() );
+	$schema = get_feedback_meta_field_schema();
 	$string = '';
 
 	foreach ( $schema as $key => $props ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
@@ -136,5 +136,5 @@ function get_consolidated_meta_string( array $meta ) {
 		}
 	}
 
-	return $string;
+	return trim( $string );
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
@@ -51,8 +51,8 @@ function is_blacklisted( array $comment_data ) {
 		'comment_author_email' => '',
 		'comment_author_url'   => '',
 		'comment_content'      => '',
-		'user_ip'              => $_SERVER['REMOTE_ADDR'],
-		'user_agent'           => $_SERVER['HTTP_USER_AGENT'],
+		'user_ip'              => $_SERVER['REMOTE_ADDR'] ?? '',
+		'user_agent'           => $_SERVER['HTTP_USER_AGENT'] ?? '',
 	);
 	$comment_data = wp_parse_args( $comment_data, $defaults );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/spam.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Spam;
+
+use WP_Error;
+use Grunion_Contact_Form_Plugin;
+use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_meta_field_schema;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Check a feedback comment against WP's blacklist and Akismet.
+ *
+ * @param array $comment_data
+ * @param array $comment_meta
+ *
+ * @return string One of three values: 'spam', 'not spam', or 'discard' (for really egregious spam).
+ */
+function spam_check( array $comment_data, array $comment_meta = array() ) {
+	$meta = $comment_data['comment_meta'] ?? $comment_meta;
+
+	// Inject feedback meta strings as the comment content for the purposes of checking for spam.
+	$comment_data['comment_content'] = get_consolidated_meta_string( $meta );
+
+	if ( is_blacklisted( $comment_data ) ) {
+		return 'spam';
+	}
+
+	$akismet_check = is_akismet_spam( $comment_data );
+
+	if ( is_wp_error( $akismet_check ) ) {
+		return 'discard';
+	} elseif ( true === $akismet_check ) {
+		return 'spam';
+	}
+
+	return 'not spam';
+}
+
+/**
+ * Check a feedback comment against WP's blacklist.
+ *
+ * @param array $comment_data
+ *
+ * @return bool
+ */
+function is_blacklisted( array $comment_data ) {
+	$defaults     = array(
+		'comment_author'       => '',
+		'comment_author_email' => '',
+		'comment_author_url'   => '',
+		'comment_content'      => '',
+		'user_ip'              => $_SERVER['REMOTE_ADDR'],
+		'user_agent'           => $_SERVER['HTTP_USER_AGENT'],
+	);
+	$comment_data = wp_parse_args( $comment_data, $defaults );
+
+	$blacklisted = wp_blacklist_check(
+		$comment_data['comment_author'],
+		$comment_data['comment_author_email'],
+		$comment_data['comment_author_url'],
+		$comment_data['comment_content'],
+		$comment_data['user_ip'],
+		$comment_data['user_agent']
+	);
+
+	return $blacklisted;
+}
+
+/**
+ * Check a feedback comment against Akismet, using methods from Jetpack's Contact Form module.
+ *
+ * Akismet's default methods are too opinionated about comments to useful to us here. Rolling our own methods
+ * seems unnecessary since Jetpack's are quite serviceable and should always be available on WordCamp sites.
+ *
+ * @param array $comment_data
+ *
+ * @return bool|WP_Error
+ */
+function is_akismet_spam( array $comment_data ) {
+	if ( ! class_exists( 'Grunion_Contact_Form_Plugin' ) ) {
+		return false;
+	}
+
+	$grunion = Grunion_Contact_Form_Plugin::init();
+
+	$prepared_data = $grunion->prepare_for_akismet( $comment_data );
+
+	return $grunion->is_spam_akismet( false, $prepared_data );
+}
+
+/**
+ * Consolidate all the string meta values into one string.
+ *
+ * This should only be used to check the meta content for spam. The concatenated meta strings won't make
+ * sense to display without the context of the questions they are answering.
+ *
+ * @param array $meta
+ *
+ * @return string
+ */
+function get_consolidated_meta_string( array $meta ) {
+	$schema = array_keys( get_feedback_meta_field_schema() );
+	$string = '';
+
+	foreach ( $schema as $key => $props ) {
+		if ( 'string' !== $props['type'] ) {
+			continue;
+		}
+
+		if ( isset( $meta[ $key ] ) ) {
+			if ( is_array( $meta[ $key ] ) ) {
+				$value = $meta[ $key ][0];
+			} else {
+				$value = $meta[ $key ];
+			}
+
+			$string .= "{$value}\n\n";
+		}
+	}
+
+	return $string;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -32,6 +32,11 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	protected static $user;
 
 	/**
+	 * @var WP_User
+	 */
+	protected static $admin;
+
+	/**
 	 * @var array
 	 */
 	protected static $valid_meta;
@@ -58,6 +63,10 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 			'role' => 'subscriber',
 		) );
 
+		self::$admin = $factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
 		self::$valid_meta = array(
 			'rating' => 1,
 			'q1'     => 'asdf 1',
@@ -75,6 +84,8 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->request = new WP_REST_Request( 'POST', '/wordcamp-speaker-feedback/v1/feedback' );
+
+		wp_set_current_user( self::$user->ID );
 	}
 
 	/**
@@ -150,6 +161,99 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		$this->assertWPError( $response );
 		$this->assertEquals( 'rest_feedback_author_data_required', $response->get_error_code() );
 		$this->assertCount( 0, get_feedback() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::duplicate_check()
+	 */
+	public function test_create_item_duplicate() {
+		// Ensure multiple comments doesn't trigger a "comment flood". Admins get a pass.
+		wp_set_current_user( self::$admin->ID );
+
+		$params = array(
+			'post'   => self::$session_post->ID,
+			'author' => self::$user->ID,
+			'meta'   => self::$valid_meta,
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response1 = self::$controller->create_item( $this->request );
+
+		$this->assertTrue( $response1 instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response1->get_status() );
+		$this->assertCount( 1, get_feedback() );
+
+		$response2 = self::$controller->create_item( $this->request );
+
+		$this->assertWPError( $response2 );
+		$this->assertEquals( 'comment_duplicate', $response2->get_error_code() );
+		$this->assertCount( 1, get_feedback() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::duplicate_check()
+	 */
+	public function test_create_item_not_duplicate() {
+		// Ensure multiple comments doesn't trigger a "comment flood". Admins get a pass.
+		wp_set_current_user( self::$admin->ID );
+
+		$params = array(
+			'post'   => self::$session_post->ID,
+			'author' => self::$user->ID,
+			'meta'   => array(
+				'rating' => 1,
+				'q1'     => 'asdf 1',
+				'q2'     => 'asdf 2',
+				'q3'     => 'asdf 3',
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response1 = self::$controller->create_item( $this->request );
+
+		$this->assertTrue( $response1 instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response1->get_status() );
+		$this->assertCount( 1, get_feedback() );
+
+		$params = array(
+			'post'   => self::$session_post->ID,
+			'author' => self::$user->ID,
+			'meta'   => array(
+				'rating' => 2, // Different value.
+				'q1'     => 'asdf 1',
+				'q2'     => 'asdf 2',
+				'q3'     => 'asdf 3',
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response2 = self::$controller->create_item( $this->request );
+
+		$this->assertTrue( $response2 instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response2->get_status() );
+		$this->assertCount( 2, get_feedback() );
+
+		$params = array(
+			'post'   => self::$session_post->ID,
+			'author' => self::$user->ID,
+			'meta'   => array(
+				'rating' => 1,
+				'q1'     => 'asdf 1',
+				'q2'     => 'asdf 2',
+				// Missing value.
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response3 = self::$controller->create_item( $this->request );
+
+		$this->assertTrue( $response3 instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response3->get_status() );
+		$this->assertCount( 3, get_feedback() );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -113,12 +113,15 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\Comment\add_feedback()
 	 */
-	public function test_add_feedback_user_id() {
-		$comment_id = add_feedback(
-			self::$session_post->ID,
-			self::$user->ID,
-			array()
+	public function test_add_feedback() {
+		$comment_data = array(
+			'comment_post_ID'      => self::$session_post->ID,
+			'comment_author'       => 'Huck Finn',
+			'comment_author_email' => 'huck.finn@example.org',
+			'comment_meta'         => array(),
 		);
+
+		$comment_id = add_feedback( $comment_data );
 
 		$comment = get_comment( $comment_id );
 
@@ -131,30 +134,14 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\Comment\add_feedback()
 	 */
-	public function test_add_feedback_user_array() {
-		$comment_id = add_feedback(
-			self::$session_post->ID,
-			array(
-				'name'  => 'Foo',
-				'email' => 'bar@example.org',
-			),
-			array()
+	public function test_add_feedback_missing_meta() {
+		$comment_data = array(
+			'comment_post_ID'      => self::$session_post->ID,
+			'comment_author'       => 'Huck Finn',
+			'comment_author_email' => 'huck.finn@example.org',
 		);
 
-		$comment = get_comment( $comment_id );
-
-		$this->assertTrue( is_feedback( $comment ) );
-	}
-
-	/**
-	 * @covers \WordCamp\SpeakerFeedback\Comment\add_feedback()
-	 */
-	public function test_add_feedback_no_user() {
-		$comment_id = add_feedback(
-			self::$session_post->ID,
-			array(),
-			array()
-		);
+		$comment_id = add_feedback( $comment_data );
 
 		$this->assertFalse( $comment_id );
 	}
@@ -163,13 +150,16 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\Comment\update_feedback()
 	 */
 	public function test_update_feedback() {
-		$comment_id = add_feedback(
-			self::$session_post->ID,
-			self::$user->ID,
-			array(
+		$comment_data = array(
+			'comment_post_ID'      => self::$session_post->ID,
+			'comment_author'       => 'Huck Finn',
+			'comment_author_email' => 'huck.finn@example.org',
+			'comment_meta'         => array(
 				'rating' => 1,
-			)
+			),
 		);
+
+		$comment_id = add_feedback( $comment_data );
 
 		$feedback = get_feedback_comment( $comment_id );
 
@@ -211,11 +201,14 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\Comment\delete_feedback()
 	 */
 	public function test_delete_feedback() {
-		$comment_id = add_feedback(
-			self::$session_post->ID,
-			self::$user->ID,
-			array()
+		$comment_data = array(
+			'comment_post_ID'      => self::$session_post->ID,
+			'comment_author'       => 'Huck Finn',
+			'comment_author_email' => 'huck.finn@example.org',
+			'comment_meta'         => array(),
 		);
+
+		$comment_id = add_feedback( $comment_data );
 
 		$deleted = delete_feedback( $comment_id );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-spam.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-spam.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_UnitTestCase;
+use function WordCamp\SpeakerFeedback\Spam\get_consolidated_meta_string;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_CommentMeta
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_Spam extends WP_UnitTestCase {
+	/**
+	 * @var array
+	 */
+	protected static $valid_meta;
+
+	/**
+	 * Set up shared fixtures for these tests.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$valid_meta = array(
+			'rating' => 1,
+			'q1'     => 'asdf 1',
+			'q2'     => 'asdf 2',
+			'q3'     => 'asdf 3',
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Spam\get_consolidated_meta_string()
+	 */
+	public function test_get_consolidated_meta_string() {
+		$expected = "asdf 1\n\nasdf 2\n\nasdf 3";
+
+		$actual = get_consolidated_meta_string( self::$valid_meta );
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -49,6 +49,7 @@ function load() {
 	require_once get_includes_path() . 'form.php';
 	require_once get_includes_path() . 'page.php';
 	require_once get_includes_path() . 'query.php';
+	require_once get_includes_path() . 'spam.php';
 
 	require_once get_includes_path() . 'admin.php';
 }


### PR DESCRIPTION
Our feedback submissions require a custom configuration for Akismet to check them correctly for spam, even though they are comments. This PR ensures that submissions get sent successfully to the Akismet API when processing requests to our REST API endpoint. It also ensures that if a feedback comment is later manually set to `spam` or `not spam`, the correct info is sent to the Akismet API so it can "learn". All of this happens through our custom list table UI such that the spam workflow is identical to that of normal comments.

Finally, this fixes a bug that was allowing duplicate feedback comments to successfully be submitted.

Fixes #346 

### Screenshot:

![spam](https://user-images.githubusercontent.com/916023/77700304-21f65200-6f71-11ea-9e44-45414a7803d8.jpg)

### To test:

1. Add a functional [Akismet API key](https://akismet.com) to your local dev environment or sandbox using this:
    ```php
    // Akismet
    add_filter( 'akismet_get_api_key', function( $key ) {
    	return '[your key goes here]';
    } );
    ```
1. [Submit some feedback comments](https://github.com/WordPress/wordcamp.org/pull/353). Try to get Akismet to mark some of them as spam. If you're having trouble, you can use `akismet-guaranteed-spam@example.com` for the `author_email` parameter and it [should work](https://akismet.com/development/api/#comment-check). I found that putting `asdf` in the meta fields `q1` - `q3` also worked :D  Note that there won't be any indication in the response from our API endpoint that the feedback comment has been marked as spam, unless it's so egregious that Akismet thinks it can be immediately discarded.
1. Check our Feedback list table. You should see your feedback comments appear either as Pending or as Spam.
1. Try marking a Pending feedback as "Spam" using the row action. Afterward, if you view it in the Spam section of the list table, the row action area should have a note saying "Flagged as spam by [username]".
1. Try marking a Spammed feedback as "Not Spam" using the row action. Afterward, if you view it in the Pending section of the list table, the row action area should have a note saying "Un-spammed by [username]".
1. Try clicking the "History" row action for a feedback. The Comment History metabox should show what Akismet originally thought the comment was, plus any changes that were made manually by a user.
1. Try submitting the same feedback twice in a row. The second time you should get an error about it being a duplicate.
1. All the phpunit tests should pass.