### PR TITLE
Speaker Feedback: Ensure feedback form & messages are in viewport

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -48,6 +48,9 @@
 			.then( function() {
 				$messageContainer.addClass( 'speaker-feedback__notice is-success' );
 				$messageContainer.append( $( '<p>' ).text( SpeakerFeedbackData.messages.submitSuccess ) );
+				$messageContainer.attr( 'tabIndex', -1 );
+				$messageContainer.focus();
+				form.scrollIntoView();
 				$( form ).replaceWith( $messageContainer );
 			} )
 			.catch( function( error ) {
@@ -69,6 +72,9 @@
 						}
 					} );
 				}
+				$messageContainer.attr( 'tabIndex', -1 );
+				$messageContainer.focus();
+				form.scrollIntoView();
 			} );
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -6,7 +6,7 @@
 		event.preventDefault();
 		var value = event.target[ 0 ].value;
 		// Use the fact that post IDs will redirect to the right page.
-		window.location = '/?p=' + value + '&sft_feedback=1';
+		window.location = '/?p=' + value + '&sft_feedback=1#sft-feedback';
 	}
 
 	function onFormSubmit( event ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -57,7 +57,7 @@ function render( $content ) {
 			wp_kses_post(
 				__( 'Did you attend this session? <a href="%s" class="sft-feedback-link">Leave feedback.</a>', 'wordcamporg' )
 			),
-			get_session_feedback_url( $post->ID )
+			get_session_feedback_url( $post->ID ) . '#sft-feedback'
 		);
 
 		$content = $content . wpautop( $html );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -54,7 +54,7 @@ defined( 'WPINC' ) || die();
 		</div>
 	<?php endif; ?>
 
-	<div id="speaker-feedback-notice" aria-live="polite" aria-relevant="additions text" aria-atomic="true"></div>
+	<div id="speaker-feedback-notice"></div>
 
 	<div class="speaker-feedback__field">
 		<fieldset class="speaker-feedback__field-rating" id="sft-rating">


### PR DESCRIPTION
Use a hash link for the feedback navigation links, to make sure the form is in the viewport when loaded. When the form is submitted, move focus (and scroll) back to the top of the form, which also reads out the message to screen reader users.

Fixes #459 

### How to test the changes in this Pull Request:

1. Go to the main feedback page & select one of the sessions
2. The page should load, and scroll you down to the form (Twenty Twenty uses smooth scrolling, other themes just move you - IMO this behavior should stay theme-controlled)
3. Fill out the form with some errors, submit it
4. You should be moved back up to the error, with focus on the error*
5. Try again with a valid reply, submit
6. You should be moved back up to the success message

*&nbsp;Moving focus to the error message does make more sense than just reading aloud the message via ARIA, and [is recommended here.](https://webaim.org/techniques/formvalidation/#error)
