### PR TITLE
Speaker Feedback: Add REST endpoint for updating feedback with specific meta values

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -274,10 +274,10 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 			return $prepared_feedback;
 		}
 
-		if ( ! isset( $prepared_feedback['comment_meta'] ) ) {
+		if ( ! isset( $prepared_feedback['comment_meta'] ) || empty( $prepared_feedback['comment_meta'] ) ) {
 			return new WP_Error(
 				'rest_feedback_meta_data_required',
-				__( 'Feedback must include data from the feedback form.', 'wordcamporg' ),
+				__( 'No valid data was submitted for update.', 'wordcamporg' ),
 				array(
 					'status' => 400,
 				)

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -6,7 +6,8 @@ use WP_UnitTestCase, WP_UnitTest_Factory;
 use WP_Post, WP_User;
 use WP_REST_Request, WP_REST_Response;
 use WordCamp\SpeakerFeedback\REST_Feedback_Controller;
-use function WordCamp\SpeakerFeedback\Comment\get_feedback;
+use function WordCamp\SpeakerFeedback\Comment\{ get_feedback, get_feedback_comment };
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
@@ -22,19 +23,14 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	protected static $controller;
 
 	/**
-	 * @var WP_Post
+	 * @var WP_Post[]
 	 */
-	protected static $session_post;
+	protected static $posts = array();
 
 	/**
-	 * @var WP_User
+	 * @var WP_User[]
 	 */
-	protected static $user;
-
-	/**
-	 * @var WP_User
-	 */
-	protected static $admin;
+	protected static $users = array();
 
 	/**
 	 * @var array
@@ -52,23 +48,35 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		self::$controller = new REST_Feedback_Controller();
-
-		self::$session_post = $factory->post->create_and_get( array(
-			'post_type' => 'wcb_session',
-		) );
-		update_post_meta( self::$session_post->ID, '_wcpt_session_type', 'session' );
-		update_post_meta( self::$session_post->ID, '_wcpt_session_time', strtotime( '- 1 day' ) );
-
 		add_post_type_support( 'wcb_session', 'wordcamp-speaker-feedback' );
 
-		self::$user = $factory->user->create_and_get( array(
+		self::$controller = new REST_Feedback_Controller();
+
+		self::$users['subscriber'] = $factory->user->create_and_get( array(
 			'role' => 'subscriber',
 		) );
 
-		self::$admin = $factory->user->create_and_get( array(
+		self::$users['admin'] = $factory->user->create_and_get( array(
 			'role' => 'administrator',
 		) );
+
+		self::$posts['valid-session'] = $factory->post->create_and_get( array(
+			'post_type'  => 'wcb_session',
+			'meta_input' => array(
+				'_wcpt_session_type' => 'session',
+				'_wcpt_session_time' => strtotime( '- 1 day' ),
+			),
+		) );
+
+		self::$posts['valid-session-with-speaker'] = $factory->post->create_and_get( array(
+			'post_type'  => 'wcb_session',
+			'meta_input' => array(
+				'_wcpt_session_type' => 'session',
+				'_wcpt_session_time' => strtotime( '- 1 day' ),
+			),
+		) );
+		// It doesn't work to add this value via `meta_input` for some reason.
+		add_post_meta( self::$posts['valid-session-with-speaker']->ID, '_wcpt_speaker_id', self::$users['subscriber']->ID );
 
 		self::$valid_meta = array(
 			'rating' => 1,
@@ -81,6 +89,19 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Remove fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+
+		foreach ( self::$users as $user ) {
+			wp_delete_user( $user->ID );
+		}
+	}
+
+	/**
 	 * Set up before each test.
 	 */
 	public function setUp() {
@@ -88,7 +109,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 
 		$this->request = new WP_REST_Request( 'POST', '/wordcamp-speaker-feedback/v1/feedback' );
 
-		wp_set_current_user( self::$user->ID );
+		wp_set_current_user( self::$users['subscriber']->ID );
 	}
 
 	/**
@@ -114,8 +135,8 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_user_id() {
 		$params = array(
-			'post'   => self::$session_post->ID,
-			'author' => self::$user->ID,
+			'post'   => self::$posts['valid-session']->ID,
+			'author' => self::$users['subscriber']->ID,
 			'meta'   => self::$valid_meta,
 		);
 
@@ -133,7 +154,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_user_array() {
 		$params = array(
-			'post'         => self::$session_post->ID,
+			'post'         => self::$posts['valid-session']->ID,
 			'author_name'  => 'Foo',
 			'author_email' => 'bar@example.org',
 			'meta'         => self::$valid_meta,
@@ -153,7 +174,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_no_user() {
 		$params = array(
-			'post' => self::$session_post->ID,
+			'post' => self::$posts['valid-session']->ID,
 			'meta' => self::$valid_meta,
 		);
 
@@ -167,15 +188,33 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::create_item()
+	 */
+	public function test_create_item_no_meta() {
+		$params = array(
+			'post'   => self::$posts['valid-session']->ID,
+			'author' => self::$users['subscriber']->ID,
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->create_item( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_meta_data_required', $response->get_error_code() );
+		$this->assertCount( 0, get_feedback() );
+	}
+
+	/**
 	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::duplicate_check()
 	 */
 	public function test_create_item_duplicate() {
 		// Ensure multiple comments doesn't trigger a "comment flood". Admins get a pass.
-		wp_set_current_user( self::$admin->ID );
+		wp_set_current_user( self::$users['admin']->ID );
 
 		$params = array(
-			'post'   => self::$session_post->ID,
-			'author' => self::$user->ID,
+			'post'   => self::$posts['valid-session']->ID,
+			'author' => self::$users['subscriber']->ID,
 			'meta'   => self::$valid_meta,
 		);
 
@@ -199,11 +238,11 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_not_duplicate() {
 		// Ensure multiple comments doesn't trigger a "comment flood". Admins get a pass.
-		wp_set_current_user( self::$admin->ID );
+		wp_set_current_user( self::$users['admin']->ID );
 
 		$params = array(
-			'post'   => self::$session_post->ID,
-			'author' => self::$user->ID,
+			'post'   => self::$posts['valid-session']->ID,
+			'author' => self::$users['subscriber']->ID,
 			'meta'   => array(
 				'rating' => 1,
 				'q1'     => 'asdf 1',
@@ -220,16 +259,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 201, $response1->get_status() );
 		$this->assertCount( 1, get_feedback() );
 
-		$params = array(
-			'post'   => self::$session_post->ID,
-			'author' => self::$user->ID,
-			'meta'   => array(
-				'rating' => 2, // Different value.
-				'q1'     => 'asdf 1',
-				'q2'     => 'asdf 2',
-				'q3'     => 'asdf 3',
-			),
-		);
+		$params['meta']['rating'] = 2; // Different value.
 
 		$this->request->set_body_params( $params );
 
@@ -239,16 +269,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 201, $response2->get_status() );
 		$this->assertCount( 2, get_feedback() );
 
-		$params = array(
-			'post'   => self::$session_post->ID,
-			'author' => self::$user->ID,
-			'meta'   => array(
-				'rating' => 1,
-				'q1'     => 'asdf 1',
-				'q2'     => 'asdf 2',
-				// Missing value.
-			),
-		);
+		unset( $params['meta']['q3'] ); // Missing value.
 
 		$this->request->set_body_params( $params );
 
@@ -264,8 +285,8 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_permissions_check_is_valid() {
 		$params = array(
-			'post'   => self::$session_post->ID,
-			'author' => self::$user->ID,
+			'post'   => self::$posts['valid-session']->ID,
+			'author' => self::$users['subscriber']->ID,
 			'meta'   => self::$valid_meta,
 		);
 
@@ -281,7 +302,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	 */
 	public function test_create_item_permissions_check_no_post() {
 		$params = array(
-			'author' => self::$user->ID,
+			'author' => self::$users['subscriber']->ID,
 			'meta'   => self::$valid_meta,
 		);
 
@@ -299,7 +320,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 	public function test_create_item_permissions_check_post_not_accepting() {
 		$params = array(
 			'post'   => 999999999,
-			'author' => self::$user->ID,
+			'author' => self::$users['subscriber']->ID,
 			'meta'   => self::$valid_meta,
 		);
 
@@ -308,5 +329,138 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		$response = self::$controller->create_item_permissions_check( $this->request );
 
 		$this->assertWPError( $response );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::update_item()
+	 */
+	public function test_update_item_is_valid() {
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_type' => COMMENT_TYPE,
+		) );
+
+		$params = array(
+			'id'   => $comment->comment_ID,
+			'meta' => array(
+				'helpful' => true,
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_item( $this->request );
+
+		$this->assertTrue( $response instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertTrue( (bool) get_feedback_comment( $comment )->helpful );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::update_item()
+	 */
+	public function test_update_item_no_comment_id() {
+		$params = array(
+			'meta' => array(
+				'helpful' => true,
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_item( $this->request );
+
+		$this->assertWPError( $response );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::update_item()
+	 */
+	public function test_update_item_no_meta() {
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_type' => COMMENT_TYPE,
+		) );
+
+		$params = array(
+			'id' => $comment->comment_ID,
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_item( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_meta_data_required', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::update_item_permissions_check()
+	 */
+	public function test_update_item_permissions_check_is_valid() {
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_type'    => COMMENT_TYPE,
+			'comment_post_ID' => self::$posts['valid-session-with-speaker']->ID,
+		) );
+
+		$params = array(
+			'id'   => $comment->comment_ID,
+			'meta' => array(
+				'helpful' => true,
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_item_permissions_check( $this->request );
+
+		$this->assertTrue( $response );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::update_item_permissions_check()
+	 */
+	public function test_update_item_permissions_check_not_feedback() {
+		wp_set_current_user( self::$users['admin']->ID );
+
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_post_ID' => self::$posts['valid-session']->ID,
+		) );
+
+		$params = array(
+			'id'   => $comment->comment_ID,
+			'meta' => array(
+				'helpful' => true,
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_item_permissions_check( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_not_feedback', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Feedback_Controller::update_item_permissions_check()
+	 */
+	public function test_update_item_permissions_check_not_speaker() {
+		$comment = $this->factory->comment->create_and_get( array(
+			'comment_type'    => COMMENT_TYPE,
+			'comment_post_ID' => self::$posts['valid-session']->ID,
+		) );
+
+		$params = array(
+			'id'   => $comment->comment_ID,
+			'meta' => array(
+				'helpful' => true,
+			),
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_item_permissions_check( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_no_permission', $response->get_error_code() );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -109,7 +109,7 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_too_long() {
-		$schema = get_feedback_meta_field_schema( 'q1' );
+		$schema = get_feedback_meta_field_schema( 'all', 'q1' );
 
 		$too_long_answer = array_fill( 0, $schema['attributes']['maxlength'] + 1, 'a' );
 		$too_long_answer = implode( '', $too_long_answer );
@@ -127,7 +127,7 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
 	public function test_validate_feedback_meta_multibyte_not_too_long() {
-		$schema = get_feedback_meta_field_schema( 'q1' );
+		$schema = get_feedback_meta_field_schema( 'all', 'q1' );
 
 		$almost_long_answer = array_fill( 0, $schema['attributes']['maxlength'], '💩' );
 		$almost_long_answer = implode( '', $almost_long_answer );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment-meta.php
@@ -69,6 +69,31 @@ class Test_SpeakerFeedback_CommentMeta extends WP_UnitTestCase {
 	/**
 	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
 	 */
+	public function test_validate_feedback_meta_booleanish() {
+		$alternate_valid_meta            = self::$valid_meta;
+		$alternate_valid_meta['helpful'] = 'true';
+
+		$result = validate_feedback_meta( $alternate_valid_meta );
+
+		$this->assertEqualSetsWithIndex( $alternate_valid_meta, $result );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
+	public function test_validate_feedback_meta_not_boolean() {
+		$invalid_meta            = self::$valid_meta;
+		$invalid_meta['helpful'] = 'spork';
+
+		$result = validate_feedback_meta( $invalid_meta );
+
+		$this->assertWPError( $result );
+		$this->assertArrayHasKey( 'helpful', $result->get_error_data() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\CommentMeta\validate_feedback_meta()
+	 */
 	public function test_validate_feedback_meta_not_numeric() {
 		$invalid_meta           = self::$valid_meta;
 		$invalid_meta['rating'] = 'spork';


### PR DESCRIPTION
Adds the ability to mark a feedback comment as "helpful" via a new API endpoint. This is stored as comment meta, just like the other values that make up the original feedback submission. However, "helpful" can only be set during feedback update, not creation. This is achieved by introducing a "context" for each possible meta field.

This also makes some changes to the way request objects are processed by our endpoint controller to allow for the flexibility to consider the context of the request.

Refs #342 

### How to test the changes in this Pull Request:

1. To make is easier to send authenticated requests to the endpoint via something like [Insomnia](https://insomnia.rest/), you'll probably want to temporarily install the [Basic Auth plugin](https://github.com/WP-API/Basic-Auth).
1. Create some feedback comments on one or more session posts.
1. To mark one of the comments as helpful, you'll need the ID of the comment.
1. The endpoint URL will be `[your-test-site].wordcamp.org/wp-json/wordcamp-speaker-feedback/v1/feedback/[comment ID]`
1. Currently there is only valid parameter for the payload:
    * `meta[helpful]` (A boolean-ish value)
1. The response to a successful request to the endpoint should be a 201 status and an empty array.
1. Try sending a non-boolean value. You should get an error message.
1. Try including other existing meta values besides `helpful` (`rating` or `q1` for example). These should be ignored and not changed during a successful request.
1. Try including `meta[helpful]` when sending a request to [create a new feedback](https://github.com/WordPress/wordcamp.org/pull/353). It should also be ignored and not be present for the newly created comment.
1. Try authenticating as a non-admin/editor user who is also not a speaker on the session. You should get an error message.
