### PR TITLE
Speaker Feedback: Add context to the sessions list

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -83,6 +83,11 @@
 			flex-direction: column;
 		}
 
+		.select2-selection__rendered {
+			margin-right: 20px;
+			padding-right: 0;
+		}
+
 		.select2-selection__arrow {
 			top: -4px;
 		}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -153,6 +153,33 @@ function get_session_speaker_user_ids( $session_id ) {
 }
 
 /**
+ * Get a list of speaker names for a given session.
+ *
+ * @param int $session_id
+ *
+ * @return array
+ */
+function get_session_speaker_names( $session_id ) {
+	$speakers         = array();
+	$speaker_post_ids = get_post_meta( $session_id, '_wcpt_speaker_id' );
+
+	if ( ! empty( $speaker_post_ids ) ) {
+		$speakers = get_posts( array(
+			'post_type'      => 'wcb_speaker',
+			'posts_per_page' => - 1,
+			'post__in'       => $speaker_post_ids,
+		) );
+	}
+
+	$names = array();
+	foreach ( $speakers as $speaker ) {
+		$names[] = apply_filters( 'the_title', $speaker->post_title );
+	}
+
+	return $names;
+}
+
+/**
  * Generate a link to the front end feedback UI for a particular session.
  *
  * @param int $post_id

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -5,11 +5,16 @@ namespace WordCamp\SpeakerFeedback\View;
 $session_args = array(
 	'post_type'      => 'wcb_session',
 	'posts_per_page' => -1,
-	'orderby'        => 'title',
+	'orderby'        => 'meta_value_num',
 	'order'          => 'asc',
+	'meta_key'       => '_wcpt_session_time',
 	// get only sessions, no breaks.
-	'meta_key'       => '_wcpt_session_type',
-	'meta_value'     => 'session',
+	'meta_query'     => array(
+		array(
+			'key'   => '_wcpt_session_type',
+			'value' => 'session',
+		),
+	),
 );
 
 $sessions = new \WP_Query( $session_args );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -30,11 +30,26 @@ if ( $sessions->have_posts() ) : ?>
 					$sessions->the_post();
 					$session_title = get_the_title();
 					$session_time  = absint( get_post_meta( get_the_ID(), '_wcpt_session_time', true ) );
-					$option_text   = sprintf( '%1$s: %2$s', wp_date( 'M d, g:ia', $session_time ), $session_title );
+					/* translators: Abbreviated date & time used in session dropdown. */
+					$session_date  = wp_date( __( 'M d, g:ia', 'wordcamporg' ), $session_time );
 
 					$speakers = get_session_speaker_names( get_the_ID() );
 					if ( ! empty( $speakers ) ) {
-						$option_text .= ' — ' . implode( ', ', $speakers );
+						$option_text = sprintf(
+							/* translators: %1$s: Date & time of the session. %2$s: Session title. %3$s: Speaker names. */
+							__( '%1$s: %2$s - %3$s', 'wordcamporg' ),
+							$session_date,
+							$session_title,
+							/* translators: used between list items, there is a space after the comma */
+							implode( __( ', ', 'wordcamporg' ), $speakers )
+						);
+					} else {
+						$option_text = sprintf(
+							/* translators: %1$s: Date & time of the session. %2$s: Session title. */
+							__( '%1$s: %2$s', 'wordcamporg' ),
+							$session_date,
+							$session_title
+						);
 					}
 					printf(
 						'<option value="%s">%s</option>',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WordCamp\SpeakerFeedback\View;
+use function WordCamp\SpeakerFeedback\Post\get_session_speaker_names;
 
 $session_args = array(
 	'post_type'      => 'wcb_session',
@@ -27,10 +28,18 @@ if ( $sessions->have_posts() ) : ?>
 			<select name="sft_session" id="sft-session">
 				<?php while ( $sessions->have_posts() ) :
 					$sessions->the_post();
+					$session_title = get_the_title();
+					$session_time  = absint( get_post_meta( get_the_ID(), '_wcpt_session_time', true ) );
+					$option_text   = sprintf( '%1$s: %2$s', wp_date( 'M d, g:ia', $session_time ), $session_title );
+
+					$speakers = get_session_speaker_names( get_the_ID() );
+					if ( ! empty( $speakers ) ) {
+						$option_text .= ' — ' . implode( ', ', $speakers );
+					}
 					printf(
 						'<option value="%s">%s</option>',
 						esc_attr( get_the_ID() ),
-						wp_kses_post( get_the_title() )
+						wp_kses_post( $option_text )
 					);
 				endwhile; ?>
 			</select>


### PR DESCRIPTION
This adds session time & speaker names to the session list on `/feedback`. It also updates the sorting from alphabetical by title to by time, so sessions are in the order they happened.

Fixes #489

### Screenshots

The full list:

![Screen Shot 2020-05-13 at 12 12 43 PM](https://user-images.githubusercontent.com/541093/81838126-b44bb880-9513-11ea-8c32-06e43633c4aa.png)

You can search for a speaker by name now, due to how selectWoo filters:

![Screen Shot 2020-05-13 at 12 12 50 PM](https://user-images.githubusercontent.com/541093/81838128-b4e44f00-9513-11ea-923c-d1dbd2fbec67.png)

### How to test the changes in this Pull Request:

1. Make sure to rebuild the CSS
2. Visit the `/feedback` page
3. Select a session by searching for any part
4. It should direct you to the feedback form/page for that session.
