### PR TITLE
Speaker Feedback: Display feedback to session speakers

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -72,6 +72,23 @@
 			} );
 	}
 
+	function onHelpfulClick( event ) {
+		event.preventDefault();
+		var button = event.target;
+		var isHelpful = 'true' === button.getAttribute( 'aria-pressed' );
+
+		wp.apiFetch( {
+			path: '/wordcamp-speaker-feedback/v1/feedback/' + button.dataset.commentId,
+			method: 'POST',
+			data: {
+				meta: { helpful: isHelpful ? 'false' : 'true' },
+			},
+		} )
+			.then( function() {
+				button.setAttribute( 'aria-pressed', isHelpful ? 'false' : 'true' );
+			} );
+	}
+
 	var navForm = document.getElementById( 'sft-navigation' );
 	if ( navForm ) {
 		navForm.addEventListener( 'submit', onFormNavigate, true );
@@ -80,6 +97,13 @@
 	var feedbackForm = document.getElementById( 'sft-feedback' );
 	if ( feedbackForm ) {
 		feedbackForm.addEventListener( 'submit', onFormSubmit, true );
+	}
+
+	var helpfulButtons = document.querySelectorAll( '.speaker-feedback__helpful button' );
+	if ( helpfulButtons.length ) {
+		helpfulButtons.forEach( function( el ) {
+			el.addEventListener( 'click', onHelpfulClick, true );
+		} );
 	}
 
 	// Submit the form if any value changes.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -81,4 +81,9 @@
 	if ( feedbackForm ) {
 		feedbackForm.addEventListener( 'submit', onFormSubmit, true );
 	}
+
+	// Submit the form if any value changes.
+	$( '#sft-filter-sort, #sft-filter-helpful' ).change( function( event ) {
+		$( event.target ).closest( 'form' ).submit();
+	} );
 }( jQuery ) );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -147,46 +147,18 @@
 	}
 }
 
+
 /**
- * WP Dashboard: Feedback list table.
+ * Question/answer display.
  */
 
-.column-name {
-	img {
-		float: left;
-		margin-right: 10px;
-		margin-top: 1px;
-	}
-}
-
-#comments-form {
-	.fixed {
-		.column-name {
-			width: 15%;
-		}
-
-		.column-rating {
-			width: 140px;
-		}
-	}
+.speaker-feedback__question {
+	margin-bottom: 0.5em;
+	font-weight: 700;
 }
 
 /**
- * WP Dashboard: Question/answer display.
- */
-
-.widefat td {
-	p.speaker-feedback__question {
-		font-weight: 700;
-	}
-
-	p.speaker-feedback__answer {
-		margin-bottom: 2em;
-	}
-}
-
-/**
- * WP Dashboard: Rating display.
+ * Rating display.
  */
 
 .speaker-feedback__meta-rating {
@@ -201,11 +173,45 @@
 		fill: currentColor;
 	}
 
