### PR TITLE
Blocks: Fix overeager sanitization

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/includes/content.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/content.php
@@ -31,6 +31,25 @@ function get_all_the_content( $post ) {
 }
 
 /**
+ * Get a trimmed excerpt from a post.
+ *
+ * @param int|WP_Post $post           Post ID or post object.
+ * @param int         $excerpt_length Number of words in excerpt.
+ *
+ * @return string The escaped post excerpt.
+ */
+function get_trimmed_content( $post, $excerpt_length = 55 ) {
+	$post = get_post( $post );
+
+	$post_excerpt = $post->post_excerpt;
+	if ( ! ( $post_excerpt ) ) {
+		$post_excerpt = $post->post_content;
+	}
+
+	return esc_html( wp_trim_words( $post_excerpt, $excerpt_length, ' &hellip; ' ) );
+}
+
+/**
  * Convert an array of strings into one string that is a punctuated, human-readable list.
  *
  * @param array $array

--- a/public_html/wp-content/mu-plugins/blocks/includes/content.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/content.php
@@ -21,7 +21,7 @@ defined( 'WPINC' ) || die();
 function get_all_the_content( $post ) {
 	$post = get_post( $post );
 
-	$content = $post->post_content;
+	$content = wp_kses_post( $post->post_content );
 
 	/** This filter is documented in wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', $content );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/view.php
@@ -3,7 +3,7 @@ namespace WordCamp\Blocks\Organizers;
 
 use WP_Post;
 use function WordCamp\Blocks\Components\{ render_item_title, render_item_content };
-use function WordCamp\Blocks\Utilities\{ get_all_the_content };
+use function WordCamp\Blocks\Utilities\{ get_all_the_content, get_trimmed_content };
 
 defined( 'WPINC' ) || die();
 
@@ -39,13 +39,11 @@ setup_postdata( $organizer ); // This is necessary for generating an excerpt fro
 	<?php endif; ?>
 
 	<?php if ( 'none' !== $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_content(
-				'excerpt' === $attributes['content']
-					? apply_filters( 'the_excerpt', get_the_excerpt( $organizer ) )
-					: get_all_the_content( $organizer ),
-				array( 'wordcamp-organizers__content', 'is-' . $attributes['content'] )
-			)
+		<?php echo render_item_content( // phpcs:ignore -- escaped in get_* functions.
+			'excerpt' === $attributes['content']
+				? get_trimmed_content( $organizer )
+				: get_all_the_content( $organizer ),
+			array( 'wordcamp-organizers__content', 'is-' . $attributes['content'] )
 		); ?>
 	<?php endif; ?>
 </div>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -3,7 +3,7 @@ namespace WordCamp\Blocks\Sessions;
 
 use WP_Post;
 use function WordCamp\Blocks\Components\{ render_featured_image, render_item_title, render_item_content, render_item_permalink };
-use function WordCamp\Blocks\Utilities\{ get_all_the_content, array_to_human_readable_list };
+use function WordCamp\Blocks\Utilities\{ array_to_human_readable_list, get_all_the_content, get_trimmed_content };
 
 defined( 'WPINC' ) || die();
 
@@ -30,8 +30,8 @@ setup_postdata( $session );
 			function( $speaker ) {
 				return sprintf(
 					'<a href="%s">%s</a>',
-					get_permalink( $speaker ),
-					get_the_title( $speaker )
+					esc_url( get_permalink( $speaker ) ),
+					esc_html( get_the_title( $speaker ) )
 				);
 			},
 			$speakers[ $session->ID ]
@@ -42,32 +42,28 @@ setup_postdata( $session );
 			<?php
 			printf(
 				/* translators: %s is a list of names. */
-				wp_kses_post( __( 'Presented by %s', 'wordcamporg' ) ),
-				wp_kses_post( array_to_human_readable_list( $speaker_linked_names ) )
+				esc_html__( 'Presented by %s', 'wordcamporg' ),
+				array_to_human_readable_list( $speaker_linked_names ) // phpcs:ignore -- Escaped above.
 			);
 			?>
 		</p>
 	<?php endif; ?>
 
 	<?php if ( true === $attributes['show_images'] ) : ?>
