### PR TITLE
WordCamp Central: Add "online" flag to virtual events in schedule and past list

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -1527,6 +1527,17 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 	color: #545454;
 	text-transform: uppercase;
 	font-size: 12px;
+	margin-right: 5px;
+}
+
+.wc-online-event {
+	display: inline-block;
+	text-transform: uppercase;
+	font-size: 11px;
+	padding: 0 5px;
+	background: #0c617c;
+	color: #fff;
+	line-height: 18px;
 }
 
 .wc-schedule #content .wc-schedule-list .wc-date {
@@ -1622,9 +1633,7 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 
 .page-template-template-past-wordcamps-php .wc-schedule-list .wc-country {
 	line-height: 14px;
-
-	display: block;
-	margin: 8px 0 3px 0;
+	margin: 6px 0 3px 0;
 }
 
 .page-template-template-past-wordcamps-php .wc-schedule .wc-schedule-more {
@@ -1639,9 +1648,10 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 
 .page-template-template-past-wordcamps-php .wc-schedule #content h2.wc-title,
 .page-template-template-past-wordcamps-php #content .wc-country,
+.page-template-template-past-wordcamps-php #content .wc-online-event,
 .page-template-template-past-wordcamps-php #content .wc-date {
 	margin-left: 145px;
-	display: block;
+	display: inline-block;
 }
 
 .page-template-template-past-wordcamps-php .wc-schedule .wc-schedule-list img,

--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -1511,6 +1511,10 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 	border-top: 1px #ececec solid;
 }
 
+.wc-schedule .wc-schedule-list li:nth-of-type(odd) {
+	clear: left;
+}
+
 .wc-schedule #content .wc-schedule-list h2.wc-title {
 	display: inline;
 	color: #028db9;

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
@@ -63,6 +63,9 @@ get_header(); ?>
 
 										<h2 class="wc-title"><?php wcpt_wordcamp_title(); ?></h2>
 										<span class="wc-country"><?php wcpt_wordcamp_location( $post->ID ); ?></span>
+										<?php if ( $post->{'Virtual event only'} ) : ?>
+											<span class="wc-online-event">Online Event</span>
+										<?php endif; ?>
 
 										<span class="wc-date">
 											<?php WordCamp_Central_Theme::the_wordcamp_date( $post->ID, true ); ?>

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
@@ -58,6 +58,9 @@ get_header(); ?>
 
 										<h2 class="wc-title"><?php wcpt_wordcamp_title(); ?></h2>
 										<span class="wc-country"><?php wcpt_wordcamp_location( $post->ID ); ?></span>
+										<?php if ( $post->{'Virtual event only'} ) : ?>
+											<span class="wc-online-event">Online Event</span>
+										<?php endif; ?>
 
 										<span class="wc-date">
 											<?php WordCamp_Central_Theme::the_wordcamp_date( $post->ID, true ); ?>


### PR DESCRIPTION
Adds a colored flag to events on the Schedule page and the Past Events page when they are marked as "Virtual event only".

Tested with Firefox, Chrome, and Safari.

Fixes #474 

### Screenshots

Schedule page

![schedule](https://user-images.githubusercontent.com/916023/81458010-366f6200-914d-11ea-9e5a-447f04611fce.jpg)

Past Events page

![past-events](https://user-images.githubusercontent.com/916023/81458016-3bccac80-914d-11ea-826a-cc6b190dda0e.jpg)

### How to test the changes in this Pull Request:

1. Load this PR on your sandbox, view the changed pages. Try different browsers.
