### PR TITLE
Speaker Feedback: Add UI for speakers to opt out of email notifications about approved feedback

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -96,6 +96,42 @@
 		$( event.target ).siblings( '.speaker-feedback__field-help' ).text( len + '/' + maxLen );
 	}
 
+	function onNotificationClick( event ) {
+		var $container = $( event.target ).closest( 'div' );
+		if ( $container.hasClass( 'is-inflight' ) ) {
+			return;
+		}
+		$container.addClass( 'is-inflight' );
+
+		var input = $container.find( 'input[type="checkbox"]' ).get( 0 );
+		var isDisabled = $container.hasClass( 'is-disabled' );
+
+		wp.apiFetch( {
+			path: '/wordcamp-speaker-feedback/v1/feedback/notifications/' + input.dataset.userId,
+			method: 'POST',
+			data: {
+				speaker_opt_out: isDisabled ? 'false' : 'true',
+			},
+		} )
+			.then( function() {
+				var $labelText = $container.find( '.sft-notifications-label-text' ),
+					$toggleText = $container.find( '.sft-notifications-toggle-text' );
+
+				$container.removeClass( 'is-inflight' );
+				$container.toggleClass( 'is-disabled' );
+				if ( isDisabled ) {
+					// Previous state was disabled, has been enabled.
+					$labelText.text( SpeakerFeedbackData.messages.notificationsEnabled );
+					$toggleText.text( SpeakerFeedbackData.messages.disableNotifications );
+					wp.a11y.speak( SpeakerFeedbackData.messages.notificationsEnabled, 'polite' );
+				} else {
+					$labelText.text( SpeakerFeedbackData.messages.notificationsDisabled );
+					$toggleText.text( SpeakerFeedbackData.messages.enableNotifications );
+					wp.a11y.speak( SpeakerFeedbackData.messages.notificationsDisabled, 'polite' );
+				}
+			} );
+	}
+
 	function onHelpfulClick( event ) {
 		var $container = $( event.target ).closest( 'footer' );
 		if ( $container.hasClass( 'is-inflight' ) ) {
@@ -135,6 +171,13 @@
 	if ( feedbackForm ) {
 		feedbackForm.addEventListener( 'submit', onFormSubmit, true );
 		$( feedbackForm ).on( 'keyup', 'textarea[data-maxlength]', lodash.debounce( characterCounter, 250 ) );
+	}
+
+	var notificationButtons = document.querySelectorAll( '.speaker-feedback__notifications input' );
+	if ( notificationButtons.length ) {
+		notificationButtons.forEach( function( el ) {
+			el.addEventListener( 'click', onNotificationClick, true );
+		} );
 	}
 
 	var helpfulButtons = document.querySelectorAll( '.speaker-feedback__helpful input' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -114,8 +114,8 @@
 			},
 		} )
 			.then( function() {
-				var $labelText = $container.find( '.sft-notifications-label-text' ),
-					$toggleText = $container.find( '.sft-notifications-toggle-text' );
+				var $labelText = $container.find( '.speaker-feedback__notifications-label-text' ),
+					$toggleText = $container.find( '.speaker-feedback__notifications-toggle-text' );
 
 				$container.removeClass( 'is-inflight' );
 				$container.toggleClass( 'is-disabled' );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -107,7 +107,7 @@
 		var isDisabled = $container.hasClass( 'is-disabled' );
 
 		wp.apiFetch( {
-			path: '/wordcamp-speaker-feedback/v1/feedback/notifications/' + input.dataset.userId,
+			path: '/wordcamp-speaker-feedback/v1/notifications/' + input.dataset.userId,
 			method: 'POST',
 			data: {
 				speaker_opt_out: isDisabled ? 'false' : 'true',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -298,6 +298,11 @@
 		}
 	}
 
+	.sft-notifications-speaker-name {
+		display: block;
+		font-weight: 700;
+	}
+
 	&.is-helpful label {
 		color: #fff;
 		border: 1px solid #31843f;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -320,6 +320,7 @@
 	}
 	// stylelint-enable
 }
+
 .speaker-feedback__helpful {
 	margin-top: 1em;
 	margin-bottom: 0;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -259,11 +259,12 @@
 }
 
 /**
- * Speaker view: "Is this helpful" form.
+ * Speaker view: "Is this helpful" form and notification opt-out form.
  */
 
+.speaker-feedback__notifications,
 .speaker-feedback__helpful {
-	margin-top: 1em;
+	margin-bottom: 1em;
 	padding: 1rem 1.5rem;
 	color: $dark-gray-900;
 	background: $light-gray-200;
@@ -318,6 +319,10 @@
 		cursor: wait;
 	}
 	// stylelint-enable
+}
+.speaker-feedback__helpful {
+	margin-top: 1em;
+	margin-bottom: 0;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -298,7 +298,7 @@
 		}
 	}
 
