### PR TITLE
Speaker Feedback: Use selectWoo for session dropdown

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -115,6 +115,7 @@
 
 	var navForm = document.getElementById( 'sft-navigation' );
 	if ( navForm ) {
+		$( navForm.querySelectorAll( 'select' ) ).select2();
 		navForm.addEventListener( 'submit', onFormNavigate, true );
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -72,9 +72,29 @@
 		align-items: stretch;
 	}
 
+	.select2-selection {
+		height: 100%;
+
+		.select2-selection__rendered,
+		.select2-selection__arrow {
+			height: 100%;
+			display: flex;
+			justify-content: center;
+			flex-direction: column;
+		}
+
+		.select2-selection__arrow {
+			top: -4px;
+		}
+	}
+
 	input[type="submit"] {
 		flex: initial;
 	}
+}
+
+.select2-results__option {
+	margin: 0;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -284,14 +284,14 @@ function enqueue_assets() {
 		wp_enqueue_style(
 			'speaker-feedback',
 			get_assets_url() . 'build/style.css',
-			array(),
+			array( 'select2' ),
 			filemtime( dirname( __DIR__ ) . '/assets/build/style.css' )
 		);
 
 		wp_enqueue_script(
 			'speaker-feedback',
 			get_assets_url() . 'js/script.js',
-			array( 'wp-api-fetch', 'jquery', 'lodash', 'wp-a11y' ),
+			array( 'wp-api-fetch', 'jquery', 'lodash', 'wp-a11y', 'select2' ),
 			filemtime( dirname( __DIR__ ) . '/assets/js/script.js' ),
 			true
 		);


### PR DESCRIPTION
Built on #472, which swapped out select2 for selectWoo. This adds better text-search through the list of sessions, so finding a session is easier.

Fixes #458 

### Screenshots

![Screen Shot 2020-05-01 at 5 54 56 PM](https://user-images.githubusercontent.com/541093/80844577-fa7c5000-8bd4-11ea-98a1-9c608a2e5fd9.png)

![Screen Shot 2020-05-01 at 5 55 04 PM](https://user-images.githubusercontent.com/541093/80844575-f9e3b980-8bd4-11ea-846a-5708685fa453.png)

### How to test the changes in this Pull Request:

1. Go to the main feedback page, `site.wordcamp.org/feedback`
2. The dropdown should switch out for a select2-style input, so you can search for talk
3. Selecting the talk, then hitting "Give Feedback" should navigate you to the feedback form for that talk
