### PR TITLE
Speaker Feedback: Fix capability checks

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/capabilities.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/capabilities.php
@@ -2,8 +2,9 @@
 
 namespace WordCamp\SpeakerFeedback\Capabilities;
 
+use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
+use function WordCamp\SpeakerFeedback\Post\get_session_speaker_user_ids;
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
-use function WordCamp\SpeakerFeedback\Comment\{ get_feedback_comment };
 
 defined( 'WPINC' ) || die();
 
@@ -33,7 +34,7 @@ function map_meta_caps( $user_caps, $current_cap, $user_id, $args = array() ) {
 			}
 
 			// Current user is a speaker for the session receiving feedback comments.
-			$session_speakers = array_map( 'absint', (array) get_post_meta( $feedback->comment_post_ID, '_wcpt_speaker_id' ) );
+			$session_speakers = get_session_speaker_user_ids( $feedback->comment_post_ID );
 			if ( in_array( $user_id, $session_speakers, true ) ) {
 				$required_caps[] = 'read';
 
@@ -64,7 +65,7 @@ function map_meta_caps( $user_caps, $current_cap, $user_id, $args = array() ) {
 			}
 
 			// Current user is a speaker for the session receiving feedback comments.
-			$session_speakers = array_map( 'absint', (array) get_post_meta( $post->ID, '_wcpt_speaker_id' ) );
+			$session_speakers = get_session_speaker_user_ids( $post->ID );
 			if ( in_array( $user_id, $session_speakers, true ) ) {
 				$required_caps[] = 'read';
 				break;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -64,3 +64,25 @@ function post_accepts_feedback( $post_id ) {
 
 	return true;
 }
+
+/**
+ * Get a list of user IDs of the speakers for a given session.
+ *
+ * @param int $session_id
+ *
+ * @return array
+ */
+function get_session_speaker_user_ids( $session_id ) {
+	$user_ids         = array();
+	$speaker_post_ids = get_post_meta( $session_id, '_wcpt_speaker_id' );
+
+	foreach ( $speaker_post_ids as $post_id ) {
+		$user_id = absint( get_post_meta( $post_id, '_wcpt_user_id', true ) );
+
+		if ( $user_id ) {
+			$user_ids[] = $user_id;
+		}
+	}
+
+	return $user_ids;
+}


### PR DESCRIPTION
When I previously created the meta caps for viewing feedback comments, I incorrectly assumed that the post meta value `_wcpt_speaker_id` that is attached to Session posts was the actual user ID of the speaker. In fact it is the _post ID_ of the Speaker post associated with the Session.

This introduces a function that can take a Session post ID and derive the actual user IDs of the speakers associated with the session, and uses that in the meta caps. It also updates existing tests and adds a couple of new ones.

### How to test the changes in this Pull Request:

1. All the phpunit tests should pass.
1. There isn't really a UI yet for speakers to view their feedback, so I'm not sure how else to test this right now.
