### PR TITLE
Add block for embedding YouTube live chat

### DIFF
--- a/public_html/wp-content/mu-plugins/virtual-embeds/package.json
+++ b/public_html/wp-content/mu-plugins/virtual-embeds/package.json
@@ -19,11 +19,8 @@
 		"root": "Setting this to true is necessary to avoid merging WordCamp.org configs with any that exist in parent folders in the developer's environment. See https://github.com/eslint/eslint/commit/c99e9b621fe46b8535cf59fe489977dd36cb2a39."
 	},
 	"eslintConfig": {
-		"extends": "plugin:@wordpress/eslint-plugin/recommended-with-formatting",
-		"root": true,
-		"rules": {
-			"object-shorthand": [ "error", "consistent-as-needed" ]
-		}
+		"extends": "../blocks/.eslintrc.js",
+		"root": true
 	},
 	"scripts": {
 		"start": "wp-scripts start",

--- a/public_html/wp-content/plugins/wc-post-types/package.json
+++ b/public_html/wp-content/plugins/wc-post-types/package.json
@@ -27,12 +27,9 @@
 	},
 	"eslintConfig": {
 		"root": true,
-		"extends": "plugin:@wordpress/eslint-plugin/recommended",
+		"extends": "../../mu-plugins/blocks/.eslintrc.js",
 		"globals": {
 			"WCPT_Session_Defaults": "true"
-		},
-		"rules": {
-			"object-shorthand": [ "error", "consistent-as-needed" ]
 		}
 	}
 }


### PR DESCRIPTION
This will help organizers who want to use YouTube as their streaming platform.

Testing is pretty straight-forward. `youtube-live-chat.js` has some notes at the top about examples of good URLs to test with.

![Screen Shot 2020-04-15 at 17 46 08](https://user-images.githubusercontent.com/484068/79402573-247d1380-7f41-11ea-9461-c723e59d0d07.png)