### PR TITLE
Speaker Feedback: Prevent feedback actions from triggering comment UI

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
@@ -1,5 +1,5 @@
 /**
- * Remove the `dimAfter` callback for feedback replies. This function is called after a comment is unapproved or
+ * Update the `dimAfter` callback for feedback replies. This function is called after a comment is unapproved or
  * approved. In the comments table, it triggers the HTML updates in the admin menu & admin bar (among others).
  * We can override this by passing in our own function, which only handles the top view + count links.
  *

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
@@ -15,11 +15,10 @@ jQuery( document ).ready( function( $ ) {
 
 	// We can assume window.theList exists because we're after `edit-comments.js`
 	// And if we know that wpList is an object, we can assume the structure of it is stable.
-	if ( window.theList[0] && 'object' === typeof window.theList[0].wpList ) {
-		window.theList[0].wpList.settings.dimAfter = function() {
+	if ( window.theList[ 0 ] && 'object' === typeof window.theList[ 0 ].wpList ) {
+		window.theList[ 0 ].wpList.settings.dimAfter = function() {
 			// Reload the page, but only the top view + count links.
 			$container.load( location.href + ' .subsubsub' );
 		};
 	}
 } );
-

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
@@ -1,0 +1,25 @@
+/**
+ * Remove the `dimAfter` callback for feedback replies. This function is called after a comment is unapproved or
+ * approved. In the comments table, it triggers the HTML updates in the admin menu & admin bar (among others).
+ * We can override this by passing in our own function, which only handles the top view + count links.
+ *
+ * See https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/lists.js?rev=46800#L181
+ * See https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/lists.js?rev=46800#L593
+ * See https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/admin/edit-comments.js?rev=47233#L349
+ */
+
+jQuery( document ).ready( function( $ ) {
+	// The `.load()` function can't load into itself, so we need to wrap the views with a container.
+	var $container = $( '<div>' ).html( $( '.subsubsub' ).get( 0 ).outerHTML );
+	$( '.subsubsub' ).replaceWith( $container );
+
+	// We can assume window.theList exists because we're after `edit-comments.js`
+	// And if we know that wpList is an object, we can assume the structure of it is stable.
+	if ( window.theList[0] && 'object' === typeof window.theList[0].wpList ) {
+		window.theList[0].wpList.settings.dimAfter = function() {
+			// Reload the page, but only the top view + count links.
+			$container.load( location.href + ' .subsubsub' );
+		};
+	}
+} );
+

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
@@ -20,6 +20,7 @@ foreach ( SUPPORTED_POST_TYPES as $supported_post_type ) {
 }
 
 add_action( 'admin_menu', __NAMESPACE__ . '\add_subpages' );
+add_filter( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'set-screen-option', __NAMESPACE__ . '\set_screen_options', 10, 3 );
 add_filter( 'wp_count_comments', __NAMESPACE__ . '\adjust_comment_counts', 10, 2 );
 add_filter( 'pre_wp_update_comment_count_now', __NAMESPACE__ . '\adjust_post_comment_count', 10, 3 );
@@ -220,6 +221,23 @@ function get_subpage_url( $post_type ) {
 		),
 		esc_url( admin_url( 'edit.php' ) )
 	);
+}
+
+/**
+ * Add assets to the form page.
+ *
+ * @param string $hook_suffix The current admin page.
+ */
+function enqueue_assets( $hook_suffix ) {
+	if ( 'wcb_session_page_wc-speaker-feedback' === $hook_suffix ) {
+		wp_enqueue_script(
+			'speaker-feedback-admin',
+			get_assets_url() . 'js/admin.js',
+			array( 'admin-comments', 'jquery' ),
+			filemtime( dirname( __DIR__ ) . '/assets/js/admin.js' ),
+			true
+		);
+	}
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -6,6 +6,7 @@ use WP_Comment, WP_User;
 use WP_Comments_List_Table;
 use function WordCamp\SpeakerFeedback\get_assets_path;
 use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
+use function WordCamp\SpeakerFeedback\Post\get_session_feedback_url;
 use function WordCamp\SpeakerFeedback\View\{ render_feedback_comment, render_feedback_rating };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
@@ -248,7 +249,7 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 		?>
 		<div class="response-links">
 			<?php echo wp_kses_post( $post_link ); ?>
-			<a href="<?php the_permalink( $post->ID ); ?>feedback/" class="comments-view-item-link">
+			<a href="<?php echo esc_url( get_session_feedback_url( $post->ID ) ); ?>" class="comments-view-item-link">
 				<?php esc_html_e( 'View Feedback', 'wordcamporg' ); ?>
 			</a>
 		</div>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -5,7 +5,6 @@ namespace WordCamp\SpeakerFeedback;
 use WP_Comment, WP_User;
 use WP_Comments_List_Table;
 use function WordCamp\SpeakerFeedback\get_assets_path;
-use function WordCamp\SpeakerFeedback\Admin\feedback_bubble;
 use function WordCamp\SpeakerFeedback\Comment\get_feedback_comment;
 use function WordCamp\SpeakerFeedback\View\{ render_feedback_comment, render_feedback_rating };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
@@ -249,12 +248,9 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 		?>
 		<div class="response-links">
 			<?php echo wp_kses_post( $post_link ); ?>
-			<a href="<?php the_permalink( $post->ID ); ?>" class="comments-view-item-link">
-				<?php echo wp_kses_post( get_post_type_object( $post->post_type )->labels->view_item ); ?>
+			<a href="<?php the_permalink( $post->ID ); ?>feedback/" class="comments-view-item-link">
+				<?php esc_html_e( 'View Feedback', 'wordcamporg' ); ?>
 			</a>
-			<span class="post-com-count-wrapper post-com-count-<?php echo esc_attr( $post->ID ); ?>">
-				<?php feedback_bubble( $post->ID ); ?>
-			</span>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
When moderating feedback and comments, the list table uses an ajax request to perform the status change. When the request succeeds, a callback is called that triggers various UI changes. We want some of those, but not all — moderating feedback should not change the Comments bubble, but it should update the views above the table.

This is handled by a callback called `dimAfter`. We can override this, and call only the changes we want. Rather than attempting to re-calculate the counts, I'm just reloading the fragment of the page that contains the view links & counts.

Fixes #432 

### How to test the changes in this Pull Request:

1. Moderate some feedback, it should still change status
2. The bubble next to Comments in the menu should not change
3. The bubble in the admin bar should not change
4. Moderate some comments, make sure they still work as expected
