### PR TITLE
Speaker Feedback: Show feedback forms to organizers even before event

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -4,6 +4,7 @@ namespace WordCamp\SpeakerFeedback\Post;
 
 use WP_Error;
 use WordCamp_Post_Types_Plugin;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
@@ -32,6 +33,11 @@ function post_accepts_feedback( $post_id ) {
 			'speaker_feedback_post_not_supported',
 			__( 'This post does not support feedback.', 'wordcamporg' )
 		);
+	}
+
+	// Organizers need to be able to test and style feedback forms.
+	if ( current_user_can( 'moderate_' . COMMENT_TYPE ) ) {
+		return true;
 	}
 
 	if ( 'publish' !== get_post_status( $post ) ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -3,7 +3,6 @@
 namespace WordCamp\SpeakerFeedback\View;
 
 use WP_Comment, WP_Error, WP_Post, WP_Query;
-use WordCamp_Loader;
 use WordCamp\SpeakerFeedback\Feedback;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
 use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, get_feedback_comment };
@@ -40,7 +39,7 @@ function has_feedback_form() {
  */
 function event_accepts_feedback() {
 	$wordcamp            = get_wordcamp_post();
-	$valid_wcpt_statuses = WordCamp_Loader::get_public_post_statuses();
+	$valid_wcpt_statuses = array( 'wcpt-scheduled', 'wcpt-closed' ); // Avoid having to load the WordCamp_Loader class.
 	$now                 = date_create( 'now', wp_timezone() );
 	$start_time          = get_earliest_session_timestamp();
 	$end_time            = get_latest_session_ending_timestamp();

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -2,7 +2,8 @@
 
 namespace WordCamp\SpeakerFeedback\View;
 
-use WP_Comment, WP_Post, WP_Query;
+use WP_Comment, WP_Error, WP_Post, WP_Query;
+use WordCamp_Loader;
 use WordCamp\SpeakerFeedback\Feedback;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
 use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, get_feedback_comment };
@@ -13,7 +14,6 @@ use function WordCamp\SpeakerFeedback\Post\{
 };
 use const WordCamp\SpeakerFeedback\{ OPTION_KEY, QUERY_VAR };
 use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
-use const WordCamp\SpeakerFeedback\Cron\SPEAKER_OPT_OUT_KEY;
 use const WordCamp\SpeakerFeedback\Post\ACCEPT_INTERVAL_IN_SECONDS;
 
 defined( 'WPINC' ) || die();
@@ -31,6 +31,58 @@ add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 function has_feedback_form() {
 	global $wp_query;
 	return false !== $wp_query->get( QUERY_VAR, false );
+}
+
+/**
+ * Check to see if feedback is open for this event site.
+ *
+ * @return bool|WP_Error
+ */
+function event_accepts_feedback() {
+	$wordcamp            = get_wordcamp_post();
+	$valid_wcpt_statuses = WordCamp_Loader::get_public_post_statuses();
+	$now                 = date_create( 'now', wp_timezone() );
+	$start_time          = get_earliest_session_timestamp();
+	$end_time            = get_latest_session_ending_timestamp();
+
+	if ( ! $start_time ) {
+		// No valid start time, the schedule probably hasn't been published yet.
+		// Assume a far future date for now.
+		$start_time = $now->getTimestamp() + YEAR_IN_SECONDS;
+	}
+
+	if ( ! $end_time ) {
+		// No valid end time, assume it's 24 hours after the start time.
+		$end_time = $start_time + DAY_IN_SECONDS;
+	}
+
+	// Organizers need to be able to test and style feedback forms.
+	if ( current_user_can( 'moderate_' . COMMENT_TYPE ) ) {
+		return true;
+	}
+
+	if ( ! $wordcamp || ! in_array( $wordcamp->post_status, $valid_wcpt_statuses, true ) ) {
+		return new WP_Error(
+			'speaker_feedback_event_feedback_unavailable',
+			__( 'Feedback forms are not available for this site.', 'wordcamporg' )
+		);
+	}
+
+	if ( $now->getTimestamp() < $start_time ) {
+		return new WP_Error(
+			'speaker_feedback_event_too_soon',
+			__( 'Feedback forms are not available until the event has started.', 'wordcamporg' )
+		);
+	}
+
+	if ( $now->getTimestamp() > $end_time + ACCEPT_INTERVAL_IN_SECONDS ) {
+		return new WP_Error(
+			'speaker_feedback_event_too_late',
+			__( 'Feedback forms are closed for this event.', 'wordcamporg' )
+		);
+	}
+
+	return true;
 }
 
 /**
@@ -64,33 +116,10 @@ function render( $content ) {
 
 		$form_content = wpautop( $html );
 	} elseif ( is_page( get_option( OPTION_KEY ) ) ) {
-		$wordcamp            = get_wordcamp_post();
-		$valid_wcpt_statuses = array( 'wcpt-scheduled', 'wcpt-closed' );
-		$start_time          = get_earliest_session_timestamp();
-		$end_time            = get_latest_session_ending_timestamp();
+		$accepts_feedback = event_accepts_feedback();
 
-		if ( ! $start_time ) {
-			// No valid start time, the event probably hasn't been scheduled yet. Use a far future date for now.
-			$start_time = $now->getTimestamp() + YEAR_IN_SECONDS;
-		}
-
-		if ( ! $end_time ) {
-			// No valid end time, assume it's 24 hours later.
-			$end_time = $start_time + DAY_IN_SECONDS;
-		}
-
-		if (
-			// The event either needs to be on the schedule, already occurred, or a test site.
-			( ! $wordcamp || ! in_array( $wordcamp->post_status, $valid_wcpt_statuses, true ) )
-			&& ! is_wordcamp_test_site()
-		) {
-			$message = __( 'Feedback forms are not available for this site.', 'wordcamporg' );
-			$file    = 'form-not-available.php';
-		} elseif ( $now->getTimestamp() < $start_time ) {
-			$message = __( 'Feedback forms are not available until the event has started.', 'wordcamporg' );
-			$file    = 'form-not-available.php';
-		} elseif ( $now->getTimestamp() > $end_time + ACCEPT_INTERVAL_IN_SECONDS ) {
-			$message = __( 'Feedback forms are closed for this event.', 'wordcamporg' );
+		if ( is_wp_error( $accepts_feedback ) ) {
+			$message = $accepts_feedback->get_error_message();
 			$file    = 'form-not-available.php';
 		} else {
 			$file = 'form-select-sessions.php';

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-feedback.php
@@ -5,6 +5,7 @@ namespace WordCamp\SpeakerFeedback\View;
 use WP_Post;
 use function WordCamp\SpeakerFeedback\get_assets_path;
 use function WordCamp\SpeakerFeedback\Post\get_session_feedback_url;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
@@ -14,6 +15,17 @@ defined( 'WPINC' ) || die();
 /** @var array   $text_questions */
 ?>
 <hr />
+
+<?php if ( current_user_can( 'moderate_' . COMMENT_TYPE ) ) : ?>
+	<div class="speaker-feedback__notice">
+		<p>
+			<?php
+			esc_html_e( 'Organizers: This form is always visible to you for testing and styling purposes, but it is not visible to site visitors until the event starts.', 'wordcamporg' );
+			?>
+		</p>
+	</div>
+<?php endif; ?>
+
 <form id="sft-feedback" class="speaker-feedback">
 
 	<h3><?php esc_html_e( 'Leave Feedback', 'wordcamporg' ); ?></h3>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\SpeakerFeedback\View;
 use function WordCamp\SpeakerFeedback\Post\get_session_speaker_names;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 $session_args = array(
 	'post_type'      => 'wcb_session',
@@ -21,6 +22,17 @@ $session_args = array(
 $sessions = new \WP_Query( $session_args );
 
 if ( $sessions->have_posts() ) : ?>
+
+	<?php if ( current_user_can( 'moderate_' . COMMENT_TYPE ) ) : ?>
+		<div class="speaker-feedback__notice">
+			<p>
+				<?php
+				esc_html_e( 'Organizers: This form is always visible to you for testing and styling purposes, but it is not visible to site visitors until the event starts.', 'wordcamporg' );
+				?>
+			</p>
+		</div>
+	<?php endif; ?>
+
 <form id="sft-navigation" class="speaker-feedback-navigation">
 	<label for="sft-session"><?php esc_html_e( 'Select a session to leave feedback', 'wordcamporg' ); ?></label>
 	<div class="speaker-feedback__wrapper">


### PR DESCRIPTION
Organizers need to be able to access the feedback forms for testing and styling purposes before the event date. This overrides the date and session time checks if the current user has the right capes.

It also adds explanatory notices so that organizers understand that they aren't necessarily seeing the same view that their site visitors will.

Fixes #505

### Screenshots

Notice on the `/feedback` page:

![session-list-form](https://user-images.githubusercontent.com/916023/83197961-3d0d4b80-a0f3-11ea-9cd3-65c1eb6b5fd5.jpg)

Notice on a session feedback form:

![feedback-form](https://user-images.githubusercontent.com/916023/83197987-4696b380-a0f3-11ea-9216-40a5a4649940.jpg)

### How to test the changes in this Pull Request:

1. Configure your session times so that you're not within the window when feedback submissions are open. (i.e. times in the future, or times more than two weeks in the past)
1. Visit the `/feedback` page while logged out and confirm that the session select form is not available. Visit the feedback URL for a single session and confirm the same there.
1. Then visit those URLs while logged in as an admin. You should see the forms, along with the notices in the screenshots above.