-	.sft-notifications-speaker-name {
+	.speaker-feedback__notifications-speaker-name {
 		display: block;
 		font-weight: 700;
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -2,13 +2,14 @@
 
 namespace WordCamp\SpeakerFeedback;
 
-use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server;
+use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server, WP_User;
 use WP_REST_Comments_Controller;
-use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use function WordCamp\SpeakerFeedback\Comment\{ add_feedback, is_feedback, update_feedback };
 use function WordCamp\SpeakerFeedback\CommentMeta\{ get_feedback_meta_field_schema, validate_feedback_meta };
 use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
 use function WordCamp\SpeakerFeedback\Spam\spam_check;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -64,6 +65,36 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+			)
+		);
+
+		// The Core users endpoint does not allow updating a user that is not a member of the site,
+		// so we have to create our own endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/notifications/(?P<id>[\d]+)',
+			array(
+				'args' => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the user.', 'wordcamporg' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_notifications' ),
+					'permission_callback' => array( $this, 'update_notifications_permissions_check' ),
+					'args'                => array(
+						'speaker_opt_out'           => array(
+							'description' => __( 'Speaker has opted out of notifications about feedback.', 'wordcamporg' ),
+							'type'        => 'boolean',
+							'required'    => false,
+							'arg_options' => array(
+								'sanitize_callback' => array( $this, 'wp_validate_boolean' ),
+							),
+						),
+					),
 				),
 			)
 		);
@@ -403,5 +434,91 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		$duplicates = get_comments( $args );
 
 		return ! empty( $duplicates );
