### PR TITLE
Central: Require login before submitting application forms and pre-fill wp.org username field

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/common.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/common.css
@@ -71,6 +71,7 @@
 	opacity: 0.5;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .wcfd-disabled-form .PDF_pageInner {
 	width: auto;
 }

--- a/public_html/wp-content/plugins/wcpt/css/applications/common.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/common.css
@@ -25,3 +25,58 @@
 	border-left-color: #dc3232;
 	color: #dc3232;
 }
+
+.wcfd-disabled-form {
+	position: relative;
+}
+
+.wcfd-disabled-form #wcorg-login-message {
+	position: absolute;
+	z-index: 10;
+	margin: 2.4em;
+	padding: 1.8em;
+	background-color: #c62828;
+	border-radius: 0.25em;
+	margin-bottom: 2em;
+}
+
+.wcfd-disabled-form #wcorg-login-message p {
+	color: #fff !important /* !important to prevent theme from unintentionally overriding */;
+}
+
+.wcfd-disabled-form #wcorg-login-message p:first-child {
+	margin-top: 0;
+}
+
+.wcfd-disabled-form #wcorg-login-message p:last-child {
+	margin-bottom: 0;
+}
+
+.wcfd-disabled-form #wcorg-login-message a {
+	color: #fff;
+}
+
+.wcfd-disabled-form #wcorg-login-message a:hover,
+.wcfd-disabled-form #wcorg-login-message a:focus,
+.wcfd-disabled-form #wcorg-login-message a:active {
+	color: #fff;
+}
+
+.wcfd-overlay {
+	position: absolute;
+	z-index: 5;
+	width: 100%;
+	height: 100%;
+	background-color: #000;
+	opacity: 0.5;
+}
+
+.wcfd-disabled-form .PDF_pageInner {
+	width: auto;
+}
+
+@media screen and ( min-width: 470px ) {
+	.wcfd-disabled-form #wcorg-login-message {
+		margin: 4em;
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -8,7 +8,7 @@ defined( 'WPINC' ) || die();
  *
  * @param array $countries
  */
-function render_meetup_application_form( $countries ) {
+function render_meetup_application_form( $countries, $wporg_username ) {
 
 	?>
 
@@ -145,7 +145,7 @@ function render_meetup_application_form( $countries ) {
 				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
-					<input type="text" name="q_wporg_username" required/>
+					<input type="text" name="q_wporg_username" value="<?php echo esc_attr( $wporg_username ); ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>

--- a/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/meetup/shortcode-application.php
@@ -8,7 +8,7 @@ defined( 'WPINC' ) || die();
  *
  * @param array $countries
  */
-function render_meetup_application_form( $countries, $wporg_username ) {
+function render_meetup_application_form( $countries, $prefilled_fields ) {
 
 	?>
 
@@ -19,7 +19,7 @@ function render_meetup_application_form( $countries, $wporg_username ) {
 				<label>
 					Please enter your full Name.
 					<span class="required-indicator">(required)</span>
-					<input type="text" name="q_name" required/>
+					<input type="text" name="q_name" value="<?php echo esc_attr( $prefilled_fields['wporg_name'] ); ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>
@@ -27,7 +27,7 @@ function render_meetup_application_form( $countries, $wporg_username ) {
 				<label>
 					Please enter your email address.
 					<span class="required-indicator">(required)</span>
-					<input type="email" name="q_email" required/>
+					<input type="email" name="q_email" value="<?php echo esc_attr( $prefilled_fields['wporg_email'] ); ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>
@@ -145,7 +145,7 @@ function render_meetup_application_form( $countries, $wporg_username ) {
 				<label>
 					Your <a href="https://wordpress.org" target="_blank">WordPress.org</a> username
 					<span class="required-indicator">(required)</span>
-					<input type="text" name="q_wporg_username" value="<?php echo esc_attr( $wporg_username ); ?>" required/>
+					<input type="text" name="q_wporg_username" value="<?php echo esc_attr( $prefilled_fields['wporg_username'] ); ?>" required/>
 				</label>
 			</div>
 			<div class="PDF_questionDivide"></div>

--- a/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
@@ -10,7 +10,7 @@ defined( 'WPINC' ) || die();
  *
  * @param array $countries
  */
-function render_wordcamp_application_form( $countries, $wporg_username ) {
+function render_wordcamp_application_form( $countries, $prefilled_fields ) {
 	?>
 
 	<form id="wordcamp-application" method="post">
@@ -71,7 +71,7 @@ function render_wordcamp_application_form( $countries, $wporg_username ) {
 						<div class="PDF_QT1400">
 							<label for="q_1079059_email">(e.g. john@example.com)</label>
 							<br/>
-							<input type="email" maxlength="100" name="q_1079059_email" id="q_1079059_email" value=""
+							<input type="email" maxlength="100" name="q_1079059_email" id="q_1079059_email" value="<?php echo esc_attr( $prefilled_fields['wporg_email'] ); ?>"
 								   class="survey-email required" autocomplete="off" required/>
 						</div>
 					</div>
@@ -96,7 +96,7 @@ function render_wordcamp_application_form( $countries, $wporg_username ) {
 
 						<div class="PDF_QT100">
 							<input maxlength="500" name="q_4236565_wporg_username" class="large required"
-								   type="text" title="What is your wordpress.org username?" value="<?php echo esc_attr( $wporg_username ); ?>" required/>
+								   type="text" title="What is your wordpress.org username?" value="<?php echo esc_attr( $prefilled_fields['wporg_username'] ); ?>" required/>
 						</div>
 					</div>
 				</div>

--- a/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
@@ -10,7 +10,7 @@ defined( 'WPINC' ) || die();
  *
  * @param array $countries
  */
-function render_wordcamp_application_form( $countries ) {
+function render_wordcamp_application_form( $countries, $wporg_username ) {
 	?>
 
 	<form id="wordcamp-application" method="post">
@@ -95,8 +95,8 @@ function render_wordcamp_application_form( $countries ) {
 						</div>
 
 						<div class="PDF_QT100">
-							<input value="" maxlength="500" name="q_4236565_wporg_username" class="large required"
-								   type="text" title="What is your wordpress.org username?" required/>
+							<input maxlength="500" name="q_4236565_wporg_username" class="large required"
+								   type="text" title="What is your wordpress.org username?" value="<?php echo esc_attr( $wporg_username ); ?>" required/>
 						</div>
 					</div>
 				</div>

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -79,6 +79,7 @@ abstract class Event_Application {
 			}
 
 			if ( ! is_user_logged_in() ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo '<div class="wcfd-disabled-form">' . wcorg_login_message( '', get_permalink() ) . '<div class="wcfd-overlay"></div><div inert>';
 			}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -74,7 +74,15 @@ abstract class Event_Application {
 				$wporg_username = $current_user->user_login;
 			}
 
+			if ( ! is_user_logged_in() ) {
+				echo '<div class="wcfd-disabled-form">' . wcorg_login_message( '', get_permalink() ) . '<div class="wcfd-overlay"></div><div inert>';
+			}
+
 			$this->render_application_form( $countries, $wporg_username );
+
+			if ( ! is_user_logged_in() ) {
+				echo '</div></div>';
+			}
 		}
 
 		return ob_get_clean();

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -67,7 +67,14 @@ abstract class Event_Application {
 			$this->submit_application( $_POST );
 		} else {
 			$countries = wcorg_get_countries();
-			$this->render_application_form( $countries );
+
+			$wporg_username = '';
+			if ( is_user_logged_in() ) {
+				$current_user = wp_get_current_user();
+				$wporg_username = $current_user->user_login;
+			}
+
+			$this->render_application_form( $countries, $wporg_username );
 		}
 
 		return ob_get_clean();
@@ -80,7 +87,7 @@ abstract class Event_Application {
 	 *
 	 * @return null
 	 */
-	abstract public function render_application_form( $countries );
+	abstract public function render_application_form( $countries, $wporg_username );
 
 	/**
 	 * Submit application details. Calls `create_post` to actually create the event.

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -72,9 +72,9 @@ abstract class Event_Application {
 			if ( is_user_logged_in() ) {
 				$current_user = wp_get_current_user();
 				$prefilled_fields = array(
-					'wporg_name'			=> $current_user->display_name,
-					'wporg_username'	=> $current_user->user_login,
-					'wporg_email'			=> $current_user->user_email,
+					'wporg_name'     => $current_user->display_name,
+					'wporg_username' => $current_user->user_login,
+					'wporg_email'    => $current_user->user_email,
 				);
 			}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -100,6 +100,9 @@ abstract class Event_Application {
 		if ( $this->is_rate_limited() ) {
 			$message        = __( 'You have submitted too many applications recently. Please wait and try again in a few hours.', 'wordcamporg' );
 			$notice_classes = 'notice-error';
+		} elseif ( ! is_user_logged_in() ) {
+			$message        = __( 'You must be logged in with your WordPress.org account to submit the application.', 'wordcamporg' );
+			$notice_classes = 'notice-error';
 		} elseif ( is_wp_error( $application_data ) ) {
 			$message        = $application_data->get_error_message();
 			$notice_classes = 'notice-error';

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -71,14 +71,18 @@ abstract class Event_Application {
 			$wporg_username = '';
 			if ( is_user_logged_in() ) {
 				$current_user = wp_get_current_user();
-				$wporg_username = $current_user->user_login;
+				$prefilled_fields = array(
+					'wporg_name'			=> $current_user->display_name,
+					'wporg_username'	=> $current_user->user_login,
+					'wporg_email'			=> $current_user->user_email,
+				);
 			}
 
 			if ( ! is_user_logged_in() ) {
 				echo '<div class="wcfd-disabled-form">' . wcorg_login_message( '', get_permalink() ) . '<div class="wcfd-overlay"></div><div inert>';
 			}
 
-			$this->render_application_form( $countries, $wporg_username );
+			$this->render_application_form( $countries, $prefilled_fields );
 
 			if ( ! is_user_logged_in() ) {
 				echo '</div></div>';
@@ -95,7 +99,7 @@ abstract class Event_Application {
 	 *
 	 * @return null
 	 */
-	abstract public function render_application_form( $countries, $wporg_username );
+	abstract public function render_application_form( $countries, $prefilled_fields );
 
 	/**
 	 * Submit application details. Calls `create_post` to actually create the event.

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -116,9 +116,9 @@ class Meetup_Application extends Event_Application {
 	 *
 	 * @return null|void
 	 */
-	public function render_application_form( $countries, $wporg_username ) {
+	public function render_application_form( $countries, $prefilled_fields ) {
 		require_once dirname( __DIR__ ) . '/views/applications/meetup/shortcode-application.php';
-		render_meetup_application_form( $countries, $wporg_username );
+		render_meetup_application_form( $countries, $prefilled_fields );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -116,9 +116,9 @@ class Meetup_Application extends Event_Application {
 	 *
 	 * @return null|void
 	 */
-	public function render_application_form( $countries ) {
+	public function render_application_form( $countries, $wporg_username ) {
 		require_once dirname( __DIR__ ) . '/views/applications/meetup/shortcode-application.php';
-		render_meetup_application_form( $countries );
+		render_meetup_application_form( $countries, $wporg_username );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -57,8 +57,8 @@ class WordCamp_Application extends Event_Application {
 	 *
 	 * @return null|void
 	 */
-	public function render_application_form( $countries ) {
-		render_wordcamp_application_form( $countries );
+	public function render_application_form( $countries, $wporg_username ) {
+		render_wordcamp_application_form( $countries, $wporg_username );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -57,8 +57,8 @@ class WordCamp_Application extends Event_Application {
 	 *
 	 * @return null|void
 	 */
-	public function render_application_form( $countries, $wporg_username ) {
-		render_wordcamp_application_form( $countries, $wporg_username );
+	public function render_application_form( $countries, $prefilled_fields ) {
+		render_wordcamp_application_form( $countries, $prefilled_fields );
 	}
 
 	/**

--- a/public_html/wp-content/wp-cache-config.php
+++ b/public_html/wp-content/wp-cache-config.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! defined('WPCACHEHOME') )
-  define( 'WPCACHEHOME', WP_PLUGIN_DIR . '/wp-super-cache/' );
+	define( 'WPCACHEHOME', WP_PLUGIN_DIR . '/wp-super-cache/' );
 
 $wpsc_version                  = 169;
 $wp_cache_debug_username       = WP_CACHE_DEBUG_USERNAME;
@@ -48,12 +48,12 @@ $ossdlcdn            = 0;
 $cache_acceptable_files    = array( 'wp-comments-popup.php', 'wp-links-opml.php', 'wp-locations.php' );
 $cache_rejected_uri        = array( 'wp-.*\\.php', 'index\\.php' );
 $cache_rejected_user_agent = array(
-  0 => 'bot',
-  1 => 'ia_archive',
-  2 => 'slurp',
-  3 => 'crawl',
-  4 => 'spider',
-  5 => 'Yandex'
+	0 => 'bot',
+	1 => 'ia_archive',
+	2 => 'slurp',
+	3 => 'crawl',
+	4 => 'spider',
+	5 => 'Yandex'
 );
 
 $cache_rebuild_files = 1;
@@ -67,7 +67,7 @@ $wp_cache_mutex_disabled = 1;
 $sem_id = 691930456;
 
 if ( '/' != substr( $cache_path, -1 ) ) {
-  $cache_path .= '/';
+	$cache_path .= '/';
 }
 
 $wp_cache_mobile           = 0;
@@ -111,3 +111,4 @@ $wp_cache_clear_on_post_edit = 1;
 $wp_cache_hello_world        = 0;
 $wp_cache_mobile_enabled     = 1;
 $wp_cache_cron_check         = 1;
+

--- a/public_html/wp-content/wp-cache-config.php
+++ b/public_html/wp-content/wp-cache-config.php
@@ -111,4 +111,3 @@ $wp_cache_clear_on_post_edit = 1;
 $wp_cache_hello_world        = 0;
 $wp_cache_mobile_enabled     = 1;
 $wp_cache_cron_check         = 1;
-

--- a/public_html/wp-content/wp-cache-config.php
+++ b/public_html/wp-content/wp-cache-config.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! defined('WPCACHEHOME') )
-	define( 'WPCACHEHOME', WP_PLUGIN_DIR . '/wp-super-cache/' );
+  define( 'WPCACHEHOME', WP_PLUGIN_DIR . '/wp-super-cache/' );
 
 $wpsc_version                  = 169;
 $wp_cache_debug_username       = WP_CACHE_DEBUG_USERNAME;
@@ -24,13 +24,13 @@ $wp_cache_no_cache_for_get     = 0;
 $wp_cache_disable_utf8         = 0;
 $cache_page_secret             = WP_CACHE_PAGE_SECRET;
 $cache_domain_mapping          = '1';
-$wp_cache_mobile_groups = '';
-$wp_cache_mobile_prefixes = 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-';
+$wp_cache_mobile_groups        = '';
+$wp_cache_mobile_prefixes      = 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-';
 $wp_cache_refresh_single_only  = 0;
 $wp_cache_mod_rewrite          = 0;
 $wp_cache_front_page_checks    = 0;
 $wp_supercache_304             = 0;
-$wp_cache_slash_check = 1;
+$wp_cache_slash_check          = 1;
 $wpsc_fix_164                  = 1;
 $wpsc_save_headers             = 0;
 $wp_cache_mfunc_enabled        = 0;
@@ -48,12 +48,12 @@ $ossdlcdn            = 0;
 $cache_acceptable_files    = array( 'wp-comments-popup.php', 'wp-links-opml.php', 'wp-locations.php' );
 $cache_rejected_uri        = array( 'wp-.*\\.php', 'index\\.php' );
 $cache_rejected_user_agent = array(
-	0 => 'bot',
-	1 => 'ia_archive',
-	2 => 'slurp',
-	3 => 'crawl',
-	4 => 'spider',
-	5 => 'Yandex'
+  0 => 'bot',
+  1 => 'ia_archive',
+  2 => 'slurp',
+  3 => 'crawl',
+  4 => 'spider',
+  5 => 'Yandex'
 );
 
 $cache_rebuild_files = 1;
@@ -67,12 +67,12 @@ $wp_cache_mutex_disabled = 1;
 $sem_id = 691930456;
 
 if ( '/' != substr( $cache_path, -1 ) ) {
-	$cache_path .= '/';
+  $cache_path .= '/';
 }
 
 $wp_cache_mobile           = 0;
 $wp_cache_mobile_whitelist = 'Stand Alone/QNws';
-$wp_cache_mobile_browsers = '2.0 MMP, 240x320, 400X240, AvantGo, BlackBerry, Blazer, Cellphone, Danger, DoCoMo, Elaine/3.0, EudoraWeb, Googlebot-Mobile, hiptop, IEMobile, KYOCERA/WX310K, LG/U990, MIDP-2., MMEF20, MOT-V, NetFront, Newt, Nintendo Wii, Nitro, Nokia, Opera Mini, Palm, PlayStation Portable, portalmmm, Proxinet, ProxiNet, SHARP-TQ-GX10, SHG-i900, Small, SonyEricsson, Symbian OS, SymbianOS, TS21i-10, UP.Browser, UP.Link, webOS, Windows CE, WinWAP, YahooSeeker/M1A1-R2D2, iPhone, iPod, iPad, Android, BlackBerry9530, LG-TU915 Obigo, LGE VX, webOS, Nokia5800';
+$wp_cache_mobile_browsers  = '2.0 MMP, 240x320, 400X240, AvantGo, BlackBerry, Blazer, Cellphone, Danger, DoCoMo, Elaine/3.0, EudoraWeb, Googlebot-Mobile, hiptop, IEMobile, KYOCERA/WX310K, LG/U990, MIDP-2., MMEF20, MOT-V, NetFront, Newt, Nintendo Wii, Nitro, Nokia, Opera Mini, Palm, PlayStation Portable, portalmmm, Proxinet, ProxiNet, SHARP-TQ-GX10, SHG-i900, Small, SonyEricsson, Symbian OS, SymbianOS, TS21i-10, UP.Browser, UP.Link, webOS, Windows CE, WinWAP, YahooSeeker/M1A1-R2D2, iPhone, iPod, iPad, Android, BlackBerry9530, LG-TU915 Obigo, LGE VX, webOS, Nokia5800';
 
 $wp_cache_plugins_dir = WP_CONTENT_DIR . '/wp-super-cache-plugins';
 

--- a/public_html/wp-content/wp-cache-config.php
+++ b/public_html/wp-content/wp-cache-config.php
@@ -24,13 +24,13 @@ $wp_cache_no_cache_for_get     = 0;
 $wp_cache_disable_utf8         = 0;
 $cache_page_secret             = WP_CACHE_PAGE_SECRET;
 $cache_domain_mapping          = '1';
-$wp_cache_mobile_groups        = '';
-$wp_cache_mobile_prefixes      = 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-';
+$wp_cache_mobile_groups = '';
+$wp_cache_mobile_prefixes = 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-';
 $wp_cache_refresh_single_only  = 0;
 $wp_cache_mod_rewrite          = 0;
 $wp_cache_front_page_checks    = 0;
 $wp_supercache_304             = 0;
-$wp_cache_slash_check          = 1;
+$wp_cache_slash_check = 1;
 $wpsc_fix_164                  = 1;
 $wpsc_save_headers             = 0;
 $wp_cache_mfunc_enabled        = 0;
@@ -72,7 +72,7 @@ if ( '/' != substr( $cache_path, -1 ) ) {
 
 $wp_cache_mobile           = 0;
 $wp_cache_mobile_whitelist = 'Stand Alone/QNws';
-$wp_cache_mobile_browsers  = '2.0 MMP, 240x320, 400X240, AvantGo, BlackBerry, Blazer, Cellphone, Danger, DoCoMo, Elaine/3.0, EudoraWeb, Googlebot-Mobile, hiptop, IEMobile, KYOCERA/WX310K, LG/U990, MIDP-2., MMEF20, MOT-V, NetFront, Newt, Nintendo Wii, Nitro, Nokia, Opera Mini, Palm, PlayStation Portable, portalmmm, Proxinet, ProxiNet, SHARP-TQ-GX10, SHG-i900, Small, SonyEricsson, Symbian OS, SymbianOS, TS21i-10, UP.Browser, UP.Link, webOS, Windows CE, WinWAP, YahooSeeker/M1A1-R2D2, iPhone, iPod, iPad, Android, BlackBerry9530, LG-TU915 Obigo, LGE VX, webOS, Nokia5800';
+$wp_cache_mobile_browsers = '2.0 MMP, 240x320, 400X240, AvantGo, BlackBerry, Blazer, Cellphone, Danger, DoCoMo, Elaine/3.0, EudoraWeb, Googlebot-Mobile, hiptop, IEMobile, KYOCERA/WX310K, LG/U990, MIDP-2., MMEF20, MOT-V, NetFront, Newt, Nintendo Wii, Nitro, Nokia, Opera Mini, Palm, PlayStation Portable, portalmmm, Proxinet, ProxiNet, SHARP-TQ-GX10, SHG-i900, Small, SonyEricsson, Symbian OS, SymbianOS, TS21i-10, UP.Browser, UP.Link, webOS, Windows CE, WinWAP, YahooSeeker/M1A1-R2D2, iPhone, iPod, iPad, Android, BlackBerry9530, LG-TU915 Obigo, LGE VX, webOS, Nokia5800';
 
 $wp_cache_plugins_dir = WP_CONTENT_DIR . '/wp-super-cache-plugins';
 


### PR DESCRIPTION
As discussed on #333, here comes the separate PR for requiring login before users can submit WordCamp or Meetup applications.

If the user is not logged in, we wrap the form into a wall and show a login prompt. Also on submit, login status is checked and the error message returned if the user is not logged in.

When user is logged in, WordPress.org username fields in both form do get pre-filled.

Maybe not the most prettiest way and does not uniform the way how these forms and `wordcamp-forms-to-drafts` plugin does the login requirement, but these forms are build in quite a different way so standardising the functionality is hard. Styles could be loaded from one and same place tho, for consistent experience - but I'll do that after this has been merged as now it's more critical to get the wall in place to mitigate spam.

See also #321 

### Screenshots

**When user is not logged in**

![](https://i.imgur.com/oG1RQI3.png)

**After user has logged in**
![](https://i.imgur.com/53Dztcc.png)

### How to test the changes in this Pull Request:

1. Visit [Meetup application page](https://central.wordcamp.test/meetup-organizer-application/) when not logged in (private browsing). You should see a login prompt.
2. With inspector remove the prompt, fill the form and submit. You should see an error message telling that WordPress.org login is required.
3. Now visit the Meetup application page when you are logged in. You should not see the login prompt and WordPress.org username field should be filled.
