### PR TITLE
WC Post Type: Remove protected status for `_wcpt_` meta keys

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -14,6 +14,7 @@ require_once 'favorite-schedule-shortcode.php';
 
 add_action( 'init', __NAMESPACE__ . '\register_sponsor_post_meta' );
 add_action( 'init', __NAMESPACE__ . '\register_session_post_meta' );
+add_action( 'is_protected_meta', __NAMESPACE__ . '\unprotect_wcpt_meta', 10, 2 );
 
 /**
  * Registers post meta to the Sponsor post type.
@@ -108,6 +109,19 @@ function register_session_post_meta() {
 			'single'       => false,
 		)
 	);
+}
+
+/**
+ * Flip our CPT meta out of "protected", so that users can edit the meta values.
+ *
+ * @param bool   $protected Whether the key is considered protected.
+ * @param string $meta_key  Metadata key.
+ */
+function unprotect_wcpt_meta( $protected, $meta_key ) {
+	if ( '_wcpt_' === substr( $meta_key, 0, 6 ) ) {
+		return false;
+	}
+	return $protected;
 }
 
 /**


### PR DESCRIPTION
By default, meta that starts with `_` is considered "protected", and can't be edited by anyone but superadmins. Our wcpt meta should be editable by anyone who can create content, so it needs to be moved out of the protected status.

Fixes #435 

I've opted to allow all `_wcpt_` values vs creating an allowed-list, since this could come up again in future CPT improvements. Switching the meta to unprotected does not allow them to be viewed in the API by default- still only those we set `show_in_rest` for are exposed. The only impact this has is on the classic editor's Custom Fields section, and that'll be phased out as each CPT is gutenberg-ified. If there are edge cases I've missed, I'm open to making an allowed-list, though.

⚠️ There's a bug that seems to happen when there are duplicate meta values. Happened to me on the 2014.seattle test data, but I spot checked a few production sites and didn't see it (including 2014.seattle). I'm assuming it's a local import bug, but something to watch for when testing.

```
Updating failed. Could not update the meta value of _wcpt_session_type in database.
```

### How to test the changes in this Pull Request:

1. Create a new session, fill out some or all of the meta
2. It should publish
3. Try editing an existing post, you should be able to update the meta & save.
4. Repeat as a different user level: `contributor`, `author`, `editor`, `admin`
