### PR TITLE
WCPT: Work around "Physical Address" requirement for online events

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -505,6 +505,11 @@ abstract class Event_Admin {
 				$values[ $key ]         = implode( ', ', $standardized_usernames );
 			}
 
+			// Set Physical Address to "Online" when an event is online-only.
+			if ( ( 'Physical Address' === $key ) && isset( $_POST['wcpt_virtual_event_only'] ) && ( 'on' === $_POST['wcpt_virtual_event_only'] ) ) {
+				$values[ $key ] = 'Online';
+			}
+
 			switch ( $value ) {
 				case 'text':
 				case 'deputy_list':

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -164,7 +164,11 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			$new_address = $_POST[ wcpt_key_to_str( 'Physical Address', 'wcpt_' ) ];
 
 			// If there is no venue, shortcut out of the request.
-			if ( empty( $new_address ) ) {
+			if ( empty( $new_address ) || 'Online' === $new_address ) {
+				$geocode_reply = $this->parse_geocode_response( array() );
+				foreach ( array_keys( $geocode_reply ) as $keys ) {
+					delete_post_meta( $post_id, $key );
+				}
 				return;
 			}
 
@@ -947,7 +951,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			}
 
 			// Show this error permanently, not just after updating.
-			if ( ! empty( $post->{'Physical Address'} ) && empty( get_post_meta( $post->ID, '_venue_coordinates', true ) ) ) {
+			if ( ! empty( $post->{'Physical Address'} ) && ( 'Online' !== $post->{'Physical Address'} ) && empty( get_post_meta( $post->ID, '_venue_coordinates', true ) ) ) {
 				$_REQUEST['wcpt_messages'] = empty( $_REQUEST['wcpt_messages'] ) ? '4' : $_REQUEST['wcpt_messages'] . ',4';
 			}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			// If there is no venue, shortcut out of the request.
 			if ( empty( $new_address ) || 'Online' === $new_address ) {
 				$geocode_reply = $this->parse_geocode_response( array() );
-				foreach ( array_keys( $geocode_reply ) as $keys ) {
+				foreach ( array_keys( $geocode_reply ) as $key ) {
 					delete_post_meta( $post_id, $key );
 				}
 				return;


### PR DESCRIPTION
The requirement checks don't have any knowledge about the current post, so there's no (easy) way to add "Physical Address" to `get_required_fields` only when another value is selected. Rather than conditionally remove the requirement, this injects a value of "Online". When the online value is used, it will also skip the geocoding process & warning.

Fixes #408

### How to test the changes in this Pull Request:

1. Create or edit a WordCamp post on central.wordcamp.test with the "scheduled" status
2. With virtual event only unchecked, make sure "Physical Address" is empty
3. Check "virtual event only"
4. Save the event
5. It should save, and still be in "scheduled", with no error messages
6. You can toggle "virtual event only", and you should see "Online" in the Physical Address field
