### PR TITLE
Speaker Feedback: Improve flow when marking/unmarking feedback helpfulness

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -74,8 +74,8 @@
 
 	function onHelpfulClick( event ) {
 		event.preventDefault();
-		var button = event.target;
-		var isHelpful = 'true' === button.getAttribute( 'aria-pressed' );
+		var button = $( event.target ).closest( 'button' ).get( 0 );
+		var isHelpful = 'is-helpful' === button.className;
 
 		wp.apiFetch( {
 			path: '/wordcamp-speaker-feedback/v1/feedback/' + button.dataset.commentId,
@@ -85,7 +85,16 @@
 			},
 		} )
 			.then( function() {
-				button.setAttribute( 'aria-pressed', isHelpful ? 'false' : 'true' );
+				$( button ).toggleClass( 'is-helpful' );
+				var $label = $( '#' + button.getAttribute( 'aria-describedby' ) );
+				if ( isHelpful ) {
+					// Previous state was helpful, has been un-marked, label should flip back to "mark as helpful".
+					wp.a11y.speak( SpeakerFeedbackData.messages.unmarkedHelpful, 'polite' );
+					$label.text( SpeakerFeedbackData.messages.markHelpful );
+				} else {
+					wp.a11y.speak( SpeakerFeedbackData.messages.markedHelpful, 'polite' );
+					$label.text( SpeakerFeedbackData.messages.unmarkHelpful );
+				}
 			} );
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -73,27 +73,24 @@
 	}
 
 	function onHelpfulClick( event ) {
-		event.preventDefault();
-		var button = $( event.target ).closest( 'button' ).get( 0 );
-		var isHelpful = 'is-helpful' === button.className;
+		var $container = $( event.target ).closest( 'footer' );
+		var input = $container.find( 'input[type="checkbox"]' ).get( 0 );
+		var isHelpful = !! input.checked;
 
 		wp.apiFetch( {
-			path: '/wordcamp-speaker-feedback/v1/feedback/' + button.dataset.commentId,
+			path: '/wordcamp-speaker-feedback/v1/feedback/' + input.dataset.commentId,
 			method: 'POST',
 			data: {
 				meta: { helpful: isHelpful ? 'false' : 'true' },
 			},
 		} )
 			.then( function() {
-				$( button ).toggleClass( 'is-helpful' );
-				var $label = $( '#' + button.getAttribute( 'aria-describedby' ) );
+				$container.toggleClass( 'is-helpful' );
 				if ( isHelpful ) {
 					// Previous state was helpful, has been un-marked, label should flip back to "mark as helpful".
-					wp.a11y.speak( SpeakerFeedbackData.messages.unmarkedHelpful, 'polite' );
-					$label.text( SpeakerFeedbackData.messages.markHelpful );
-				} else {
 					wp.a11y.speak( SpeakerFeedbackData.messages.markedHelpful, 'polite' );
-					$label.text( SpeakerFeedbackData.messages.unmarkHelpful );
+				} else {
+					wp.a11y.speak( SpeakerFeedbackData.messages.unmarkedHelpful, 'polite' );
 				}
 			} );
 	}
@@ -108,7 +105,7 @@
 		feedbackForm.addEventListener( 'submit', onFormSubmit, true );
 	}
 
