### PR TITLE
Speaker Feedback: Add blurb about wporg account in speaker email notification

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -200,7 +200,14 @@ function notify_speakers_approved_feedback() {
 
 		$message  = sprintf( esc_html__( 'Hi %s,', 'wordcamporg' ), $speaker->display_name );
 		$message .= "\n\n";
-		$message .= esc_html__( 'You have new feedback submissions to read on the following sessions:', 'wordcamporg' );
+		$message .= sprintf(
+			esc_html( _n(
+				'Follow the link below and log in using your WordPress.org account to read your feedback:',
+				'Follow the links below and log in using your WordPress.org account to read your feedback:',
+				count( $feedback_info ),
+				'wordcamporg'
+			) )
+		);
 		$message .= "\n\n";
 
 		foreach ( $feedback_info as $info ) {


### PR DESCRIPTION
Since the link takes the speaker directly to a login screen, where there isn't any explanation of which login to use or where they're going, we should include it in the notification email instead.

Fixes #493

### How to test the changes in this Pull Request:

1. [Send a speaker notification.](https://github.com/WordPress/wordcamp.org/pull/441) The changed wording should correctly be singular or plural depending on how many sessions have new feedback submissions.