-	span.star__full {
+	.star {
+		display: inline-block;
+	}
+
+	.star__full {
 		color: $star-selected;
 	}
 
-	span.star__empty {
+	.star__empty {
 		color: $star-default;
+	}
+}
+
+/**
+ * WP Dashboard: Feedback list table.
+ */
+
+.column-name {
+	img {
+		float: left;
+		margin-right: 10px;
+		margin-top: 1px;
+	}
+}
+
+.column-feedback {
+	.speaker-feedback__answer {
+		margin-bottom: 2em;
+	}
+}
+
+#comments-form {
+	.fixed {
+		.column-name {
+			width: 15%;
+		}
+
+		.column-rating {
+			width: 140px;
+		}
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -152,7 +152,7 @@
  */
 
 .speaker-feedback__overview {
-	margin-bottom: 4rem;
+	margin-bottom: 2rem;
 
 	strong {
 		margin-right: 5px;
@@ -164,22 +164,33 @@
  */
 
 .speaker-feedback__filters {
-	display: flex;
+	display: -ms-grid;
+	display: grid;
+	-ms-grid-columns: auto 1fr;
+	grid-template-columns: auto 1fr;
 	align-items: center;
 	margin-bottom: 4rem;
 
 	.speaker-feedback__filter-sort {
 		display: flex;
+		-ms-grid-column: 1;
+		grid-column: 1;
 		align-items: center;
 		margin-right: 1em;
 
 		label { // stylelint-disable-line no-descending-specificity
 			margin-bottom: 0;
+			min-width: 4em;
 		}
 
 		select {
 			margin-left: 0.5em;
 		}
+	}
+
+	.speaker-feedback__filter-helpful {
+		-ms-grid-column: 2;
+		grid-column: 2;
 	}
 
 	@media (max-width: 600px) {
@@ -208,6 +219,7 @@
  */
 
 .speaker-feedback__helpful {
+	margin-top: 1em;
 	padding: 1rem 1.5rem;
 	background: #ddd;
 	border-radius: 5px;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -147,6 +147,91 @@
 	}
 }
 
+/**
+ * Speaker view: Session overview.
+ */
+
+.speaker-feedback__overview {
+	margin-bottom: 4rem;
+
+	strong {
+		margin-right: 5px;
+	}
+}
+
+/**
+ * Speaker view: Feedback filters.
+ */
+
+.speaker-feedback__filters {
+	display: flex;
+	align-items: center;
+	margin-bottom: 4rem;
+
+	.speaker-feedback__filter-sort {
+		display: flex;
+		align-items: center;
+		margin-right: 1em;
+
+		label {
+			margin-bottom: 0;
+		}
+
+		select {
+			margin-left: 0.5em;
+		}
+	}
+
+	@media (max-width: 600px) {
+		display: block;
+
+		.speaker-feedback__filter-sort {
+			margin-bottom: 1em;
+		}
+	}
+}
+
+/**
+ * Speaker view: Feedback in list.
+ */
+
+.speaker-feedback__comment {
+	margin-bottom: 4rem;
+}
+
+.speaker-feedback__comment-content {
+	margin-top: 1em;
+}
+
+/**
+ * Speaker view: "Is this helpful" form.
+ */
+
+.speaker-feedback__helpful {
+	padding: 1rem 1.5rem;
+	background: #ddd;
+	border-radius: 5px;
+	max-width: 460px;
+
+	form {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	button {
+		display: inline-block;
+		font-size: 1.2em;
+		letter-spacing: 0;
+		line-height: 1.25;
+		margin: 0 0 0 1em;
+		padding: 0.4em 0.8em;
+		text-align: center;
+		text-decoration: none;
+		text-transform: none;
+		word-wrap: normal;
+	}
+}
 
 /**
  * Question/answer display.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -173,7 +173,7 @@
 		align-items: center;
 		margin-right: 1em;
 
-		label {
+		label { // stylelint-disable-line no-descending-specificity
 			margin-bottom: 0;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -211,13 +211,10 @@
 	padding: 1rem 1.5rem;
 	background: #ddd;
 	border-radius: 5px;
-	max-width: 460px;
-
-	form {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
+	max-width: 30em;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 
 	button {
 		display: inline-block;
@@ -230,6 +227,14 @@
 		text-decoration: none;
 		text-transform: none;
 		word-wrap: normal;
+
+		&[aria-pressed="true"]::before {
+			content: "✓ ";
+		}
+
+		&[aria-pressed="false"]::before {
+			content: "";
+		}
 	}
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -67,7 +67,7 @@ class Walker_Feedback extends Walker_Comment {
 		$comment_id = $comment->comment_ID;
 
 		?>
-		<div <?php comment_class( '', $comment ); ?>>
+		<div <?php comment_class( 'speaker-feedback__comment', $comment ); ?>>
 			<article id="speaker-feedback-<?php echo absint( $comment_id ); ?>" class="speaker-feedback__comment-body comment-body">
 				<header class="speaker-feedback__comment-meta comment-meta">
 					<div class="speaker-feedback__comment-author comment-author vcard">
@@ -95,7 +95,7 @@ class Walker_Feedback extends Walker_Comment {
 					<?php render_feedback_comment( $comment ); ?>
 				</div><!-- .comment-content -->
 
-				<footer class="speaker-feedback__comment-meta comment-meta">
+				<footer class="speaker-feedback__helpful">
 					<form>
 						<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
 							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -96,18 +96,17 @@ class Walker_Feedback extends Walker_Comment {
 				</div><!-- .comment-content -->
 
 				<footer class="speaker-feedback__helpful">
-					<form>
-						<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
-							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
-						</span>
-						<button
-							type="submit"
-							aria-pressed="<?php echo ( $comment->helpful ) ? 'true' : 'false'; ?>"
-							aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
-						>
-							<?php esc_html_e( 'Yes' ); ?>
-						</button>
-					</form>
+					<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
+						<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
+					</span>
+					<button
+						type="button"
+						data-comment-id="<?php echo absint( $comment_id ); ?>"
+						aria-pressed="<?php echo ( $comment->helpful ) ? 'true' : 'false'; ?>"
+						aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
+					>
+						<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
+					</button>
 				</footer>
 			</article><!-- .comment-body -->
 		<?php

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback;
+
+use Walker_Comment;
+use function WordCamp\SpeakerFeedback\View\{ render_feedback_comment, render_feedback_rating };
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Walker_Feedback.
+ *
+ * Render feedback submissions on the frontend of the site.
+ */
+class Walker_Feedback extends Walker_Comment {
+	/**
+	 * What the class handles.
+	 *
+	 * @var string
+	 */
+	public $tree_type = COMMENT_TYPE;
+
+	/**
+	 * Starts the element output.
+	 *
+	 * @global int        $comment_depth
+	 * @global WP_Comment $comment       Global comment object.
+	 *
+	 * @param string     $output  Used to append additional content. Passed by reference.
+	 * @param WP_Comment $comment Comment data object.
+	 * @param int        $depth   Optional. Depth of the current comment in reference to parents. Default 0.
+	 * @param array      $args    Optional. An array of arguments. Default empty array.
+	 * @param int        $id      Optional. ID of the current comment. Default 0 (unused).
+	 */
+	public function start_el( &$output, $comment, $depth = 0, $args = array(), $id = 0 ) {
+		$depth++;
+		$GLOBALS['comment_depth'] = $depth; // phpcs:ignore
+		$GLOBALS['comment']       = $comment; // phpcs:ignore
+
+		ob_start();
+		$this->render_feedback( $comment, $depth, $args );
+		$output .= ob_get_clean();
+	}
+
+	/**
+	 * Ends the element output, if needed.
+	 *
+	 * @param string     $output  Used to append additional content. Passed by reference.
+	 * @param WP_Comment $comment The current comment object. Default current comment.
+	 * @param int        $depth   Optional. Depth of the current comment. Default 0.
+	 * @param array      $args    Optional. An array of arguments. Default empty array.
+	 */
+	public function end_el( &$output, $comment, $depth = 0, $args = array() ) {
+		$output .= "</div><!-- #comment-## -->\n";
+	}
+
+	/**
+	 * Outputs a feedback submission.
+	 *
+	 * @param WP_Comment $comment Comment to display.
+	 * @param int        $depth   Depth of the current comment.
+	 * @param array      $args    An array of arguments.
+	 */
+	protected function render_feedback( $comment, $depth, $args ) {
+		$commenter = wp_get_current_commenter();
+		$comment_id = $comment->comment_ID;
+
+		?>
+		<div <?php comment_class( '', $comment ); ?>>
+			<article id="speaker-feedback-<?php echo absint( $comment_id ); ?>" class="speaker-feedback__comment-body comment-body">
+				<header class="speaker-feedback__comment-meta comment-meta">
+					<div class="speaker-feedback__comment-author comment-author vcard">
+						<?php
+						if ( 0 != $args['avatar_size'] ) {
+							echo get_avatar( $comment_id, $args['avatar_size'] );
+						}
+						?>
+						<?php printf( '<b class="fn">%s</b>', get_comment_author_link( $comment_id ) ); ?>
+					</div><!-- .comment-author -->
+
+					<div class="speaker-feedback__comment-metadata comment-metadata">
+						<time datetime="<?php echo esc_attr( get_comment_date( 'c', $comment_id ) ); ?>">
+							<?php
+								echo esc_html( get_comment_date( '', $comment_id ) );
+							?>
+						</time>
+					</div><!-- .comment-metadata -->
+				</header><!-- .comment-meta -->
+
+				<div class="speaker-feedback__comment-content comment-content">
+					<p class="speaker-feedback__question"><?php esc_html_e( 'Rating', 'wordcamporg' ); ?></p>
+					<p class="speaker-feedback__answer"><?php render_feedback_rating( $comment ); ?></p>
+
+					<?php render_feedback_comment( $comment ); ?>
+				</div><!-- .comment-content -->
+
+				<footer class="speaker-feedback__comment-meta comment-meta">
+					<form>
+						<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
+							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
+						</span>
+						<button
+							type="submit"
+							aria-pressed="<?php echo ( $comment->helpful ) ? 'true' : 'false'; ?>"
+							aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
+						>
+							<?php esc_html_e( 'Yes' ); ?>
+						</button>
+					</form>
+				</footer>
+			</article><!-- .comment-body -->
+		<?php
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -180,24 +180,25 @@ function update_feedback( $comment_id, array $feedback_meta ) {
  * @param array $post__in   Optional. An array of post IDs whose feedback comments should be included. An empty array
  *                          will include all posts. Default empty.
  * @param array $status     Optional. An array of statuses to include in the results.
- * @param array $meta_query Optional. A valid `WP_Meta_Query` array.
+ * @param array $args       Optional. Additional args to be passed to get_comments.
  *
  * @return array A collection of WP_Comment objects.
  */
-function get_feedback( array $post__in = array(), array $status = array( 'hold', 'approve' ), array $meta_query = array() ) {
-	$args = array(
-		'status'  => $status,
-		'type'    => COMMENT_TYPE,
-		'orderby' => 'comment_date',
-		'order'   => 'asc',
+function get_feedback( array $post__in = array(), array $status = array( 'hold', 'approve' ), array $args = array() ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'orderby' => 'comment_date',
+			'order'   => 'asc',
+		)
 	);
+
+	// Set up these fixed args.
+	$args['status'] = $status;
+	$args['type']   = COMMENT_TYPE;
 
 	if ( ! empty( $post__in ) ) {
 		$args['post__in'] = $post__in;
-	}
-
-	if ( ! empty( $meta_query ) ) {
-		$args['meta_query'] = $meta_query;
 	}
 
 	$comments = get_comments( $args );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -8,6 +8,7 @@ use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
 use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_questions;
 use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
 
 defined( 'WPINC' ) || die();
@@ -42,7 +43,13 @@ function render( $content ) {
 
 	$now = date_create( 'now', wp_timezone() );
 
-	if ( has_feedback_form() ) {
+	if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post->ID ) ) {
+		ob_start();
+
+		require get_views_path() . 'view-feedback.php';
+
+		$content = $content . ob_get_clean(); // Append feedback to the normal content.
+	} elseif ( has_feedback_form() ) {
 		$accepts_feedback = post_accepts_feedback( $post->ID );
 
 		ob_start();

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -4,7 +4,7 @@ namespace WordCamp\SpeakerFeedback\View;
 
 use WP_Post, WP_Query;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
-use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
+use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, get_feedback_comment };
 use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_questions;
 use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
@@ -45,6 +45,25 @@ function render( $content ) {
 
 	if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post->ID ) ) {
 		ob_start();
+
+		$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ) );
+		$avg_rating = 0;
+
+		if ( count( $feedback ) ) {
+			$sum_rating = array_reduce(
+				$feedback,
+				function( $carry, $item ) {
+					$carry += absint( $item->rating );
+					return $carry;
+				},
+				0
+			);
+			$avg_rating = round( $sum_rating / count( $feedback ) );
+		}
+
+		$feedback_count = count_feedback( $post->ID );
+		$approved       = absint( $feedback_count['approved'] );
+		$moderated      = absint( $feedback_count['moderated'] );
 
 		require get_views_path() . 'view-feedback.php';
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -43,53 +43,53 @@ function render( $content ) {
 
 	$now = date_create( 'now', wp_timezone() );
 
-	if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post->ID ) ) {
-		ob_start();
+	if ( has_feedback_form() ) {
+		if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post->ID ) ) {
+			ob_start();
 
-		$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ) );
-		$avg_rating = 0;
+			$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ) );
+			$avg_rating = 0;
 
-		if ( count( $feedback ) ) {
-			$sum_rating = array_reduce(
-				$feedback,
-				function( $carry, $item ) {
-					$carry += absint( $item->rating );
-					return $carry;
+			if ( count( $feedback ) ) {
+				$sum_rating = array_reduce(
+					$feedback,
+					function( $carry, $item ) {
+						$carry += absint( $item->rating );
+						return $carry;
+					},
+					0
+				);
+				$avg_rating = round( $sum_rating / count( $feedback ) );
+			}
+
+			$feedback_count = count_feedback( $post->ID );
+			$approved       = absint( $feedback_count['approved'] );
+			$moderated      = absint( $feedback_count['moderated'] );
+
+			require get_views_path() . 'view-feedback.php';
+		} else {
+			$accepts_feedback = post_accepts_feedback( $post->ID );
+
+			ob_start();
+
+			if ( is_wp_error( $accepts_feedback ) ) {
+				$message = $accepts_feedback->get_error_message();
+				require get_views_path() . 'form-not-available.php';
+				return $content . ob_get_clean(); // Append the error message, return early.
+			}
+
+			$questions       = get_feedback_questions();
+			$rating_question = $questions['rating'];
+			$text_questions  = array_filter( array_map(
+				function( $key, $question ) {
+					return ( 'q' === $key[0] ) ? array( $key, $question ) : false;
 				},
-				0
-			);
-			$avg_rating = round( $sum_rating / count( $feedback ) );
+				array_keys( $questions ),
+				$questions
+			) );
+
+			require get_views_path() . 'form-feedback.php';
 		}
-
-		$feedback_count = count_feedback( $post->ID );
-		$approved       = absint( $feedback_count['approved'] );
-		$moderated      = absint( $feedback_count['moderated'] );
-
-		require get_views_path() . 'view-feedback.php';
-
-		$content = $content . ob_get_clean(); // Append feedback to the normal content.
-	} elseif ( has_feedback_form() ) {
-		$accepts_feedback = post_accepts_feedback( $post->ID );
-
-		ob_start();
-
-		if ( is_wp_error( $accepts_feedback ) ) {
-			$message = $accepts_feedback->get_error_message();
-			require get_views_path() . 'form-not-available.php';
-			return $content . ob_get_clean(); // Append the error message, return early.
-		}
-
-		$questions       = get_feedback_questions();
-		$rating_question = $questions['rating'];
-		$text_questions  = array_filter( array_map(
-			function( $key, $question ) {
-				return ( 'q' === $key[0] ) ? array( $key, $question ) : false;
-			},
-			array_keys( $questions ),
-			$questions
-		) );
-
-		require get_views_path() . 'form-feedback.php';
 
 		$content = $content . ob_get_clean(); // Append form to the normal content.
 	} elseif ( is_page( get_option( OPTION_KEY ) ) ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -6,7 +6,7 @@ use WP_Post, WP_Query;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
 use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, get_feedback_comment };
 use function WordCamp\SpeakerFeedback\CommentMeta\get_feedback_questions;
-use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
+use function WordCamp\SpeakerFeedback\Post\{ get_session_speaker_user_ids, post_accepts_feedback };
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
@@ -44,7 +44,8 @@ function render( $content ) {
 	$now = date_create( 'now', wp_timezone() );
 
 	if ( has_feedback_form() ) {
-		if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post->ID ) ) {
+		$session_speakers = get_session_speaker_user_ids( $post->ID );
+		if ( in_array( get_current_user_id(), $session_speakers, true ) ) {
 			ob_start();
 
 			$query_args = parse_feedback_args();

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -47,7 +47,8 @@ function render( $content ) {
 		if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post->ID ) ) {
 			ob_start();
 
-			$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ) );
+			$query_args = parse_feedback_args();
+			$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ), $query_args );
 			$avg_rating = 0;
 
 			if ( count( $feedback ) ) {
@@ -128,6 +129,45 @@ function render( $content ) {
 	}
 
 	return $content;
+}
+
+/**
+ * Parse the GET args to the feedback list into WP_Comment_Query-friendly format.
+ *
+ * @return array Sorting & filtering args in WP_Comment_Query format.
+ */
+function parse_feedback_args() {
+	$args = array();
+
+	if ( isset( $_GET['forder'] ) ) {
+		switch ( $_GET['forder'] ) {
+			case 'newest':
+				$args['orderby'] = 'comment_date';
+				$args['order']   = 'desc';
+				break;
+			case 'highest':
+				$args['orderby'] = 'meta_value_num';
+				$args['meta_key'] = 'rating';
+				$args['order'] = 'desc';
+				break;
+			case 'oldest':
+			default:
+				$args['orderby'] = 'comment_date';
+				$args['order']   = 'asc';
+				break;
+		}
+	}
+
+	if ( isset( $_GET['helpful'] ) && 'yes' === $_GET['helpful'] ) {
+		$args['meta_query'] = array(
+			array(
+				'key'     => 'helpful',
+				'value'   => '1',
+			),
+		);
+	}
+
+	return $args;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -3,24 +3,80 @@
 namespace WordCamp\SpeakerFeedback\View;
 
 use WordCamp\SpeakerFeedback\Walker_Feedback;
-use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
-use function WordCamp\SpeakerFeedback\get_assets_path;
-use function WordCamp\SpeakerFeedback\Comment\get_feedback;
+use function WordCamp\SpeakerFeedback\View\render_rating_stars;
 
 defined( 'WPINC' ) || die();
+
+$approved_string = '';
+$moderated_string = '';
+if ( $approved > 0 ) {
+	$approved_string = sprintf( _n( '%d submission', '%d submissions', $approved, 'wordcamporg' ), $approved );
+}
+if ( $moderated > 0 ) {
+	$moderated_string = sprintf(
+		_n( '%d submission pending', '%d submissions pending', $moderated, 'wordcamporg' ),
+		$moderated
+	);
+}
+
+if ( '' === $approved_string || '' === $moderated_string ) {
+	$count_string = $approved_string . $moderated_string; // One is empty, so this does not need a separator.
+} else {
+	// Translators: Combined string of X submussions, Y submissions pending.
+	$count_string = sprintf( __( '%1$s, %2$s', 'wordcamporg' ), $approved_string, $moderated_string );
+}
 
 ?>
 <hr />
 <div class="speaker-feedback">
-	<?php
-	$feedback = get_feedback( array( get_the_ID() ), array( 'approve' ) );
-	wp_list_comments(
-		array(
-			// Note: `Walker_Feedback` does not support the callback or format args.
-			'walker' => new Walker_Feedback(),
-			'style' => 'div',
-		),
-		$feedback
-	);
-	?>
+	<h3><?php esc_html_e( 'Session Feedback', 'wordcamporg' ); ?></h3>
+
+	<?php if ( $approved >= 1 ) : ?>
+		<div class="speaker-feedback__overview">
+			<strong><?php esc_html_e( 'Overall rating:', 'wordcamporg' ); ?></strong>
+			<?php echo render_rating_stars( $avg_rating ); //phpcs:ignore -- escaped in function. ?>
+
+			<p><?php echo esc_html( $count_string ); ?></p>
+		</div>
+
+		<div class="speaker-feedback__filters">
+			<div class="speaker-feedback__filter-sort">
+				<label for="sft-filter-sort">
+					<?php esc_html_e( 'Sort by', 'wordcamporg' ); ?>
+				</label>
+				<select id="sft-filter-sort">
+					<option><?php esc_html_e( 'Oldest first', 'wordcamporg' ); ?></option>
+					<option><?php esc_html_e( 'Newest first', 'wordcamporg' ); ?></option>
+					<option><?php esc_html_e( 'Highest rated first', 'wordcamporg' ); ?></option>
+				</select>
+			</div>
+			<div class="speaker-feedback__filter-helpful">
+				<label>
+					<input type="checkbox" />
+					<?php esc_html_e( 'Only show comments marked as helpful', 'wordcamporg' ); ?>
+				</label>
+			</div>
+		</div>
+
+		<div class="speaker-feedback__list comment-list">
+			<?php
+			wp_list_comments(
+				array(
+					// Note: `Walker_Feedback` does not support the callback or format args.
+					'walker' => new Walker_Feedback(),
+					'style' => 'div',
+				),
+				$feedback
+			);
+			?>
+		</div>
+	<?php elseif ( $moderated >= 1 ) : ?>
+		<div class="speaker-feedback__overview">
+			<p><?php echo esc_html( $count_string ); ?></p>
+		</div>
+	<?php else : ?>
+		<div class="speaker-feedback__overview">
+			<p><?php echo esc_html_e( 'No feedback has been submitted yet.', 'wordcamporg' ); ?></p>
+		</div>
+	<?php endif; ?>
 </div>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\View;
+
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+use function WordCamp\SpeakerFeedback\get_assets_path;
+use function WordCamp\SpeakerFeedback\Comment\get_feedback;
+
+defined( 'WPINC' ) || die();
+
+?>
+<hr />
+<div class="speaker-feedback">
+	<?php
+	$feedback = get_feedback( array( get_the_ID() ), array( 'approve' ) );
+	wp_list_comments(
+		array(
+			// Custom Walker? JS & API?
+		),
+		$feedback
+	);
+	?>
+</div>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -68,7 +68,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 						id="sft-filter-helpful"
 						<?php checked( $show_helpful ); ?>
 					/>
-					<?php esc_html_e( 'Only show comments marked as helpful', 'wordcamporg' ); ?>
+					<?php esc_html_e( 'Only show feedback marked as helpful', 'wordcamporg' ); ?>
 				</label>
 			</div>
 			<input type="submit" class="screen-reader-text" value="Filter" />

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -32,7 +32,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 ?>
 <hr />
 <div class="speaker-feedback">
-	<h3><?php esc_html_e( 'Session Feedback', 'wordcamporg' ); ?></h3>
+	<h2><?php esc_html_e( 'Session Feedback', 'wordcamporg' ); ?></h2>
 
 	<?php if ( $approved >= 1 ) : ?>
 		<div class="speaker-feedback__overview">

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -26,6 +26,9 @@ if ( '' === $approved_string || '' === $moderated_string ) {
 	$count_string = sprintf( __( '%1$s, %2$s', 'wordcamporg' ), $approved_string, $moderated_string );
 }
 
+$show_helpful = isset( $_GET['helpful'] ) && 'yes' === $_GET['helpful'];
+$show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
+
 ?>
 <hr />
 <div class="speaker-feedback">
@@ -39,24 +42,37 @@ if ( '' === $approved_string || '' === $moderated_string ) {
 			<p><?php echo esc_html( $count_string ); ?></p>
 		</div>
 
-		<div class="speaker-feedback__filters">
+		<form action="" method="get" class="speaker-feedback__filters">
 			<div class="speaker-feedback__filter-sort">
 				<label for="sft-filter-sort">
 					<?php esc_html_e( 'Sort by', 'wordcamporg' ); ?>
 				</label>
-				<select id="sft-filter-sort">
-					<option><?php esc_html_e( 'Oldest first', 'wordcamporg' ); ?></option>
-					<option><?php esc_html_e( 'Newest first', 'wordcamporg' ); ?></option>
-					<option><?php esc_html_e( 'Highest rated first', 'wordcamporg' ); ?></option>
+				<select id="sft-filter-sort" name="forder">
+					<option <?php selected( $show_order, 'oldest' ); ?> value="oldest">
+						<?php esc_html_e( 'Oldest first', 'wordcamporg' ); ?>
+					</option>
+					<option <?php selected( $show_order, 'newest' ); ?> value="newest">
+						<?php esc_html_e( 'Newest first', 'wordcamporg' ); ?>
+					</option>
+					<option <?php selected( $show_order, 'highest' ); ?> value="highest">
+						<?php esc_html_e( 'Highest rated first', 'wordcamporg' ); ?>
+					</option>
 				</select>
 			</div>
 			<div class="speaker-feedback__filter-helpful">
 				<label>
-					<input type="checkbox" />
+					<input
+						name="helpful"
+						type="checkbox"
+						value="yes"
+						id="sft-filter-helpful"
+						<?php checked( $show_helpful ); ?>
+					/>
 					<?php esc_html_e( 'Only show comments marked as helpful', 'wordcamporg' ); ?>
 				</label>
 			</div>
-		</div>
+			<input type="submit" class="screen-reader-text" value="Filter" />
+		</form>
 
 		<div class="speaker-feedback__list comment-list">
 			<?php

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\SpeakerFeedback\View;
 
+use WordCamp\SpeakerFeedback\Walker_Feedback;
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use function WordCamp\SpeakerFeedback\get_assets_path;
 use function WordCamp\SpeakerFeedback\Comment\get_feedback;
@@ -15,7 +16,9 @@ defined( 'WPINC' ) || die();
 	$feedback = get_feedback( array( get_the_ID() ), array( 'approve' ) );
 	wp_list_comments(
 		array(
-			// Custom Walker? JS & API?
+			// Note: `Walker_Feedback` does not support the callback or format args.
+			'walker' => new Walker_Feedback(),
+			'style' => 'div',
 		),
 		$feedback
 	);

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -43,6 +43,7 @@ if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_
 function load() {
 	require_once get_includes_path() . 'class-feedback.php';
 	require_once get_includes_path() . 'class-rest-feedback-controller.php';
+	require_once get_includes_path() . 'class-walker-feedback.php';
 	require_once get_includes_path() . 'capabilities.php';
 	require_once get_includes_path() . 'comment.php';
 	require_once get_includes_path() . 'comment-meta.php';


### PR DESCRIPTION
When a session's speaker views the feedback URL, switch out the feedback form for a list of approved feedback. The speaker can sort by date & rating, and toggle only the helpful feedback. They can also mark each feedback as helpful (or un-mark it, by clicking the button again).

Fixes #347 

### Screenshots

On Twenty Twenty:
![-ZDHUZlMAl](https://user-images.githubusercontent.com/541093/79018287-725cda80-7b41-11ea-9c8e-d882f532f6dc.png)

[See screenshots from other themes here](https://cloudup.com/c22cZShSide)

### How to test the changes in this Pull Request:

1. Make sure you have some feedback approved on a session
2. Make sure the session has an attached speaker, and that speaker has the wp.org profile filled in to a real user on the network
3. Logged in as that user, view `your-session/feedback`
4. You should see the list of approved feedback
5. You should be able to sort the feedback using the filters at the top of the page
6. You should be able to mark feedback as helpful (need to be a user on the site too, until #425 is fixed)
7. It should say how many approved feedback + how many pending, or "No feedback has been submitted yet."

Try it with different sessions— one with no feedback submitted, or only pending, or you're not a speaker on, etc.

