### PR TITLE
Helpers: Add functions to check test sites, get lists of blog IDs

### DIFF
--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -29,6 +29,49 @@ function get_wordcamp_environment() {
 }
 
 /**
+ * Check if a WordCamp site is for testing.
+ *
+ * Currently the `wordcamp_test_site` blogmeta key needs to be set manually via wp-cli.
+ *
+ * @param int|null $blog_id Optional. The blog ID to check. Defaults to current blog ID.
+ *
+ * @return bool
+ */
+function is_wordcamp_test_site( $blog_id = null ) {
+	if ( is_null( $blog_id ) ) {
+		$blog_id = get_current_blog_id();
+	}
+
+	return wp_validate_boolean( get_site_meta( $blog_id, 'wordcamp_test_site', true ) );
+}
+
+/**
+ * Get a list of IDs for sites that have a specific blogmeta key, and optionally a specific value.
+ *
+ * @param string $key
+ * @param mixed  $value
+ *
+ * @return int[] An array of blog ID integers.
+ */
+function get_wordcamp_blog_ids_from_meta( $key, $value = null ) {
+	global $wpdb;
+
+	$where_subs   = array( $key );
+	$where_string = 'WHERE meta_key = %s';
+	if ( ! is_null( $value ) ) {
+		$where_subs[]  = $value;
+		$where_string .= ' AND meta_value = %s';
+	}
+
+	$blog_ids = $wpdb->get_col( $wpdb->prepare(
+		"SELECT blog_id FROM $wpdb->blogmeta $where_string", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$where_subs
+	) );
+
+	return array_map( 'absint', $blog_ids );
+}
+
+/**
  * Determine if a specific feature should be skipped on the current site
  *
  * Warning: Pay careful attention to how things are named, since setting a flag here is typically done when you

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -40,16 +40,10 @@ add_filter( 'close_comments_for_post_types', 'wcorg_close_comments_for_post_type
  * that they receive SSL certificates, because our Let's Encrypt script only installs
  * certificates for public sites.
  *
- * @param string $value
- *
  * @return string
  */
-function wcorg_enforce_public_blog_option( $value ) {
-	$private_sites = array(
-		206,     // testing.wordcamp.org.
-	);
-
-	if ( in_array( get_current_blog_id(), $private_sites, true ) ) {
+function wcorg_enforce_public_blog_option() {
+	if ( is_wordcamp_test_site() ) {
 		$value = '0';
 	} else {
 		$value = '1';
@@ -57,6 +51,7 @@ function wcorg_enforce_public_blog_option( $value ) {
 
 	return $value;
 }
+add_filter( 'pre_option_blog_public', 'wcorg_enforce_public_blog_option' );
 add_filter( 'pre_update_option_blog_public', 'wcorg_enforce_public_blog_option' );
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-reports/index.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/index.php
@@ -370,8 +370,5 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\register_file_exports' );
  * @return array
  */
 function get_excluded_site_ids() {
-	return array(
-		206, // 2016.testing
-		928, // 2017.testing
-	);
+	return get_wordcamp_blog_ids_from_meta( 'wordcamp_test_site', 1 );
 }


### PR DESCRIPTION
After adding a `wordcamp_test_site` key to the blogmeta for our test sites (which I've already done in production), this allows us to check if a site is a test site with a simple `is_wordcamp_test_site()` call.

Additionally, this adds a helper function that queries the blogmeta table directly and returns an array of blog IDs based on the specified meta key, and optionally an associated meta value. This is useful for situations where we want to get a list of all sites with a specific meta entry, like all test sites, or all sites that have opted into a specific beta. It could also be used to address #448.

This PR also updates some places in the codebase to use these new functions.

Refs #287 

### How to test the changes in this Pull Request:

1. The most direct way to test the new functions is probably to run this PR on your sandbox and use the wp-cli shell.
1. I've already set the three existing test sites on the network to have the `wordcamp_test_site` blogmeta, so once in shell, try this:
`get_wordcamp_blog_ids_from_meta( 'wordcamp_test_site', 1 )`
1. You should get an array back with three integers. Then try inputting one of the integers into this function:
`is_wordcamp_test_site( $my_integer )`
1. You should get back a boolean `true`. Using a different arbitrary integer should give you a `false`.
1. Check that the **Search engine visibility** input in Settings > Reading for one of the test sites is checked, and cannot be saved to an unchecked state.