### PR TITLE
 Speaker Feedback: Display unapproved feedbacks in admin menu

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/admin.js
@@ -16,6 +16,8 @@ jQuery( document ).ready( function( $ ) {
 	function loadTopCounts() {
 		// Reload the page, but only the top view + count links.
 		$container.load( location.href + ' .subsubsub' );
+		// Reload the admin menu comment bubble.
+		$( '#adminmenu .sft-feedback-unread' ).load( location.href + ' #adminmenu .sft-feedback-unread-count' );
 	}
 
 	// We can assume window.theList exists because we're after `edit-comments.js`

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
@@ -224,8 +224,8 @@ function add_feedback_bubble( $screen ) {
 		return;
 	}
 
-	$pending_count = get_feedback( array(), array( 'hold' ), array( 'count' => true ) );
-	if ( $pending_count <= 0 ) {
+	$counts = count_feedback();
+	if ( $counts['moderated'] <= 0 ) {
 		return;
 	}
 
@@ -240,8 +240,8 @@ function add_feedback_bubble( $screen ) {
 			if ( $menu_slug === $menu_item[2] ) {
 				$bubble = sprintf(
 					" <span class='sft-feedback-unread count-%d awaiting-mod'><span class='sft-feedback-unread-count'>%s</span></span>",
-					$pending_count,
-					number_format_i18n( $pending_count )
+					$counts['moderated'],
+					number_format_i18n( $counts['moderated'] )
 				);
 
 				if ( $is_section ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -187,7 +187,7 @@ function update_feedback( $comment_id, array $feedback_meta ) {
  * @param array $status     Optional. An array of statuses to include in the results.
  * @param array $args       Optional. Additional args to be passed to get_comments.
  *
- * @return array A collection of WP_Comment objects.
+ * @return array|int A collection of WP_Comment objects, or the count of comments (if $args[`count`]).
  */
 function get_feedback( array $post__in = array(), array $status = array( 'hold', 'approve' ), array $args = array() ) {
 	$args = wp_parse_args(
@@ -207,6 +207,10 @@ function get_feedback( array $post__in = array(), array $status = array( 'hold',
 	}
 
 	$comments = get_comments( $args );
+
+	if ( isset( $args['count'] ) && $args['count'] ) {
+		return $comments;
+	}
 
 	// This makes loading meta values for comments much faster.
 	wp_queue_comments_for_comment_meta_lazyload( $comments );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/comment.php
@@ -187,7 +187,7 @@ function update_feedback( $comment_id, array $feedback_meta ) {
  * @param array $status     Optional. An array of statuses to include in the results.
  * @param array $args       Optional. Additional args to be passed to get_comments.
  *
- * @return array|int A collection of WP_Comment objects, or the count of comments (if $args[`count`]).
+ * @return array A collection of WP_Comment objects.
  */
 function get_feedback( array $post__in = array(), array $status = array( 'hold', 'approve' ), array $args = array() ) {
 	$args = wp_parse_args(
@@ -207,10 +207,6 @@ function get_feedback( array $post__in = array(), array $status = array( 'hold',
 	}
 
 	$comments = get_comments( $args );
-
-	if ( isset( $args['count'] ) && $args['count'] ) {
-		return $comments;
-	}
 
 	// This makes loading meta values for comments much faster.
 	wp_queue_comments_for_comment_meta_lazyload( $comments );


### PR DESCRIPTION
Add a count-bubble with the unapproved feedbacks count to the Sessions menu item. This moves to the Feedback item when the Sessions menu is opened (when on Sessions list, tracks, etc). When a feedback is approved/unapproved, the bubble count should be updated using the same JS action as the top row counts.

Fixes #478

### Screenshots

![Screen Shot 2020-05-05 at 5 56 52 PM](https://user-images.githubusercontent.com/541093/81119977-d16ffe00-8ef9-11ea-82ba-40abf06461e3.png)

![Screen Shot 2020-05-05 at 5 56 34 PM](https://user-images.githubusercontent.com/541093/81119976-d16ffe00-8ef9-11ea-8911-1c4a3218607e.png)

### How to test the changes in this Pull Request:

1. Have some unapproved feedbacks
2. From the dashboard, or posts, etc, see the count on Sessions
3. Click into Sessions (or any sub-item)
4. The count should move to Feedback
5. Go to Sessions -> Feedback
6. Approve some feedbacks
7. The bubble count should update to reflect the real count

_Note:_ I'm really not happy with this JS solution, as it's loading the page twice now behind the scenes… I don't think we're at risk of DoSing ourselves, since an org still needs to physically click a link to trigger it, but… 🤷‍♀️  I wish this was better?