### PR TITLE
WCPT: Add fields to wordcamp endpoint for online events

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -404,6 +404,10 @@ class WordCamp_Loader extends Event_Loader {
 			'session_start_time',
 			array(
 				'get_callback' => function( $object, $field_name ) {
+					// Short out if the event is not scheduled.
+					if ( $object['status'] !== 'wcpt-scheduled' ) {
+						return 0;
+					}
 					$site_id = get_post_meta( $object['id'], '_site_id', true );
 					switch_to_blog( $site_id );
 					$sessions = get_posts( array(

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -403,6 +403,10 @@ class WordCamp_Loader extends Event_Loader {
 			'wordcamp',
 			'session_start_time',
 			array(
+				'schema'       => array(
+					'type'        => 'string',
+					'description' => __( 'The start time of the first session of WordCamp, when WordCamp content will begin.', 'wordcamporg' ),
+				),
 				'get_callback' => function( $object, $field_name ) {
 					// Short out if the event is not scheduled.
 					if ( 'wcpt-scheduled' !== $object['status'] ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -398,6 +398,33 @@ class WordCamp_Loader extends Event_Loader {
 				)
 			);
 		}
+
+		register_rest_field(
+			'wordcamp',
+			'session_start_time',
+			array(
+				'get_callback' => function( $object, $field_name ) {
+					$site_id = get_post_meta( $object['id'], '_site_id', true );
+					switch_to_blog( $site_id );
+					$sessions = get_posts( array(
+						'post_type'      => 'wcb_session',
+						'posts_per_page' => 1,
+						'meta_key'       => '_wcpt_session_time',
+						'orderby'        => 'meta_value_num',
+						'order'          => 'asc',
+					) );
+					if ( count( $sessions ) < 1 ) {
+						restore_current_blog();
+						return 0;
+					}
+					$session = $sessions[0];
+					$value = absint( get_post_meta( $session->ID, '_wcpt_session_time', true ) );
+
+					restore_current_blog();
+					return $value;
+				},
+			)
+		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -364,6 +364,7 @@ class WordCamp_Loader extends Event_Loader {
 			'Number of Anticipated Attendees',
 			'Organizer Name',
 			'WordPress.org Username',
+			'Virtual event only',
 			'Venue Name',
 			'Physical Address',
 			'Maximum Capacity',

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -405,7 +405,7 @@ class WordCamp_Loader extends Event_Loader {
 			array(
 				'get_callback' => function( $object, $field_name ) {
 					// Short out if the event is not scheduled.
-					if ( $object['status'] !== 'wcpt-scheduled' ) {
+					if ( 'wcpt-scheduled' !== $object['status'] ) {
 						return 0;
 					}
 					$site_id = get_post_meta( $object['id'], '_site_id', true );


### PR DESCRIPTION
This adds two fields to the `/wp/v2/wordcamps` endpoint, `Virtual event only` & `session_start_time`. The first is a boolean which says whether this is an online-only event. The other, `session_start_time`, is added to all WordCamps, regardless of online status. This picks out the earliest published session, and uses the UTC timestamp of that session to mark the "start time" of the WordCamp.

See #400 — this is necessary for adding WordCamps to [the online events page.](https://make.wordpress.org/community/events/online/)

This does increase the time for the API response, but only by ~0.5s (on my sandbox), which seems acceptable.

### How to test the changes in this Pull Request:

1. Make a request to `https://central.wordcamp.org/wp-json/wp/v2/wordcamps`
2. You should see these two fields in the response
3. Pick a scheduled WordCamp that has published sessions, it should have that first session's start time as `session_start_time`
4. Toggle the "Virtual event only" in the WordCamp post on central; it should update the API response

