### PR TITLE
Speaker Feedback: Show both form and approved feedback to organizers on the front end

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -97,22 +97,22 @@ class Walker_Feedback extends Walker_Comment {
 					<?php render_feedback_comment( $comment ); ?>
 				</div><!-- .comment-content -->
 
-				<?php if ( in_array( get_current_user_id(), $session_speakers, true ) ) : ?>
-					<footer class="speaker-feedback__helpful <?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>">
-						<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
-							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
-						</span>
-						<label>
+				<footer class="speaker-feedback__helpful <?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>">
+					<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
+						<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
+					</span>
+					<label>
+						<?php if ( in_array( get_current_user_id(), $session_speakers, true ) ) : ?>
 							<input
 								type="checkbox"
 								data-comment-id="<?php echo absint( $comment_id ); ?>"
 								aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
 								<?php checked( $comment->helpful ); ?>
 							/>
-							<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
-						</label>
-					</footer>
-				<?php endif; ?>
+						<?php endif; ?>
+						<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
+					</label>
+				</footer>
 			</article><!-- .comment-body -->
 		<?php
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -2,7 +2,8 @@
 
 namespace WordCamp\SpeakerFeedback;
 
-use Walker_Comment;
+use WP_Comment, Walker_Comment;
+use function WordCamp\SpeakerFeedback\Post\get_session_speaker_user_ids;
 use function WordCamp\SpeakerFeedback\View\{ render_feedback_comment, render_feedback_rating };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
@@ -66,7 +67,7 @@ class Walker_Feedback extends Walker_Comment {
 		$commenter = wp_get_current_commenter();
 		$comment_id = $comment->comment_ID;
 		$comment_author = $comment->comment_author_email;
-
+		$session_speakers = get_session_speaker_user_ids( $comment->comment_post_ID );
 		?>
 		<div <?php comment_class( 'speaker-feedback__comment', $comment ); ?>>
 			<article id="speaker-feedback-<?php echo absint( $comment_id ); ?>" class="speaker-feedback__comment-body comment-body">
@@ -96,20 +97,22 @@ class Walker_Feedback extends Walker_Comment {
 					<?php render_feedback_comment( $comment ); ?>
 				</div><!-- .comment-content -->
 
-				<footer class="speaker-feedback__helpful <?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>">
-					<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
-						<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
-					</span>
-					<label>
-						<input
-							type="checkbox"
-							data-comment-id="<?php echo absint( $comment_id ); ?>"
-							aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
-							<?php checked( $comment->helpful ); ?>
-						/>
-						<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
-					</button>
-				</footer>
+				<?php if ( in_array( get_current_user_id(), $session_speakers, true ) ) : ?>
+					<footer class="speaker-feedback__helpful <?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>">
+						<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
+							<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
+						</span>
+						<label>
+							<input
+								type="checkbox"
+								data-comment-id="<?php echo absint( $comment_id ); ?>"
+								aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
+								<?php checked( $comment->helpful ); ?>
+							/>
+							<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
+						</label>
+					</footer>
+				<?php endif; ?>
 			</article><!-- .comment-body -->
 		<?php
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -11,7 +11,6 @@ use function WordCamp\SpeakerFeedback\Post\{
 	get_session_speaker_user_ids, post_accepts_feedback, get_session_feedback_url
 };
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
-use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
 
 defined( 'WPINC' ) || die();

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -2,7 +2,8 @@
 
 namespace WordCamp\SpeakerFeedback\View;
 
-use WP_Post, WP_Query;
+use WP_Comment, WP_Post, WP_Query;
+use WordCamp\SpeakerFeedback\Feedback;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
 use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, get_feedback_comment };
 use function WordCamp\SpeakerFeedback\CommentMeta\{ get_feedback_meta_field_schema, get_feedback_questions };
@@ -11,6 +12,7 @@ use function WordCamp\SpeakerFeedback\Post\{
 	get_session_speaker_user_ids, post_accepts_feedback, get_session_feedback_url
 };
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
 
 defined( 'WPINC' ) || die();
@@ -42,61 +44,14 @@ function has_feedback_form() {
  */
 function render( $content ) {
 	global $post;
+	if ( ! $post instanceof WP_Post ) {
+		return $content;
+	}
 
 	$now = date_create( 'now', wp_timezone() );
 
 	if ( has_feedback_form() ) {
-		$session_speakers = get_session_speaker_user_ids( $post->ID );
-		if ( in_array( get_current_user_id(), $session_speakers, true ) ) {
-			ob_start();
-
-			$query_args = parse_feedback_args();
-			$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ), $query_args );
-			$avg_rating = 0;
-
-			if ( count( $feedback ) ) {
-				$sum_rating = array_reduce(
-					$feedback,
-					function( $carry, $item ) {
-						$carry += absint( $item->rating );
-						return $carry;
-					},
-					0
-				);
-				$avg_rating = round( $sum_rating / count( $feedback ) );
-			}
-
-			$feedback_count = count_feedback( $post->ID );
-			$approved       = absint( $feedback_count['approved'] );
-			$moderated      = absint( $feedback_count['moderated'] );
-
-			require get_views_path() . 'view-feedback.php';
-		} else {
-			$accepts_feedback = post_accepts_feedback( $post->ID );
-
-			ob_start();
-
-			if ( is_wp_error( $accepts_feedback ) ) {
-				$message = $accepts_feedback->get_error_message();
-				require get_views_path() . 'form-not-available.php';
-				return $content . ob_get_clean(); // Append the error message, return early.
-			}
-
-			$questions       = get_feedback_questions();
-			$schema          = get_feedback_meta_field_schema();
-			$rating_question = $questions['rating'];
-			$text_questions  = array_filter( array_map(
-				function( $key, $question ) {
-					return ( 'q' === $key[0] ) ? array( $key, $question ) : false;
-				},
-				array_keys( $questions ),
-				$questions
-			) );
-
-			require get_views_path() . 'form-feedback.php';
-		}
-
-		$content = $content . ob_get_clean(); // Append form to the normal content.
+		$content = $content . render_feedback_view(); // Append form to the normal content.
 	} elseif ( is_single() && true === post_accepts_feedback( $post->ID ) ) {
 		$html = sprintf(
 			wp_kses_post(
@@ -149,42 +104,54 @@ function render( $content ) {
 }
 
 /**
- * Parse the GET args to the feedback list into WP_Comment_Query-friendly format.
+ * Render the content that will be appended to the session when the feedback view is requested.
  *
- * @return array Sorting & filtering args in WP_Comment_Query format.
+ * @return string
  */
-function parse_feedback_args() {
-	$args = array();
+function render_feedback_view() {
+	global $post;
 
-	if ( isset( $_GET['forder'] ) ) {
-		switch ( $_GET['forder'] ) {
-			case 'newest':
-				$args['orderby'] = 'comment_date';
-				$args['order']   = 'desc';
-				break;
-			case 'highest':
-				$args['orderby'] = 'meta_value_num';
-				$args['meta_key'] = 'rating';
-				$args['order'] = 'desc';
-				break;
-			case 'oldest':
-			default:
-				$args['orderby'] = 'comment_date';
-				$args['order']   = 'asc';
-				break;
+	ob_start();
+
+	// Show the form to everyone except the speaker.
+	$session_speakers = get_session_speaker_user_ids( $post->ID );
+	if ( ! in_array( get_current_user_id(), $session_speakers, true ) ) {
+		$accepts_feedback = post_accepts_feedback( $post->ID );
+
+		if ( is_wp_error( $accepts_feedback ) ) {
+			$message = $accepts_feedback->get_error_message();
+
+			require get_views_path() . 'form-not-available.php';
+		} else {
+			$questions       = get_feedback_questions();
+			$schema          = get_feedback_meta_field_schema();
+			$rating_question = $questions['rating'];
+			$text_questions  = array_filter( array_map(
+				function( $key, $question ) {
+					return ( 'q' === $key[0] ) ? array( $key, $question ) : false;
+				},
+				array_keys( $questions ),
+				$questions
+			) );
+
+			require get_views_path() . 'form-feedback.php';
 		}
 	}
 
-	if ( isset( $_GET['helpful'] ) && 'yes' === $_GET['helpful'] ) {
-		$args['meta_query'] = array(
-			array(
-				'key'     => 'helpful',
-				'value'   => '1',
-			),
-		);
+	// Only show the approved feedback to the speaker and organizers.
+	if ( current_user_can( 'read_post_' . COMMENT_TYPE ) ) {
+		$query_args = parse_feedback_args();
+		$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ), $query_args );
+		$avg_rating = get_feedback_average_rating( $feedback );
+
+		$feedback_count = count_feedback( $post->ID );
+		$approved       = absint( $feedback_count['approved'] );
+		$moderated      = absint( $feedback_count['moderated'] );
+
+		require get_views_path() . 'view-feedback.php';
 	}
 
-	return $args;
+	return ob_get_clean(); // Append form to the normal content.
 }
 
 /**
@@ -312,4 +279,68 @@ function enqueue_assets() {
 			'before'
 		);
 	}
+}
+
+/**
+ * Parse the GET args to the feedback list into WP_Comment_Query-friendly format.
+ *
+ * @return array Sorting & filtering args in WP_Comment_Query format.
+ */
+function parse_feedback_args() {
+	$args = array();
+
+	if ( isset( $_GET['forder'] ) ) {
+		switch ( $_GET['forder'] ) {
+			case 'newest':
+				$args['orderby'] = 'comment_date';
+				$args['order']   = 'desc';
+				break;
+			case 'highest':
+				$args['orderby'] = 'meta_value_num';
+				$args['meta_key'] = 'rating';
+				$args['order'] = 'desc';
+				break;
+			case 'oldest':
+			default:
+				$args['orderby'] = 'comment_date';
+				$args['order']   = 'asc';
+				break;
+		}
+	}
+
+	if ( isset( $_GET['helpful'] ) && 'yes' === $_GET['helpful'] ) {
+		$args['meta_query'] = array(
+			array(
+				'key'     => 'helpful',
+				'value'   => '1',
+			),
+		);
+	}
+
+	return $args;
+}
+
+/**
+ * Calculate the average rating of a group of feedbacks.
+ *
+ * @param Feedback[] $feedback
+ *
+ * @return int
+ */
+function get_feedback_average_rating( array $feedback ) {
+	$count = count( $feedback );
+	if ( 0 === $count ) {
+		return 0;
+	}
+
+	$sum_rating = array_reduce(
+		$feedback,
+		function( $carry, $item ) {
+			$carry += absint( $item->rating );
+			return $carry;
+		},
+		0
+	);
+
+	return intval( round( $sum_rating / $count ) );
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -114,8 +114,10 @@ function render_feedback_view() {
 	ob_start();
 
 	// Show the form to everyone except the speaker.
-	$session_speakers = get_session_speaker_user_ids( $post->ID );
-	if ( ! in_array( get_current_user_id(), $session_speakers, true ) ) {
+	$session_speakers   = get_session_speaker_user_ids( $post->ID );
+	$is_session_speaker = in_array( get_current_user_id(), $session_speakers, true );
+
+	if ( ! $is_session_speaker ) {
 		$accepts_feedback = post_accepts_feedback( $post->ID );
 
 		if ( is_wp_error( $accepts_feedback ) ) {
@@ -139,7 +141,7 @@ function render_feedback_view() {
 	}
 
 	// Only show the approved feedback to the speaker and organizers.
-	if ( current_user_can( 'read_post_' . COMMENT_TYPE ) ) {
+	if ( current_user_can( 'read_post_' . COMMENT_TYPE, $post ) ) {
 		$query_args = parse_feedback_args();
 		$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ), $query_args );
 		$avg_rating = get_feedback_average_rating( $feedback );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -8,6 +8,7 @@ use function WordCamp\SpeakerFeedback\View\render_rating_stars;
 
 defined( 'WPINC' ) || die();
 
+/** @var bool $is_session_speaker */
 /** @var Feedback[] $feedback */
 /** @var int $avg_rating */
 /** @var int $approved */
@@ -79,6 +80,12 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 			</div>
 			<input type="submit" class="screen-reader-text" value="Filter" />
 		</form>
+
+		<?php if ( ! $is_session_speaker ) : ?>
+			<p class="speaker-feedback__notice">
+				<?php esc_html_e( 'Only feedback recipients can mark submissions as helpful.', 'wordcamporg' ); ?>
+			</p>
+		<?php endif; ?>
 
 		<div class="speaker-feedback__list comment-list">
 			<?php

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -2,10 +2,16 @@
 
 namespace WordCamp\SpeakerFeedback\View;
 
+use WordCamp\SpeakerFeedback\Feedback;
 use WordCamp\SpeakerFeedback\Walker_Feedback;
 use function WordCamp\SpeakerFeedback\View\render_rating_stars;
 
 defined( 'WPINC' ) || die();
+
+/** @var Feedback[] $feedback */
+/** @var int $avg_rating */
+/** @var int $approved */
+/** @var int $moderated */
 
 $approved_string = '';
 $moderated_string = '';


### PR DESCRIPTION
Organizers need to be able to see what a speaker would see when viewing their approved feedback, especially so the view can be styled to match the rest of the site. But organizers should also be able to submit feedback about a session through the form, just like everyone
else. So this makes it so everyone except the session speaker sees the form, and both the session speaker and organizers see the approved feedback list.

This also hides the "helpful" button on approved feedbacks from organizers. Only the speakers should be able to mark something as helpful.

Fixes #457

### How to test the changes in this Pull Request:

1. View the feedback URL for a session while logged out. Only the feedback form should be visible.
1. View the feedback URL for a session while logged in as a session speaker. Only the list of approved feedback should be visible.
1. View the feedback URL for a session while logged in as a site admin. Both the feedback form and the list of approved feedback should be visible. However, the "Was this feedback helpful?" section should be omitted from each approved feedback.
