### PR TITLE
Speaker Feedback: Update helpfulness UI

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/_variables.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/_variables.scss
@@ -1,7 +1,3 @@
-// Colors.
-$star-default: #ccc;
-$star-selected: #f3940d;
-
 // Alert colors.
 $alert-yellow: #f0b849;
 $alert-red: #d94f4f;
@@ -9,3 +5,25 @@ $alert-green: #4ab866;
 
 $blue-medium-500: #00a0d2;
 $blue-medium-100: #e5f5fa;
+
+$light-gray-200: #f3f4f5;
+$light-gray-700: #ccd0d4;
+$light-gray-900: #a2aab2;
+
+$dark-gray-300: #6c7781;
+$dark-gray-500: #555d66;
+$dark-gray-600: #40464d;
+$dark-gray-900: #191e23;
+
+// Star colors
+$star-default: $light-gray-700;
+$star-selected: #f3940d;
+
+// Hide content visually only, leave visible to screen reader users
+@mixin visually-hidden() {
+	clip: rect(1px, 1px, 1px, 1px);
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -193,6 +193,11 @@
 		grid-column: 2;
 	}
 
+	input[type="submit"] {
+
+		@include visually-hidden;
+	}
+
 	@media (max-width: 600px) {
 		display: block;
 
@@ -221,27 +226,55 @@
 .speaker-feedback__helpful {
 	margin-top: 1em;
 	padding: 1rem 1.5rem;
-	background: #d5d5d5;
+	color: $dark-gray-900;
+	background: $light-gray-200;
 	border-radius: 5px;
 	max-width: 30em;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 
-	&.is-helpful {
-		border: 2px solid currentColor;
-	}
-
-	label { // stylelint-disable-line no-descending-specificity
+	// stylelint-disable no-descending-specificity
+	label {
+		position: relative;
 		margin-bottom: 0;
+		padding: 0.33em 2em;
+		color: $dark-gray-500;
+		border: 1px solid $light-gray-900;
+		box-sizing: border-box;
+		border-radius: 3px;
 		font-size: 1em;
-		display: flex;
-		align-items: center;
+		cursor: pointer;
+
+		&:hover,
+		&:focus-within {
+			color: $dark-gray-600;
+			border: 1px solid $dark-gray-300;
+		}
 
 		input {
-			margin-right: 6px;
+
+			@include visually-hidden;
 		}
 	}
+
+	&.is-helpful label {
+		color: #fff;
+		border: 1px solid #31843f;
+		background: #389547;
+
+		&::before {
+			content: "👍";
+		}
+
+		&:hover,
+		&:focus-within {
+			color: $dark-gray-600;
+			border: 1px solid $light-gray-900;
+			background: #fff;
+		}
+	}
+	// stylelint-enable
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -71,7 +71,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 					<?php esc_html_e( 'Only show feedback marked as helpful', 'wordcamporg' ); ?>
 				</label>
 			</div>
-			<input type="submit" class="screen-reader-text" value="Filter" />
+			<input type="submit" value="Filter" />
 		</form>
 
 		<div class="speaker-feedback__list comment-list">


### PR DESCRIPTION
Update the helpfulness UI to be a button style, with more indication of when it's selected (green + 👍 ). Still a checkbox + label behind the scenes, so it make sense for screen reader users too.

Fixes #462 

### Screenshots

Neutral
![Screen Shot 2020-04-30 at 2 58 36 PM](https://user-images.githubusercontent.com/541093/80748819-8a49cd80-8af3-11ea-8daa-4c7dbaf427b6.png)

Helpful
![Screen Shot 2020-04-30 at 3 01 37 PM](https://user-images.githubusercontent.com/541093/80748820-8ae26400-8af3-11ea-9845-0f437f8d6be7.png)
