### PR TITLE
Tools: Use composer's phpunit to run tests on travis

### DIFF
--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -47,6 +47,7 @@ function main() {
 
 		foreach ( $affected_files as $record ) {
 			list( $change, $file ) = explode( "\t", trim( $record ) );
+			$cmd_status = 0;
 
 			switch ( $change ) {
 				case 'M':

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:
         - composer run-script test-version
+        - composer run-script test-which
         - composer run-script test -- -c phpunit.xml.dist
 
     - name: "PHP Code Standards"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
 php: 7.2
-env: WP_VERSION=latest WP_MULTISITE=1
+env: WP_VERSION=latest WP_MULTISITE=1 COMPOSER_BIN_DIR=$TRAVIS_BUILD_DIR/public_html/wp-content/mu-plugins/vendor/bin
 services:
   - mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,8 @@ jobs:
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:
-        - composer run-script test-version
-        - composer run-script test-which
-        - composer run-script test -- -c phpunit.xml.dist
+        - $HOME/.composer/vendor/bin/phpunit --version
+        - $HOME/.composer/vendor/bin/phpunit -c phpunit.xml.dist
 
     - name: "PHP Code Standards"
       # Only run if we're on the "pull request build", otherwise the diffs are empty.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
     - name: "PHP Unit Tests"
       install:
         - bash .docker/bin/install-wp-tests.sh wcorg_test root '' localhost $WP_VERSION
-        - composer install
+        - composer install --ignore-platform-reqs
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,12 @@ jobs:
 
     - name: "PHP Unit Tests"
       install:
-        - bash .docker/bin/install-wp-tests.sh wcorg_test root '' localhost $WP_VERSION
-        - composer install --ignore-platform-reqs
+        - |
+          # Install WP Test suite, install PHPUnit globally:
+          if [[ ! -z "$WP_VERSION" ]]; then
+            bash .docker/bin/install-wp-tests.sh wcorg_test root '' localhost $WP_VERSION
+            composer global require "phpunit/phpunit=5.7.*|7.5.*"
+          fi
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
 php: 7.2
-env: WP_VERSION=latest WP_MULTISITE=1 COMPOSER_BIN_DIR=$TRAVIS_BUILD_DIR/public_html/wp-content/mu-plugins/vendor/bin
+env: WP_VERSION=latest WP_MULTISITE=1
 services:
   - mysql
 
@@ -34,6 +34,7 @@ jobs:
 
     - name: "PHP Unit Tests"
       install:
+        - export PATH="$HOME/.composer/vendor/bin:$PATH"
         - |
           # Install WP Test suite, install PHPUnit globally:
           if [[ ! -z "$WP_VERSION" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ jobs:
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:
-        - which phpunit
-        - phpunit --version
+        - composer run-script test-version
         - composer run-script test -- -c phpunit.xml.dist
 
     - name: "PHP Code Standards"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ jobs:
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:
+        - which phpunit
+        - phpunit --version
         - composer run-script test -- -c phpunit.xml.dist
 
     - name: "PHP Code Standards"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,18 +34,17 @@ jobs:
 
     - name: "PHP Unit Tests"
       install:
-        - export PATH="$HOME/.composer/vendor/bin:$PATH"
         - |
           # Install WP Test suite, install PHPUnit globally:
           if [[ ! -z "$WP_VERSION" ]]; then
             bash .docker/bin/install-wp-tests.sh wcorg_test root '' localhost $WP_VERSION
-            composer global require "phpunit/phpunit=5.7.*|7.5.*"
+            composer install
           fi
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:
-        - $HOME/.composer/vendor/bin/phpunit --version
-        - $HOME/.composer/vendor/bin/phpunit -c phpunit.xml.dist
+        - ./public_html/wp-content/mu-plugins/vendor/bin/phpunit --version
+        - ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist
 
     - name: "PHP Code Standards"
       # Only run if we're on the "pull request build", otherwise the diffs are empty.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,11 @@ jobs:
 
     - name: "PHP Unit Tests"
       install:
-        - |
-          # Install WP Test suite, install PHPUnit globally:
-          if [[ ! -z "$WP_VERSION" ]]; then
-            bash .docker/bin/install-wp-tests.sh wcorg_test root '' localhost $WP_VERSION
-            composer install
-          fi
+        - bash .docker/bin/install-wp-tests.sh wcorg_test root '' localhost $WP_VERSION
+        - composer install
         # We need Jetpack installed
         - svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
       script:
-        - ./public_html/wp-content/mu-plugins/vendor/bin/phpunit --version
         - ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist
 
     - name: "PHP Code Standards"

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"lint": "phpcs",
 		"test": "phpunit",
 		"test-version": "phpunit --version",
+		"test-which": "which phpunit",
 		"phpcs-changed": "phpcs-changed",
 		"_comment": "Below script names left in for back-compat",
 		"phpcs": "phpcs",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"format": "phpcbf -p",
 		"lint": "phpcs",
 		"test": "phpunit",
+		"test-version": "phpunit --version",
 		"phpcs-changed": "phpcs-changed",
 		"_comment": "Below script names left in for back-compat",
 		"phpcs": "phpcs",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,6 @@
 		"format": "phpcbf -p",
 		"lint": "phpcs",
 		"test": "phpunit",
-		"test-version": "phpunit --version",
-		"test-which": "which phpunit",
 		"phpcs-changed": "phpcs-changed",
 		"_comment": "Below script names left in for back-compat",
 		"phpcs": "phpcs",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
 		"platform": {
 			"php": "7.2"
 		},
-		"bin-dir": "vendor/bin",
 		"vendor-dir": "public_html/wp-content/mu-plugins/vendor",
 		"_comment": "Work around `test:watch` timeout, see https://github.com/spatie/phpunit-watcher/issues/63#issuecomment-545633709",
 		"process-timeout": 0

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 		"platform": {
 			"php": "7.2"
 		},
+		"bin-dir": "vendor/bin",
 		"vendor-dir": "public_html/wp-content/mu-plugins/vendor",
 		"_comment": "Work around `test:watch` timeout, see https://github.com/spatie/phpunit-watcher/issues/63#issuecomment-545633709",
 		"process-timeout": 0


### PR DESCRIPTION
Call the locally installed (via composer) version of phpunit directly, avoiding any version conflicts with the travis-bundled version.

Previously, travis was using `/home/travis/.phpenv/versions/7.2.15/bin/phpunit`, which was version 8.0.2, causing an error with the WordPress test suite:

```
Error: Looks like you're using PHPUnit 8.0.2. WordPress is currently only compatible with PHPUnit up to 7.x.
Please use the latest PHPUnit version from the 7.x branch.
```

This is fixed by using the composer-installed version, which is fixed to the 7.x branch.

### How to test the changes in this Pull Request:

Make sure travis passes ✅ 
