### PR TITLE
Speaker Feedback: Add feedback rendering helper functions

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -7,7 +7,7 @@ use WP_Comments_List_Table;
 use function WordCamp\SpeakerFeedback\get_assets_path;
 use function WordCamp\SpeakerFeedback\Admin\feedback_bubble;
 use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
-use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_questions;
+use function WordCamp\SpeakerFeedback\View\{ render_feedback_comment, render_feedback_rating };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
@@ -173,24 +173,7 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	 * @return void
 	 */
 	public function column_feedback( $comment ) {
-		$feedback  = get_feedback_comment( $comment );
-		$questions = get_feedback_questions( $feedback->version );
-
-		foreach ( $questions as $key => $question ) {
-			if ( 'rating' === $key ) {
-				continue;
-			}
-
-			$answer = $feedback->$key;
-
-			if ( $answer ) {
-				printf(
-					'<p class="speaker-feedback__question">%s</p><p class="speaker-feedback__answer">%s</p>',
-					wp_kses_data( $question ),
-					wp_kses_data( $answer )
-				);
-			}
-		}
+		render_feedback_comment( $comment );
 	}
 
 	/**
@@ -201,32 +184,7 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	 * @return void
 	 */
 	public function column_rating( $comment ) {
-		$feedback = get_feedback_comment( $comment );
-
-		$rating      = $feedback->rating;
-		$max_stars   = 5;
-		$star_output = 0;
-		?>
-		<span class="screen-reader-text">
-			<?php
-			printf(
-				esc_html__( '%d stars', 'wordcamporg' ),
-				absint( $rating )
-			);
-			?>
-		</span>
-		<span class="speaker-feedback__meta-rating">
-			<?php while ( $star_output < $max_stars ) :
-				$class = ( $star_output < $rating ) ? 'star__full' : 'star__empty';
-				?>
-				<span class="star <?php echo esc_attr( $class ); ?>">
-					<?php require get_assets_path() . 'svg/star.svg'; ?>
-				</span>
-				<?php
-				$star_output ++;
-			endwhile; ?>
-		</span>
-		<?php
+		render_feedback_rating( $comment );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WordCamp\SpeakerFeedback\Form;
+namespace WordCamp\SpeakerFeedback\View;
 
 use WP_Post, WP_Query;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -3,7 +3,8 @@
 namespace WordCamp\SpeakerFeedback\View;
 
 use WP_Post, WP_Query;
-use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url };
+use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
+use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
 use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_questions;
 use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
@@ -101,6 +102,94 @@ function render( $content ) {
 	}
 
 	return $content;
+}
+
+/**
+ * Render a single feedback comment to a human-readable HTML string.
+ *
+ * @param WP_Comment|Feedback|string|int $comment A comment/feedback object or a comment ID.
+ * @param bool                           $echo    Whether to echo the output or return it. Default true.
+ *
+ * @return string The feedback in a question-answer HTML display (or empty string).
+ */
+function render_feedback_comment( $comment, $echo = true ) {
+	$feedback  = get_feedback_comment( $comment );
+	$questions = get_feedback_questions( $feedback->version );
+	$output    = '';
+
+	foreach ( $questions as $key => $question ) {
+		if ( 'rating' === $key ) {
+			continue;
+		}
+
+		$answer = $feedback->$key;
+
+		if ( $answer ) {
+			$output .= sprintf(
+				'<p class="speaker-feedback__question">%s</p><p class="speaker-feedback__answer">%s</p>',
+				wp_kses_data( $question ),
+				wp_kses_data( $answer )
+			);
+		}
+	}
+
+	if ( ! $echo ) {
+		return $output;
+	}
+
+	echo $output; // phpcs:ignore -- sanitized above.
+}
+
+/**
+ * Render the star rating for a given feedback comment.
+ *
+ * @param WP_Comment|Feedback|string|int $comment A comment/feedback object or a comment ID.
+ * @param bool                           $echo    Whether to echo the output or return it. Default true.
+ *
+ * @return string The feedback rating stars in HTML.
+ */
+function render_feedback_rating( $comment, $echo = true ) {
+	$feedback = get_feedback_comment( $comment );
+	$output   = render_rating_stars( $feedback->rating );
+
+	if ( ! $echo ) {
+		return $output;
+	}
+
+	echo $output; // phpcs:ignore -- sanitized in `render_rating_stars`.
+}
+
+/**
+ * Render a rating of X out of Y stars. Used by `render_feedback_rating`.
+ *
+ * @param int $rating    The selected rating value (stars below this will be "filled").
+ * @param int $max_stars The total rating value (will render this many stars).
+ *
+ * @return string The feedback rating stars in HTML.
+ */
+function render_rating_stars( $rating, $max_stars = 5 ) {
+	$star_output = 0;
+	$label = sprintf(
+		_n( '%d star', '%d stars', $rating, 'wordcamporg' ),
+		absint( $rating )
+	);
+
+	ob_start();
+	?>
+	<span role="img" aria-label="<?php echo esc_attr( $label ); ?>" class="speaker-feedback__meta-rating">
+		<?php while ( $star_output < $max_stars ) :
+			$class = ( $star_output < $rating ) ? 'star__full' : 'star__empty';
+			?>
+			<span class="star <?php echo esc_attr( $class ); ?>">
+				<?php require get_assets_path() . 'svg/star.svg'; ?>
+			</span>
+			<?php
+			$star_output++;
+		endwhile; ?>
+	</span>
+	<?php
+
+	return ob_get_clean();
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -46,11 +46,11 @@ function load() {
 	require_once get_includes_path() . 'capabilities.php';
 	require_once get_includes_path() . 'comment.php';
 	require_once get_includes_path() . 'comment-meta.php';
-	require_once get_includes_path() . 'form.php';
 	require_once get_includes_path() . 'page.php';
 	require_once get_includes_path() . 'post.php';
 	require_once get_includes_path() . 'query.php';
 	require_once get_includes_path() . 'spam.php';
+	require_once get_includes_path() . 'view.php';
 
 	require_once get_includes_path() . 'admin.php';
 }


### PR DESCRIPTION
This adds three functions that can be reused by the front & back end when viewing feedback, `render_rating_stars`, `render_feedback_rating`, and `render_feedback_comment`. The frontend doesn't exist yet, so this updates the list table view to use these new functions. 

There should be no visual changes, the only markup change is for screen reader interaction. The star container is now an "image", so that we can label it as one unit and prevent screen readers from accidentally interacting with the raw SVGs.

See #347 

(another PR for the frontend view is in progress 🙂  )

### How to test the changes in this Pull Request:

1. View the Sessions -> Feedback table
2. It should look the same as on `production`, content should have questions & answers, rating should have the star ratings

Optionally, check the accessibility:
- use browser dev tools to check the accessibility information of the star container & stars
- Or use a screen reader & move through the list table to hear how the ratings are labelled
