### PR TITLE
Speaker Feedback: Add a daily cron job to notify speakers of new feedback

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -143,6 +143,16 @@ function get_feedback_meta_field_schema( $context = 'all', $key = '' ) {
 			'default'           => false,
 			'required'          => false,
 		),
+		'speaker_notified' => array(
+			'sft_context'       => array( 'update' ),
+			'description'       => 'The speaker has been notified about this feedback.',
+			'type'              => 'boolean',
+			'single'            => true,
+			'sanitize_callback' => 'wp_validate_boolean',
+			'show_in_rest'      => false,
+			'default'           => false,
+			'required'          => false,
+		),
 	);
 
 	if ( 'all' !== $context ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment-meta.php
@@ -144,7 +144,7 @@ function get_feedback_meta_field_schema( $context = 'all', $key = '' ) {
 			'required'          => false,
 		),
 		'speaker_notified' => array(
-			'sft_context'       => array( 'update' ),
+			'sft_context'       => array( 'internal' ),
 			'description'       => 'The speaker has been notified about this feedback.',
 			'type'              => 'boolean',
 			'single'            => true,

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -76,7 +76,7 @@ function notify_speakers_approved_feedback() {
 				'feedback_ids' => $associated_feedbacks,
 				'title'        => get_the_title( $session_id ),
 				'count'        => count( $associated_feedbacks ),
-				'link'         => get_session_feedback_url( $session_id ),
+				'link'         => wp_login_url( get_session_feedback_url( $session_id ) ),
 			);
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -35,7 +35,11 @@ function notify_speakers_approved_feedback() {
 	$wordcamp_name = get_wordcamp_name( get_current_blog_id() );
 
 	$feedbacks       = get_unnotified_feedback();
-	$post_ids        = wp_list_pluck( $feedbacks, 'comment_post_ID', 'comment_ID' );
+	$post_ids        = array_combine(
+		// Using the 'index_key' parameter doesn't work here, maybe because the values are numeric?
+		wp_list_pluck( $feedbacks, 'comment_ID' ),
+		wp_list_pluck( $feedbacks, 'comment_post_ID' )
+	);
 	$unique_post_ids = array_unique( array_values( $post_ids ) );
 
 	$speaker_session_ids = array_reduce(

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -3,7 +3,7 @@
 namespace WordCamp\SpeakerFeedback\Cron;
 
 use function WordCamp\SpeakerFeedback\Comment\{ get_feedback, update_feedback };
-use function WordCamp\SpeakerFeedback\Post\get_session_speaker_user_ids;
+use function WordCamp\SpeakerFeedback\Post\{ get_session_speaker_user_ids, get_session_feedback_url };
 
 defined( 'WPINC' ) || die();
 
@@ -68,7 +68,7 @@ function notify_speakers_approved_feedback() {
 				'feedback_ids' => $associated_feedbacks,
 				'title'        => get_the_title( $session_id ),
 				'count'        => count( $associated_feedbacks ),
-				'link'         => trailingslashit( get_permalink( $session_id ) ) . 'feedback/',
+				'link'         => get_session_feedback_url( $session_id ),
 			);
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -60,11 +60,15 @@ function notify_speakers_approved_feedback() {
 	);
 
 	foreach ( $speaker_session_ids as $user_id => $session_ids ) {
-		$speaker       = get_user_by( 'id', $user_id );
+		$speaker = get_user_by( 'id', $user_id );
+		// Todo: Implement a UI for toggling this user meta value.
+		if ( true === $speaker->sft_speaker_notifications_opt_out ) {
+			continue;
+		}
+
 		$feedback_info = array(
 			'total_new' => 0,
 		);
-
 		foreach ( $session_ids as $session_id ) {
 			$associated_feedbacks = array_keys( $post_ids, $session_id );
 			$feedback_info['total_new'] += count( $associated_feedbacks );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -100,7 +100,12 @@ function notify_speakers_approved_feedback() {
 		foreach ( $feedback_info as $info ) {
 			$message .= sprintf(
 				// translators: 1. Number of new submissions. 2. Session title.
-				esc_html__( '%1$s new submissions on %2$s', 'wordcamporg' ),
+				esc_html( _n(
+					'%1$s new submission on %2$s',
+					'%1$s new submissions on %2$s',
+					$info['count'],
+					'wordcamporg'
+				) ),
 				number_format_i18n( $info['count'] ),
 				$info['title']
 			);

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -68,7 +68,7 @@ function notify_speakers_approved_feedback() {
 				'feedback_ids' => $associated_feedbacks,
 				'title'        => get_the_title( $session_id ),
 				'count'        => count( $associated_feedbacks ),
-				'link'         => trailingslashit( get_permalink( $session_id ) ) . 'feedback',
+				'link'         => trailingslashit( get_permalink( $session_id ) ) . 'feedback/',
 			);
 		}
 
@@ -107,7 +107,7 @@ function notify_speakers_approved_feedback() {
 
 		$message .= sprintf(
 			// translators: %s is the name of the WordCamp.
-			esc_html__( "Sincerely,\nthe %s organizing team", 'wordcamporg' ),
+			esc_html__( "Sincerely,\nThe %s organizing team", 'wordcamporg' ),
 			esc_html( $wordcamp_name )
 		);
 
@@ -116,7 +116,7 @@ function notify_speakers_approved_feedback() {
 		restore_current_locale();
 
 		if ( $result ) {
-			foreach ( $feedback_info['feedback_ids'] as $feedback_id ) {
+			foreach ( $info['feedback_ids'] as $feedback_id ) {
 				update_feedback(
 					$feedback_id,
 					array(

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -72,6 +72,9 @@ function notify_speakers_approved_feedback() {
 			);
 		}
 
+		$speaker_locale = get_user_locale( $speaker );
+		switch_to_locale( $speaker_locale );
+
 		$subject = sprintf(
 			// translators: 1. Number of feedback submissions. 2. WordCamp name.
 			esc_html( _n(
@@ -94,7 +97,7 @@ function notify_speakers_approved_feedback() {
 			$message .= sprintf(
 				// translators: 1. Number of new submissions. 2. Session title.
 				esc_html__( '%1$s new submissions on %2$s', 'wordcamporg' ),
-				$info['count'],
+				number_format_i18n( $info['count'] ),
 				$info['title']
 			);
 			$message .= "\n";
@@ -109,6 +112,8 @@ function notify_speakers_approved_feedback() {
 		);
 
 		$result = wp_mail( $speaker->user_email, $subject, $message );
+
+		restore_current_locale();
 
 		if ( $result ) {
 			foreach ( $feedback_info['feedback_ids'] as $feedback_id ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -62,7 +62,7 @@ function notify_speakers_approved_feedback() {
 	foreach ( $speaker_session_ids as $user_id => $session_ids ) {
 		$speaker = get_user_by( 'id', $user_id );
 		// Todo: Implement a UI for toggling this user meta value.
-		if ( true === $speaker->sft_speaker_notifications_opt_out ) {
+		if ( true === wp_validate_boolean( $speaker->sft_speaker_notifications_opt_out ) ) {
 			continue;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Cron;
+
+use function WordCamp\SpeakerFeedback\Comment\{ get_feedback, update_feedback };
+use function WordCamp\SpeakerFeedback\Post\get_session_speaker_user_ids;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\schedule_jobs' );
+add_action( 'sft_notify_speakers_approved_feedback', __NAMESPACE__ . '\notify_speakers_approved_feedback' );
+
+/**
+ * Add cron jobs to the schedule.
+ *
+ * @return void
+ */
+function schedule_jobs() {
+	if ( ! wp_next_scheduled( 'sft_notify_speakers_approved_feedback' ) ) {
+		$next_time = strtotime( 'Next day 6pm ' . wp_timezone_string() );
+		wp_schedule_single_event( $next_time, 'sft_notify_speakers_approved_feedback' );
+	}
+}
+
+/**
+ * Notify speakers via email about newly approved feedback submissions.
+ *
+ * @return void
+ */
+function notify_speakers_approved_feedback() {
+	if ( ! speaker_notifications_are_enabled() ) {
+		return;
+	}
+
+	$wordcamp_name = get_wordcamp_name( get_current_blog_id() );
+
+	$feedbacks       = get_unnotified_feedback();
+	$post_ids        = wp_list_pluck( $feedbacks, 'comment_post_ID', 'comment_ID' );
+	$unique_post_ids = array_unique( array_values( $post_ids ) );
+
+	$speaker_session_ids = array_reduce(
+		$unique_post_ids,
+		function( $carry, $post_id ) {
+			$user_ids = get_session_speaker_user_ids( $post_id );
+
+			foreach ( $user_ids as $user_id ) {
+				if ( ! isset( $carry[ $user_id ] ) ) {
+					$carry[ $user_id ] = array();
+				}
+				$carry[ $user_id ][] = $post_id;
+			}
+
+			return $carry;
+		},
+		array()
+	);
+
+	foreach ( $speaker_session_ids as $user_id => $session_ids ) {
+		$speaker       = get_user_by( 'id', $user_id );
+		$feedback_info = array(
+			'total_new' => 0,
+		);
+
+		foreach ( $session_ids as $session_id ) {
+			$associated_feedbacks = array_keys( $post_ids, $session_id );
+			$feedback_info['total_new'] += count( $associated_feedbacks );
+			$feedback_info[] = array(
+				'feedback_ids' => $associated_feedbacks,
+				'title'        => get_the_title( $session_id ),
+				'count'        => count( $associated_feedbacks ),
+				'link'         => trailingslashit( get_permalink( $session_id ) ) . 'feedback',
+			);
+		}
+
+		$subject = sprintf(
+			// translators: 1. Number of feedback submissions. 2. WordCamp name.
+			esc_html( _n(
+				'You have %1$s new feedback submission from %2$s',
+				'You have %1$s new feedback submissions from %2$s',
+				$feedback_info['total_new'],
+				'wordcamporg'
+			) ),
+			number_format_i18n( $feedback_info['total_new'] ),
+			esc_html( $wordcamp_name )
+		);
+		unset( $feedback_info['total_new'] );
+
+		$message  = sprintf( esc_html__( 'Hi %s,', 'wordcamporg' ), $speaker->display_name );
+		$message .= "\n\n";
+		$message .= esc_html__( 'You have new feedback submissions to read on the following sessions:', 'wordcamporg' );
+		$message .= "\n\n";
+
+		foreach ( $feedback_info as $info ) {
+			$message .= sprintf(
+				// translators: 1. Number of new submissions. 2. Session title.
+				esc_html__( '%1$s new submissions on %2$s', 'wordcamporg' ),
+				$info['count'],
+				$info['title']
+			);
+			$message .= "\n";
+			$message .= esc_url_raw( $info['link'] );
+			$message .= "\n\n";
+		}
+
+		$message .= sprintf(
+			// translators: %s is the name of the WordCamp.
+			esc_html__( "Sincerely,\nthe %s organizing team", 'wordcamporg' ),
+			esc_html( $wordcamp_name )
+		);
+
+		$result = wp_mail( $speaker->user_email, $subject, $message );
+
+		if ( $result ) {
+			foreach ( $feedback_info['feedback_ids'] as $feedback_id ) {
+				update_feedback(
+					$feedback_id,
+					array(
+						'speaker_notified' => true,
+					)
+				);
+			}
+		}
+	}
+}
+
+/**
+ * Check to see if the conditions are right to send notifications.
+ *
+ * @return bool
+ */
+function speaker_notifications_are_enabled() {
+	$now       = date_create( 'now', wp_timezone() );
+	$stop_date = get_option( 'sft_speaker_notification_stop_date', false );
+
+	if ( false !== $stop_date && $now->getTimestamp() > $stop_date ) {
+		return false;
+	}
+
+	$first_session_time = get_transient( 'sft_first_session_time' );
+
+	if ( ! $first_session_time ) {
+		$earliest_session = get_posts( array(
+			'post_type'      => 'wcb_session',
+			'post_status'    => 'publish',
+			'meta_key'       => '_wcpt_session_time',
+			'orderby'        => 'meta_value_num',
+			'order'          => 'ASC',
+			'posts_per_page' => 1,
+		) );
+
+		if ( ! empty( $earliest_session ) ) {
+			$first_session_time = absint( $earliest_session[0]->_wcpt_session_time );
+		}
+
+		if ( ! $first_session_time ) {
+			return false;
+		}
+
+		// Session times can change, so this is a transient.
+		set_transient( 'sft_first_session_time', $first_session_time, DAY_IN_SECONDS );
+
+		$stop_date = strtotime( '+ 3 months', $first_session_time );
+		update_option( 'sft_speaker_notification_stop_date', $stop_date, false );
+	}
+
+	return $now->getTimestamp() > $first_session_time;
+}
+
+/**
+ * Get a list of approved feedback comments that speakers have not yet been notified about.
+ *
+ * @return array
+ */
+function get_unnotified_feedback() {
+	$args = array(
+		'meta_query' => array(
+			array(
+				'key'     => 'speaker_notified',
+				'compare' => 'NOT EXISTS',
+			),
+		),
+	);
+
+	return get_feedback( array(), array( 'approve' ), $args );
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -86,3 +86,20 @@ function get_session_speaker_user_ids( $session_id ) {
 
 	return $user_ids;
 }
+
+/**
+ * Generate a link to the front end feedback UI for a particular session.
+ *
+ * @param int $post_id
+ *
+ * @return string
+ */
+function get_session_feedback_url( $post_id ) {
+	$url = '';
+
+	if ( post_type_supports( get_post_type( $post_id ), 'wordcamp-speaker-feedback' ) ) {
+		$url = trailingslashit( get_permalink( $post_id ) ) . 'feedback/';
+	}
+
+	return $url;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -2,10 +2,15 @@
 
 namespace WordCamp\SpeakerFeedback\View;
 
+use WP_Post;
 use function WordCamp\SpeakerFeedback\get_assets_path;
+use function WordCamp\SpeakerFeedback\Post\get_session_feedback_url;
 
 defined( 'WPINC' ) || die();
 
+/** @var WP_Post $post */
+/** @var string $rating_question */
+/** @var array $text_questions */
 ?>
 <hr />
 <form id="sft-feedback" class="speaker-feedback">
@@ -17,7 +22,7 @@ defined( 'WPINC' ) || die();
 		<div class="speaker-feedback__notice">
 			<p><?php echo wp_kses_post( sprintf(
 				__( '<a href="%s">Log in to your WordPress.org account,</a> or add your name & email to leave feedback.', 'wordcamporg' ),
-				wp_login_url( get_permalink() . 'feedback' )
+				wp_login_url( get_session_feedback_url( $post->ID ) )
 			) ); ?></p>
 		</div>
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -44,6 +44,7 @@ function load() {
 	require_once get_includes_path() . 'class-feedback.php';
 	require_once get_includes_path() . 'class-rest-feedback-controller.php';
 	require_once get_includes_path() . 'class-walker-feedback.php';
+	require_once get_includes_path() . 'cron.php';
 	require_once get_includes_path() . 'capabilities.php';
 	require_once get_includes_path() . 'comment.php';
 	require_once get_includes_path() . 'comment-meta.php';


### PR DESCRIPTION
This creates a system that gathers feedback comments that have been approved but have not yet been included in a notification (using a `speaker_notified` comment meta value). From those comments it derives a list of the related session posts, and from that derives a list of speaker user accounts. Each speaker is then sent one email with a list of each of their sessions that has newly approved feedback on it. The cron job is set up to ensure this doesn't happen more than once per day. 6pm in the WordCamp site's local timezone was chosen for the send time so that organizers may have time to approve some feedback comments the same day that the event occurred and still have notifications go out.

This also includes a user meta value, `sft_speaker_notifications_opt_out` that will skip sending an email notification if it is set for a user. However, it does not include any UI for toggling the value. I've left that for a separate ticket/PR since it will need some design work.

Fixes #422 

### How to test the changes in this Pull Request:

1. Set up the data:
    * Two speaker posts with usernames that exist on the network.
    * Three or more session posts. One for each of the speakers, and one with both of the speakers. The session times should be a day or two before the current time to ensure they fall within the window when notification emails will be sent out.
    * Add some feedback comments to each session, but leave them unapproved.
1. Open up MailCatcher so you can see when email notifications get sent out.
1. You can trigger the cron job manually with wp-cli. On the docker environment it will be something like
    `wp --allow-root --url=https://2014.seattle.wordcamp.org cron event run sft_notify_speakers_approved_feedback`
1. When you trigger it before approving any feedback, no emails should be sent out.
1. Approve a feedback comment for each session, and then trigger the cron job again. This time there should be emails in MailCatcher. Notice that there should be one email per speaker, not per session. The email should list each session that has new feedback.
1. If you then immediately trigger the cron job again, no new emails should be sent out, because the approved feedback comments have all been marked as `speaker_notified`. If you unapprove comments and then reapprove them, it should not reset the notified status.
1. Try changing the timestamp of the sessions to get outside the window when email notifications will be sent (earliest session + 3 months). You'll need to use wp-cli to delete the `sft_speaker_notification_start_time` transient in order to test this.