-	var helpfulButtons = document.querySelectorAll( '.speaker-feedback__helpful button' );
+	var helpfulButtons = document.querySelectorAll( '.speaker-feedback__helpful input' );
 	if ( helpfulButtons.length ) {
 		helpfulButtons.forEach( function( el ) {
 			el.addEventListener( 'click', onHelpfulClick, true );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -233,7 +233,14 @@
 	}
 
 	label { // stylelint-disable-line no-descending-specificity
+		margin-bottom: 0;
 		font-size: 1em;
+		display: flex;
+		align-items: center;
+
+		input {
+			margin-right: 6px;
+		}
 	}
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -221,42 +221,19 @@
 .speaker-feedback__helpful {
 	margin-top: 1em;
 	padding: 1rem 1.5rem;
-	background: #ddd;
+	background: #d5d5d5;
 	border-radius: 5px;
 	max-width: 30em;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 
-	button {
-		display: inline-block;
-		font-size: 1.2em;
-		letter-spacing: 0;
-		line-height: 1.25;
-		margin: 0 0 0 1em;
-		padding: 0.4em 0.8em;
-		text-align: center;
-		text-decoration: none;
-		text-transform: none;
-		word-wrap: normal;
+	&.is-helpful {
+		border: 2px solid currentColor;
+	}
 
-		.speaker-feedback__helpful-msg-helpful {
-			display: none;
-		}
-
-		.speaker-feedback__helpful-msg-neutral {
-			display: inline;
-		}
-
-		&.is-helpful {
-			.speaker-feedback__helpful-msg-helpful {
-				display: inline;
-			}
-
-			.speaker-feedback__helpful-msg-neutral {
-				display: none;
-			}
-		}
+	label { // stylelint-disable-line no-descending-specificity
+		font-size: 1em;
 	}
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -240,12 +240,22 @@
 		text-transform: none;
 		word-wrap: normal;
 
-		&[aria-pressed="true"]::before {
-			content: "✓ ";
+		.speaker-feedback__helpful-msg-helpful {
+			display: none;
 		}
 
-		&[aria-pressed="false"]::before {
-			content: "";
+		.speaker-feedback__helpful-msg-neutral {
+			display: inline;
+		}
+
+		&.is-helpful {
+			.speaker-feedback__helpful-msg-helpful {
+				display: inline;
+			}
+
+			.speaker-feedback__helpful-msg-neutral {
+				display: none;
+			}
 		}
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -98,15 +98,24 @@ class Walker_Feedback extends Walker_Comment {
 
 				<footer class="speaker-feedback__helpful">
 					<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
-						<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
+						<?php if ( $comment->helpful ) : ?>
+							<?php esc_html_e( 'This feedback was marked helpful.', 'wordcamporg' ); ?>
+						<?php else : ?>
+							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
+						<?php endif; ?>
 					</span>
 					<button
 						type="button"
 						data-comment-id="<?php echo absint( $comment_id ); ?>"
-						aria-pressed="<?php echo ( $comment->helpful ) ? 'true' : 'false'; ?>"
+						class="<?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>"
 						aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
 					>
-						<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
+						<span class="speaker-feedback__helpful-msg-neutral">
+							<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
+						</span>
+						<span class="speaker-feedback__helpful-msg-helpful">
+							<?php esc_html_e( 'Remove', 'wordcamporg' ); ?>
+						</span>
 					</button>
 				</footer>
 			</article><!-- .comment-body -->

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -96,26 +96,18 @@ class Walker_Feedback extends Walker_Comment {
 					<?php render_feedback_comment( $comment ); ?>
 				</div><!-- .comment-content -->
 
-				<footer class="speaker-feedback__helpful">
+				<footer class="speaker-feedback__helpful <?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>">
 					<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
-						<?php if ( $comment->helpful ) : ?>
-							<?php esc_html_e( 'This feedback was marked helpful.', 'wordcamporg' ); ?>
-						<?php else : ?>
-							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
-						<?php endif; ?>
+						<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
 					</span>
-					<button
-						type="button"
-						data-comment-id="<?php echo absint( $comment_id ); ?>"
-						class="<?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>"
-						aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
-					>
-						<span class="speaker-feedback__helpful-msg-neutral">
-							<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
-						</span>
-						<span class="speaker-feedback__helpful-msg-helpful">
-							<?php esc_html_e( 'Remove', 'wordcamporg' ); ?>
-						</span>
+					<label>
+						<input
+							type="checkbox"
+							data-comment-id="<?php echo absint( $comment_id ); ?>"
+							aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
+							<?php checked( $comment->helpful ); ?>
+						/>
+						<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
 					</button>
 				</footer>
 			</article><!-- .comment-body -->

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -284,8 +284,6 @@ function enqueue_assets() {
 				'submitSuccess'   => __( 'Feedback submitted.', 'wordcamporg' ),
 				'markedHelpful'   => __( 'Feedback marked as helpful.', 'wordcamporg' ),
 				'unmarkedHelpful' => __( 'Feedback unmarked as helpful.', 'wordcamporg' ),
-				'markHelpful'     => __( 'Was this feedback helpful?', 'wordcamporg' ),
-				'unmarkHelpful'   => __( 'This feedback was marked helpful.', 'wordcamporg' ),
 			),
 		);
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -274,14 +274,18 @@ function enqueue_assets() {
 		wp_enqueue_script(
 			'speaker-feedback',
 			get_assets_url() . 'js/script.js',
-			array( 'wp-api-fetch', 'jquery' ),
+			array( 'wp-api-fetch', 'jquery', 'wp-a11y' ),
 			filemtime( dirname( __DIR__ ) . '/assets/js/script.js' ),
 			true
 		);
 
 		$data = array(
 			'messages' => array(
-				'submitSuccess' => __( 'Feedback submitted.', 'wordcamporg' ),
+				'submitSuccess'   => __( 'Feedback submitted.', 'wordcamporg' ),
+				'markedHelpful'   => __( 'Feedback marked as helpful.', 'wordcamporg' ),
+				'unmarkedHelpful' => __( 'Feedback unmarked as helpful.', 'wordcamporg' ),
+				'markHelpful'     => __( 'Was this feedback helpful?', 'wordcamporg' ),
+				'unmarkHelpful'   => __( 'This feedback was marked helpful.', 'wordcamporg' ),
 			),
 		);
 


### PR DESCRIPTION
The feedback UI implemented in #428 was a little confusing when it comes to toggling helpfulness of feedback. We only have "helpful" and "neutral" states, so we don't want to imply it's possible to mark comments as unhelpful. Now feedback submissions show different action labels reflecting whether they're helpful or neutral, and clicking the button makes it more obvious what will happen in either state. This also adds a `speak` notification, so that screen reader users will hear that a change has happened.

Fixes #430 

### Screenshots

Default/neutral feedback gets the actionable question:

![neutral](https://user-images.githubusercontent.com/541093/79160923-9f5ef680-7da8-11ea-85e4-634ba3874396.png)

Helpful feedback gets the status label + "Remove" button:

![helpful](https://user-images.githubusercontent.com/541093/79160933-a2f27d80-7da8-11ea-9fd0-92502eb44814.png)

Screen reader users will hear status updates when the API request finishes:

```
Feedback marked as helpful.
```

```
Feedback unmarked as helpful
```

@enriquesanchez This is a bit different than what you designed in #347, so I'd like your 👍 / 👎  Also open to different copy for labels & screen reader content. 🙂 

### How to test the changes in this Pull Request:

0. Build the branch with `yarn workspace wordcamp-speaker-feedback build`
1. Make sure you have some feedback approved on a session
2. Make sure the session has an attached speaker, and that speaker has the wp.org profile filled in to a real user on the network
3. Logged in as that user, view your-session/feedback
4. You should see the list of approved feedback
5. Mark & unmark some feedback submissions
6. The labels should update shown above
7. Reload the page, and each marked feedback should display correctly
8. Try with a screen reader, you should hear "Feedback marked as helpful"/"Feedback unmarked as helpful".
