### PR TITLE
Speaker Feedback: Update page content for Leave Feedback page

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -19,7 +19,6 @@ defined( 'WPINC' ) || die();
 
 add_filter( 'the_content', __NAMESPACE__ . '\render' );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
-add_filter( 'jetpack_open_graph_tags', __NAMESPACE__ . '\inject_page_description' );
 
 /**
  * Check if the current page should include the feedback form.
@@ -347,17 +346,4 @@ function get_feedback_average_rating( array $feedback ) {
 	);
 
 	return intval( round( $sum_rating / $count ) );
-}
-
-/**
- * Filter the og:description for the main feedback page.
- *
- * @param array $tags Array of Open Graph Meta tags.
- * @return array
- */
-function inject_page_description( $tags ) {
-	if ( is_page( get_option( OPTION_KEY ) ) ) {
-		$tags['og:description'] = __( 'You can show your appreciation and contribute back to the community by leaving constructive feedback. This not only helps speakers know what worked in their presentation and what didn’t, but it helps organizers get a sense of how successful the event was as a whole.', 'wordcamporg' );
-	}
-	return $tags;
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -105,7 +105,19 @@ function add_feedback_page() {
 
 	$organizer_note  = '<!-- wp:paragraph {"textColor":"white","customBackgroundColor":"#94240b"} -->';
 	$organizer_note .= '<p style="background-color:#94240b" class="has-text-color has-background has-white-color">';
-	$organizer_note .= __( 'This page is a placeholder for the Speaker Feedback form. The content here will not be shown on the site.', 'wordcamporg' );
+	$organizer_note .= __( 'Organizer Note: This page is used to display the session list for Speaker Feedback form. It will be added after the content you enter here. You can remove this note.', 'wordcamporg' );
+	$organizer_note .= '</p>';
+	$organizer_note .= '<!-- /wp:paragraph -->';
+
+	$organizer_note .= '<!-- wp:paragraph -->';
+	$organizer_note .= '<p>';
+	$organizer_note .= __( 'You can show your appreciation and contribute back to the community by leaving constructive feedback. This not only helps speakers know what worked in their presentation and what didn’t, but it helps organizers get a sense of how successful the event was as a whole.', 'wordcamporg' );
+	$organizer_note .= '</p>';
+	$organizer_note .= '<!-- /wp:paragraph -->';
+
+	$organizer_note .= '<!-- wp:paragraph -->';
+	$organizer_note .= '<p>';
+	$organizer_note .= __( 'The feedback you give will only be shown to speakers & organizers.', 'wordcamporg' );
 	$organizer_note .= '</p>';
 	$organizer_note .= '<!-- /wp:paragraph -->';
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -117,7 +117,7 @@ function add_feedback_page() {
 
 	$organizer_note .= '<!-- wp:paragraph -->';
 	$organizer_note .= '<p>';
-	$organizer_note .= __( 'The feedback you give will only be shown to speakers & organizers.', 'wordcamporg' );
+	$organizer_note .= __( 'The feedback you give will only be shown to speakers and organizers.', 'wordcamporg' );
 	$organizer_note .= '</p>';
 	$organizer_note .= '<!-- /wp:paragraph -->';
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -105,7 +105,7 @@ function add_feedback_page() {
 
 	$organizer_note  = '<!-- wp:paragraph {"textColor":"white","customBackgroundColor":"#94240b"} -->';
 	$organizer_note .= '<p style="background-color:#94240b" class="has-text-color has-background has-white-color">';
-	$organizer_note .= __( 'Organizer Note: This page is used to display the session list for Speaker Feedback form. It will be added after the content you enter here. You can remove this note.', 'wordcamporg' );
+	$organizer_note .= __( 'Organizer Note: This page is used to display the session list for the Speaker Feedback form. It will be added after the content you enter here. You can remove this note.', 'wordcamporg' );
 	$organizer_note .= '</p>';
 	$organizer_note .= '<!-- /wp:paragraph -->';
 


### PR DESCRIPTION
The main feedback page content shows up on the feedback form page. This updates the content to be more descriptive, and indicates that the red box is only an organizer note that can be removed. Since the content is editable now, the hard-coded description is also removed.

Fixes #461 

### Screenshots

![Screen Shot 2020-05-06 at 11 18 26 AM](https://user-images.githubusercontent.com/541093/81195255-91f1f200-8f8b-11ea-9a61-2c849275babb.png)

The new content is:

> Organizer Note: This page is used to display the session list for Speaker Feedback form. It will be added after the content you enter here. You can remove this note.
>
> You can show your appreciation and contribute back to the community by leaving constructive feedback. This not only helps speakers know what worked in their presentation and what didn’t, but it helps organizers get a sense of how successful the event was as a whole.
>
> The feedback you give will only be shown to speakers & organizers.

### How to test the changes in this Pull Request:

1. Force re-creation of this page with `wp --url=yoursite post delete [ID] --force`
2. Load the `site.wordcamp.org/feedback` page
3. You should see this new placeholder content
