### PR TITLE
Speaker Feedback: Add "Inappropriate" action to comments list table

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
@@ -13,12 +13,15 @@ jQuery( document ).ready( function( $ ) {
 	var $container = $( '<div>' ).html( $( '.subsubsub' ).get( 0 ).outerHTML );
 	$( '.subsubsub' ).replaceWith( $container );
 
+	function loadTopCounts() {
+		// Reload the page, but only the top view + count links.
+		$container.load( location.href + ' .subsubsub' );
+	}
+
 	// We can assume window.theList exists because we're after `edit-comments.js`
 	// And if we know that wpList is an object, we can assume the structure of it is stable.
 	if ( window.theList[ 0 ] && 'object' === typeof window.theList[ 0 ].wpList ) {
-		window.theList[ 0 ].wpList.settings.dimAfter = function() {
-			// Reload the page, but only the top view + count links.
-			$container.load( location.href + ' .subsubsub' );
-		};
+		window.theList[ 0 ].wpList.settings.dimAfter = loadTopCounts;
+		window.theList[ 0 ].wpList.settings.delAfter = loadTopCounts;
 	}
 } );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -319,3 +319,12 @@
 		}
 	}
 }
+
+.row-actions span.inappropriate a {
+	color: #a00;
+
+	&:hover {
+		color: #dc3232;
+		border: none;
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -317,11 +317,5 @@
 				border-left: 4px solid #ffb900;
 			}
 		}
-
-		.row-actions {
-			.unapprove {
-				display: none;
-			}
-		}
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
@@ -503,8 +503,7 @@ function feedback_extra_actions( $actions, $comment ) {
 			'action' => 'unmark-inappropriate',
 			'_wpnonce' => wp_create_nonce( "inappropriate-comment_{ $comment_id }" ),
 			'bulk_edit_nonce' => wp_create_nonce( 'bulk_edit_' . COMMENT_TYPE ),
-		),
-		get_subpage_url( get_post_type( $comment->comment_post_ID ) )
+		)
 	);
 
 	$inappropriate_url = add_query_arg(
@@ -513,8 +512,7 @@ function feedback_extra_actions( $actions, $comment ) {
 			'action' => 'mark-inappropriate',
 			'_wpnonce' => wp_create_nonce( "inappropriate-comment_{ $comment_id }" ),
 			'bulk_edit_nonce' => wp_create_nonce( 'bulk_edit_' . COMMENT_TYPE ),
-		),
-		get_subpage_url( get_post_type( $comment->comment_post_ID ) )
+		)
 	);
 
 	if ( 'inappropriate' === $comment->comment_approved ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
@@ -528,13 +528,21 @@ function feedback_extra_actions( $actions, $comment ) {
 			__( 'Move to Pending', 'wordcamporg' )
 		);
 	} else {
-		$actions['inappropriate'] = sprintf(
-			'<a href="%1$s" data-wp-lists="%2$s" class="vim-a vim-destructive aria-button-if-js" aria-label="%3$s">%4$s</a>',
-			esc_url( $inappropriate_url ),
-			"delete:the-comment-list:comment-{$comment_id}:e7e7d3:action=dim-comment&amp;new=inappropriate",
-			esc_attr__( 'Mark as Inappropriate', 'wordcamporg' ),
-			__( 'Inappropriate', 'wordcamporg' )
+		$action_inappropriate = array(
+			'inappropriate' => sprintf(
+				'<a href="%1$s" data-wp-lists="%2$s" class="vim-a vim-destructive aria-button-if-js" aria-label="%3$s">%4$s</a>',
+				esc_url( $inappropriate_url ),
+				"delete:the-comment-list:comment-{$comment_id}:e7e7d3:action=dim-comment&amp;new=inappropriate",
+				esc_attr__( 'Mark as Inappropriate', 'wordcamporg' ),
+				__( 'Inappropriate', 'wordcamporg' )
+			),
 		);
+
+		$key_indexes = array_keys( $actions );
+		$after       = array_slice( $actions, array_search( 'spam', $key_indexes, true ), null, true );
+		$before      = array_slice( $actions, 0, count( $actions ) - count( $after ), true );
+
+		$actions = $before + $action_inappropriate + $after;
 	}
 
 	return $actions;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
@@ -525,7 +525,7 @@ function feedback_extra_actions( $actions, $comment ) {
 			// See https://core.trac.wordpress.org/browser/trunk/src/js/_enqueues/lib/lists.js?rev=46800#L217.
 			"delete:the-comment-list:comment-{$comment_id}:e7e7d3:action=dim-comment&amp;new=uninappropriate",
 			esc_attr__( 'Move this comment to pending', 'wordcamporg' ),
-			__( 'Pending', 'wordcamporg' )
+			__( 'Move to Pending', 'wordcamporg' )
 		);
 	} else {
 		$actions['inappropriate'] = sprintf(


### PR DESCRIPTION
Fixes #447 — Adds "Inappropriate" status action to the row actions on each comment. This should allow users to toggle the inappropriate status on a single feedback. In the Inappropriate view, the status can be set back to Pending (`hold`, technically, but for UI consistency Pending seemed a better string).

### Screenshots

![Screen Shot 2020-04-27 at 2 51 18 PM](https://user-images.githubusercontent.com/541093/80422135-9f342000-88ab-11ea-8bc5-a2ad7febab07.png)

### How to test the changes in this Pull Request:

1. Try toggling the status of various feedbacks (both to/from inappropriate, but also trash/spam/approved)
2. This should also work with JS disabled (it uses the bulk edit action in that case).
