### PR TITLE
WCPT: Remove internationalization from new site content

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -1,24 +1,19 @@
-<?php /** @var WordCamp_New_Site $this */ ?>
+<?php
+/** @var WordCamp_New_Site $this */
+
+?>
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php printf(
-	// translators: %s: URL for code of conduct policy
-	__( '<em>Organizers note:</em> Below is a boilerplate code of conduct that you can customize; another great example is the Ada Initiative <a href="%s">anti-harassment policy.</a>', 'wordcamporg' ),
-	'http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy'
-); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> Below is a boilerplate code of conduct that you can customize; another great example is the Ada Initiative <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">anti-harassment policy.</a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php printf(
-	// translators: %s: URL for article about harassment reports
-	__( 'We also recommend the organizing team read this article on <a href="%s">how to take a harassment report</a>', 'wordcamporg' ),
-	'http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports'
-); ?></p>
+<p style="background-color:#eeeeee" class="has-background">We also recommend the organizing team read this article on <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports">how to take a harassment report</a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( 'Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>. You can use the "Remove Formatting" button on the toolbar (the eraser icon on the second line) to remove the color and underline.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background">Please update the portions <span style="color: red; text-decoration: underline;">with red text.</span> To remove the red underline formatting, click the arrow in the toolbar called "more rich text controls," and toggle off the underline.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list {"ordered":true} -->
-<?php echo $this->get_code_of_conduct(); ?>
+<?php echo $this->get_code_of_conduct(); /* phpcs:ignore */ ?>
 <!-- /wp:list -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/contact.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/contact.php
@@ -1,7 +1,7 @@
-<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Contact Request', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
-<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Name', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/contact-form {"subject":"WordCamp Contact Request","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-name {"label":"Name","required":true} /-->
 
-<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Message', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-textarea {"label":"Message","required":true} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/day-of-event.php
@@ -4,15 +4,15 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>
+<h2>Schedule</h2>
 <!-- /wp:heading -->
 
 <!-- wp:wordcamp/live-schedule {"level":3} -->
-<div data-now="<?php esc_html_e( 'On Now', 'wordcamporg' ); ?>" data-next="<?php esc_html_e( 'Next Up', 'wordcamporg' ); ?>" data-level="3" class="wp-block-wordcamp-live-schedule"></div>
+<div data-now="On Now" data-next="Next Up" data-level="3" class="wp-block-wordcamp-live-schedule"></div>
 <!-- /wp:wordcamp/live-schedule -->
 
 <!-- wp:heading -->
-<h2><?php esc_html_e( 'Latest Posts', 'wordcamporg' ); ?></h2>
+<h2>Latest Posts</h2>
 <!-- /wp:heading -->
 
 <!-- wp:latest-posts {"displayPostDate":true,"liveUpdateEnabled":true} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/offline.php
