### PR TITLE
Speaker Feedback: Add custom cap to speakers for viewing their own sessions

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/capabilities.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/capabilities.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\SpeakerFeedback\Capabilities;
 
+use WP_User;
 use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
 use function WordCamp\SpeakerFeedback\Post\get_session_speaker_user_ids;
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
@@ -9,6 +10,7 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 defined( 'WPINC' ) || die();
 
 add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_meta_caps', 10, 4 );
+add_filter( 'user_has_cap', __NAMESPACE__ . '\add_caps', 10, 4 );
 
 /**
  * Determine capabilities needed for various feedback operations.
@@ -36,7 +38,7 @@ function map_meta_caps( $user_caps, $current_cap, $user_id, $args = array() ) {
 			// Current user is a speaker for the session receiving feedback comments.
 			$session_speakers = get_session_speaker_user_ids( $feedback->comment_post_ID );
 			if ( in_array( $user_id, $session_speakers, true ) ) {
-				$required_caps[] = 'read';
+				$required_caps[] = $current_cap;
 
 				// The speaker can only read approved comments, unless they already can edit them.
 				$can_edit = user_can( $user_id, 'edit_comment', $feedback->comment_ID );
@@ -67,7 +69,7 @@ function map_meta_caps( $user_caps, $current_cap, $user_id, $args = array() ) {
 			// Current user is a speaker for the session receiving feedback comments.
 			$session_speakers = get_session_speaker_user_ids( $post->ID );
 			if ( in_array( $user_id, $session_speakers, true ) ) {
-				$required_caps[] = 'read';
+				$required_caps[] = $current_cap;
 				break;
 			}
 
@@ -85,4 +87,51 @@ function map_meta_caps( $user_caps, $current_cap, $user_id, $args = array() ) {
 	}
 
 	return $user_caps;
+}
+
+/**
+ * Add new capabilities to a user for some feedback operations.
+ *
+ * @param array   $allcaps The original list of caps for the given user.
+ * @param array   $caps    Unused.
+ * @param array   $args    Arguments that accompany the requested capability check.
+ * @param WP_User $user    The user object.
+ *
+ * @return array The modified list of caps for the given user.
+ */
+function add_caps( $allcaps, $caps, $args, $user ) {
+	$requested_cap = $args[0] ?? null;
+	$context       = $args[2] ?? null;
+
+	switch ( $requested_cap ) {
+		case 'read_' . COMMENT_TYPE:
+			// Context is a comment ID or object.
+			$feedback = get_feedback_comment( $context );
+			if ( is_null( $feedback ) ) {
+				break;
+			}
+
+			// Current user is a speaker for the session receiving feedback comments.
+			$session_speakers = get_session_speaker_user_ids( $feedback->comment_post_ID );
+			if ( in_array( $user->ID, $session_speakers, true ) ) {
+				$allcaps[ $requested_cap ] = true;
+			}
+			break;
+
+		case 'read_post_' . COMMENT_TYPE:
+			// Context is a post ID or object.
+			$post = get_post( $context );
+			if ( is_null( $post ) ) {
+				break;
+			}
+
+			// Current user is a speaker for the session receiving feedback comments.
+			$session_speakers = get_session_speaker_user_ids( $post->ID );
+			if ( in_array( $user->ID, $session_speakers, true ) ) {
+				$allcaps[ $requested_cap ] = true;
+			}
+			break;
+	}
+
+	return $allcaps;
 }


### PR DESCRIPTION
Instead of requiring the `read` capability for speakers when they are attempting to view the feedback on their sessions, require a custom capability instead. Then conditionally add that capability to the speaker user via a filter when the right conditions are met. This way the speaker user doesn't have to be a member of the site, they just need to be logged into the network.

Fixes #425 

### How to test the changes in this Pull Request:

1. Set up the following data:
  * A speaker post with a user ID of a user that is in the network, but not added to the site
  * A session post linking to that speaker
  * Add some feedback comments to the session and approve them
1. Log in to the network as the speaker user, and navigate to the feedback URL for their session
1. The feedback comments should be visible instead of the feedback form
1. Marking a feedback comment as "helpful" should succeed (this is what wasn't happening before)
