### PR TITLE
Speaker Feedback: Add check for whether a session is currently accepting feedback

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -6,6 +6,7 @@ use WP_Post, WP_Query;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };
 use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
+use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
 
 defined( 'WPINC' ) || die();
 
@@ -37,8 +38,7 @@ function has_feedback_form() {
 function render( $content ) {
 	global $post;
 
-	$feedback_window = WEEK_IN_SECONDS * 2;
-	$now             = date_create( time(), wp_timezone() );
+	$now = date_create( time(), wp_timezone() );
 
 	if ( has_feedback_form() ) {
 		$accepts_feedback = post_accepts_feedback( $post->ID );
@@ -62,7 +62,7 @@ function render( $content ) {
 		if ( $now->getTimestamp() < absint( $start_date ) ) {
 			$message = __( 'Feedback forms are not available until the event has started.', 'wordcamporg' );
 			$file    = 'form-not-available.php';
-		} elseif ( $now->getTimestamp() > absint( $end_date ) + $feedback_window ) {
+		} elseif ( $now->getTimestamp() > absint( $end_date ) + ACCEPT_INTERVAL_IN_SECONDS ) {
 			$message = __( 'Feedback forms are closed for this event.', 'wordcamporg' );
 			$file    = 'form-not-available.php';
 		} else {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -38,7 +38,7 @@ function has_feedback_form() {
 function render( $content ) {
 	global $post;
 
-	$now = date_create( time(), wp_timezone() );
+	$now = date_create( 'now', wp_timezone() );
 
 	if ( has_feedback_form() ) {
 		$accepts_feedback = post_accepts_feedback( $post->ID );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -55,9 +55,23 @@ function render( $content ) {
 
 		$content = $content . ob_get_clean(); // Append form to the normal content.
 	} elseif ( is_page( get_option( OPTION_KEY ) ) ) {
-		$wordcamp   = get_wordcamp_post();
-		$start_date = $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ?? $now->getTimestamp() + YEAR_IN_SECONDS;
-		$end_date   = $wordcamp->meta['End Date (YYYY-mm-dd)'][0] ?? $start_date + DAY_IN_SECONDS;
+		$wordcamp = get_wordcamp_post();
+
+		if ( isset( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ) {
+			$date_string = gmdate( 'Y-m-d', $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] );
+			$start_date  = date_create( $date_string, wp_timezone() )->getTimestamp();
+		} else {
+			// No start date set, the event probably hasn't been scheduled yet. Use a far future date for now.
+			$start_date = $now->getTimestamp() + YEAR_IN_SECONDS;
+		}
+
+		if ( isset( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] ) ) {
+			$date_string = gmdate( 'Y-m-d', $wordcamp->meta['End Date (YYYY-mm-dd)'][0] );
+			$end_date    = date_create( $date_string, wp_timezone() )->getTimestamp();
+		} else {
+			// No end date set, assume it's 24 hours later.
+			$end_date = $start_date + DAY_IN_SECONDS;
+		}
 
 		if ( $now->getTimestamp() < absint( $start_date ) ) {
 			$message = __( 'Feedback forms are not available until the event has started.', 'wordcamporg' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/form.php
@@ -1,14 +1,23 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\Form;
-use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
+
+use WP_Post, WP_Query;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };
+use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
+use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
+
+defined( 'WPINC' ) || die();
 
 add_filter( 'the_content', __NAMESPACE__ . '\render' );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
  * Check if the current page should include the feedback form.
+ *
+ * @global WP_Query $wp_query
+ *
+ * @return bool
  */
 function has_feedback_form() {
 	global $wp_query;
@@ -17,16 +26,53 @@ function has_feedback_form() {
 
 /**
  * Short-circuit the content, and output the feedback form (or the session select).
+ *
+ * This assumes that `wcb_session` is the only post type supporting speaker feedback. This will need to be updated
+ * if more post type support is added.
+ *
+ * @global WP_Post $post
+ *
+ * @return string
  */
 function render( $content ) {
+	global $post;
+
+	$feedback_window = WEEK_IN_SECONDS * 2;
+	$now             = date_create( time(), wp_timezone() );
+
 	if ( has_feedback_form() ) {
+		$accepts_feedback = post_accepts_feedback( $post->ID );
+
+		if ( is_wp_error( $accepts_feedback ) ) {
+			$message = $accepts_feedback->get_error_message();
+			$file    = 'form-not-available.php';
+		} else {
+			$file = 'form-feedback.php';
+		}
+
 		ob_start();
-		require get_views_path() . 'form-feedback.php';
-		return $content . ob_get_clean();
+		require get_views_path() . $file;
+
+		$content = $content . ob_get_clean(); // Append form to the normal content.
 	} elseif ( is_page( get_option( OPTION_KEY ) ) ) {
+		$wordcamp   = get_wordcamp_post();
+		$start_date = $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ?? $now->getTimestamp() + YEAR_IN_SECONDS;
+		$end_date   = $wordcamp->meta['End Date (YYYY-mm-dd)'][0] ?? $start_date + DAY_IN_SECONDS;
+
+		if ( $now->getTimestamp() < absint( $start_date ) ) {
+			$message = __( 'Feedback forms are not available until the event has started.', 'wordcamporg' );
+			$file    = 'form-not-available.php';
+		} elseif ( $now->getTimestamp() > absint( $end_date ) + $feedback_window ) {
+			$message = __( 'Feedback forms are closed for this event.', 'wordcamporg' );
+			$file    = 'form-not-available.php';
+		} else {
+			$file = 'form-select-sessions.php';
+		}
+
 		ob_start();
-		require get_views_path() . 'form-select-sessions.php';
-		return ob_get_clean();
+		require get_views_path() . $file;
+
+		$content = ob_get_clean(); // Replace the content.
 	}
 
 	return $content;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -6,6 +6,8 @@ use WP_Error;
 
 defined( 'WPINC' ) || die();
 
+define( __NAMESPACE__ . '\ACCEPT_INTERVAL_IN_SECONDS', WEEK_IN_SECONDS * 2 );
+
 /**
  * Check to see if feedback comments can be added to a post.
  *
@@ -14,9 +16,8 @@ defined( 'WPINC' ) || die();
  * @return bool|WP_Error
  */
 function post_accepts_feedback( $post_id ) {
-	$post            = get_post( $post_id );
-	$now             = date_create( 'now', wp_timezone() );
-	$feedback_window = WEEK_IN_SECONDS * 2;
+	$post = get_post( $post_id );
+	$now  = date_create( 'now', wp_timezone() );
 
 	if ( ! $post ) {
 		return new WP_Error(
@@ -54,7 +55,7 @@ function post_accepts_feedback( $post_id ) {
 		);
 	}
 
-	if ( $now->getTimestamp() > absint( $post->_wcpt_session_time ) + $feedback_window ) {
+	if ( $now->getTimestamp() > absint( $post->_wcpt_session_time ) + ACCEPT_INTERVAL_IN_SECONDS ) {
 		return new WP_Error(
 			'speaker_feedback_session_too_late',
 			__( 'This session is no longer accepting feedback.', 'wordcamporg' )

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Post;
+
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Check to see if feedback comments can be added to a post.
+ *
+ * @param int $post_id
+ *
+ * @return bool|WP_Error
+ */
+function post_accepts_feedback( $post_id ) {
+	$post            = get_post( $post_id );
+	$now             = date_create( 'now', wp_timezone() );
+	$feedback_window = WEEK_IN_SECONDS * 2;
+
+	if ( ! $post ) {
+		return new WP_Error(
+			'speaker_feedback_invalid_post_id',
+			__( 'The post does not exist. Feedback must relate to a post.', 'wordcamporg' )
+		);
+	}
+
+	if ( ! post_type_supports( get_post_type( $post ), 'wordcamp-speaker-feedback' ) ) {
+		return new WP_Error(
+			'speaker_feedback_post_not_supported',
+			__( 'This post does not support feedback.', 'wordcamporg' )
+		);
+	}
+
+	if ( 'publish' !== get_post_status( $post ) ) {
+		return new WP_Error(
+			'speaker_feedback_post_unavailable',
+			__( 'This post does is not available for feedback.', 'wordcamporg' )
+		);
+	}
+
+	// These assume the post type is `wcb_session`.
+	if ( 'session' !== $post->_wcpt_session_type ) {
+		return new WP_Error(
+			'speaker_feedback_invalid_session_type',
+			__( 'This type of session does not accept feedback.', 'wordcamporg' )
+		);
+	}
+
+	if ( $now->getTimestamp() < absint( $post->_wcpt_session_time ) ) {
+		return new WP_Error(
+			'speaker_feedback_session_too_soon',
+			__( 'This session will not accept feedback until it has started.', 'wordcamporg' )
+		);
+	}
+
+	if ( $now->getTimestamp() > absint( $post->_wcpt_session_time ) + $feedback_window ) {
+		return new WP_Error(
+			'speaker_feedback_session_too_late',
+			__( 'This session is no longer accepting feedback.', 'wordcamporg' )
+		);
+	}
+
+	return true;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -36,7 +36,7 @@ function post_accepts_feedback( $post_id ) {
 	if ( 'publish' !== get_post_status( $post ) ) {
 		return new WP_Error(
 			'speaker_feedback_post_unavailable',
-			__( 'This post does is not available for feedback.', 'wordcamporg' )
+			__( 'This post is not available for feedback.', 'wordcamporg' )
 		);
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -57,6 +57,9 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		self::$session_post = $factory->post->create_and_get( array(
 			'post_type' => 'wcb_session',
 		) );
+		update_post_meta( self::$session_post->ID, '_wcpt_session_type', 'session' );
+		update_post_meta( self::$session_post->ID, '_wcpt_session_time', strtotime( '- 1 day' ) );
+
 		add_post_type_support( 'wcb_session', 'wordcamp-speaker-feedback' );
 
 		self::$user = $factory->user->create_and_get( array(
@@ -278,7 +281,6 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_permissions_check_no_post() {
 		$params = array(
-			'post'   => 9999999999,
 			'author' => self::$user->ID,
 			'meta'   => self::$valid_meta,
 		);
@@ -294,11 +296,9 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item_permissions_check()
 	 */
-	public function test_create_item_permissions_check_not_supported() {
-		$post = self::factory()->post->create_and_get();
-
+	public function test_create_item_permissions_check_post_not_accepting() {
 		$params = array(
-			'post'   => $post->ID,
+			'post'   => 999999999,
 			'author' => self::$user->ID,
 			'meta'   => self::$valid_meta,
 		);
@@ -308,29 +308,5 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		$response = self::$controller->create_item_permissions_check( $this->request );
 
 		$this->assertWPError( $response );
-		$this->assertEquals( 'rest_feedback_post_not_supported', $response->get_error_code() );
-	}
-
-	/**
-	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item_permissions_check()
-	 */
-	public function test_create_item_permissions_check_not_published() {
-		$post = self::factory()->post->create_and_get( array(
-			'post_type'   => 'wcb_session',
-			'post_status' => 'draft',
-		) );
-
-		$params = array(
-			'post'   => $post->ID,
-			'author' => self::$user->ID,
-			'meta'   => self::$valid_meta,
-		);
-
-		$this->request->set_body_params( $params );
-
-		$response = self::$controller->create_item_permissions_check( $this->request );
-
-		$this->assertWPError( $response );
-		$this->assertEquals( 'rest_feedback_post_unavailable', $response->get_error_code() );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-post.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_UnitTestCase, WP_UnitTest_Factory;
+use WP_Post;
+use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_Post
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_Post extends WP_UnitTestCase {
+	/**
+	 * @var WP_Post[]
+	 */
+	protected static $posts = array();
+
+	/**
+	 * Set up fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		add_post_type_support( 'wcb_session', 'wordcamp-speaker-feedback' );
+
+		self::$posts['yes'] = $factory->post->create_and_get( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'publish',
+			'meta_input'  => array(
+				'_wcpt_session_type' => 'session',
+				'_wcpt_session_time' => strtotime( '- 1 day' ),
+			),
+		) );
+
+		self::$posts['no-support'] = $factory->post->create_and_get( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+		) );
+
+		self::$posts['no-status'] = $factory->post->create_and_get( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'draft',
+		) );
+
+		self::$posts['no-session-type'] = $factory->post->create_and_get( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'publish',
+			'meta_input'  => array(
+				'_wcpt_session_type' => 'custom',
+				'_wcpt_session_time' => strtotime( '- 1 day' ),
+			),
+		) );
+
+		self::$posts['no-too-soon'] = $factory->post->create_and_get( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'publish',
+			'meta_input'  => array(
+				'_wcpt_session_type' => 'session',
+				'_wcpt_session_time' => strtotime( '+ 1 day' ),
+			),
+		) );
+
+		self::$posts['no-too-late'] = $factory->post->create_and_get( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'publish',
+			'meta_input'  => array(
+				'_wcpt_session_type' => 'session',
+				'_wcpt_session_time' => strtotime( '- 15 days' ),
+			),
+		) );
+	}
+
+	/**
+	 * Remove fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback() {
+		$result = post_accepts_feedback( self::$posts['yes']->ID );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback_no_post() {
+		$result = post_accepts_feedback( 999999999 );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'speaker_feedback_invalid_post_id', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback_no_support() {
+		$result = post_accepts_feedback( self::$posts['no-support']->ID );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'speaker_feedback_post_not_supported', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback_no_status() {
+		$result = post_accepts_feedback( self::$posts['no-status']->ID );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'speaker_feedback_post_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback_no_session_type() {
+		$result = post_accepts_feedback( self::$posts['no-session-type']->ID );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'speaker_feedback_invalid_session_type', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback_no_too_soon() {
+		$result = post_accepts_feedback( self::$posts['no-too-soon']->ID );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'speaker_feedback_session_too_soon', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\Post\post_accepts_feedback()
+	 */
+	public function test_post_accepts_feedback_no_too_late() {
+		$result = post_accepts_feedback( self::$posts['no-too-late']->ID );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'speaker_feedback_session_too_late', $result->get_error_code() );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-spam.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-spam.php
@@ -8,7 +8,7 @@ use function WordCamp\SpeakerFeedback\Spam\get_consolidated_meta_string;
 defined( 'WPINC' ) || die();
 
 /**
- * Class Test_SpeakerFeedback_CommentMeta
+ * Class Test_SpeakerFeedback_Spam
  *
  * @group wordcamp-speaker-feedback
  */

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -1,13 +1,16 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\View;
+
 use function WordCamp\SpeakerFeedback\get_assets_path;
+
+defined( 'WPINC' ) || die();
 
 ?>
 <hr />
 <form id="sft-feedback" class="speaker-feedback">
 	<h3><?php esc_html_e( 'Rate this talk', 'wordcamporg' ); ?></h3>
-	
+
 	<div class="speaker-feedback__field">
 		<fieldset class="speaker-feedback__field-rating" aria-label="<?php esc_attr_e( 'Rate this talk', 'wordcamporg' ); ?>">
 			<input
@@ -44,7 +47,7 @@ use function WordCamp\SpeakerFeedback\get_assets_path;
 			</label>
 		</fieldset>
 	</div>
-	
+
 	<div class="speaker-feedback__field">
 		<label for="sft-question-1">
 			<?php esc_html_e( 'What’s one good thing you’d keep in this presentation?', 'wordcamporg' ); ?>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-not-available.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-not-available.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\View;
+
+defined( 'WPINC' ) || die();
+
+/** @var string $message */
+?>
+
+<hr />
+
+<p>
+	<?php echo wp_kses_data( $message ); ?>
+</p>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -48,6 +48,7 @@ function load() {
 	require_once get_includes_path() . 'comment-meta.php';
 	require_once get_includes_path() . 'form.php';
 	require_once get_includes_path() . 'page.php';
+	require_once get_includes_path() . 'post.php';
 	require_once get_includes_path() . 'query.php';
 	require_once get_includes_path() . 'spam.php';
 


### PR DESCRIPTION
This adds a function to comprehensively check whether a post can and is currently accepting feedback comments. The checks include whether it's the right type of session, and close the current time is to the session's start time, plus some other things. This is useful in both the REST API and front end templates for determining what kind of response or content to return.

Both the REST API controller and the feedback form renderer are also updated to use this function.

Fixes #343, Fixes #394

### Screenshots

![free-lunch](https://user-images.githubusercontent.com/916023/78081775-38801d00-7366-11ea-9320-ba9ed4c1ab7d.jpg)

### How to test the changes in this Pull Request:

1. Try viewing the feedback form for a session post (i.e. `site.wordcamp.test/session-slug/feedback`)
1. If the session type is set to regular and the session time is slightly before the current time, you should see the feedback form. Otherwise, you should see a message explaining why the feedback form isn't available. Try changing those parameters to get different messages.
1. Try submitting feedback for that same session post using the [REST API](https://github.com/WordPress/wordcamp.org/pull/353). The same error messages should be in the API responses when the session's conditions aren't met.
1. All phpunit tests should pass.
