### PR TITLE
Organizer Reminders: Add placeholder to output link to session feedback

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/bootstrap.php
@@ -10,10 +10,13 @@ if ( 'cli' !== php_sapi_name() ) {
  * Load the plugins that we'll need to be active for the tests.
  */
 function manually_load_plugin() {
-	require_once( dirname( __DIR__ )            . '/bootstrap.php'                      );
-	require_once( dirname( dirname( __DIR__ ) ) . '/multi-event-sponsors/bootstrap.php' );
-	require_once( dirname( dirname( __DIR__ ) ) . '/wcpt/wcpt-event/class-event-loader.php' );
-	require_once( dirname( dirname( __DIR__ ) ) . '/wcpt/wcpt-wordcamp/wordcamp-loader.php' );
-	require_once( dirname( dirname( __DIR__ ) ) . '/wcpt/wcpt-functions.php'            );
+	// Needed for `get_wordcamp_site_id()`.
+	require_once WP_MU_PLUGIN_DIR . '/4-helpers-wcpt.php';
+
+	require_once dirname( __DIR__ )            . '/bootstrap.php';
+	require_once dirname( dirname( __DIR__ ) ) . '/multi-event-sponsors/bootstrap.php';
+	require_once dirname( dirname( __DIR__ ) ) . '/wcpt/wcpt-event/class-event-loader.php';
+	require_once dirname( dirname( __DIR__ ) ) . '/wcpt/wcpt-wordcamp/wordcamp-loader.php';
+	require_once dirname( dirname( __DIR__ ) ) . '/wcpt/wcpt-functions.php';
 }
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
@@ -1,4 +1,8 @@
-<?php defined( 'WPINC' ) || die(); ?>
+<?php
+use function WordCamp\SpeakerFeedback\Admin\get_subpage_url;
+
+defined( 'WPINC' ) || die();
+?>
 
 <h4>Available Placeholders:</h4>
 
@@ -73,4 +77,5 @@
 
 <ul class="ul-disc">
 	<li>[multi_event_sponsor_info]</li>
+	<li>[session_feedback_list_url]</li>
 </ul>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
@@ -1,8 +1,4 @@
-<?php
-use function WordCamp\SpeakerFeedback\Admin\get_subpage_url;
-
-defined( 'WPINC' ) || die();
-?>
+<?php defined( 'WPINC' ) || die(); ?>
 
 <h4>Available Placeholders:</h4>
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -1,6 +1,7 @@
 <?php
 
 use function WordCamp\Logger\log;
+use function WordCamp\SpeakerFeedback\Admin\get_subpage_url;
 
 /**
  * Sends e-mails at time-based intervals and on triggers
@@ -241,6 +242,10 @@ class WCOR_Mailer {
 			'[multi_event_sponsor_info]',
 		);
 
+		if ( is_callable( 'get_subpage_url' ) ) {
+			$search[] = '[session_feedback_list_url]';
+		}
+
 		$replace = array(
 			// The WordCamp
 			$wordcamp->post_title,
@@ -303,6 +308,10 @@ class WCOR_Mailer {
 			// Miscellaneous
 			$this->get_mes_info( $wordcamp->ID ),
 		);
+
+		if ( is_callable( 'get_subpage_url' ) ) {
+			$replace[] = get_subpage_url( 'wcb_session' );
+		}
 
 		return str_replace( $search, $replace, $content );
 	}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -1,7 +1,6 @@
 <?php
 
 use function WordCamp\Logger\log;
-use function WordCamp\SpeakerFeedback\Admin\get_subpage_url;
 
 /**
  * Sends e-mails at time-based intervals and on triggers
@@ -240,11 +239,8 @@ class WCOR_Mailer {
 
 			// Miscellaneous
 			'[multi_event_sponsor_info]',
+			'[session_feedback_list_url]',
 		);
-
-		if ( is_callable( 'get_subpage_url' ) ) {
-			$search[] = '[session_feedback_list_url]';
-		}
 
 		$replace = array(
 			// The WordCamp
@@ -307,11 +303,8 @@ class WCOR_Mailer {
 
 			// Miscellaneous
 			$this->get_mes_info( $wordcamp->ID ),
+			$this->get_feedback_list_table_url( $wordcamp ),
 		);
-
-		if ( is_callable( 'get_subpage_url' ) ) {
-			$replace[] = get_subpage_url( 'wcb_session' );
-		}
 
 		return str_replace( $search, $replace, $content );
 	}
@@ -357,6 +350,37 @@ class WCOR_Mailer {
 		}
 
 		return trim( str_replace( "\t", '', ob_get_clean() ) );
+	}
+
+	/**
+	 * Get the URL for the Feedback list table screen on a particular WordCamp site.
+	 *
+	 * @param WP_Post $wordcamp The WordCamp post.
+	 *
+	 * @return string
+	 */
+	protected function get_feedback_list_table_url( $wordcamp ) {
+		$url     = '';
+		$site_id = get_wordcamp_site_id( $wordcamp );
+
+		switch_to_blog( $site_id );
+
+		// This is just used to detect whether the Speaker Feedback Tool is active on the site.
+		$page_id = get_option( 'sft_feedback_page', 0 );
+
+		if ( $page_id ) {
+			$url = add_query_arg(
+				array(
+					'post_type' => 'wcb_session',
+					'page'      => 'wc-speaker-feedback',
+				),
+				esc_url( admin_url( 'edit.php' ) )
+			);
+		}
+
+		restore_current_blog();
+
+		return $url;
 	}
 
 	/**


### PR DESCRIPTION
This placeholder can be used when sending a reminder to organizers that they need to go and approve feedback that has been submitted for sessions at their event. The link will go directly to the Feedback list table where the organizer can approve/trash/spam each feedback submission.

Refs #411 

### How to test the changes in this Pull Request:

1. On local dev, go to WC Central's [Organizer Reminders screen](https://central.wordcamp.test/wp-admin/edit.php?post_type=organizer-reminder).
1. Create a new reminder, add some content that includes the new `[session_feedback_list_url]` placeholder.
1. On the sidebar, select a test WordCamp site, check the box to manually send the email, and Update.
1. In [MailCatcher](http://localhost:1080/) you should see an email come in. The placeholder should be replaced with the full URL of the Feedback screen for the WordCamp site that you picked.
