### PR TITLE
CampTix: Add an attendee content block with check-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"workspaces": [
 		"public_html/wp-content/mu-plugins/blocks",
 		"public_html/wp-content/mu-plugins/virtual-embeds",
+		"public_html/wp-content/plugins/camptix",
 		"public_html/wp-content/plugins/wc-post-types",
 		"public_html/wp-content/plugins/wcpt",
 		"public_html/wp-content/plugins/wordcamp-forms-to-drafts",

--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -528,7 +528,8 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 					$this->log( sprintf( 'Viewing private content using %s', @$_SERVER['REMOTE_ADDR'] ), $attendee->ID, $_SERVER );
 
 					// Mark attendee as attended.
-					if ( ! get_post_meta( $attendee->ID, 'tix_attended', true ) ) {
+					$mark_attended = isset( $_POST['tix_mark_attended'] ) && rest_sanitize_boolean( $_POST['tix_mark_attended'] );
+					if ( $mark_attended && ! get_post_meta( $attendee->ID, 'tix_attended', true ) ) {
 						update_post_meta( $attendee->ID, 'tix_attended', true );
 					}
 				}
@@ -564,6 +565,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 
 		$args = shortcode_atts(
 			array(
+				'mark_attended'            => true,
 				'ticket_ids'               => null,
 				'logged_out_message'       => '',
 				'logged_out_message_after' => '',
@@ -657,6 +659,11 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 			<form method="POST" action="#tix">
 				<input type="hidden" name="tix_private_shortcode_submit" value="1" />
 				<input type="hidden" name="tix_post_id" value="<?php the_ID(); ?>" />
+				<input
+					type="hidden"
+					name="tix_mark_attended"
+					value="<?php echo $atts['mark_attended'] ? 'true' : 'false'; ?>"
+				/>
 				<table class="tix-private-form">
 					<tr>
 						<th class="tix-left" colspan="2"><?php esc_html_e( 'Have a ticket? Sign in', 'wordcamporg' ); ?></th>

--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -526,6 +526,11 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 					add_post_meta( $attendee->ID, 'tix_private_form_submit_entry', $_SERVER );
 					add_post_meta( $attendee->ID, 'tix_private_form_submit_ip', @$_SERVER['REMOTE_ADDR'] );
 					$this->log( sprintf( 'Viewing private content using %s', @$_SERVER['REMOTE_ADDR'] ), $attendee->ID, $_SERVER );
+
+					// Mark attendee as attended.
+					if ( ! get_post_meta( $attendee->ID, 'tix_attended', true ) ) {
+						update_post_meta( $attendee->ID, 'tix_attended', true );
+					}
 				}
 			} else {
 				$camptix->error( __( 'No tickets were found for this email. Please try again.', 'wordcamporg' ) );

--- a/public_html/wp-content/plugins/camptix/blocks/blocks.php
+++ b/public_html/wp-content/plugins/camptix/blocks/blocks.php
@@ -11,34 +11,19 @@ defined( 'WPINC' ) || die();
  * @return void
  */
 function register_assets() {
-	$path        = __DIR__ . '/build/attendee-content.js';
-	$deps_path   = __DIR__ . '/build/attendee-content.asset.php';
-	$script_info = file_exists( $deps_path )
-		? require $deps_path
-		: array(
-			'dependencies' => array(),
-			'version'      => filemtime( $path ),
-		);
-
-	wp_register_script(
-		'camptix-blocks',
-		plugins_url( 'build/attendee-content.js', __FILE__ ),
-		$script_info['dependencies'],
-		$script_info['version'],
-		false
-	);
-
-	wp_set_script_translations( 'camptix-blocks', 'wordcamporg' );
-
 	// Set up the Attendee Content block.
-	register_block_type(
-		'camptix/attendee-content',
+	register_block_type_from_metadata(
+		__DIR__ . '/src/attendee-content',
 		array(
-			'editor_script'   => 'camptix-blocks',
 			'render_callback' => function( $attributes, $content ) {
-				return sprintf( '[camptix_private]%s[/camptix_private]', $content );
+				return sprintf(
+					'[camptix_private mark_attended="%s"]%s[/camptix_private]',
+					$attributes['markAttended'],
+					$content
+				);
 			},
 		)
 	);
+	wp_set_script_translations( 'camptix-attendee-content-editor-script', 'wordcamporg' );
 }
 add_action( 'init', __NAMESPACE__ . '\register_assets' );

--- a/public_html/wp-content/plugins/camptix/blocks/blocks.php
+++ b/public_html/wp-content/plugins/camptix/blocks/blocks.php
@@ -1,0 +1,44 @@
+<?php
+namespace CampTix\Blocks;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register assets.
+ *
+ * The assets get enqueued automatically by the registered block types.
+ *
+ * @return void
+ */
+function register_assets() {
+	$path        = __DIR__ . '/build/attendee-content.js';
+	$deps_path   = __DIR__ . '/build/attendee-content.asset.php';
+	$script_info = file_exists( $deps_path )
+		? require $deps_path
+		: array(
+			'dependencies' => array(),
+			'version'      => filemtime( $path ),
+		);
+
+	wp_register_script(
+		'camptix-blocks',
+		plugins_url( 'build/attendee-content.js', __FILE__ ),
+		$script_info['dependencies'],
+		$script_info['version'],
+		false
+	);
+
+	wp_set_script_translations( 'camptix-blocks', 'wordcamporg' );
+
+	// Set up the Attendee Content block.
+	register_block_type(
+		'camptix/attendee-content',
+		array(
+			'editor_script'   => 'camptix-blocks',
+			'render_callback' => function( $attributes, $content ) {
+				return sprintf( '[camptix_private]%s[/camptix_private]', $content );
+			},
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_assets' );

--- a/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/block.json
+++ b/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/block.json
@@ -1,0 +1,12 @@
+{
+	"name": "camptix/attendee-content",
+	"icon": "welcome-view-site",
+	"category": "widgets",
+	"attributes": {},
+	"supports": {
+		"customClassName": false,
+		"className": false,
+		"html": false,
+		"multiple": false
+	}
+}

--- a/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/block.json
+++ b/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/block.json
@@ -2,7 +2,12 @@
 	"name": "camptix/attendee-content",
 	"icon": "welcome-view-site",
 	"category": "widgets",
-	"attributes": {},
+	"attributes": {
+		"markAttended": {
+			"type": "boolean",
+			"default": true
+		}
+	},
 	"supports": {
 		"customClassName": false,
 		"className": false,

--- a/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/block.json
+++ b/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/block.json
@@ -8,5 +8,6 @@
 		"className": false,
 		"html": false,
 		"multiple": false
-	}
+	},
+	"editorScript": "file://../../build/attendee-content.js"
 }

--- a/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/edit.js
+++ b/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/edit.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+
+export default function( { attributes, setAttributes } ) {
+	const { markAttended } = attributes;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wordcamporg' ) } initialOpen>
+					<ToggleControl
+						label={ __( 'Mark viewers as attended?', 'wordcamporg' ) }
+						help={ __(
+							'When an attendee logs in to view this content, it will mark them as attending the event.',
+							'wordcamporg'
+						) }
+						checked={ markAttended }
+						onChange={ () => setAttributes( { markAttended: ! markAttended } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div style={ { background: 'rgba(0,0,0,0.1)' } }>
+				<p>
+					<em>{ __( 'The content below is only shown to registered attendees.', 'wordcamporg' ) }</em>
+				</p>
+			</div>
+			<InnerBlocks />
+			<div style={ { background: 'rgba(0,0,0,0.1)' } }>
+				<p>
+					<em>{ __( 'End of attendee content.', 'wordcamporg' ) }</em>
+				</p>
+			</div>
+		</>
+	);
+}

--- a/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/index.js
+++ b/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/index.js
@@ -9,6 +9,7 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import metadata from './block.json';
+import Edit from './edit.js';
 
 const { name, ...settings } = metadata;
 
@@ -17,20 +18,6 @@ registerBlockType( name, {
 	title: __( 'Attendee Content', 'wordcamporg' ),
 	description: __( 'This content is only shown once the viewer enters a valid attendee email.', 'wordcamporg' ),
 	keywords: [ __( 'private content', 'wordcamporg' ), __( 'restricted content', 'wordcamporg' ) ],
-	edit: () => (
-		<>
-			<div style={ { background: 'rgba(0,0,0,0.1)' } }>
-				<p>
-					<em>{ __( 'The content below is only shown to registered attendees.', 'wordcamporg' ) }</em>
-				</p>
-			</div>
-			<InnerBlocks />
-			<div style={ { background: 'rgba(0,0,0,0.1)' } }>
-				<p>
-					<em>{ __( 'End of attendee content.', 'wordcamporg' ) }</em>
-				</p>
-			</div>
-		</>
-	),
+	edit: Edit,
 	save: () => <InnerBlocks.Content />,
 } );

--- a/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/index.js
+++ b/public_html/wp-content/plugins/camptix/blocks/src/attendee-content/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { name, ...settings } = metadata;
+
+registerBlockType( name, {
+	...settings,
+	title: __( 'Attendee Content', 'wordcamporg' ),
+	description: __( 'This content is only shown once the viewer enters a valid attendee email.', 'wordcamporg' ),
+	keywords: [ __( 'private content', 'wordcamporg' ), __( 'restricted content', 'wordcamporg' ) ],
+	edit: () => (
+		<>
+			<div style={ { background: 'rgba(0,0,0,0.1)' } }>
+				<p>
+					<em>{ __( 'The content below is only shown to registered attendees.', 'wordcamporg' ) }</em>
+				</p>
+			</div>
+			<InnerBlocks />
+			<div style={ { background: 'rgba(0,0,0,0.1)' } }>
+				<p>
+					<em>{ __( 'End of attendee content.', 'wordcamporg' ) }</em>
+				</p>
+			</div>
+		</>
+	),
+	save: () => <InnerBlocks.Content />,
+} );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -67,6 +67,10 @@ class CampTix_Plugin {
 		require( dirname( __FILE__ ) . '/inc/class-camptix-addon.php' );
 		require( dirname( __FILE__ ) . '/inc/class-camptix-payment-method.php' );
 
+		if ( true ) { // Test env flag.
+			require( dirname( __FILE__ ) . '/blocks/blocks.php' );
+		}
+
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			require_once( dirname( __FILE__ ) . '/inc/class-wp-cli-commands.php' );
 		}

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -67,7 +67,7 @@ class CampTix_Plugin {
 		require( dirname( __FILE__ ) . '/inc/class-camptix-addon.php' );
 		require( dirname( __FILE__ ) . '/inc/class-camptix-payment-method.php' );
 
-		if ( true ) { // Test env flag.
+		if ( is_wordcamp_beta( 'camptix_blocks' ) ) {
 			require( dirname( __FILE__ ) . '/blocks/blocks.php' );
 		}
 

--- a/public_html/wp-content/plugins/camptix/package.json
+++ b/public_html/wp-content/plugins/camptix/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "camptix",
+	"version": "1.0.0",
+	"description": "Ticketing tools for WordCamps.",
+	"author": "WordCamp Team",
+	"license": "GPL-2.0-or-later",
+	"private": true,
+	"keywords": [],
+	"homepage": "https://github.com/WordPress/wordcamp.org/tree/production/public_html/wp-content/plugins/camptix",
+	"repository": "git+https://github.com/WordPress/wordcamp.org.git",
+	"bugs": {
+		"url": "https://github.com/WordPress/wordcamp.org/issues?q=label%3A%22%5BComponent%5D+CampTix%22"
+	},
+	"devDependencies": {
+		"@wordpress/scripts": "8.0.1"
+	},
+	"scripts": {
+		"start": "wp-scripts start blocks/src/index.js --output-path='./blocks/build'",
+		"build": "wp-scripts build blocks/src/index.js --output-path='./blocks/build'",
+		"lint:js": "wp-scripts lint-js blocks/src",
+		"format:js": "wp-scripts format-js",
+		"lint:pkg-json": "wp-scripts lint-pkg-json"
+	},
+	"eslintConfig": {
+		"extends": "../../../../.eslintrc.js"
+	},
+	"prettier": "../../../../.prettierrc.js",
+	"stylelint": {
+		"extends": "../../../../.stylelintrc"
+	}
+}

--- a/public_html/wp-content/plugins/camptix/package.json
+++ b/public_html/wp-content/plugins/camptix/package.json
@@ -15,8 +15,8 @@
 		"@wordpress/scripts": "8.0.1"
 	},
 	"scripts": {
-		"start": "wp-scripts start blocks/src/index.js --output-path='./blocks/build'",
-		"build": "wp-scripts build blocks/src/index.js --output-path='./blocks/build'",
+		"start": "wp-scripts start attendee-content='./blocks/src/attendee-content/index.js' --output-path='./blocks/build'",
+		"build": "wp-scripts build attendee-content='./blocks/src/attendee-content/index.js' --output-path='./blocks/build'",
 		"lint:js": "wp-scripts lint-js blocks/src",
 		"format:js": "wp-scripts format-js",
 		"lint:pkg-json": "wp-scripts lint-pkg-json"

--- a/public_html/wp-content/plugins/camptix/package.json
+++ b/public_html/wp-content/plugins/camptix/package.json
@@ -18,6 +18,7 @@
 		"start": "wp-scripts start attendee-content='./blocks/src/attendee-content/index.js' --output-path='./blocks/build'",
 		"build": "wp-scripts build attendee-content='./blocks/src/attendee-content/index.js' --output-path='./blocks/build'",
 		"lint:js": "wp-scripts lint-js blocks/src",
+		"lint:css": "echo \"No CSS linting in this repo.\" && exit 0",
 		"format:js": "wp-scripts format-js",
 		"lint:pkg-json": "wp-scripts lint-pkg-json"
 	},


### PR DESCRIPTION
Add a more obvious way (a block) to show content to only people who have registered for the event, and check them in as "attended" when it's viewed. This also cleans up the conditions for displaying login or content & the validation errors. Lastly, this removes the notices about logging in & the success message, since these are obvious from context and just create noise on the page.

This block can be used on pages to provide Zoom passwords or other "private" content, without relying on attendees saving an email.

### Screenshots

In the editor, this wraps the InnerBlocks with some text explaining that the content will be private. IMO this needs the start & end visuals, since it's hard to know if you're in the inner-block container or not, and it would be bad for private content to be accidentally public. But I'd like a designer's eye for a better UI than this :)

![attendee-content-editor](https://user-images.githubusercontent.com/541093/84932820-e0260500-b0a2-11ea-847b-61a14133936c.png)

On the front-end, it uses the `camptix_private` UI for everything. If unauthenticated, the form asks for an email. Once logged in, the protected content is displayed.

![Screen Shot 2020-06-17 at 12 21 39 PM](https://user-images.githubusercontent.com/541093/84932823-e0be9b80-b0a2-11ea-92d3-1a25d699d898.png)

Errors verifying info will show above the form.

<img width="628" alt="Screen Shot 2020-06-17 at 2 20 11 PM" src="https://user-images.githubusercontent.com/541093/84934671-a9052300-b0a5-11ea-9893-8c09b3f1a2c9.png">

### How to test the changes in this Pull Request:

1. Add an "Attendee Content" block to your page
2. You should only be allowed to add it once, but you can add it to multiple pages
3. Add any content inside the block
4. Save the page
5. View the page, you should see a login form instead of the content
6. Log in using a valid attendee email — make sure the attendee is not "marked attended" yet
7. After success, you should see the content, and now the attendee is marked as attended
8. Reload the page, the content should still be visible

Try creating edge cases by removing or altering the `tix_view_token` cookie, or `tix_view_token` meta value, or by changing the attendee to cancelled, or by using different emails, etc.

(Note: tagging as COVID-19 Response since it can help track attendance in online WordCamps)