@@ -1,13 +1,13 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php esc_html_e( "Organizers note: Update this page with some basic information about your WordCamp. It will be stored in site visitor's browsers, and automatically shown if they try to visit the site without an internet connection.", 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background">Organizers note: Update this page with some basic information about your WordCamp. It will be stored in site visitor's browsers, and automatically shown if they try to visit the site without an internet connection.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php esc_html_e( "This page couldn't be loaded because you appear to be offline. Please try again once you have a network connection.", 'wordcamporg' ); ?></p>
+<p>This page couldn't be loaded because you appear to be offline. Please try again once you have a network connection.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2><?php esc_html_e( 'Location & Date', 'wordcamporg' ); ?></h2>
+<h2>Location & Date</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -16,7 +16,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2><?php esc_html_e( 'Schedule', 'wordcamporg' ); ?></h2>
+<h2>Schedule</h2>
 <!-- /wp:heading -->
 
 <!-- wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
@@ -1,5 +1,5 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/organizers {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/schedule.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/schedule.php
@@ -1,9 +1,9 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2><?php _e( 'Saturday, January 1st', 'wordcamporg' ) ?></h2>
+<h2>Saturday, January 1st</h2>
 <!-- /wp:heading -->
 
 <!-- wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
@@ -1,5 +1,5 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/sessions {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/social-media-stream.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/social-media-stream.php
@@ -1,5 +1,5 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> The [[tagregator]] shortcode will pull in a stream of social media posts and display them. In order to use it, you\'ll need to follow the setup instructions at http://wordpress.org/plugins/tagregator/installation, and then update "#wcxyz" below with your hashtag.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> The [[tagregator]] shortcode will pull in a stream of social media posts and display them. In order to use it, you'll need to follow the setup instructions at <a href="http://wordpress.org/plugins/tagregator/installation">wordpress.org/plugins/tagregator/installation,</a> and then update "#wcxyz" below with your hashtag.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
@@ -1,5 +1,5 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/speakers {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
@@ -1,25 +1,21 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php printf(
-	/* translators: %s: Global Community Sponsorship page URL */
-	__( "<em>Organizers note:</em> Multi-event sponsors have been automatically created in the Sponsors menu, but you'll need to remove the ones that don't apply to your specific event. To find out which ones apply, please visit the <a href=\"%s\">Global Community Sponsorship</a> handbook page. After that, you should add the sponsors that are specific to your event. For non-English sites, make sure the URL below matches the Call for Sponsors page.", 'wordcamporg' ),
-	'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/fundraising/global-community-sponsorship-for-event-organizers/'
-); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> Multi-event sponsors have been automatically created in the Sponsors menu, but you'll need to remove the ones that don't apply to your specific event. To find out which ones apply, please visit the <a href="https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/fundraising/global-community-sponsorship-for-event-organizers/">Global Community Sponsorship</a> handbook page. After that, you should add the sponsors that are specific to your event. For non-English sites, make sure the URL below matches the Call for Sponsors page.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2><?php _e( 'Our Sponsors', 'wordcamporg' ) ?></h2>
+<h2>Our Sponsors</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'Blurb thanking sponsors', 'wordcamporg' ); ?></p>
+<p>Blurb thanking sponsors</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/sponsors {"mode":"all"} /-->
 
 <!-- wp:heading -->
-<h2><?php _e( 'Interested in sponsoring WordCamp this year?', 'wordcamporg' ) ?></h2>
+<h2>Interested in sponsoring WordCamp this year?</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'Check out our <a href="/call-for-sponsors">Call for Sponsors</a> post for details on how you can help make this year\'s WordCamp the best it can be!', 'wordcamporg' ); ?></p>
+<p>Check out our <a href="/call-for-sponsors">Call for Sponsors</a> post for details on how you can help make this year's WordCamp the best it can be!</p>
 <!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/tickets.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/tickets.php
@@ -1,5 +1,5 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( "<em>Organizers note:</em> If you'd like to change the slug for this page, please make sure you do that before opening ticket sales. Changing the page slug after tickets have started selling will break the link that users receive in their receipt e-mail.", 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> If you'd like to change the slug for this page, please make sure you do that before opening ticket sales. Changing the page slug after tickets have started selling will break the link that users receive in their receipt e-mail.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/videos.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/videos.php
@@ -1,5 +1,5 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> After your WordCamp is over and the sessions are published to WordPress.tv, you can embed them here. Just enter the event slug into the shortcode below, and hit the <em>Publish</em> button.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> After your WordCamp is over and the sessions are published to WordPress.tv, you can embed them here. Just enter the event slug into the shortcode below, and hit the <em>Publish</em> button.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:shortcode -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
@@ -1,25 +1,25 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> Submissions to this form will automatically create draft posts for the Speaker and Session post types. Feel free to customize the form, but deleting or renaming the following fields will break the automation: Name, Email, WordPress.org Username, Your Bio, Session Title, Session Description.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> Submissions to this form will automatically create draft posts for the Speaker and Session post types. Feel free to customize the form, but deleting or renaming the following fields will break the automation: Name, Email, WordPress.org Username, Your Bio, Session Title, Session Description.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php _e( "If you'd like to propose multiple topics, please submit the form multiple times, once for each topic. [Other speaker instructions/info goes here.]", 'wordcamporg' ); ?></p>
+<p>If you'd like to propose multiple topics, please submit the form multiple times, once for each topic. [Other speaker instructions/info goes here.]</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Speaker Request', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
-<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Name', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/contact-form {"subject":"WordCamp Speaker Request","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-name {"label":"Name","required":true} /-->
 
-<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email Address', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email Address","required":true} /-->
 
-<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'WordPress.org Username', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-text {"label":"WordPress.org Username","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Your Bio', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-textarea {"label":"Your Bio","required":true} /-->
 
-<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Topic Title', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-text {"label":"Topic Title","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Topic Description', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-textarea {"label":"Topic Description","required":true} /-->
 
-<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Intended Audience', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-text {"label":"Intended Audience","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Past Speaking Experience (not necessary to apply)', 'wordcamporg' ); ?>"} /-->
+<!-- wp:jetpack/field-textarea {"label":"Past Speaking Experience (not necessary to apply)"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
@@ -1,21 +1,21 @@
 <!-- wp:paragraph -->
-<p><?php _e( 'Blurb with information for potential sponsors.', 'wordcamporg' ); ?></p>
+<p>Blurb with information for potential sponsors.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Sponsor Request', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
-<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Contact Name', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/contact-form {"subject":"WordCamp Sponsor Request","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-text {"label":"Contact Name","required":true} /-->
 
-<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Company Name', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-name {"label":"Company Name","required":true} /-->
 
-<!-- wp:jetpack/field-url {"label":"<?php esc_attr_e( 'Company Website', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-url {"label":"Company Website","required":true} /-->
 
-<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email","required":true} /-->
 
-<!-- wp:jetpack/field-telephone {"label":"<?php esc_attr_e( 'Phone Number', 'wordcamporg' ); ?>"} /-->
+<!-- wp:jetpack/field-telephone {"label":"Phone Number"} /-->
 
-<!-- wp:jetpack/field-select {"label":"<?php esc_attr_e( 'Sponsorship Level', 'wordcamporg' ); ?>","options":["Bronze","Silver","Gold"]} /-->
+<!-- wp:jetpack/field-select {"label":"Sponsorship Level","options":["Bronze","Silver","Gold"]} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Why Would you Like to Sponsor WordCamp?', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-textarea {"label":"Why Would you Like to Sponsor WordCamp?","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Questions / Comments', 'wordcamporg' ); ?>"} /-->
+<!-- wp:jetpack/field-textarea {"label":"Questions / Comments"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
@@ -1,15 +1,15 @@
 <!-- wp:paragraph -->
-<p><?php _e( 'Blurb with information for potential volunteers.', 'wordcamporg' ); ?></p>
+<p>Blurb with information for potential volunteers.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'WordCamp Volunteer Application', 'wordcamporg' ); ?>","hasFormSettingsSet":"yes"} -->
-<!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Name', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/contact-form {"subject":"WordCamp Volunteer Application","hasFormSettingsSet":"yes"} -->
+<!-- wp:jetpack/field-name {"label":"Name","required":true} /-->
 
-<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Email', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Skills / Interests / Experience (not necessary to volunteer)', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-textarea {"label":"Skills / Interests / Experience (not necessary to volunteer)","required":true} /-->
 
-<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Number of Hours Available', 'wordcamporg' ); ?>","required":true} /-->
+<!-- wp:jetpack/field-text {"label":"Number of Hours Available","required":true} /-->
 
-<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Questions / Comments', 'wordcamporg' ); ?>"} /-->
+<!-- wp:jetpack/field-textarea {"label":"Questions / Comments"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/welcome.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/welcome.php
@@ -1,15 +1,15 @@
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><?php _e( '<em>Organizers note:</em> Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>.', 'wordcamporg' ); ?></p>
+<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> Please update the portions <span style="color: red; text-decoration: underline;">with red text</span>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php _e( 'We\'re happy to announce that <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> is officially on the calendar!', 'wordcamporg' ); ?></p>
+<p>We're happy to announce that <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> is officially on the calendar!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php _e( '<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> will be <span style="color: red; text-decoration: underline;">DATE(S)</span> at <span style="color: red; text-decoration: underline;">LOCATION</span>.', 'wordcamporg' ); ?></p>
+<p><span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> will be <span style="color: red; text-decoration: underline;">DATE(S)</span> at <span style="color: red; text-decoration: underline;">LOCATION</span>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><?php _e( '<span style="color: red; text-decoration: underline;">Subscribe using the form in the sidebar</span> to stay up to date on the most recent news. We’ll be keeping you posted on all the details over the coming months, including speaker submissions, ticket sales and more!', 'wordcamporg' ); ?></p>
+<p><span style="color: red; text-decoration: underline;">Subscribe using the form in the sidebar</span> to stay up to date on the most recent news. We’ll be keeping you posted on all the details over the coming months, including speaker submissions, ticket sales and more!</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
When creating the new WordCamp site, default content is injected into the site. This content isn't translated, because a locale is not set yet. Since the content can't be translated, putting it through translation functions is not necessary, and might be creating extra work for translators.

See https://meta.trac.wordpress.org/ticket/2885

Eventually we want this content to be translatable, but that requires knowing & setting a locale before creating the site. See [#603-meta](https://meta.trac.wordpress.org/ticket/603) for related discussion.

### How to test the changes in this Pull Request:

1. Create a new WordCamp site
2. All the content should appear as expected