+	}
+
+	/**
+	 * Updates a user's notification preferences.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
+	 */
+	public function update_notifications( $request ) {
+		$user = new WP_User( $request['id'] );
+		if ( ! $user->exists() ) {
+			return new WP_Error(
+				'rest_feedback_notifications_invalid_user_id',
+				__( 'Invalid user ID.', 'wordcamporg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! isset( $request['speaker_opt_out'] ) ) {
+			return new WP_Error(
+				'rest_feedback_notifications_data_required',
+				__( 'No valid notifications parameters were submitted.', 'wordcamporg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$requested_state = wp_validate_boolean( $request['speaker_opt_out'] );
+		$current_state   = wp_validate_boolean( get_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true ) );
+
+		if ( $requested_state === $current_state ) {
+			return new WP_Error(
+				'rest_feedback_notifications_data_not_changed',
+				__( 'The requested notifications update has already been applied.', 'wordcamporg' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( true === $requested_state ) {
+			$result = update_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true );
+		} else {
+			$result = delete_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY );
+		}
+
+		if ( false === $result ) {
+			return new WP_Error(
+				'rest_feedback_notifications_update_failed',
+				__( 'The requested notifications update could not be completed.', 'wordcamporg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$response = array(); // At this point we have no reason to return details about the updated notifications.
+		$response = rest_ensure_response( $response );
+
+		$response->set_status( 201 ); // This is a sufficient signal that the request was successful.
+
+		return $response;
+	}
+
+	/**
+	 * Checks if a given REST request has access to update a user.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|bool True if the request has access to update the item, error object otherwise.
+	 */
+	public function update_notifications_permissions_check( $request ) {
+		$user = new WP_User( $request['id'] );
+		if ( ! $user->exists() ) {
+			return new WP_Error(
+				'rest_feedback_invalid_user_id',
+				__( 'Invalid user ID.', 'wordcamporg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_user', $user->ID ) ) {
+			return new WP_Error(
+				'rest_feedback_cannot_edit_user',
+				__( 'Sorry, you are not allowed to edit this user.', 'wordcamporg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-feedback-controller.php
@@ -2,14 +2,13 @@
 
 namespace WordCamp\SpeakerFeedback;
 
-use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server, WP_User;
+use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server;
 use WP_REST_Comments_Controller;
 use function WordCamp\SpeakerFeedback\Comment\{ add_feedback, is_feedback, update_feedback };
 use function WordCamp\SpeakerFeedback\CommentMeta\{ get_feedback_meta_field_schema, validate_feedback_meta };
 use function WordCamp\SpeakerFeedback\Post\post_accepts_feedback;
 use function WordCamp\SpeakerFeedback\Spam\spam_check;
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
-use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -31,8 +30,6 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 
 	/**
 	 * Registers the routes for the objects of the controller.
-	 *
-	 * Currently, the only route needed for feedback is `create`.
 	 *
 	 * @return void
 	 */
@@ -65,36 +62,6 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 					'callback'            => array( $this, 'update_item' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-				),
-			)
-		);
-
-		// The Core users endpoint does not allow updating a user that is not a member of the site,
-		// so we have to create our own endpoint.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/notifications/(?P<id>[\d]+)',
-			array(
-				'args' => array(
-					'id' => array(
-						'description' => __( 'Unique identifier for the user.', 'wordcamporg' ),
-						'type'        => 'integer',
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'update_notifications' ),
-					'permission_callback' => array( $this, 'update_notifications_permissions_check' ),
-					'args'                => array(
-						'speaker_opt_out'           => array(
-							'description' => __( 'Speaker has opted out of notifications about feedback.', 'wordcamporg' ),
-							'type'        => 'boolean',
-							'required'    => false,
-							'arg_options' => array(
-								'sanitize_callback' => array( $this, 'wp_validate_boolean' ),
-							),
-						),
-					),
 				),
 			)
 		);
@@ -434,91 +401,5 @@ class REST_Feedback_Controller extends WP_REST_Comments_Controller {
 		$duplicates = get_comments( $args );
 
 		return ! empty( $duplicates );
-	}
-
-	/**
-	 * Updates a user's notification preferences.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
-	 */
-	public function update_notifications( $request ) {
-		$user = new WP_User( $request['id'] );
-		if ( ! $user->exists() ) {
-			return new WP_Error(
-				'rest_feedback_notifications_invalid_user_id',
-				__( 'Invalid user ID.', 'wordcamporg' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		if ( ! isset( $request['speaker_opt_out'] ) ) {
-			return new WP_Error(
-				'rest_feedback_notifications_data_required',
-				__( 'No valid notifications parameters were submitted.', 'wordcamporg' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		$requested_state = wp_validate_boolean( $request['speaker_opt_out'] );
-		$current_state   = wp_validate_boolean( get_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true ) );
-
-		if ( $requested_state === $current_state ) {
-			return new WP_Error(
-				'rest_feedback_notifications_data_not_changed',
-				__( 'The requested notifications update has already been applied.', 'wordcamporg' ),
-				array( 'status' => 409 )
-			);
-		}
-
-		if ( true === $requested_state ) {
-			$result = update_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true );
-		} else {
-			$result = delete_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY );
-		}
-
-		if ( false === $result ) {
-			return new WP_Error(
-				'rest_feedback_notifications_update_failed',
-				__( 'The requested notifications update could not be completed.', 'wordcamporg' ),
-				array( 'status' => 500 )
-			);
-		}
-
-		$response = array(); // At this point we have no reason to return details about the updated notifications.
-		$response = rest_ensure_response( $response );
-
-		$response->set_status( 201 ); // This is a sufficient signal that the request was successful.
-
-		return $response;
-	}
-
-	/**
-	 * Checks if a given REST request has access to update a user.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return WP_Error|bool True if the request has access to update the item, error object otherwise.
-	 */
-	public function update_notifications_permissions_check( $request ) {
-		$user = new WP_User( $request['id'] );
-		if ( ! $user->exists() ) {
-			return new WP_Error(
-				'rest_feedback_invalid_user_id',
-				__( 'Invalid user ID.', 'wordcamporg' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		if ( ! current_user_can( 'edit_user', $user->ID ) ) {
-			return new WP_Error(
-				'rest_feedback_cannot_edit_user',
-				__( 'Sorry, you are not allowed to edit this user.', 'wordcamporg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		return true;
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-notifications-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-notifications-controller.php
@@ -4,6 +4,7 @@ namespace WordCamp\SpeakerFeedback;
 
 use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server, WP_User;
 use WP_REST_Controller;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
 
 defined( 'WPINC' ) || die();
@@ -134,7 +135,9 @@ class REST_Notifications_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( ! current_user_can( 'edit_user', $user->ID ) ) {
+		// On multisite, only super admins can edit users. Single site admins should be able to modify notifications
+		// for speakers, so we also check our custom feedback moderation capability here.
+		if ( ! current_user_can( 'edit_user', $user->ID ) && ! current_user_can( 'moderate_' . COMMENT_TYPE ) ) {
 			return new WP_Error(
 				'rest_feedback_cannot_edit_user',
 				__( 'Sorry, you are not allowed to edit this user.', 'wordcamporg' ),

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-notifications-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/class-rest-notifications-controller.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback;
+
+use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server, WP_User;
+use WP_REST_Controller;
+use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class REST_Notifications_Controller
+ *
+ * @package WordCamp\SpeakerFeedback
+ */
+class REST_Notifications_Controller extends WP_REST_Controller {
+	/**
+	 * REST_Feedback_Controller constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wordcamp-speaker-feedback/v1';
+		$this->rest_base = 'notifications';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// The Core users endpoint does not allow updating a user that is not a member of the site,
+		// so we have to create our own endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args' => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the user.', 'wordcamporg' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_notifications' ),
+					'permission_callback' => array( $this, 'update_notifications_permissions_check' ),
+					'args'                => array(
+						'speaker_opt_out'           => array(
+							'description' => __( 'Speaker has opted out of notifications about feedback.', 'wordcamporg' ),
+							'type'        => 'boolean',
+							'required'    => false,
+							'arg_options' => array(
+								'sanitize_callback' => 'wp_validate_boolean',
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Updates a user's notification preferences.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
+	 */
+	public function update_notifications( $request ) {
+		$user = new WP_User( $request['id'] );
+		if ( ! $user->exists() ) {
+			return new WP_Error(
+				'rest_feedback_notifications_invalid_user_id',
+				__( 'Invalid user ID.', 'wordcamporg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! isset( $request['speaker_opt_out'] ) ) {
+			return new WP_Error(
+				'rest_feedback_notifications_data_required',
+				__( 'No valid notifications parameters were submitted.', 'wordcamporg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$requested_state = wp_validate_boolean( $request['speaker_opt_out'] );
+		$current_state   = wp_validate_boolean( get_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true ) );
+
+		if ( $requested_state === $current_state ) {
+			return new WP_Error(
+				'rest_feedback_notifications_data_not_changed',
+				__( 'The requested notifications update has already been applied.', 'wordcamporg' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( true === $requested_state ) {
+			$result = update_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true );
+		} else {
+			$result = delete_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY );
+		}
+
+		if ( false === $result ) {
+			return new WP_Error(
+				'rest_feedback_notifications_update_failed',
+				__( 'The requested notifications update could not be completed.', 'wordcamporg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$response = array(); // At this point we have no reason to return details about the updated notifications.
+		$response = rest_ensure_response( $response );
+
+		$response->set_status( 201 ); // This is a sufficient signal that the request was successful.
+
+		return $response;
+	}
+
+	/**
+	 * Checks if a given REST request has access to update a user.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_Error|bool True if the request has access to update the item, error object otherwise.
+	 */
+	public function update_notifications_permissions_check( $request ) {
+		$user = new WP_User( $request['id'] );
+		if ( ! $user->exists() ) {
+			return new WP_Error(
+				'rest_feedback_invalid_user_id',
+				__( 'Invalid user ID.', 'wordcamporg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_user', $user->ID ) ) {
+			return new WP_Error(
+				'rest_feedback_cannot_edit_user',
+				__( 'Sorry, you are not allowed to edit this user.', 'wordcamporg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -66,7 +66,6 @@ function notify_speakers_approved_feedback() {
 
 	foreach ( $speaker_session_ids as $user_id => $session_ids ) {
 		$speaker = get_user_by( 'id', $user_id );
-		// Todo: Implement a UI for toggling this user meta value.
 		if ( true === wp_validate_boolean( $speaker->{SPEAKER_OPT_OUT_KEY} ) ) {
 			continue;
 		}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -10,6 +10,8 @@ use function WordCamp\SpeakerFeedback\Post\{
 
 defined( 'WPINC' ) || die();
 
+const SPEAKER_OPT_OUT_KEY = 'sft_notifications_speaker_opt_out';
+
 add_action( 'init', __NAMESPACE__ . '\schedule_jobs' );
 add_action( 'sft_notify_speakers_approved_feedback', __NAMESPACE__ . '\notify_speakers_approved_feedback' );
 
@@ -65,7 +67,7 @@ function notify_speakers_approved_feedback() {
 	foreach ( $speaker_session_ids as $user_id => $session_ids ) {
 		$speaker = get_user_by( 'id', $user_id );
 		// Todo: Implement a UI for toggling this user meta value.
-		if ( true === wp_validate_boolean( $speaker->sft_speaker_notifications_opt_out ) ) {
+		if ( true === wp_validate_boolean( $speaker->{SPEAKER_OPT_OUT_KEY} ) ) {
 			continue;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -13,6 +13,7 @@ use function WordCamp\SpeakerFeedback\Post\{
 };
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
 use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
 
 defined( 'WPINC' ) || die();
@@ -152,6 +153,8 @@ function render_feedback_view() {
 		$approved       = absint( $feedback_count['approved'] );
 		$moderated      = absint( $feedback_count['moderated'] );
 
+		$notifications_opt_out = get_user_meta( get_current_user_id(), SPEAKER_OPT_OUT_KEY, true );
+
 		require get_views_path() . 'view-feedback.php';
 	}
 
@@ -268,9 +271,13 @@ function enqueue_assets() {
 
 		$data = array(
 			'messages' => array(
-				'submitSuccess'   => __( 'Feedback submitted.', 'wordcamporg' ),
-				'markedHelpful'   => __( 'Feedback marked as helpful.', 'wordcamporg' ),
-				'unmarkedHelpful' => __( 'Feedback unmarked as helpful.', 'wordcamporg' ),
+				'submitSuccess'         => __( 'Feedback submitted.', 'wordcamporg' ),
+				'markedHelpful'         => __( 'Feedback marked as helpful.', 'wordcamporg' ),
+				'unmarkedHelpful'       => __( 'Feedback unmarked as helpful.', 'wordcamporg' ),
+				'notificationsEnabled'  => __( 'Feedback notifications are enabled.', 'wordcamporg' ),
+				'notificationsDisabled' => __( 'Feedback notifications are disabled.', 'wordcamporg' ),
+				'enableNotifications'   => __( 'Enable', 'wordcamporg' ),
+				'disableNotifications'  => __( 'Disable', 'wordcamporg' ),
 			),
 		);
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -153,8 +153,6 @@ function render_feedback_view() {
 		$approved       = absint( $feedback_count['approved'] );
 		$moderated      = absint( $feedback_count['moderated'] );
 
-		$notifications_opt_out = get_user_meta( get_current_user_id(), SPEAKER_OPT_OUT_KEY, true );
-
 		require get_views_path() . 'view-feedback.php';
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-feedback-controller.php
@@ -12,7 +12,7 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 defined( 'WPINC' ) || die();
 
 /**
- * Class Test_SpeakerFeedback_Comment
+ * Class Test_SpeakerFeedback_REST_Feedback_Controller
  *
  * @group wordcamp-speaker-feedback
  */
@@ -70,7 +70,7 @@ class Test_SpeakerFeedback_REST_Feedback_Controller extends WP_UnitTestCase {
 		) );
 
 		self::$posts['speaker'] = $factory->post->create_and_get( array(
-			'post_type'  => 'wcb_session',
+			'post_type'  => 'wcb_speaker',
 			'meta_input' => array(
 				'_wcpt_user_id' => self::$users['speaker']->ID,
 			),

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-notifications-controller.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-class-rest-notifications-controller.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_UnitTestCase, WP_UnitTest_Factory;
+use WP_Comment, WP_Post, WP_User;
+use WP_REST_Request, WP_REST_Response;
+use WordCamp\SpeakerFeedback\REST_Notifications_Controller;
+use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_REST_Notifications_Controller
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_REST_Notifications_Controller extends WP_UnitTestCase {
+	/**
+	 * @var REST_Notifications_Controller
+	 */
+	protected static $controller;
+
+	/**
+	 * @var WP_User[]
+	 */
+	protected static $users = array();
+
+	/**
+	 * @var WP_Post[]
+	 */
+	protected static $posts = array();
+
+	/**
+	 * @var WP_REST_Request
+	 */
+	protected $request;
+
+	/**
+	 * Set up shared fixtures for these tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$controller = new REST_Notifications_Controller();
+		tests_add_filter( 'rest_api_init', array( self::$controller, 'register_routes' ) );
+
+		self::$users['speaker'] = $factory->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
+
+		self::$users['non-speaker'] = $factory->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
+
+		self::$users['administrator'] = $factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		self::$posts['speaker'] = $factory->post->create_and_get( array(
+			'post_type'  => 'wcb_speaker',
+			'meta_input' => array(
+				'_wcpt_user_id' => self::$users['speaker']->ID,
+			),
+		) );
+
+		self::$posts['session'] = $factory->post->create_and_get( array(
+			'post_type'  => 'wcb_session',
+			'meta_input' => array(
+				'_wcpt_session_type' => 'session',
+				'_wcpt_session_time' => strtotime( '- 1 day' ),
+			),
+		) );
+		// It doesn't work to add this value via `meta_input` for some reason.
+		add_post_meta( self::$posts['session']->ID, '_wcpt_speaker_id', self::$posts['speaker']->ID );
+	}
+
+	/**
+	 * Remove fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+
+		foreach ( self::$users as $user ) {
+			wp_delete_user( $user->ID );
+		}
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( self::$users['speaker']->ID );
+
+		$this->request = new WP_REST_Request( 'POST', '/wordcamp-speaker-feedback/v1/notifications' );
+	}
+
+	/**
+	 * Reset after each test.
+	 */
+	public function tearDown() {
+		$this->request = null;
+
+		foreach ( self::$users as $user ) {
+			delete_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications()
+	 */
+	public function test_update_notifications_speaker_opt_out() {
+		$params = array(
+			'id'              => self::$users['speaker']->ID,
+			'speaker_opt_out' => 'true',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response1 = self::$controller->update_notifications( $this->request );
+
+		$this->assertTrue( $response1 instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response1->get_status() );
+		$this->assertTrue( (bool) self::$users['speaker']->{SPEAKER_OPT_OUT_KEY} );
+
+		$response2 = self::$controller->update_notifications( $this->request );
+
+		$this->assertWPError( $response2 );
+		$this->assertEquals( 'rest_feedback_notifications_data_not_changed', $response2->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications()
+	 */
+	public function test_update_notifications_speaker_opt_back_in() {
+		update_user_meta( self::$users['speaker']->ID, SPEAKER_OPT_OUT_KEY, true );
+
+		$params = array(
+			'id'              => self::$users['speaker']->ID,
+			'speaker_opt_out' => 'false',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response1 = self::$controller->update_notifications( $this->request );
+
+		$this->assertTrue( $response1 instanceof WP_REST_Response );
+		$this->assertEquals( 201, $response1->get_status() );
+		$this->assertFalse( (bool) self::$users['speaker']->{SPEAKER_OPT_OUT_KEY} );
+
+		$response2 = self::$controller->update_notifications( $this->request );
+
+		$this->assertWPError( $response2 );
+		$this->assertEquals( 'rest_feedback_notifications_data_not_changed', $response2->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications()
+	 */
+	public function test_update_notifications_no_id() {
+		$params = array(
+			'speaker_opt_out' => 'true',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_notifications( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_notifications_invalid_user_id', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications()
+	 */
+	public function test_update_notifications_invalid_parameter() {
+		$params = array(
+			'id'              => self::$users['speaker']->ID,
+			'out_opt_speaker' => 'true',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_notifications( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_notifications_data_required', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications_permissions_check()
+	 */
+	public function test_update_notifications_permissions_check_can_edit_self() {
+		$params = array(
+			'id'              => self::$users['speaker']->ID,
+			'speaker_opt_out' => 'true',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_notifications_permissions_check( $this->request );
+
+		$this->assertTrue( $response );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications_permissions_check()
+	 */
+	public function test_update_notifications_permissions_check_cannot_edit() {
+		wp_set_current_user( self::$users['non-speaker']->ID );
+
+		$params = array(
+			'id'              => self::$users['speaker']->ID,
+			'speaker_opt_out' => 'true',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_notifications_permissions_check( $this->request );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'rest_feedback_cannot_edit_user', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\REST_Notifications_Controller::update_notifications_permissions_check()
+	 */
+	public function test_update_notifications_permissions_check_admin_can_edit() {
+		wp_set_current_user( self::$users['administrator']->ID );
+
+		$params = array(
+			'id'              => self::$users['speaker']->ID,
+			'speaker_opt_out' => 'true',
+		);
+
+		$this->request->set_body_params( $params );
+
+		$response = self::$controller->update_notifications_permissions_check( $this->request );
+
+		$this->assertTrue( $response );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -44,11 +44,28 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 <div class="speaker-feedback">
 	<h2><?php esc_html_e( 'Session Feedback', 'wordcamporg' ); ?></h2>
 
-	<?php if ( ! $is_session_speaker ) : ?>
-		<p class="speaker-feedback__notice">
-			<?php esc_html_e( 'Only feedback recipients can mark submissions as helpful.', 'wordcamporg' ); ?>
-		</p>
-	<?php endif; ?>
+	<p class="speaker-feedback__notice">
+		<?php if ( $is_session_speaker ) : ?>
+			<?php
+			esc_html_e( '
+				Email notifications are sent up to once per day when new feedback submissions have been approved.
+				Disabling this will turn off feedback notifications on all WordCamp sites.
+				',
+				'wordcamporg'
+			);
+			?>
+		<?php else : ?>
+			<?php
+			esc_html_e( '
+				Email notifications to speakers are sent up to once per day when new feedback submissions have been
+				approved. Disabling these emails for a speaker will turn off feedback notifications for them on all
+				WordCamp sites.
+				',
+				'wordcamporg'
+			);
+			?>
+		<?php endif; ?>
+	</p>
 
 	<?php foreach ( $session_speakers as $session_speaker ) :
 		if ( $is_session_speaker && get_current_user_id() !== $session_speaker ) {
@@ -128,6 +145,12 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 			</div>
 			<input type="submit" value="Filter" />
 		</form>
+
+		<?php if ( ! $is_session_speaker ) : ?>
+			<p class="speaker-feedback__notice">
+				<?php esc_html_e( 'Only feedback recipients can mark submissions as helpful.', 'wordcamporg' ); ?>
+			</p>
+		<?php endif; ?>
 
 		<div class="speaker-feedback__list comment-list">
 			<?php

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -77,11 +77,11 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 		<div class="speaker-feedback__notifications <?php echo ( $notifications_opt_out ) ? 'is-disabled' : ''; ?>">
 			<span>
 				<?php if ( ! $is_session_speaker ) : ?>
-					<span class="sft-notifications-speaker-name">
+					<span class="speaker-feedback__notifications-speaker-name">
 						<?php echo esc_html( $user->user_login ); ?>
 					</span>
 				<?php endif; ?>
-				<span class="sft-notifications-label-text">
+				<span class="speaker-feedback__notifications-label-text">
 					<?php if ( $notifications_opt_out ) : ?>
 						<?php esc_html_e( 'Feedback notifications are disabled.', 'wordcamporg' ); ?>
 					<?php else : ?>
@@ -95,7 +95,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 					data-user-id="<?php echo absint( $user->ID ); ?>"
 					<?php checked( $notifications_opt_out ); ?>
 				/>
-				<span class="sft-notifications-toggle-text">
+				<span class="speaker-feedback__notifications-toggle-text">
 					<?php if ( $notifications_opt_out ) : ?>
 						<?php esc_html_e( 'Enable', 'wordcamporg' ); ?>
 					<?php else : ?>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -75,7 +75,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 		$notifications_opt_out = get_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true );
 		?>
 		<div class="speaker-feedback__notifications <?php echo ( $notifications_opt_out ) ? 'is-disabled' : ''; ?>">
-			<span>
+			<span id="sft-notifications-description">
 				<?php if ( ! $is_session_speaker ) : ?>
 					<span class="speaker-feedback__notifications-speaker-name">
 						<?php echo esc_html( $user->user_login ); ?>
@@ -92,6 +92,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 			<label>
 				<input
 					type="checkbox"
+					aria-describedby="sft-notifications-description"
 					data-user-id="<?php echo absint( $user->ID ); ?>"
 					<?php checked( $notifications_opt_out ); ?>
 				/>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -75,7 +75,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 		$notifications_opt_out = get_user_meta( $user->ID, SPEAKER_OPT_OUT_KEY, true );
 		?>
 		<div class="speaker-feedback__notifications <?php echo ( $notifications_opt_out ) ? 'is-disabled' : ''; ?>">
-			<span id="sft-notifications-description">
+			<span id="sft-notifications-description-<?php echo esc_attr( absint( $user->ID ) ); ?>">
 				<?php if ( ! $is_session_speaker ) : ?>
 					<span class="speaker-feedback__notifications-speaker-name">
 						<?php echo esc_html( $user->user_login ); ?>
@@ -92,7 +92,7 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 			<label>
 				<input
 					type="checkbox"
-					aria-describedby="sft-notifications-description"
+					aria-describedby="sft-notifications-description-<?php echo esc_attr( absint( $user->ID ) ); ?>"
 					data-user-id="<?php echo absint( $user->ID ); ?>"
 					<?php checked( $notifications_opt_out ); ?>
 				/>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -43,6 +43,7 @@ if ( ! wcorg_skip_feature( 'speaker_feedback' ) && class_exists( 'WordCamp_Post_
 function load() {
 	require_once get_includes_path() . 'class-feedback.php';
 	require_once get_includes_path() . 'class-rest-feedback-controller.php';
+	require_once get_includes_path() . 'class-rest-notifications-controller.php';
 	require_once get_includes_path() . 'class-walker-feedback.php';
 	require_once get_includes_path() . 'cron.php';
 	require_once get_includes_path() . 'capabilities.php';
@@ -139,8 +140,11 @@ function add_page_endpoint() {
  * @return void
  */
 function register_rest_routes() {
-	$controller = new REST_Feedback_Controller();
-	$controller->register_routes();
+	$feedback_controller = new REST_Feedback_Controller();
+	$feedback_controller->register_routes();
+
+	$notifications_controller = new REST_Notifications_Controller();
+	$notifications_controller->register_routes();
 }
 
 /**


### PR DESCRIPTION
Building on the usermeta value introduced in #441, this adds a toggle to the frontend Session Feedback view where speakers and organizers can disable and re-enable email notifications about newly approved feedback submissions. The toggle updates the usermeta value, which carries over across all WordCamp sites in the network.

To accomplish this, I created a new endpoint on our custom REST API route for feedback. The standard `users` endpoint doesn't work for updating this usermeta value because it requires that the user be a member on the current site. Most speakers are not added as members on the WordCamp sites that they speak at. The custom endpoint allows us to circumvent that.

Note that this does **not** include a metabox or other UI on the Speaker CPT screen for toggling this value. Adding a metabox that would be functional in the block editor turned out to be overly-complex, given the necessary interaction with the existing `WordPress.org Username` metabox field. Building a custom sidebar plugin is beyond the scope of this PR, but it might be simpler, and doable as a separate PR, once the other metabox fields for the Speaker CPT have been converted to sidebar panels, as was [recently done](https://github.com/WordPress/wordcamp.org/pull/303) for the Sessions CPT. In the mean time, organizers can toggle this value for speakers upon request by going to the frontend feedback view, where they will see the same UI that speakers do, but with a separate toggle for each speaker in the session.

Fixes #488 

### Screenshots

Speaker UI, notifications enabled (default)

![speaker-view-enabled](https://user-images.githubusercontent.com/916023/81439825-d912eb00-9123-11ea-935e-5255138ca204.jpg)

Speaker UI, notifications disabled

![speaker-view-disabled](https://user-images.githubusercontent.com/916023/81439837-e203bc80-9123-11ea-86ca-ba8c111ac7d6.jpg)

Organizer UI

![admin-view](https://user-images.githubusercontent.com/916023/81453076-7c242e80-913d-11ea-8351-338b46f337b3.jpg)

### How to test the changes in this Pull Request:

1. Rebuild the stylesheet to get the style updates.
1. With the same testing setup as for #441, open the feedback moderation screen and approve a new feedback submission.
1. Run the cron job and note that an email is sent in MailCatcher.
1. In a separate tab, navigate to the frontend feedback view for a session while logged in as a speaker. Click the toggle to disable notifications.
1. Approve another feedback submission and run the cron job. No new email should be sent.
1. Re-enable notifications for the speaker, and run the cron job again. Now the email should get sent.
