### PR TITLE
Update Docker instructions to checkout 5.4

### DIFF
--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -19,7 +19,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 	mkcert -cert-file wordcamp.test.pem -key-file wordcamp.test.key.pem wordcamp.test *.wordcamp.test *.seattle.wordcamp.test *.shinynew.wordcamp.test buddycamp.test *.buddycamp.test *.brighton.buddycamp.test
 	```
 	
-	_Using zsh? You may see `zsh: no matches found: *.wordcamp.test` running the final cert command above. Try prefixing the final command with `noglob`, i.e. `noglob mkcert -cert-file ...`
+	_Using zsh? You may see `zsh: no matches found: *.wordcamp.test` running the final cert command above. Try prefixing the final command with `noglob`, i.e. `noglob mkcert -cert-file ...`_
 
 	_Note: That list of domains is generated with `docker-compose exec wordcamp.test wp site list --field=url`, but that command won't be available until after you've built the environment in the next steps._
 
@@ -30,7 +30,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
     cd public_html
     git clone git://core.git.wordpress.org/ mu
     cd mu
-    git checkout 5.2
+    git checkout 5.4
     ```
 
 1. Install 3rd-party PHP packages used on WordCamp.org. For this, you must have [Composer](https://getcomposer.org/doc/00-intro.md) installed. Once it is, change back to the root directory of the project where the main **composer.json** file is located. (Not the one in .docker/config.)


### PR DESCRIPTION
In 5.4 the `switch_blog` action received a third argument. Running this environment with anything prior causes `wcorg_switch_to_blog_locale()` to cause a fatal error, which breaks WP-CLI/setup flow.

Also, forgot a closing underscore for italics treatment on last PR re: zsh & mkcert 😇 

```bash
docker-compose exec wordcamp.test wp site list --field=url --allow-root

Fatal error: Uncaught ArgumentCountError: Too few arguments to function wcorg_switch_to_blog_locale(), 2 passed in /usr/src/public_html/mu/wp-includes/class-wp-hook.php on line 286 and exactly 3 expected in /usr/src/public_html/wp-content/mu-plugins/wcorg-misc.php:318
```