### PR TITLE
Speaker Feedback: Set an `og:description` for the main feedback page

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -19,6 +19,7 @@ defined( 'WPINC' ) || die();
 
 add_filter( 'the_content', __NAMESPACE__ . '\render' );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_filter( 'jetpack_open_graph_tags', __NAMESPACE__ . '\inject_page_description' );
 
 /**
  * Check if the current page should include the feedback form.
@@ -345,4 +346,17 @@ function get_feedback_average_rating( array $feedback ) {
 	);
 
 	return intval( round( $sum_rating / $count ) );
+}
+
+/**
+ * Filter the og:description for the main feedback page.
+ *
+ * @param array $tags Array of Open Graph Meta tags.
+ * @return array
+ */
+function inject_page_description( $tags ) {
+	if ( is_page( get_option( OPTION_KEY ) ) ) {
+		$tags['og:description'] = __( 'You can show your appreciation and contribute back to the community by leaving constructive feedback. This not only helps speakers know what worked in their presentation and what didn’t, but it helps organizers get a sense of how successful the event was as a whole.', 'wordcamporg' );
+	}
+	return $tags;
 }


### PR DESCRIPTION
This prevents the placeholder content from showing up on social share embeds.

See #461 

The content used was pulled from the new handbook page, it says

> You can show your appreciation and contribute back to the community by leaving constructive feedback. This not only helps speakers know what worked in their presentation and what didn’t, but it helps organizers get a sense of how successful the event was as a whole.

happy to change this if there's feedback (:pundog:) ^

### How to test the changes in this Pull Request:

Requires active Jetpack— since Jetpack pulls the post content for the description, this isn't a problem on non-Jetpack sites.

1. Try embedding the `/feedback/` page on another post on the site, the embed should use the new content
2. Or just view source, the `og:description` should be the new content, no "placeholder"
