### PR TITLE
WCPT: Add application question, is event IRL/online

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/wordcamp.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/wordcamp.css
@@ -946,6 +946,8 @@ SPECIFIC CSS STYLES FOR JANE
  #pd-divider-23,
 #pd-question-28,
  #pd-divider-28,
+#pd-question-30,
+ #pd-divider-30,
 .qNumber {
 	display: none;
 }

--- a/public_html/wp-content/plugins/wcpt/css/applications/wordcamp.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/wordcamp.css
@@ -946,8 +946,6 @@ SPECIFIC CSS STYLES FOR JANE
  #pd-divider-23,
 #pd-question-28,
  #pd-divider-28,
-#pd-question-30,
- #pd-divider-30,
 .qNumber {
 	display: none;
 }

--- a/public_html/wp-content/plugins/wcpt/javascript/applications/wordcamp.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/applications/wordcamp.js
@@ -10,6 +10,7 @@ jQuery( document ).ready( function( $ ) {
 	questions[ "pd-question-20" ] = Array( "21" );
 	questions[ "pd-question-22" ] = Array( "23" );
 	questions[ "pd-question-27" ] = Array( "28" );
+	questions[ "pd-question-35" ] = Array( "30" );
 
 	var yesanswers                 = Array();
 	yesanswers[ "pd-question-6" ]  = Array( "Yes, more than one", "Yes, I've been to one" );
@@ -19,6 +20,7 @@ jQuery( document ).ready( function( $ ) {
 	yesanswers[ "pd-question-20" ] = Array( "Yes, I've planned events of similar size/scope", "I've organized similar types of events, but smaller", "I've organized other events" );
 	yesanswers[ "pd-question-22" ] = Array( "Yes, I have co-organizers already" );
 	yesanswers[ "pd-question-27" ] = Array( "Yes, I know lots of local WordPress users/developers", "Yes, I know a couple of people who would be qualified" );
+	yesanswers[ "pd-question-35" ] = Array( "It would be an in-person event", "It would be both in-person and streamed online" );
 
 	$( "input" ).click( function() {
 		qid = $( this ).closest( ".PDF_question" ).attr( "id" );

--- a/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
@@ -1321,6 +1321,46 @@ function render_wordcamp_application_form( $countries ) {
 
 				<div class="PDF_questionDivide" id="pd-divider-29"></div>
 
+				<div class="PDF_question" id="pd-question-35">
+					<div class="qNumber">
+						Q.35
+					</div>
+
+					<div class="qContent">
+						<div class="qText">
+							Would this WordCamp be an in-person event or streamed online?
+						</div>
+
+						<div class="PDF_QT400">
+							<ul>
+								<li>
+									<input type="radio" name="q_in_person_online"
+									       value="It would be an in-person event" id="q_in_person_online_1" />
+
+									<label for="q_in_person_online_1">
+										It would be an in-person event </label>
+								</li>
+								<li>
+									<input type="radio" name="q_in_person_online"
+									       value="It would be an online event" id="q_in_person_online_2" />
+
+									<label for="q_in_person_online_2">
+										It would be an online event </label>
+								</li>
+								<li>
+									<input type="radio" name="q_in_person_online"
+									       value="It would be both in-person and streamed online" id="q_in_person_online_3" />
+
+									<label for="q_in_person_online_3">
+										It would be both in-person and streamed online </label>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<div class="PDF_questionDivide" id="pd-divider-35"></div>
+
 				<div class="PDF_question" id="pd-question-30">
 					<div class="qNumber">
 						Q.30

--- a/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
@@ -1335,21 +1335,21 @@ function render_wordcamp_application_form( $countries ) {
 							<ul>
 								<li>
 									<input type="radio" name="q_in_person_online"
-									       value="It would be an in-person event" id="q_in_person_online_1" />
+										value="It would be an in-person event" id="q_in_person_online_1" />
 
 									<label for="q_in_person_online_1">
 										It would be an in-person event </label>
 								</li>
 								<li>
 									<input type="radio" name="q_in_person_online"
-									       value="It would be an online event" id="q_in_person_online_2" />
+										value="It would be an online event" id="q_in_person_online_2" />
 
 									<label for="q_in_person_online_2">
 										It would be an online event </label>
 								</li>
 								<li>
 									<input type="radio" name="q_in_person_online"
-									       value="It would be both in-person and streamed online" id="q_in_person_online_3" />
+										value="It would be both in-person and streamed online" id="q_in_person_online_3" />
 
 									<label for="q_in_person_online_3">
 										It would be both in-person and streamed online </label>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -146,6 +146,7 @@ class WordCamp_Application extends Event_Application {
 			'q_1068220_interested_sponsors'              => '',
 			'q_1046009_good_presenters'                  => '',
 			'q_1046021_presenter_names'                  => '',
+			'q_in_person_online'                         => '',
 			'q_1068197_venue_connections'                => '',
 			'q_1068212_venues_considering'               => '',
 			'q_4236565_wporg_username'                   => '',
@@ -237,6 +238,10 @@ class WordCamp_Application extends Event_Application {
 				$data['q_1079060_country'] ? $countries[ $data['q_1079060_country'] ]['name'] : ''
 			)
 		);
+
+		if ( 'It would be an online event' === $data['q_in_person_online'] ) {
+			add_post_meta( $post_id, 'Virtual event only', true );
+		}
 
 		add_post_meta(
 			$post_id,


### PR DESCRIPTION
Adds a question, "Would this WordCamp be an in-person event or streamed online?" to the WordCamp application form, above the question about possible venues.

If an answer is not chosen that includes IRL, the possible venues question is hidden.

If the answer is chosen that the event will be online only, the "Virtual event only" postmeta value is set when the WordCamp application post is created.

Fixes #498 


### Screenshots

![event-irl](https://user-images.githubusercontent.com/916023/85627867-1116b480-b624-11ea-936f-d49ed5d46d0a.jpg)

![event-online](https://user-images.githubusercontent.com/916023/85627882-15db6880-b624-11ea-824b-cad431e5ecc2.jpg)


### How to test the changes in this Pull Request:

1. In your local dev environment, go to the [WordCamp Application form](https://central.wordcamp.test/wordcamp-organizer-application/).
1. Fill out the form (most fields aren't required) and choose "It would be an online event" for the new question. The resulting WordCamp post should have the "Virtual event only" checkbox checked already.
1. Fill out the form again and choose one of the other options for the new question. The resulting WordCamp post should not have that checkbox checked.
