### PR TITLE
Speaker Feedback: Add "inappropriate" comment status for feedback that is not spam but should not be sent to the speaker

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -200,6 +200,14 @@
 			margin-bottom: 1em;
 		}
 	}
+
+	.inappropriate {
+		th {
+			&.check-column {
+				border-left: 4px solid #ffb900;
+			}
+		}
+	}
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -200,20 +200,6 @@
 			margin-bottom: 1em;
 		}
 	}
-
-	.inappropriate {
-		th {
-			&.check-column {
-				border-left: 4px solid #ffb900;
-			}
-		}
-
-		.row-actions {
-			.unapprove {
-				display: none;
-			}
-		}
-	}
 }
 
 /**
@@ -328,6 +314,20 @@
 
 		.column-rating {
 			width: 140px;
+		}
+	}
+
+	.inappropriate {
+		th {
+			&.check-column {
+				border-left: 4px solid #ffb900;
+			}
+		}
+
+		.row-actions {
+			.unapprove {
+				display: none;
+			}
 		}
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -207,6 +207,12 @@
 				border-left: 4px solid #ffb900;
 			}
 		}
+
+		.row-actions {
+			.unapprove {
+				display: none;
+			}
+		}
 	}
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -48,6 +48,43 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	}
 
 	/**
+	 * Add more bulk actions.
+	 *
+	 * @return array
+	 */
+	protected function get_bulk_actions() {
+		$bulk_actions = parent::get_bulk_actions();
+
+		global $comment_status;
+
+		$key_indexes = array_keys( $bulk_actions );
+		$slice_index = array_search( 'spam', $key_indexes, true );
+		$new_actions = array();
+
+		if ( in_array( $comment_status, array( 'all', 'moderated' ) ) ) {
+			$new_actions['mark-inappropriate'] = __( 'Mark as Inappropriate', 'wordcamporg' );
+		}
+
+		if ( in_array( $comment_status, array( 'all', 'inappropriate' ) ) ) {
+			$new_actions['unmark-inappropriate'] = __( 'Unmark as Inappropriate', 'wordcamporg' );
+
+			if ( false === $slice_index ) {
+				$slice_index = 0;
+				$new_actions['spam'] = _x( 'Mark as Spam', 'comment' );
+			}
+		}
+
+		if ( false !== $slice_index && ! empty( $new_actions ) ) {
+			$after  = array_slice( $bulk_actions, $slice_index, null, true );
+			$before = array_slice( $bulk_actions, 0, count( $bulk_actions ) - count( $after ), true );
+
+			$bulk_actions = $before + $new_actions + $after;
+		}
+
+		return $bulk_actions;
+	}
+
+	/**
 	 * Other controls above/below the list table besides bulk actions.
 	 *
 	 * @param string $which

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -61,11 +61,11 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 		$slice_index = array_search( 'spam', $key_indexes, true );
 		$new_actions = array();
 
-		if ( in_array( $comment_status, array( 'all', 'moderated' ) ) ) {
+		if ( in_array( $comment_status, array( 'all', 'approved', 'moderated' ) ) ) {
 			$new_actions['mark-inappropriate'] = __( 'Mark as Inappropriate', 'wordcamporg' );
 		}
 
-		if ( in_array( $comment_status, array( 'all', 'inappropriate' ) ) ) {
+		if ( in_array( $comment_status, array( 'inappropriate' ) ) ) {
 			$new_actions['unmark-inappropriate'] = __( 'Unmark as Inappropriate', 'wordcamporg' );
 
 			if ( false === $slice_index ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -378,15 +378,17 @@ function count_helpful_feedback( $post_id = 0 ) {
 		$post__in[] = absint( $post_id );
 	}
 
-	$meta_query = array(
-		array(
-			'key'   => 'helpful',
-			'value' => 1,
-			'type'  => 'NUMERIC',
+	$args = array(
+		'meta_query' => array(
+			array(
+				'key'   => 'helpful',
+				'value' => 1,
+				'type'  => 'NUMERIC',
+			),
 		),
 	);
 
-	$feedbacks = get_feedback( $post__in, array( 'hold', 'approve' ), $meta_query );
+	$feedbacks = get_feedback( $post__in, array( 'hold', 'approve' ), $args );
 
 	$helpful_count = 0;
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -3,6 +3,7 @@
 namespace WordCamp\SpeakerFeedback\CommentMeta;
 
 use WP_Error;
+use function WordCamp\SpeakerFeedback\Comment\get_feedback;
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
@@ -362,4 +363,38 @@ function get_feedback_questions( $version = META_VERSION ) {
 	}
 
 	return $questions;
+}
+
+/**
+ * Count feedback comments marked as helpful for a specific post or overall.
+ *
+ * @param int $post_id
+ *
+ * @return int
+ */
+function count_helpful_feedback( $post_id = 0 ) {
+	$post__in = array();
+	if ( $post_id ) {
+		$post__in[] = absint( $post_id );
+	}
+
+	$meta_query = array(
+		array(
+			'key'   => 'helpful',
+			'value' => 1,
+			'type'  => 'NUMERIC',
+		),
+	);
+
+	$feedbacks = get_feedback( $post__in, array( 'hold', 'approve' ), $meta_query );
+
+	$helpful_count = 0;
+
+	foreach ( $feedbacks as $feedback ) {
+		if ( $feedback->helpful ) {
+			$helpful_count ++;
+		}
+	}
+
+	return $helpful_count;
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -78,7 +78,6 @@ function count_feedback( $post_id = 0 ) {
 			case 'inappropriate':
 				$feedback_count['inappropriate']   = $row['total'];
 				$feedback_count['total_comments'] += $row['total'];
-				$feedback_count['all']            += $row['total'];
 				break;
 			default:
 				break;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -2,7 +2,7 @@
 
 namespace WordCamp\SpeakerFeedback\Comment;
 
-use WP_Comment;
+use WP_Comment, WP_Error;
 use WordCamp\SpeakerFeedback\Feedback;
 
 defined( 'WPINC' ) || die();
@@ -45,6 +45,7 @@ function count_feedback( $post_id = 0 ) {
 	$feedback_count = array(
 		'approved'       => 0,
 		'moderated'      => 0, // Originally this was `awaiting_moderation` but it doesn't appear that it is used.
+		'inappropriate'  => 0, // This one is custom.
 		'spam'           => 0,
 		'trash'          => 0,
 		'post-trashed'   => 0,
@@ -71,6 +72,11 @@ function count_feedback( $post_id = 0 ) {
 				break;
 			case '0':
 				$feedback_count['moderated']       = $row['total'];
+				$feedback_count['total_comments'] += $row['total'];
+				$feedback_count['all']            += $row['total'];
+				break;
+			case 'inappropriate':
+				$feedback_count['inappropriate']   = $row['total'];
 				$feedback_count['total_comments'] += $row['total'];
 				$feedback_count['all']            += $row['total'];
 				break;
@@ -221,4 +227,45 @@ function get_feedback( array $post__in = array(), array $status = array( 'hold',
  */
 function delete_feedback( $comment_id, $force_delete = false ) {
 	return wp_delete_comment( $comment_id, $force_delete );
+}
+
+/**
+ * Mark a feedback comment as inappropriate.
+ *
+ * @param int|WP_Comment $comment_id Comment ID or WP_Comment object.
+ *
+ * @return bool
+ */
+function mark_feedback_inappropriate( $comment_id ) {
+	$comment = get_comment( $comment_id );
+	if ( ! $comment || ! is_feedback( $comment ) ) {
+		return false;
+	}
+
+	$result = wp_update_comment( array(
+		'comment_ID'       => $comment->comment_ID,
+		'comment_approved' => 'inappropriate',
+	) );
+
+	return wp_validate_boolean( $result );
+}
+
+/**
+ * Change a feedback comment status from inappropriate back to hold.
+ *
+ * @param int|WP_Comment $comment_id Comment ID or WP_Comment object.
+ *
+ * @return bool|WP_Error
+ */
+function unmark_feedback_inappropriate( $comment_id ) {
+	$comment = get_comment( $comment_id );
+	if ( ! $comment || ! is_feedback( $comment ) ) {
+		return false;
+	}
+
+	if ( 'inappropriate' !== $comment->comment_approved ) {
+		return false;
+	}
+
+	return wp_set_comment_status( $comment->comment_ID, 'hold' );
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
@@ -8,6 +8,7 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 defined( 'WPINC' ) || die();
 
 add_action( 'pre_get_comments', __NAMESPACE__ . '\pre_get_comments', 99 );
+add_action( 'comments_clauses', __NAMESPACE__ . '\comments_clauses', 10, 2 );
 
 /**
  * Only return feedback comments from the query when that type is specifically called for.
@@ -37,4 +38,25 @@ function pre_get_comments( &$query_ref ) {
 	}
 
 	$query_ref->query_vars['type__not_in'] = $type_vars['type__not_in'];
+}
+
+/**
+ * Include custom statuses when 'all' is the status query argument.
+ *
+ * @param array            $clauses
+ * @param WP_Comment_Query $query
+ *
+ * @return string|string[]
+ */
+function comments_clauses( $clauses, $query ) {
+	$status = $query->query_vars['status'];
+	$status = (array) $status; // $query is passed by reference, don't want to alter it.
+
+	if ( in_array( 'all', $status, true ) || in_array( '', $status, true ) ) {
+		$search  = "( comment_approved = '0' OR comment_approved = '1' )";
+		$replace = "( comment_approved = '0' OR comment_approved = '1' OR comment_approved = 'inappropriate' )";
+		$clauses = str_replace( $search, $replace, $clauses );
+	}
+
+	return $clauses;
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
@@ -8,7 +8,6 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 defined( 'WPINC' ) || die();
 
 add_action( 'pre_get_comments', __NAMESPACE__ . '\pre_get_comments', 99 );
-add_action( 'comments_clauses', __NAMESPACE__ . '\comments_clauses', 10, 2 );
 
 /**
  * Only return feedback comments from the query when that type is specifically called for.
@@ -38,25 +37,4 @@ function pre_get_comments( &$query_ref ) {
 	}
 
 	$query_ref->query_vars['type__not_in'] = $type_vars['type__not_in'];
-}
-
-/**
- * Include custom statuses when 'all' is the status query argument.
- *
- * @param array            $clauses
- * @param WP_Comment_Query $query
- *
- * @return string|string[]
- */
-function comments_clauses( $clauses, $query ) {
-	$status = $query->query_vars['status'];
-	$status = (array) $status; // $query is passed by reference, don't want to alter it.
-
-	if ( in_array( 'all', $status, true ) || in_array( '', $status, true ) ) {
-		$search  = "( comment_approved = '0' OR comment_approved = '1' )";
-		$replace = "( comment_approved = '0' OR comment_approved = '1' OR comment_approved = 'inappropriate' )";
-		$clauses = str_replace( $search, $replace, $clauses );
-	}
-
-	return $clauses;
 }


### PR DESCRIPTION
This shoehorns in a custom comment status, despite WP Core's best efforts to prevent it. Feedback comments can be marked as `inappropriate` via bulk editing in the list table. A new list table view shows just feedback marked with this new status, along with a total count.

At this point it does not include row actions for asynchronously marking/unmarking feedbacks as inappropriate, because I haven't been able to find a way to make it work with the existing **edit-comments.js** implementation (somewhat related: #432). @ryelle maybe you'd be able to take a crack at this? Could be in a subsequent PR.

It also adds a list table view for feedbacks that the speaker has marked as "helpful".

Fixes #414 

### Screenshots

Marking a feedback as "inappropriate" via bulk edit

![bulk-edit-inappropriate](https://user-images.githubusercontent.com/916023/79281986-d72d7300-7e68-11ea-9e30-7746148a8c12.jpg)

Viewing all feedbacks that have been marked as "inappropriate"

![view-inappropriate](https://user-images.githubusercontent.com/916023/79281993-db599080-7e68-11ea-9468-60e954c6bec7.jpg)

### How to test the changes in this Pull Request:

1. Create some feedbacks.
1. On the Feedbacks list table, check the box for one or more feedbacks and select "Mark as Inappropriate" from the bulk edit select. Click Apply.
1. The screen will refresh. The selected feedback(s) should now have an orange left border (instead of the red used for unapproved comments). The view links and the comment bubbles should have updated counts.
1. Click on the "Inappropriate" view link. You should see a list table containing only "inappropriate" feedbacks.
1. Mark a few feedbacks as "helpful".
1. Back on the list table screen, click the "Helpful" view link. You should see a list table containing only "helpful" feedbacks.
