### PR TITLE
Speaker Feedback: Consistently use sessions to determine start/end times of the event

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -3,6 +3,7 @@
 namespace WordCamp\SpeakerFeedback\Post;
 
 use WP_Error;
+use WordCamp_Post_Types_Plugin;
 
 defined( 'WPINC' ) || die();
 
@@ -48,21 +49,56 @@ function post_accepts_feedback( $post_id ) {
 		);
 	}
 
-	if ( $now->getTimestamp() < absint( $post->_wcpt_session_time ) ) {
-		return new WP_Error(
-			'speaker_feedback_session_too_soon',
-			__( 'This session will not accept feedback until it has started.', 'wordcamporg' )
-		);
-	}
-
-	if ( $now->getTimestamp() > absint( $post->_wcpt_session_time ) + ACCEPT_INTERVAL_IN_SECONDS ) {
-		return new WP_Error(
-			'speaker_feedback_session_too_late',
-			__( 'This session is no longer accepting feedback.', 'wordcamporg' )
-		);
-	}
-
 	return true;
+}
+
+/**
+ * Find the timestamp of the earliest published session.
+ *
+ * @return bool|int An integer timestamp, or false if no valid sessions are found.
+ */
+function get_earliest_session_timestamp() {
+	$earliest_session = get_posts( array(
+		'post_type'      => 'wcb_session',
+		'post_status'    => 'publish',
+		'meta_key'       => '_wcpt_session_time',
+		'orderby'        => 'meta_value_num',
+		'order'          => 'ASC',
+		'posts_per_page' => 1,
+	) );
+
+	if ( empty( $earliest_session ) ) {
+		return false;
+	}
+
+	return absint( $earliest_session[0]->_wcpt_session_time );
+}
+
+/**
+ * Find the timestamp of the end of the latest published session.
+ *
+ * @return bool|int An integer timestamp, or false if no valid sessions are found.
+ */
+function get_latest_session_ending_timestamp() {
+	$latest_session = get_posts( array(
+		'post_type'      => 'wcb_session',
+		'post_status'    => 'publish',
+		'meta_key'       => '_wcpt_session_time',
+		'orderby'        => 'meta_value_num',
+		'order'          => 'DESC',
+		'posts_per_page' => 1,
+	) );
+
+	if ( empty( $latest_session ) ) {
+		return false;
+	}
+
+	$duration = $latest_session[0]->_wcpt_session_duration;
+	if ( ! $duration ) {
+		$duration = WordCamp_Post_Types_Plugin::SESSION_DEFAULT_DURATION;
+	}
+
+	return absint( $latest_session[0]->_wcpt_session_time ) + absint( $duration );
 }
 
 /**


### PR DESCRIPTION
Currently we are using different values in different places to determine when the WordCamp event as a whole starts and ends. Some places we are using the start time of the earliest session as a start time, some places we are using `Start Date (YYYY-MM-DD)` from the WordCamp post. For the ending time, we are mostly extrapolating from whatever we're using as the start time.

This creates new functions for getting a timestamp for the earliest session and a timestamp for the end of the latest session, which I think are the most relevant numbers to use in the context of this plugin, which is all about the sessions.

This also makes it easier for us to test the plugin on a production site. We can use a test site that doesn't have an associated WordCamp post, as long as the session times are set up correctly.

### How to test the changes in this Pull Request:

1. Set up some sessions so that the earliest published session is 2 days ago. Then visit the Leave Feedback page on the site. It should be available.
1. Try adjusting the session times so that the event falls outside of the window for leaving feedback (either the earliest session hasn't happened yet, or the latest session is more than two weeks in the past). Then you should no longer get the session selection form on the Leave Feedback page.
1. The above tests are regardless of what the `Start Date (YYYY-MM-DD)` value is in the WordCamp post for your test site.
