### PR TITLE
Speaker Feedback: Fix toggle action when feedback is marked helpful

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -92,6 +92,11 @@
 
 	function onHelpfulClick( event ) {
 		var $container = $( event.target ).closest( 'footer' );
+		if ( $container.hasClass( 'is-inflight' ) ) {
+			return;
+		}
+		$container.addClass( 'is-inflight' );
+
 		var input = $container.find( 'input[type="checkbox"]' ).get( 0 );
 		var isHelpful = $container.hasClass( 'is-helpful' );
 
@@ -103,6 +108,7 @@
 			},
 		} )
 			.then( function() {
+				$container.removeClass( 'is-inflight' );
 				$container.toggleClass( 'is-helpful' );
 				if ( isHelpful ) {
 					// Previous state was helpful, has been un-marked, label should flip back to "mark as helpful".

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -93,7 +93,7 @@
 	function onHelpfulClick( event ) {
 		var $container = $( event.target ).closest( 'footer' );
 		var input = $container.find( 'input[type="checkbox"]' ).get( 0 );
-		var isHelpful = !! input.checked;
+		var isHelpful = $container.hasClass( 'is-helpful' );
 
 		wp.apiFetch( {
 			path: '/wordcamp-speaker-feedback/v1/feedback/' + input.dataset.commentId,

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -313,6 +313,10 @@
 			background: #fff;
 		}
 	}
+
+	&.is-inflight label {
+		cursor: wait;
+	}
 	// stylelint-enable
 }
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-walker-feedback.php
@@ -64,10 +64,12 @@ class Walker_Feedback extends Walker_Comment {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function render_feedback( $comment, $depth, $args ) {
-		$commenter = wp_get_current_commenter();
-		$comment_id = $comment->comment_ID;
-		$comment_author = $comment->comment_author_email;
+		$commenter        = wp_get_current_commenter();
+		$comment_id       = $comment->comment_ID;
+		$comment_author   = $comment->comment_author_email;
 		$session_speakers = get_session_speaker_user_ids( $comment->comment_post_ID );
+		$is_helpful       = wp_validate_boolean( $comment->helpful );
+
 		?>
 		<div <?php comment_class( 'speaker-feedback__comment', $comment ); ?>>
 			<article id="speaker-feedback-<?php echo absint( $comment_id ); ?>" class="speaker-feedback__comment-body comment-body">
@@ -97,7 +99,7 @@ class Walker_Feedback extends Walker_Comment {
 					<?php render_feedback_comment( $comment ); ?>
 				</div><!-- .comment-content -->
 
-				<footer class="speaker-feedback__helpful <?php echo ( $comment->helpful ) ? 'is-helpful' : ''; ?>">
+				<footer class="speaker-feedback__helpful <?php echo ( $is_helpful ) ? 'is-helpful' : ''; ?>">
 					<span id="sft-helpful-<?php echo absint( $comment_id ); ?>">
 						<?php esc_html_e( 'Was this feedback helpful?', 'wordcamporg' ); ?>
 					</span>
@@ -107,7 +109,7 @@ class Walker_Feedback extends Walker_Comment {
 								type="checkbox"
 								data-comment-id="<?php echo absint( $comment_id ); ?>"
 								aria-describedby="sft-helpful-<?php echo absint( $comment_id ); ?>"
-								<?php checked( $comment->helpful ); ?>
+								<?php checked( $is_helpful ); ?>
 							/>
 						<?php endif; ?>
 						<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>


### PR DESCRIPTION
While testing #469, I noticed that the helpful toggle wasn't behaving correctly — it was sending the opposite status for helpfulness. I think it's due to the browser checking the checkbox & running our click callback at the same time, so that `input.checked` is already in the opposite state. Instead of relying on something the browser changes, this now checks against the `is-helpful` class, which we intentionally toggle on/off.

### How to test the changes in this Pull Request:

1. Log in as a speaker for a session
2. Try toggling a feedback's helpfulness, the helpful state should visibly toggle
3. Reload the page, the feedback(s) you just marked should stay in the same state

Note about testing: The JS assumes the request did the right thing, so it _appears_ to work on production, but if you reload the page, everything's opposite.
