### PR TITLE
Camptix: change payment gateways account selector label

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
@@ -59,7 +59,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 	function payment_settings_fields() {
 		// Allow pre-defined accounts if any are defined by plugins.
 		if ( count( $this->get_predefined_accounts() ) > 0 ) {
-			$this->add_settings_field_helper( 'api_predef', __( 'Predefined Account', 'wordcamporg' ), array( $this, 'field_api_predef'	) );
+			$this->add_settings_field_helper( 'api_predef', __( 'Custom Account', 'wordcamporg' ), array( $this, 'field_api_predef'	) );
 		}
 
 		// Settings fields are not needed when a predefined account is chosen.

--- a/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-paypal.php
@@ -59,7 +59,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 	function payment_settings_fields() {
 		// Allow pre-defined accounts if any are defined by plugins.
 		if ( count( $this->get_predefined_accounts() ) > 0 ) {
-			$this->add_settings_field_helper( 'api_predef', __( 'Custom Account', 'wordcamporg' ), array( $this, 'field_api_predef'	) );
+			$this->add_settings_field_helper( 'api_predef', __( 'Account', 'wordcamporg' ), array( $this, 'field_api_predef'	) );
 		}
 
 		// Settings fields are not needed when a predefined account is chosen.
@@ -97,7 +97,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 		?>
 
 		<select id="camptix-paypal-predef-select" name="<?php echo esc_attr( $args['name'] ); ?>">
-			<option value=""><?php _e( 'None', 'wordcamporg' ); ?></option>
+			<option value=""><?php _e( 'Custom', 'wordcamporg' ); ?></option>
 
 			<?php foreach ( $accounts as $key => $account ) : ?>
 				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $args['value'], $key ); ?>>

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -214,7 +214,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	public function payment_settings_fields() {
 		// Allow pre-defined accounts if any are defined by plugins.
 		if ( count( $this->get_predefined_accounts() ) > 0 ) {
-			$this->add_settings_field_helper( 'api_predef', __( 'Custom Account', 'wordcamporg' ), array( $this, 'field_api_predef' ) );
+			$this->add_settings_field_helper( 'api_predef', __( 'Account', 'wordcamporg' ), array( $this, 'field_api_predef' ) );
 		}
 
 		// Settings fields are not needed when a predefined account is chosen.
@@ -253,7 +253,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		?>
 
 		<select id="camptix-stripe-predef-select" name="<?php echo esc_attr( $args['name'] ); ?>">
-			<option value=""><?php _e( 'None', 'wordcamporg' ); ?></option>
+			<option value=""><?php _e( 'Custom', 'wordcamporg' ); ?></option>
 
 			<?php foreach ( $accounts as $key => $account ) : ?>
 				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $args['value'], $key ); ?>>

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -214,7 +214,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	public function payment_settings_fields() {
 		// Allow pre-defined accounts if any are defined by plugins.
 		if ( count( $this->get_predefined_accounts() ) > 0 ) {
-			$this->add_settings_field_helper( 'api_predef', __( 'Predefined Account', 'wordcamporg' ), array( $this, 'field_api_predef' ) );
+			$this->add_settings_field_helper( 'api_predef', __( 'Custom Account', 'wordcamporg' ), array( $this, 'field_api_predef' ) );
 		}
 
 		// Settings fields are not needed when a predefined account is chosen.


### PR DESCRIPTION
Make Paypal and Stripe gateway account selector label clearer.

Fixes #520 

### How to test the changes in this Pull Request:

1. Navigate to Camptix setup and Payments tab
