### PR TITLE
Speaker Feedback: Fix feedback table on small screens

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -301,11 +301,12 @@
 }
 
 .wp-list-table.fixed {
-	.is-expanded .column-name {
+	.is-expanded .column-name,
+	.is-expanded .column-rating {
 		display: none !important; // Needs important to override expanded !important.
 	}
 
-	.column-feedback .comment-author {
+	.column-feedback .comment-meta {
 		display: none;
 		margin-bottom: 0.6em;
 	}
@@ -321,12 +322,18 @@
 	}
 
 	@media screen and (max-width: 782px) {
-		.column-name {
+		.column-name,
+		.column-rating {
 			display: none;
 		}
 
-		.column-feedback .comment-author {
+		.column-feedback .comment-meta {
 			display: block;
+
+			.speaker-feedback__meta-rating {
+				display: block;
+				margin: 0.5em 0 1em;
+			}
 		}
 
 		tr.is-expanded td:last-child {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -300,8 +300,17 @@
 	}
 }
 
-#comments-form {
-	.fixed {
+.wp-list-table.fixed {
+	.is-expanded .column-name {
+		display: none !important; // Needs important to override expanded !important.
+	}
+
+	.column-feedback .comment-author {
+		display: none;
+		margin-bottom: 0.6em;
+	}
+
+	@media screen and (min-width: 783px) {
 		.column-name {
 			width: 15%;
 		}
@@ -311,11 +320,17 @@
 		}
 	}
 
-	.inappropriate {
-		th {
-			&.check-column {
-				border-left: 4px solid #ffb900;
-			}
+	@media screen and (max-width: 782px) {
+		.column-name {
+			display: none;
+		}
+
+		.column-feedback .comment-author {
+			display: block;
+		}
+
+		tr.is-expanded td:last-child {
+			padding-bottom: 1.5rem !important; // Needs important to override a long selector.
 		}
 	}
 }
@@ -326,5 +341,19 @@
 	&:hover {
 		color: #dc3232;
 		border: none;
+	}
+}
+
+.inappropriate {
+	th {
+		&.check-column {
+			border-left: 4px solid #ffb900;
+		}
+	}
+
+	.row-actions {
+		.unapprove {
+			display: none;
+		}
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -211,8 +211,9 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	 */
 	public function column_feedback( $comment ) {
 		// This is only displayed on smaller screens.
-		echo '<div class="comment-author">';
+		echo '<div class="comment-meta">';
 		$this->column_author( $comment );
+		$this->column_rating( $comment );
 		echo '</div>';
 
 		render_feedback_comment( $comment );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -210,6 +210,11 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	 * @return void
 	 */
 	public function column_feedback( $comment ) {
+		// This is only displayed on smaller screens.
+		echo '<div class="comment-author">';
+		$this->column_author( $comment );
+		echo '</div>';
+
 		render_feedback_comment( $comment );
 	}
 


### PR DESCRIPTION
Update styles in wp-admin for the smaller-screen view of the feedback list. This better matches the comments screen behavior by switching over to a mostly "single column" view for each item in the table, and fixes the expanded view.

### Screenshots

Before:

![Screen Shot 2020-04-28 at 12 55 57 PM](https://user-images.githubusercontent.com/541093/80515444-fe4b7080-894f-11ea-9c3c-56f39594300b.png)

After:

![Screen Shot 2020-04-28 at 12 49 55 PM](https://user-images.githubusercontent.com/541093/80515460-01def780-8950-11ea-8949-47a18a2b8ef3.png)


### How to test the changes in this Pull Request:

1. Build the styles
2. Resize your screen to <782px
3. It should be readable, no overlapping text or awkwardly small columns
