### PR TITLE
Tools: Update functions for skip flags to use blogmeta

### DIFF
--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -89,14 +89,21 @@ function get_wordcamp_blog_ids_from_meta( $key, $value = null ) {
  *
  * See WordCamp_CLI_Miscellaneous::set_skip_feature_flag() for how to set the flags.
  *
+ * Updated June 2020 to use the blog meta table for storing flags instead of a site's options table.
+ *
  * @param string $flag
+ * @param int    $blog_id
  *
  * @return bool
  */
-function wcorg_skip_feature( $flag ) {
-	$flags = get_option( 'wordcamp_skip_features', array() );
+function wcorg_skip_feature( $flag, $blog_id = null ) {
+	if ( is_null( $blog_id ) ) {
+		$blog_id = get_current_blog_id();
+	}
 
-	return isset( $flags[ $flag ] );
+	$flags = get_site_meta( $blog_id, 'wordcamp_skip_feature' );
+
+	return in_array( $flag, $flags, true );
 }
 
 /**


### PR DESCRIPTION
This updates the `wcorg_skip_feature` function and the two CLI commands that are used to set/unset feature flags so that they use the network-wide blogmeta table (via *_site_meta functions) instead of each site's individual options table.

Fixes #448 

### How to test the changes in this Pull Request:

In preparation for this, I wrote a [single-use script](https://wordcamp.trac.wordpress.org/browser/bin/wp-cli/single-use/general/migrate-skip-flags-blogmeta.php) and non-destructively migrated all existing skip feature flags from each site into the blogmeta table. So you may be able to test these changes on your sandbox more easily than in a local environment.

1. To test `wcorg_skip_feature`, you can compare two sites, one that has the skip flag and one that doesn't. To see which flags a site has, run `get_site_meta( {blog_id}, 'wordcamp_skip_feature' )` from within wp shell. To see which sites have a particular skip flag, run `get_wordcamp_blog_ids_from_meta( 'wordcamp_skip_feature', {flag name} )`.
1. To test `set_skip_feature_flag`, try adding a `test` skip flag using a very low max site ID. Then you can use `get_site_meta( {blog_id}, 'wordcamp_skip_feature' )` to see if it was set correctly.
1. To test `skip_feature_flag`, you can run it with `get` to check the test skip flag you just added, and then run it again with `unset` to remove the skip flag from the site(s) it was added to.