### PR TITLE
Tools: Adjust phpcs-branch to use accurate data for phpcs-changed

### DIFF
--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -20,7 +20,7 @@ function run_phpcs( $file, $bin_dir ) {
 function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
 	$name = basename( $file );
 	exec( "$git diff $base_branch HEAD $file > $name.diff" );
-	exec( "$git show HEAD:$file | $bin_dir/phpcs --standard=./phpcs.xml.dist --report=json -nq > $name.orig.phpcs" );
+	exec( "$git show $base_branch:$file | $bin_dir/phpcs --standard=./phpcs.xml.dist --report=json -nq > $name.orig.phpcs" );
 	exec( "cat $file | $bin_dir/phpcs --standard=./phpcs.xml.dist --report=json -nq > $name.phpcs" );
 	
 	$cmd = "$bin_dir/phpcs-changed --diff $name.diff --phpcs-orig $name.orig.phpcs --phpcs-new $name.phpcs";

--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -22,7 +22,7 @@ function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
 	exec( "$git diff $base_branch HEAD $file > $name.diff" );
 	exec( "$git show $base_branch:$file | $bin_dir/phpcs --standard=./phpcs.xml.dist --report=json -nq > $name.orig.phpcs" );
 	exec( "cat $file | $bin_dir/phpcs --standard=./phpcs.xml.dist --report=json -nq > $name.phpcs" );
-	
+
 	$cmd = "$bin_dir/phpcs-changed --diff $name.diff --phpcs-orig $name.orig.phpcs --phpcs-new $name.phpcs";
 	exec( $cmd, $output, $exec_exit_status );
 	echo implode( "\n", $output );

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-status.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-status.php
@@ -138,8 +138,6 @@ class WordCamp_Status extends Base_Status {
 				);
 			}
 		}
-
-		$asdf='asdf' ;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-status.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-status.php
@@ -138,6 +138,8 @@ class WordCamp_Status extends Base_Status {
 				);
 			}
 		}
+
+		$asdf='asdf' ;
 	}
 
 	/**


### PR DESCRIPTION
The command to create the phpcs report for the "original" file for comparison with the changes in the branch was using `$git show HEAD:$file`. So it was actually pulling the report for the current branch instead of the base branch.

### How to test the changes in this Pull Request:

1. When this PR is opened, the Travis build should fail for coding standards. It should show three errors for a file that actually has quite a few more.
1. When I add another commit to fix those errors, the build should pass!