-		<?php echo wp_kses_post(
-			render_featured_image(
-				$session,
-				$attributes['featured_image_width'],
-				array( 'wordcamp-sessions__featured-image', 'align-' . esc_attr( $attributes['image_align'] ) ),
-				get_permalink( $session )
-			)
+		<?php echo render_featured_image( // phpcs:ignore -- User input escaped in function.
+			$session,
+			$attributes['featured_image_width'],
+			array( 'wordcamp-sessions__featured-image', 'align-' . esc_attr( $attributes['image_align'] ) ),
+			get_permalink( $session )
 		); ?>
 	<?php endif; ?>
 
 	<?php if ( 'none' !== $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_content(
-				'excerpt' === $attributes['content']
-					? apply_filters( 'the_excerpt', get_the_excerpt( $session ) )
-					: get_all_the_content( $session ),
-				array( 'wordcamp-sessions__content', 'is-' . $attributes['content'] )
-			)
+		<?php echo render_item_content( // phpcs:ignore -- escaped in get_* functions.
+			'excerpt' === $attributes['content']
+				? get_trimmed_content( $session )
+				: get_all_the_content( $session ),
+			array( 'wordcamp-sessions__content', 'is-' . $attributes['content'] )
 		); ?>
 	<?php endif; ?>
 
@@ -117,7 +113,7 @@ setup_postdata( $session );
 				<div class="wordcamp-sessions__categories">
 					<?php
 					/* translators: used between list items, there is a space after the comma */
-					echo wp_kses_post( implode( __( ', ', 'wordcamporg' ), $categories ) );
+					echo implode( esc_html__( ', ', 'wordcamporg' ), $categories ); // phpcs:ignore -- Escaped above.
 					?>
 				</div>
 			<?php endif; ?>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
@@ -3,7 +3,7 @@ namespace WordCamp\Blocks\Speakers;
 
 use WP_Post;
 use function WordCamp\Blocks\Components\{ render_item_title, render_item_content, render_item_permalink };
-use function WordCamp\Blocks\Utilities\{ get_all_the_content };
+use function WordCamp\Blocks\Utilities\{ get_all_the_content, get_trimmed_content };
 
 defined( 'WPINC' ) || die();
 
@@ -40,13 +40,11 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 	<?php endif; ?>
 
 	<?php if ( 'none' !== $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_content(
-				'excerpt' === $attributes['content']
-					? apply_filters( 'the_excerpt', get_the_excerpt( $speaker ) )
-					: get_all_the_content( $speaker ),
-				array( 'wordcamp-speakers__content', 'is-' . $attributes['content'] )
-			)
+		<?php echo render_item_content( // phpcs:ignore -- escaped in get_* functions.
+			'excerpt' === $attributes['content']
+				? get_trimmed_content( $speaker )
+				: get_all_the_content( $speaker ),
+			array( 'wordcamp-speakers__content', 'is-' . $attributes['content'] )
 		); ?>
 	<?php endif; ?>
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/view.php
@@ -3,7 +3,7 @@ namespace WordCamp\Blocks\Sponsors;
 
 use WP_Post;
 use function WordCamp\Blocks\Components\{ render_featured_image, render_item_title, render_item_content, render_item_permalink };
-use function WordCamp\Blocks\Utilities\{ get_all_the_content };
+use function WordCamp\Blocks\Utilities\{ get_all_the_content, get_trimmed_content };
 
 defined( 'WPINC' ) || die();
 
@@ -27,24 +27,20 @@ setup_postdata( $sponsor ); // This is necessary for generating an excerpt from 
 	<?php endif; ?>
 
 	<?php if ( true === $attributes['show_logo'] ) : ?>
-		<?php echo wp_kses_post(
-			render_featured_image(
-				$sponsor,
-				$attributes['featured_image_width'],
-				array( 'wordcamp-sponsors__featured-image', 'wordcamp-sponsors__logo', 'align-' . esc_attr( $attributes['image_align'] ) ),
-				get_permalink( $sponsor )
-			)
+		<?php echo render_featured_image( // phpcs:ignore -- User input escaped in function.
+			$sponsor,
+			$attributes['featured_image_width'],
+			array( 'wordcamp-sponsors__featured-image', 'wordcamp-sponsors__logo', 'align-' . esc_attr( $attributes['image_align'] ) ),
+			get_permalink( $sponsor )
 		); ?>
 	<?php endif; ?>
 
 	<?php if ( 'none' !== $attributes['content'] ) : ?>
-		<?php echo wp_kses_post(
-			render_item_content(
-				'excerpt' === $attributes['content']
-					? apply_filters( 'the_excerpt', get_the_excerpt( $sponsor ) )
-					: get_all_the_content( $sponsor ),
-				array( 'wordcamp-sponsors__content', 'is-' . $attributes['content'] )
-			)
+		<?php echo render_item_content( // phpcs:ignore -- escaped in get_* functions.
+			'excerpt' === $attributes['content']
+				? get_trimmed_content( $sponsor )
+				: get_all_the_content( $sponsor ),
+			array( 'wordcamp-sponsors__content', 'is-' . $attributes['content'] )
 		); ?>
 	<?php endif; ?>
 </div>

--- a/public_html/wp-content/mu-plugins/blocks/source/components/image/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/image/controller.php
@@ -35,20 +35,19 @@ function render_featured_image( $post, $width, $class_names = array(), $image_li
 
 	$image = render_featured_image_element( $post, $size );
 
-	ob_start();
-	?>
-		<div class="<?php echo esc_attr( $container_classes ); ?>">
-			<?php if ( '' !== $image_link ) { ?>
-				<a href="<?php echo esc_html( $image_link ); ?>" class="wordcamp-image__featured-image-link">
-					<?php echo wp_kses_post( $image ); ?>
-				</a>
-			<?php } else { ?>
-				<?php echo wp_kses_post( $image ); ?>
-			<?php } ?>
-		</div>
-	<?php
+	$output = '<div class="' . esc_attr( $container_classes ) . '">';
+	if ( '' !== $image_link ) {
+		$output .= sprintf(
+			'<a href="%1$s" class="wordcamp-image__featured-image-link">%2$s</a>',
+			esc_attr( $image_link ),
+			$image
+		);
+	} else {
+		$output .= $image;
+	}
+	$output .= '</div>';
 
-	return ob_get_clean();
+	return $output;
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/controller.php
@@ -36,20 +36,22 @@ function render_item_title( $title, $link = '', $heading_level = 3, array $class
 		$style = "text-align:$align;";
 	}
 
-	ob_start();
-	?>
-	<<?php echo esc_html( $tag ); ?> class="<?php echo esc_attr( $classes ); ?>" style="<?php echo esc_attr( $style ); ?>">
-	<?php if ( $link ) : ?>
-		<a href="<?php echo esc_url( $link ); ?>">
-	<?php endif; ?>
-	<?php echo wp_kses_post( $title ); ?>
-	<?php if ( $link ) : ?>
-		</a>
-	<?php endif; ?>
-	</<?php echo esc_html( $tag ); ?>>
-	<?php
+	$output = sprintf(
+		'<%1$s class="%2$s" style="%3$s">',
+		esc_html( $tag ),
+		esc_attr( $classes ),
+		esc_attr( $style )
+	);
+	if ( $link ) {
+		$output .= '<a href="' . esc_url( $link ) . '">';
+	}
+	$output .= $title;
+	if ( $link ) {
+		$output .= '</a>';
+	}
+	$output .= '</' . esc_html( $tag ) . '>';
 
-	return ob_get_clean();
+	return $output;
 }
 
 /**
@@ -66,14 +68,11 @@ function render_item_content( $content, array $classes = array() ) {
 		$classes
 	) );
 
-	ob_start();
-	?>
-	<div class="<?php echo esc_attr( $classes ); ?>">
-		<?php echo wp_kses_post( wpautop( $content ) ); ?>
-	</div>
-	<?php
-
-	return ob_get_clean();
+	return sprintf(
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( $classes ),
+		wpautop( $content )
+	);
 }
 
 /**
@@ -95,14 +94,10 @@ function render_item_permalink( $link, $label = '', array $classes = array() ) {
 		$classes
 	) );
 
-	ob_start();
-	?>
-	<p class="<?php echo esc_attr( $classes ); ?>">
-		<a href="<?php echo esc_url( $link ); ?>">
-			<?php echo esc_html( $label ); ?>
-		</a>
-	</p>
-	<?php
-
-	return ob_get_clean();
+	return sprintf(
+		'<p class="%1$s"><a href="%2$s>%3$s</a></p>',
+		esc_attr( $classes ),
+		esc_url( $link ),
+		esc_html( $label )
+	);
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/post-list/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/post-list/controller.php
@@ -39,16 +39,11 @@ function render_post_list( array $rendered_items, $layout = 'list', $columns = 1
 
 	$container_classes = render_class_string( $container_classes );
 
-	ob_start();
-	?>
-		<ul class="<?php echo esc_attr( $container_classes ); ?>">
-			<?php foreach ( $rendered_items as $item ) : ?>
-				<li class="wordcamp-post-list__post wordcamp-clearfix">
-					<?php echo wp_kses_post( $item ); ?>
-				</li>
-			<?php endforeach; ?>
-		</ul>
-	<?php
+	$output = '<ul class="' . esc_attr( $container_classes ) . '">';
+	foreach ( $rendered_items as $item ) {
+		$output .= '<li class="wordcamp-post-list__post wordcamp-clearfix">' . $item . '</li>';
+	}
+	$output .= '</ul>';
 
-	return ob_get_clean();
+	return $output;
 }

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -61,27 +61,6 @@ function lower_brute_protect_api_timeout( $timeout ) {
 add_filter( 'jetpack_protect_connect_timeout', __NAMESPACE__ . '\lower_brute_protect_api_timeout' );
 
 /**
- * Update kses filter.
- *
- * Allow `noscript`: this is used by Jetpack's lazy-loading before we output the content, and by default is
- * stripped by the `wp_kses_post` function, causing duplicate images.
- *
- * @param array $tags
- * @return array
- */
-function allow_noscript_blocks( $tags, $context ) {
-	global $post;
-
-	// Only allow noscript through if we're showing a post with blocks.
-	if ( 'post' === $context && isset( $post, $post->post_content ) && has_blocks( $post->post_content ) ) {
-		$tags['noscript'] = array();
-	}
-
-	return $tags;
-}
-add_action( 'wp_kses_allowed_html', __NAMESPACE__ . '\allow_noscript_blocks', 10, 2 );
-
-/**
  * Register caching routes for Jetpack with the frontend service worker.
  *
  * Jetpack uses wp.com domains for loading assets, which need to be cached regexes that match from the start of

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -76,12 +76,12 @@ function register_caching_routes( WP_Service_Worker_Scripts $scripts ) {
 	$asset_cache_strategy_args = array(
 		'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_FIRST,
 		'cacheName' => 'wc-jetpack',
-		'plugins'   => [
-			'expiration' => [
+		'plugins'   => array(
+			'expiration' => array(
 				'maxEntries'    => 50,
 				'maxAgeSeconds' => DAY_IN_SECONDS,
-			],
-		],
+			),
+		),
 	);
 
 	/*
@@ -119,7 +119,6 @@ add_action( 'wp_front_service_worker', __NAMESPACE__ . '\register_caching_routes
  *
  * Jetpack defaults to send an email about each subscriber to each WordCamp to the owner
  * of the Jetpack connection.  No need to receive these emails.
- *
  */
 function disable_jetpack_blog_follow_emails() {
 	$social_notifications_subscribe = get_option( 'social_notifications_subscribe' );


### PR DESCRIPTION
This PR removes the aggressive `wp_kses_post` calls from the render helper functions, and uses more context-aware sanitization & escaping functions — for example, esc_html on content that should not have HTML tags. `wp_kses_post` is still used on the title & content, but is added before `the_content` filter is run, so that it's only applied to user content, not rendered blocks.

Lastly this removes the `noscript` exception, since it's not necessary with the earlier sanitization.

Fixes #349

### How to test the changes in this Pull Request:

- Try viewing one of each block, there should be no visual changes.
- Replicate the issue in #349 by adding a social links block to a speaker, then in your speakers block, show the full content. When you view the post, you should see the social link icons.
