### PR TITLE
Tooling: Remove `no-descending-specificity` stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,7 +2,7 @@
 	"extends" : "stylelint-config-wordpress/scss",
 	"rules"   : {
 		"max-line-length": 115,
-
+		"no-descending-specificity": null,
 		"rule-empty-line-before" : [ "always-multi-line", {
 			"except" : [ "first-nested", "after-single-line-comment" ]
 		} ]

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.scss
@@ -44,8 +44,6 @@ body.block-editor-page {
 	color: #23282d;
 }
 
-// Avoid false positives; see https://github.com/stylelint/stylelint/issues/3135.
-// stylelint-disable no-descending-specificity
 .wordcamp-schedule__session-title,
 .editor-styles-wrapper h4.wordcamp-schedule__session-title, /* Override TwentySixteen. */
 .wordcamp-schedule__session-tracks,
@@ -61,8 +59,6 @@ body.block-editor-page {
 			text-decoration: underline;
 		}
 	}
-
-	/* stylelint-enable no-descending-specificity */
 }
 
 dl.wordcamp-schedule__session-speakers,

--- a/public_html/wp-content/plugins/wcpt/css/applications/admin.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/admin.css
@@ -1,4 +1,3 @@
-/* stylelint-disable no-descending-specificity */
 span.swag-needed-icon {
 	color: #daa520;
 }

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/scss/style.scss
@@ -222,7 +222,7 @@
 		align-items: center;
 		margin-right: 1em;
 
-		label { // stylelint-disable-line no-descending-specificity
+		label {
 			margin-bottom: 0;
 			min-width: 4em;
 		}
@@ -279,7 +279,6 @@
 	justify-content: space-between;
 	align-items: center;
 
-	// stylelint-disable no-descending-specificity
 	label {
 		position: relative;
 		margin-bottom: 0;
@@ -328,7 +327,6 @@
 	&.is-inflight label {
 		cursor: wait;
 	}
-	// stylelint-enable
 }
 
 .speaker-feedback__helpful {


### PR DESCRIPTION
We've been disabling this rule ad-hoc across projects. While descending specificity is generally a code smell (because the earlier, higher-specificity rule will override the later rule), this is only true if they're both setting the same property. In some cases, this is flagging places where we're overriding core styles, and it isn't possible or doesn't make sense to refactor just to satisfy this rule.

### How to test the changes in this Pull Request:

1. Travis should pass
