### PR TITLE
Speaker Feedback: Add a text-label for status on each feedback in "all" view

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -362,7 +362,8 @@
  * WP Dashboard: Feedback list table.
  */
 
-.column-name {
+.column-name,
+.comment-meta {
 	img {
 		float: left;
 		margin-right: 10px;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -217,7 +217,7 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	public function column_feedback( $comment ) {
 		// This is only displayed on smaller screens.
 		echo '<div class="comment-meta">';
-		$this->column_author( $comment );
+		$this->column_name( $comment );
 		$this->column_rating( $comment );
 		echo '</div>';
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-feedback-list-table.php
@@ -172,6 +172,7 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 	 * @return void
 	 */
 	public function column_name( $comment ) {
+		global $comment_status;
 		$feedback = get_feedback_comment( $comment );
 
 		echo '<strong>';
@@ -199,6 +200,10 @@ class Feedback_List_Table extends WP_Comments_List_Table {
 				esc_url( 'mailto:' . $email ),
 				esc_html( $email )
 			);
+		}
+
+		if ( 'all' === $comment_status ) {
+			printf( '<p><em>%s</em></p>', esc_html( wp_get_comment_status( $feedback->comment_ID ) ) );
 		}
 	}
 


### PR DESCRIPTION
To add clarity to the feedback table, this adds a text label with the current status on the "all" view. Since only native statuses are shown in this view, we can use `wp_get_comment_status` directly.

Fixes #477

I've added this under the author name, which felt both out-of-the-way while still being visible.

### Screenshots

![Screen Shot 2020-05-05 at 3 09 32 PM](https://user-images.githubusercontent.com/541093/81107110-a333f380-8ee4-11ea-8cde-9d8814342433.png)

### How to test the changes in this Pull Request:

1. View the list table, "all" view
2. These status labels should show up under the author
3. Try another view, ex "Pending"
4. No status labels, since they're all the same status
5. Back to "all", shrink your viewport to <600px
6. The status labels should be visible in the small-screen view too
