### PR TITLE
Speaker Feedback: Generate stat reports

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
@@ -33,7 +33,7 @@ class WordCamp_Speaker_Feedback extends Base {
 	 *
 	 * @var string
 	 */
-	public static $description = 'Statistics from the Speaker Feedback Tool.';
+	public static $description = 'Export a CSV file of statistics from the Speaker Feedback Tool.';
 
 	/**
 	 * Report methodology.
@@ -42,8 +42,46 @@ class WordCamp_Speaker_Feedback extends Base {
 	 */
 	public static $methodology = "
 		<ol>
-			<li>TBD</li>
+			<li>Generate stats for each WordCamp whose start date is within the date range, if the WordCamp has any speaker feedback.</li>
+			<li>Compile the data into a CSV file.</li>
 		</ol>
+		<p>Most of the stat headings in the spreadsheet are self-explanatory, but here's a glossary for some that maybe aren't:</p>
+		<table class=\"widefat striped\">
+			<tbody>
+				<tr>
+					<td><code>total_unique_feedback_authors</code></td>
+					<td>The number of unique individuals who submitted feedback, based on their email address.</td>
+				</tr>
+				<tr>
+					<td><code>average_feedback_approved_per_ticket</code></td>
+					<td>The number of feedback submissions per ticket issued for the event. This number is rounded to one decimal place, so for an event with a high number of tickets, this might show up as zero.</td>
+				</tr>
+				<tr>
+					<td><code>average_feedback_approved_per_ticket_attended</code></td>
+					<td>Same as <code>average_feedback_approved_per_ticket</code>, but only for tickets that were marked as attended.</td>
+				</tr>
+				<tr>
+					<td><code>percent_feedback_approved_helpful</code></td>
+					<td>Notable that this is a percentage of <em>approved</em> feedback, not <em>total</em> feedback.</td>
+				</tr>
+				<tr>
+					<td><code>percent_speakers_viewed_feedback</code></td>
+					<td>The percentage of event speakers who have viewed their feedback at least once.</td>
+				</tr>
+				<tr>
+					<td><code>most_feedback_by_author</code></td>
+					<td>The individual(s) with the most total feedback submissions, and the count of those submissions. This may list multiple individuals if there are more than one with the same highest count of submissions.</td>
+				</tr>
+				<tr>
+					<td><code>most_feedback_approved_for_session</code></td>
+					<td>The session(s) with the most approved feedback. This may list multiple session IDs if there are more than one with the same highest count of submissions.</td>
+				</tr>
+				<tr>
+					<td><code>error</code></td>
+					<td>If some stat columns are empty, this field might explain why.</td>
+				</tr>
+			</tbody>
+		</table>
 	";
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
@@ -288,7 +288,7 @@ class WordCamp_Speaker_Feedback extends Base {
 		}
 
 		if ( $this->wordcamp_id ) {
-			$post_args['post__in'] = $this->wordcamp_id;
+			$post_args['post__in'] = array( $this->wordcamp_id );
 		}
 
 		return get_posts( $post_args );

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
@@ -359,7 +359,16 @@ class WordCamp_Speaker_Feedback extends Base {
 							}
 
 							if ( is_array( $value ) ) {
-								$row[ $key ] = print_r( $value, true );
+								$string_value = '';
+								foreach ( $value as $subkey => $subvalue ) {
+									$subvalue = array_map( 'esc_html', (array) $subvalue );
+									$string_value .= sprintf(
+										'%1$s: %2$s; ',
+										esc_html( $subkey ),
+										implode( ', ', $subvalue )
+									);
+								}
+								$row[ $key ] = $string_value;
 							}
 						}
 					}

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace WordCamp\Reports\Report;
+
+use DateInterval, DateTime, Exception;
+use WordCamp_Loader;
+use WordCamp\Utilities\Export_CSV;
+use WordCamp\Reports\Utility\Date_Range;
+use function WordCamp\Reports\get_views_dir_path;
+use function WordCamp\Reports\Validation\{ validate_date_range, validate_wordcamp_id };
+use function WordCamp\SpeakerFeedback\Stats\{ should_generate_stats, gather_data, generate_stats, stat_keys };
+
+defined( 'WPINC' ) || die();
+
+
+class WordCamp_Speaker_Feedback extends Base {
+	/**
+	 * Report name.
+	 *
+	 * @var string
+	 */
+	public static $name = 'WordCamp Speaker Feedback';
+
+	/**
+	 * Report slug.
+	 *
+	 * @var string
+	 */
+	public static $slug = 'wordcamp-speaker-feedback';
+
+	/**
+	 * Report description.
+	 *
+	 * @var string
+	 */
+	public static $description = 'Statistics from the Speaker Feedback Tool.';
+
+	/**
+	 * Report methodology.
+	 *
+	 * @var string
+	 */
+	public static $methodology = "
+		<ol>
+			<li>TBD</li>
+		</ol>
+	";
+
+	/**
+	 * Report group.
+	 *
+	 * @var string
+	 */
+	public static $group = 'wordcamp';
+
+	/**
+	 * The date range that defines the scope of the report data.
+	 *
+	 * @var null|Date_Range
+	 */
+	public $range = null;
+
+	/**
+	 * WordCamp post ID.
+	 *
+	 * @var int The ID of the WordCamp post for this report.
+	 */
+	public $wordcamp_id = 0;
+
+	/**
+	 * WordCamp site ID.
+	 *
+	 * @var int The ID of the WordCamp site where the invoices are located.
+	 */
+	public $wordcamp_site_id = 0;
+
+	/**
+	 * WordCamp_Speaker_Feedback constructor.
+	 *
+	 * @param string $start_date  The start of the date range for the report.
+	 * @param string $end_date    The end of the date range for the report.
+	 * @param int    $wordcamp_id Optional. The ID of a WordCamp post to limit this report to.
+	 * @param array  $options
+	 *     Optional. Additional report parameters.
+	 *     See Base::__construct and Date_Range::__construct for additional parameters.
+	 */
+	public function __construct( $start_date, $end_date, $wordcamp_id = 0, array $options = array() ) {
+		$this->load_sft_dependencies();
+
+		parent::__construct( $options );
+
+		try {
+			$this->range = validate_date_range( $start_date, $end_date, $options );
+		} catch ( Exception $e ) {
+			$this->error->add(
+				self::$slug . '-date-error',
+				$e->getMessage()
+			);
+		}
+
+		if ( $wordcamp_id ) {
+			try {
+				$valid = validate_wordcamp_id( $wordcamp_id );
+
+				$this->wordcamp_id      = $valid->post_id;
+				$this->wordcamp_site_id = $valid->site_id;
+			} catch ( Exception $e ) {
+				$this->error->add(
+					self::$slug . '-wordcamp-id-error',
+					$e->getMessage()
+				);
+			}
+		}
+	}
+
+	/**
+	 * Generate a cache key.
+	 *
+	 * @return string
+	 */
+	protected function get_cache_key() {
+		$cache_key_segments = array(
+			parent::get_cache_key(),
+			$this->range->generate_cache_key_segment(),
+		);
+
+		if ( $this->wordcamp_id ) {
+			$cache_key_segments[] = $this->wordcamp_id;
+		}
+
+		return implode( '_', $cache_key_segments );
+	}
+
+	/**
+	 * Generate a cache expiration interval.
+	 *
+	 * @return int A time interval in seconds.
+	 */
+	protected function get_cache_expiration() {
+		return $this->range->generate_cache_duration( parent::get_cache_expiration() );
+	}
+
+	/**
+	 * Query and parse the data for the report.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		// Bail if there are errors.
+		if ( ! empty( $this->error->get_error_messages() ) ) {
+			return array();
+		}
+
+		// Maybe use cached data.
+		$data = $this->maybe_get_cached_data();
+		if ( is_array( $data ) ) {
+			return $data;
+		}
+
+		// This script is a bit of a memory hog.
+		ini_set( 'memory_limit', '512M' ); // phpcs:ignore WordPress.PHP.IniSet.memory_limit_Blacklisted
+
+		$data      = array();
+		$wordcamps = $this->get_wordcamps();
+
+		foreach ( $wordcamps as $wordcamp ) {
+			$blog_id = get_wordcamp_site_id( $wordcamp );
+			if ( ! $blog_id ) {
+				continue;
+			}
+
+			$event_data = array(
+				'id'         => $wordcamp->ID,
+				'name'       => get_wordcamp_name( $blog_id ),
+				'url'        => get_post_meta( $wordcamp->ID, 'URL', true ),
+				'start_date' => get_post_meta( $wordcamp->ID, 'Start Date (YYYY-mm-dd)', true ),
+			);
+
+			switch_to_blog( $blog_id );
+
+			if ( should_generate_stats() ) {
+				$blog_data = gather_data();
+				$stats     = generate_stats( $blog_data );
+
+				$data[] = array_merge( $event_data, $stats );
+			}
+
+			restore_current_blog();
+		}
+
+		$this->maybe_cache_data( $data );
+
+		return $data;
+	}
+
+	/**
+	 * Compile the report data into results.
+	 *
+	 * @param array $data The data to compile.
+	 *
+	 * @return array
+	 */
+	public function compile_report_data( array $data ) {
+		return $data;
+	}
+
+	/**
+	 * Load the necessary files from the SFT plugin, since it's not activated on Central.
+	 *
+	 * @return void
+	 */
+	protected function load_sft_dependencies() {
+		$path = WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/includes/';
+		require_once $path . 'class-feedback.php';
+		require_once $path . 'comment.php';
+		require_once $path . 'post.php';
+		require_once $path . 'view.php';
+		require_once $path . 'spam.php';
+		require_once $path . 'stats.php';
+	}
+
+	/**
+	 * Get data from a WordCamp Details report and filter it.
+	 *
+	 * @return array|null
+	 */
+	protected function get_wordcamps() {
+		$post_args = array(
+			'post_type'           => WCPT_POST_TYPE_ID,
+			'post_status'         => WordCamp_Loader::get_public_post_statuses(),
+			'posts_per_page'      => 9999,
+			'nopaging'            => true,
+			'no_found_rows'       => false,
+			'ignore_sticky_posts' => true,
+			'orderby'             => 'id',
+			'order'               => 'ASC',
+		);
+
+		if ( $this->range instanceof Date_Range ) {
+			// This replaces the default meta query.
+			$post_args['meta_query'] = array(
+				array(
+					'key'     => 'Start Date (YYYY-mm-dd)',
+					'value'   => array( $this->range->start->getTimestamp(), $this->range->end->getTimestamp() ),
+					'compare' => 'BETWEEN',
+					'type'    => 'NUMERIC',
+				),
+			);
+			$post_args['orderby'] = 'meta_value_num title';
+		}
+
+		if ( $this->wordcamp_id ) {
+			$post_args['post__in'] = $this->wordcamp_id;
+		}
+
+		return get_posts( $post_args );
+	}
+
+	/**
+	 * Render the page for this report in the WP Admin.
+	 *
+	 * @return void
+	 */
+	public static function render_admin_page() {
+		$start_date  = filter_input( INPUT_POST, 'start-date' );
+		$end_date    = filter_input( INPUT_POST, 'end-date' );
+		$wordcamp_id = filter_input( INPUT_POST, 'wordcamp-id' );
+		$refresh     = filter_input( INPUT_POST, 'refresh', FILTER_VALIDATE_BOOLEAN );
+
+		include get_views_dir_path() . 'report/wordcamp-speaker-feedback.php';
+	}
+
+	/**
+	 * Export the report data to a file.
+	 *
+	 * @return void
+	 */
+	public static function export_to_file() {
+		$start_date  = filter_input( INPUT_POST, 'start-date' );
+		$end_date    = filter_input( INPUT_POST, 'end-date' );
+		$wordcamp_id = filter_input( INPUT_POST, 'wordcamp-id' );
+		$refresh     = filter_input( INPUT_POST, 'refresh', FILTER_VALIDATE_BOOLEAN );
+		$action      = filter_input( INPUT_POST, 'action' );
+		$nonce       = filter_input( INPUT_POST, self::$slug . '-nonce' );
+
+		$report = null;
+
+		if ( 'Export CSV' !== $action ) {
+			return;
+		}
+
+		if ( wp_verify_nonce( $nonce, 'run-report' ) && current_user_can( 'manage_network' ) ) {
+			$options = array(
+				'public'         => false,
+				'earliest_start' => new DateTime( '2020-01-01' ), // Speaker Feedback Tool was introduced in 2020.
+				'max_interval'   => new DateInterval( 'P1Y1M' ),
+			);
+
+			if ( $refresh ) {
+				$options['flush_cache'] = true;
+			}
+
+			$report = new self( $start_date, $end_date, $wordcamp_id, $options );
+
+			$filename = array( $report::$name );
+			if ( $report->wordcamp_site_id ) {
+				$filename[] = get_wordcamp_name( $report->wordcamp_site_id );
+			}
+			$filename[] = $report->range->start->format( 'Y-m-d' );
+			$filename[] = $report->range->end->format( 'Y-m-d' );
+
+			$data = $report->get_data();
+
+			array_walk(
+				$data,
+				function( &$row ) {
+					foreach ( $row as $key => $value ) {
+						if ( 'start_date' === $key ) {
+							$row[ $key ] = wp_date( 'Y-m-d', $value );
+						}
+
+						if ( is_array( $value ) ) {
+							$row[ $key ] = print_r( $value, true );
+						}
+					}
+				}
+			);
+
+			$headers = array_merge(
+				array(
+					'id',
+					'name',
+					'url',
+					'start_date',
+				),
+				stat_keys(),
+				array(
+					'error',
+				)
+			);
+
+			$exporter = new Export_CSV( array(
+				'filename' => $filename,
+				'headers'  => $headers,
+				'data'     => $data,
+			) );
+
+			if ( ! empty( $report->error->get_error_messages() ) ) {
+				$exporter->error = $report->merge_errors( $report->error, $exporter->error );
+			}
+
+			$exporter->emit_file();
+		}
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-speaker-feedback.php
@@ -340,29 +340,31 @@ class WordCamp_Speaker_Feedback extends Base {
 
 			$report = new self( $start_date, $end_date, $wordcamp_id, $options );
 
-			$filename = array( $report::$name );
-			if ( $report->wordcamp_site_id ) {
-				$filename[] = get_wordcamp_name( $report->wordcamp_site_id );
-			}
-			$filename[] = $report->range->start->format( 'Y-m-d' );
-			$filename[] = $report->range->end->format( 'Y-m-d' );
+			if ( empty( $report->error->get_error_messages() ) ) {
+				$filename = array( $report::$name );
+				if ( $report->wordcamp_site_id ) {
+					$filename[] = get_wordcamp_name( $report->wordcamp_site_id );
+				}
+				$filename[] = $report->range->start->format( 'Y-m-d' );
+				$filename[] = $report->range->end->format( 'Y-m-d' );
 
-			$data = $report->get_data();
+				$data = $report->get_data();
 
-			array_walk(
-				$data,
-				function( &$row ) {
-					foreach ( $row as $key => $value ) {
-						if ( 'start_date' === $key ) {
-							$row[ $key ] = wp_date( 'Y-m-d', $value );
-						}
+				array_walk(
+					$data,
+					function ( &$row ) {
+						foreach ( $row as $key => $value ) {
+							if ( 'start_date' === $key ) {
+								$row[ $key ] = wp_date( 'Y-m-d', $value );
+							}
 
-						if ( is_array( $value ) ) {
-							$row[ $key ] = print_r( $value, true );
+							if ( is_array( $value ) ) {
+								$row[ $key ] = print_r( $value, true );
+							}
 						}
 					}
-				}
-			);
+				);
+			}
 
 			$headers = array_merge(
 				array(

--- a/public_html/wp-content/plugins/wordcamp-reports/index.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/index.php
@@ -139,6 +139,7 @@ function get_report_classes() {
 		__NAMESPACE__ . '\Report\Meetup_Details',
 		__NAMESPACE__ . '\Report\WordCamp_Counts',
 		__NAMESPACE__ . '\Report\Sponsor_Details',
+		__NAMESPACE__ . '\Report\WordCamp_Speaker_Feedback',
 	);
 }
 

--- a/public_html/wp-content/plugins/wordcamp-reports/views/report/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/report/wordcamp-speaker-feedback.php
@@ -35,11 +35,11 @@ use WordCamp\Reports\Report;
 			<tbody>
 			<tr>
 				<th scope="row"><label for="start-date">Start Date</label></th>
-				<td><input type="date" id="start-date" name="start-date" value="<?php echo esc_attr( $start_date ); ?>" /></td>
+				<td><input type="date" id="start-date" name="start-date" value="<?php echo esc_attr( $start_date ); ?>" required /></td>
 			</tr>
 			<tr>
 				<th scope="row"><label for="end-date">End Date</label></th>
-				<td><input type="date" id="end-date" name="end-date" value="<?php echo esc_attr( $end_date ); ?>" /></td>
+				<td><input type="date" id="end-date" name="end-date" value="<?php echo esc_attr( $end_date ); ?>" required /></td>
 			</tr>
 			<tr>
 				<th scope="row"><label for="wordcamp-id">WordCamp (optional)</label></th>

--- a/public_html/wp-content/plugins/wordcamp-reports/views/report/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/report/wordcamp-speaker-feedback.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Views\Report\WordCamp_Speaker_Feedback;
+defined( 'WPINC' ) || die();
+
+use WordCamp\Reports;
+use WordCamp\Reports\Report;
+
+/** @var string $start_date */
+/** @var string $end_date */
+/** @var int $wordcamp_id */
+/** @var string $report */
+?>
+
+<div class="wrap">
+	<h1>
+		<a href="<?php echo esc_attr( Reports\get_page_url() ); ?>">WordCamp Reports</a>
+		&raquo;
+		<?php echo esc_html( Report\WordCamp_Speaker_Feedback::$name ); ?>
+	</h1>
+
+	<?php echo wp_kses_post( wpautop( Report\WordCamp_Speaker_Feedback::$description ) ); ?>
+
+	<h4>Methodology</h4>
+
+	<?php echo wp_kses_post( wpautop( Report\WordCamp_Speaker_Feedback::$methodology ) ); ?>
+
+	<form method="post" action="">
+		<?php wp_nonce_field( 'run-report', Report\WordCamp_Speaker_Feedback::$slug . '-nonce' ); ?>
+
+		<table class="form-table">
+			<tbody>
+			<tr>
+				<th scope="row"><label for="start-date">Start Date</label></th>
+				<td><input type="date" id="start-date" name="start-date" value="<?php echo esc_attr( $start_date ); ?>" /></td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="end-date">End Date</label></th>
+				<td><input type="date" id="end-date" name="end-date" value="<?php echo esc_attr( $end_date ); ?>" /></td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="wordcamp-id">WordCamp (optional)</label></th>
+				<td><?php echo get_wordcamp_dropdown( 'wordcamp-id', array(), $wordcamp_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="refresh">Refresh results</label></th>
+				<td><input type="checkbox" id="refresh" name="refresh" /></td>
+			</tr>
+			</tbody>
+		</table>
+
+		<?php submit_button( 'Export CSV', 'secondary', 'action', false ); ?>
+	</form>
+</div>

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/cron.php
@@ -3,7 +3,7 @@
 namespace WordCamp\SpeakerFeedback\Cron;
 
 use function WordCamp\SpeakerFeedback\Admin\get_subpage_url;
-use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, update_feedback };
+use function WordCamp\SpeakerFeedback\Comment\{ maybe_get_cached_feedback_count, get_feedback, update_feedback };
 use function WordCamp\SpeakerFeedback\Post\{
 	get_earliest_session_timestamp, get_latest_session_ending_timestamp,
 	get_session_speaker_user_ids, get_session_feedback_url
@@ -47,7 +47,7 @@ function notify_organizers_unapproved_feedback() {
 	$wordcamp_name = get_wordcamp_name( get_current_blog_id() );
 	$wordcamp_post = get_wordcamp_post();
 
-	$feedback_counts = count_feedback();
+	$feedback_counts = (array) maybe_get_cached_feedback_count();
 
 	if ( $feedback_counts['moderated'] < 1 ) {
 		return;

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/post.php
@@ -9,6 +9,8 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 defined( 'WPINC' ) || die();
 
 define( __NAMESPACE__ . '\ACCEPT_INTERVAL_IN_SECONDS', WEEK_IN_SECONDS * 2 );
+// Defined here so that wc-post-types is not a dependency for this file.
+define( __NAMESPACE__ . '\SESSION_DEFAULT_DURATION', 50 * MINUTE_IN_SECONDS );
 
 /**
  * Check to see if feedback comments can be added to a post.
@@ -52,7 +54,7 @@ function post_accepts_feedback( $post_id ) {
 		$session_time     = absint( $post->_wcpt_session_time );
 		$session_duration = absint( $post->_wcpt_session_duration );
 		if ( ! $session_duration ) {
-			$session_duration = WordCamp_Post_Types_Plugin::SESSION_DEFAULT_DURATION;
+			$session_duration = SESSION_DEFAULT_DURATION;
 		}
 
 		if ( 'session' !== $session_type ) {
@@ -130,7 +132,7 @@ function get_latest_session_ending_timestamp() {
 
 	$duration = $latest_session[0]->_wcpt_session_duration;
 	if ( ! $duration ) {
-		$duration = WordCamp_Post_Types_Plugin::SESSION_DEFAULT_DURATION;
+		$duration = SESSION_DEFAULT_DURATION;
 	}
 
 	return absint( $latest_session[0]->_wcpt_session_time ) + absint( $duration );

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/stats.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/stats.php
@@ -7,6 +7,7 @@ use WordCamp\SpeakerFeedback\Feedback;
 use function WordCamp\SpeakerFeedback\Comment\{ maybe_get_cached_feedback_count, get_feedback };
 use function WordCamp\SpeakerFeedback\View\{ event_accepts_feedback, get_feedback_average_rating };
 use const WordCamp\SpeakerFeedback\Spam\DELETED_SPAM_KEY;
+use const WordCamp\SpeakerFeedback\View\SPEAKER_VIEWED_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -93,6 +94,7 @@ function generate_stats( $data ) {
 		'total_feedback_spam',
 		'total_sessions',
 		'total_speakers',
+		'total_speakers_viewed_feedback',
 		'total_tickets',
 		'total_tickets_attended',
 		'total_unique_feedback_authors',
@@ -107,6 +109,7 @@ function generate_stats( $data ) {
 		'percent_feedback_approved_helpful',
 		'percent_feedback_inappropriate',
 		'percent_feedback_spam',
+		'percent_speakers_viewed_feedback',
 
 		'most_feedback_by_author',
 		'most_feedback_helpful_by_author',
@@ -268,6 +271,24 @@ function calculate_total_speakers( array $data ) {
 	}
 
 	return count( $data['speaker_posts'] );
+}
+
+/**
+ * Calculate the total number of speakers who viewed their feedback.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_speakers_viewed_feedback( array $data ) {
+	if ( ! isset( $data['speaker_posts'] ) ) {
+		return new WP_Error();
+	}
+
+	$viewership = wp_list_pluck( $data['attendee_posts'], SPEAKER_VIEWED_KEY );
+	$viewed     = array_filter( $viewership );
+
+	return count( $viewed );
 }
 
 /**
@@ -475,6 +496,22 @@ function calculate_percent_feedback_spam( array $data, array $stats ) {
 	}
 
 	return round( 100 * $stats['total_feedback_spam'] / $stats['total_feedback'], 1 );
+}
+
+/**
+ * Calculate the percentage of speakers who viewed their feedback.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_percent_speakers_viewed_feedback( array $data, array $stats ) {
+	if ( ! isset( $stats['total_speakers'], $stats['total_speakers_viewed_feedback'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( 100 * $stats['total_speakers_viewed_feedback'] / $stats['total_speakers'], 1 );
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/stats.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/stats.php
@@ -1,0 +1,621 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Stats;
+
+use WP_Error;
+use WordCamp\SpeakerFeedback\Feedback;
+use function WordCamp\SpeakerFeedback\Comment\{ maybe_get_cached_feedback_count, get_feedback };
+use function WordCamp\SpeakerFeedback\View\{ event_accepts_feedback, get_feedback_average_rating };
+use const WordCamp\SpeakerFeedback\Spam\DELETED_SPAM_KEY;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Should stats be generated for this event yet?
+ *
+ * Stats shouldn't be generated if the event hasn't started yet.
+ *
+ * @return bool
+ */
+function should_generate_stats() {
+	$event_check = event_accepts_feedback();
+
+	if ( is_wp_error( $event_check ) && 'speaker_feedback_event_too_late' !== $event_check->get_error_code() ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Collect data used to generate the stats.
+ *
+ * @return array
+ */
+function gather_data() {
+	$data = array();
+
+	$data['session_posts'] = get_posts( array(
+		'post_type'      => 'wcb_session',
+		'post_status'    => 'publish',
+		'posts_per_page' => - 1,
+		// get only sessions, no breaks.
+		'meta_query'     => array(
+			array(
+				'key'   => '_wcpt_session_type',
+				'value' => 'session',
+			),
+		),
+	) );
+
+	$data['speaker_posts'] = get_posts( array(
+		'post_type'      => 'wcb_speaker',
+		'post_status'    => 'publish',
+		'posts_per_page' => - 1,
+	) );
+
+	$data['attendee_posts'] = get_posts( array(
+		'post_type'      => 'tix_attendee',
+		'post_status'    => 'publish',
+		'posts_per_page' => - 1,
+	) );
+
+	$data['feedback_counts']        = maybe_get_cached_feedback_count();
+	$data['feedback_approved']      = get_feedback( array(), array( 'approve' ) );
+	$data['feedback_inappropriate'] = get_feedback( array(), array( 'inappropriate' ) );
+
+	$data['feedback_spam_deleted_count'] = get_option( DELETED_SPAM_KEY, 0 );
+
+	return $data;
+}
+
+/**
+ * Generate stats based on the given data.
+ *
+ * To add a new stat, add a key for it in the array, and then create a corresponding `calculate_{$key_name}` function.
+ *
+ * The stats are handled within a `while` loop so that we don't have to manage a specific order that they must be
+ * calculated in, since some stats depend on the values of other stats.
+ *
+ * @param array $data
+ *
+ * @return array
+ */
+function generate_stats( $data ) {
+	$stats = array();
+
+	$stat_keys = array(
+		'total_feedback',
+		'total_feedback_approved',
+		'total_feedback_helpful',
+		'total_feedback_inappropriate',
+		'total_feedback_pending',
+		'total_feedback_spam',
+		'total_sessions',
+		'total_speakers',
+		'total_tickets',
+		'total_tickets_attended',
+		'total_unique_feedback_authors',
+
+		'average_feedback_approved_per_ticket',
+		'average_feedback_approved_per_ticket_attended',
+		'average_feedback_approved_per_session',
+		'average_feedback_approved_rating',
+		'average_feedback_helpful_per_session',
+
+		'percent_feedback_approved',
+		'percent_feedback_approved_helpful',
+		'percent_feedback_inappropriate',
+		'percent_feedback_spam',
+
+		'most_feedback_by_author',
+		'most_feedback_helpful_by_author',
+		'most_feedback_inappropriate_by_author',
+		'most_feedback_approved_for_session',
+	);
+
+	while ( ! empty( $stat_keys ) ) {
+		$previous_stat_keys = $stat_keys;
+
+		foreach ( $stat_keys as $index => $stat_key ) {
+			$function = __NAMESPACE__ . '\calculate_' . $stat_key;
+
+			$stat_value = call_user_func( $function, $data, $stats );
+
+			if ( is_wp_error( $stat_value ) ) {
+				continue;
+			}
+
+			$stats[ $stat_key ] = $stat_value;
+			unset( $stat_keys[ $index ] );
+		}
+
+		if ( $stat_keys === $previous_stat_keys ) {
+			// Bail, no more stats can be calculated at this point.
+			$stats['error'] = array(
+				'message' => 'Some stats could not be calculated.',
+				'data'    => $stat_keys,
+			);
+			break;
+		}
+	}
+
+	return $stats;
+}
+
+/**
+ * Calculate the total number of feedback comments, excluding ones in the trash.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_feedback( array $data ) {
+	if ( ! isset( $data['feedback_counts'] ) ) {
+		return new WP_Error();
+	}
+
+	return intval( $data['feedback_counts']->total_comments );
+}
+
+/**
+ * Calculate the total number of approved feedback comments.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_feedback_approved( array $data ) {
+	if ( ! isset( $data['feedback_counts'] ) ) {
+		return new WP_Error();
+	}
+
+	return intval( $data['feedback_counts']->approved );
+}
+
+/**
+ * Calculate the total number of approved feedback comments that have been marked as helpful.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_feedback_helpful( array $data ) {
+	if ( ! isset( $data['feedback_approved'] ) ) {
+		return new WP_Error();
+	}
+
+	$helpful_feedback = array_filter(
+		$data['feedback_approved'],
+		function( $item ) {
+			return $item->helpful;
+		}
+	);
+
+	return count( $helpful_feedback );
+}
+
+/**
+ * Calculate the total number of inappropriate feedback comments.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_feedback_inappropriate( array $data ) {
+	if ( ! isset( $data['feedback_counts'] ) ) {
+		return new WP_Error();
+	}
+
+	return intval( $data['feedback_counts']->inappropriate );
+}
+
+/**
+ * Calculate the total number of pending/moderated feedback comments.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_feedback_pending( array $data ) {
+	if ( ! isset( $data['feedback_counts'] ) ) {
+		return new WP_Error();
+	}
+
+	return intval( $data['feedback_counts']->moderated );
+}
+
+/**
+ * Calculate the total number of spam feedback comments, including ones that have already been auto-deleted.
+ *
+ * @param array $data
+ *
+ * @return bool|mixed|void|WP_Error
+ */
+function calculate_total_feedback_spam( array $data ) {
+	if ( ! isset( $data['feedback_counts'], $data['feedback_spam_deleted_count'] ) ) {
+		return new WP_Error();
+	}
+
+	return intval( $data['feedback_counts']->spam + $data['feedback_spam_deleted_count'] );
+}
+
+/**
+ * Calculate the total number of published session posts.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_sessions( array $data ) {
+	if ( ! isset( $data['session_posts'] ) ) {
+		return new WP_Error();
+	}
+
+	return count( $data['session_posts'] );
+}
+
+/**
+ * Calculate the total number of published speaker posts.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_speakers( array $data ) {
+	if ( ! isset( $data['speaker_posts'] ) ) {
+		return new WP_Error();
+	}
+
+	return count( $data['speaker_posts'] );
+}
+
+/**
+ * Calculate the total number of published attendee posts (tickets issued).
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_tickets( array $data ) {
+	if ( ! isset( $data['attendee_posts'] ) ) {
+		return new WP_Error();
+	}
+
+	return count( $data['attendee_posts'] );
+}
+
+/**
+ * Calculate the total number of tickets issued that have been marked as "attended".
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_tickets_attended( array $data ) {
+	if ( ! isset( $data['attendee_posts'] ) ) {
+		return new WP_Error();
+	}
+
+	$attendance = wp_list_pluck( $data['attendee_posts'], 'tix_attended' );
+	$attended   = array_filter( $attendance );
+
+	return count( $attended );
+}
+
+/**
+ * Calculate the total number of unique feedback authors (excluding spammed and trashed feedback),
+ * based on their email address.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_total_unique_feedback_authors( array $data ) {
+	if ( ! isset( $data['feedback_approved'], $data['feedback_inappropriate'] ) ) {
+		return new WP_Error();
+	}
+
+	$all_reviewed_feedback = array_merge( $data['feedback_approved'], $data['feedback_inappropriate'] );
+
+	$author_counts = get_feedback_author_counts( $all_reviewed_feedback );
+	$authors       = array_keys( $author_counts );
+
+	return count( $authors );
+}
+
+/**
+ * Calculate the amount of approved feedback per issued ticket.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_average_feedback_approved_per_ticket( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback_approved'], $stats['total_tickets'] ) ) {
+		return new WP_Error();
+	}
+
+	if ( $stats['total_tickets'] < 1 ) {
+		// Avoid dividing by 0.
+		return floatval( 0 );
+	}
+
+	return round( $stats['total_feedback_approved'] / $stats['total_tickets'], 1 );
+}
+
+/**
+ * Calculate the amount of approved feedback per attended ticket.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_average_feedback_approved_per_ticket_attended( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback_approved'], $stats['total_tickets_attended'] ) ) {
+		return new WP_Error();
+	}
+
+	if ( $stats['total_tickets_attended'] < 1 ) {
+		// Avoid dividing by 0.
+		return floatval( 0 );
+	}
+
+	return round( $stats['total_feedback_approved'] / $stats['total_tickets_attended'], 1 );
+}
+
+/**
+ * Calculate the amount of approved feedback per event session.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_average_feedback_approved_per_session( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback_approved'], $stats['total_sessions'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( $stats['total_feedback_approved'] / $stats['total_sessions'], 1 );
+}
+
+/**
+ * Calculate the average rating of all approved feedback.
+ *
+ * @param array $data
+ *
+ * @return int|WP_Error
+ */
+function calculate_average_feedback_approved_rating( array $data ) {
+	if ( ! isset( $data['feedback_approved'] ) ) {
+		return new WP_Error();
+	}
+
+	return get_feedback_average_rating( $data['feedback_approved'] );
+}
+
+/**
+ * Calculate the amount of feedback marked as helpful per event session.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_average_feedback_helpful_per_session( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback_helpful'], $stats['total_sessions'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( $stats['total_feedback_helpful'] / $stats['total_sessions'], 1 );
+}
+
+/**
+ * Calculate the percentage of total feedback that has been approved.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_percent_feedback_approved( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback'], $stats['total_feedback_approved'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( 100 * $stats['total_feedback_approved'] / $stats['total_feedback'], 1 );
+}
+
+/**
+ * Calculate the percentage of total feedback that has been marked as helpful.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_percent_feedback_approved_helpful( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback_approved'], $stats['total_feedback_helpful'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( 100 * $stats['total_feedback_helpful'] / $stats['total_feedback_approved'], 1 );
+}
+
+/**
+ * Calculate the percentage of total feedback that has been marked as inappropriate.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_percent_feedback_inappropriate( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback'], $stats['total_feedback_inappropriate'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( 100 * $stats['total_feedback_inappropriate'] / $stats['total_feedback'], 1 );
+}
+
+/**
+ * Calculate the percentage of total feedback that has been marked as spam.
+ *
+ * @param array $data  Unused.
+ * @param array $stats
+ *
+ * @return float|WP_Error
+ */
+function calculate_percent_feedback_spam( array $data, array $stats ) {
+	if ( ! isset( $stats['total_feedback'], $stats['total_feedback_spam'] ) ) {
+		return new WP_Error();
+	}
+
+	return round( 100 * $stats['total_feedback_spam'] / $stats['total_feedback'], 1 );
+}
+
+/**
+ * Calculate which feedback author(s) submitted the most comments, excluding spammed and trashed comments.
+ *
+ * @param array $data
+ *
+ * @return array|WP_Error
+ */
+function calculate_most_feedback_by_author( array $data ) {
+	if ( ! isset( $data['feedback_approved'], $data['feedback_inappropriate'] ) ) {
+		return new WP_Error();
+	}
+
+	$all_reviewed_feedback = array_merge( $data['feedback_approved'], $data['feedback_inappropriate'] );
+
+	$author_counts = get_feedback_author_counts( $all_reviewed_feedback );
+
+	reset( $author_counts );
+	$highest_count = current( $author_counts );
+
+	return array(
+		'author' => array_keys( $author_counts, $highest_count, true ),
+		'number' => $highest_count,
+	);
+}
+
+/**
+ * Calculate which feedback author(s) submitted the most comments that were marked as helpful.
+ *
+ * @param array $data
+ *
+ * @return array|WP_Error
+ */
+function calculate_most_feedback_helpful_by_author( array $data ) {
+	if ( ! isset( $data['feedback_approved'] ) ) {
+		return new WP_Error();
+	}
+
+	$helpful_feedback = array_filter(
+		$data['feedback_approved'],
+		function( $item ) {
+			return $item->helpful;
+		}
+	);
+
+	$author_counts = get_feedback_author_counts( $helpful_feedback );
+
+	reset( $author_counts );
+	$highest_count = current( $author_counts );
+
+	return array(
+		'author' => array_keys( $author_counts, $highest_count, true ),
+		'number' => $highest_count,
+	);
+}
+
+/**
+ * Calculate which feedback author(s) submitted the most comments that were marked as inappropriate.
+ *
+ * @param array $data
+ *
+ * @return array|WP_Error
+ */
+function calculate_most_feedback_inappropriate_by_author( array $data ) {
+	if ( ! isset( $data['feedback_inappropriate'] ) ) {
+		return new WP_Error();
+	}
+
+	$author_counts = get_feedback_author_counts( $data['feedback_inappropriate'] );
+
+	reset( $author_counts );
+	$highest_count = current( $author_counts );
+
+	return array(
+		'author' => array_keys( $author_counts, $highest_count, true ),
+		'number' => $highest_count,
+	);
+}
+
+/**
+ * Calculate which session(s) received the most feedback comments, excluding spammed and trashed comments.
+ *
+ * @param array $data
+ *
+ * @return array|WP_Error
+ */
+function calculate_most_feedback_approved_for_session( array $data ) {
+	if ( ! isset( $data['feedback_approved'], $data['feedback_inappropriate'] ) ) {
+		return new WP_Error();
+	}
+
+	$all_reviewed_feedback = array_merge( $data['feedback_approved'], $data['feedback_inappropriate'] );
+
+	$session_counts = array_reduce(
+		$all_reviewed_feedback,
+		function( $carry, $item ) {
+			$post_id = (string) $item->comment_post_ID; // Convert to string to retain array keys.
+			if ( ! isset( $carry[ $post_id ] ) ) {
+				$carry[ $post_id ] = 0;
+			}
+			$carry[ $post_id ] ++;
+
+			return $carry;
+		},
+		array()
+	);
+
+	arsort( $session_counts );
+	reset( $session_counts );
+	$highest_count = current( $session_counts );
+
+	return array(
+		'session' => array_map( 'intval', array_keys( $session_counts, $highest_count, true ) ),
+		'number'  => $highest_count,
+	);
+}
+
+/**
+ * List the number of feedback comments for each author, by email address, sorted high to low.
+ *
+ * @param Feedback[] $feedback
+ *
+ * @return array
+ */
+function get_feedback_author_counts( $feedback ) {
+	$counts = array_reduce(
+		$feedback,
+		function( $carry, $item ) {
+			$author_email = $item->comment_author_email;
+			if ( ! isset( $carry[ $author_email ] ) ) {
+				$carry[ $author_email ] = 0;
+			}
+			$carry[ $author_email ] ++;
+
+			return $carry;
+		},
+		array()
+	);
+
+	arsort( $counts );
+
+	return $counts;
+}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -5,7 +5,7 @@ namespace WordCamp\SpeakerFeedback\View;
 use WP_Comment, WP_Error, WP_Post, WP_Query;
 use WordCamp\SpeakerFeedback\Feedback;
 use function WordCamp\SpeakerFeedback\{ get_views_path, get_assets_url, get_assets_path };
-use function WordCamp\SpeakerFeedback\Comment\{ count_feedback, get_feedback, get_feedback_comment };
+use function WordCamp\SpeakerFeedback\Comment\{ maybe_get_cached_feedback_count, get_feedback, get_feedback_comment };
 use function WordCamp\SpeakerFeedback\CommentMeta\{ get_feedback_meta_field_schema, get_feedback_questions };
 use function WordCamp\SpeakerFeedback\Post\{
 	get_earliest_session_timestamp, get_latest_session_ending_timestamp,
@@ -176,7 +176,7 @@ function render_feedback_view() {
 		$feedback   = get_feedback( array( get_the_ID() ), array( 'approve' ), $query_args );
 		$avg_rating = get_feedback_average_rating( $feedback );
 
-		$feedback_count = count_feedback( $post->ID );
+		$feedback_count = (array) maybe_get_cached_feedback_count( $post->ID );
 		$approved       = absint( $feedback_count['approved'] );
 		$moderated      = absint( $feedback_count['moderated'] );
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -53,6 +53,7 @@ function load() {
 	require_once get_includes_path() . 'post.php';
 	require_once get_includes_path() . 'query.php';
 	require_once get_includes_path() . 'spam.php';
+	require_once get_includes_path() . 'stats.php';
 	require_once get_includes_path() . 'view.php';
 
 	require_once get_includes_path() . 'admin.php';


### PR DESCRIPTION
This adds functionality within the Speaker Feedback Tool plugin for generating stats for an individual site, as well as a new report in the WordCamp Reports plugin for aggregating those stats across multiple sites into a CSV file.

Fixes #344

### Screenshots

![sft-report-ui](https://user-images.githubusercontent.com/916023/84092791-4f1da280-a9ad-11ea-9185-9172779bf184.jpg)

### How to test the changes in this Pull Request:

1. It's probably easiest to test this PR on a sandbox, which has access to speaker feedback data from multiple real WordCamps.
1. Go to the [WordCamp Speaker Feedback report](https://central.wordcamp.org/wp-admin/index.php?page=wordcamp-reports&report=wordcamp-speaker-feedback) in the WordCamp Central admin.
1. Set a date range that includes recent WordCamps that used the tool. 2020-04-01 to 2020-06-08 should give you all three.
1. Download the CSV file. You can check some of the numbers in the file against the feedback counts shown in the Feedback list table for each of the individual WordCamp sites.
