### PR TITLE
Speaker Feedback: Use the event name as the sender in notif emails

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -120,7 +120,9 @@ function notify_organizers_unapproved_feedback() {
 	$message .= "\n\n";
 	$message .= get_subpage_url( 'wcb_session' );
 
+	add_filter( 'wp_mail_from_name', __NAMESPACE__ . '\filter_notification_from_name' );
 	wp_mail( $to, $subject, $message );
+	remove_filter( 'wp_mail_from_name', __NAMESPACE__ . '\filter_notification_from_name' );
 }
 
 /**
@@ -226,7 +228,9 @@ function notify_speakers_approved_feedback() {
 			esc_html( $wordcamp_name )
 		);
 
+		add_filter( 'wp_mail_from_name', __NAMESPACE__ . '\filter_notification_from_name' );
 		$result = wp_mail( $speaker->user_email, $subject, $message );
+		remove_filter( 'wp_mail_from_name', __NAMESPACE__ . '\filter_notification_from_name' );
 
 		restore_current_locale();
 
@@ -291,4 +295,19 @@ function get_unnotified_feedback() {
 	);
 
 	return get_feedback( array(), array( 'approve' ), $args );
+}
+
+/**
+ * Replace the default sender name with the name of the WordCamp.
+ *
+ * @param string $name
+ *
+ * @return string
+ */
+function filter_notification_from_name( $name ) {
+	if ( 'WordPress' === $name ) {
+		$name = get_wordcamp_name( get_current_blog_id() );
+	}
+
+	return $name;
 }


### PR DESCRIPTION
This provides a bit more context for the recipients of the email notifications, instead of just coming from "WordPress".

Fixes #479

### How to test the changes in this Pull Request:

1. Try testing the email notifications for [organizers](https://github.com/WordPress/wordcamp.org/pull/504) or for [speakers](https://github.com/WordPress/wordcamp.org/pull/441). The `From:` header in the email notification should be something like `WordCamp Test 2020 <wordpress@2020.test.wordcamp.org>`. Without this patch, the `From:` header would be `WordPress <wordpress@2020.test.wordcamp.org>`.
