### PR TITLE
About WordCamps page in logos section not showing properly.

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -2015,7 +2015,7 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 
 #content .logos {
 	float: right;
-	width: 711px;
+	width: auto;
 }
 
 #content .logos ul {


### PR DESCRIPTION
wordcamp.org : about wordcamps page in logo section not showing properly on small screen

Fixes #501 
