### PR TITLE
WCPT: Use separate Code of Conduct page stub for online events

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -51,7 +51,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:list -->
-<ul><li>Be considerate, respectful, and collaborative.</li><li>Refrain from demeaning, discriminatory or harassing behavior and speech.</li><li>Be mindful of your surroundings and of your fellow participants. Alert conference organizers if you notice a dangerous situation or someone in distress.</li><li>Participate in an authentic and active way. In doing so, you help to create <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> and make it your own.</li></ul>
+<ul><li>Be considerate, respectful, and collaborative.</li><li>Refrain from demeaning, discriminatory or harassing behavior and speech.</li><li>Be mindful of your fellow participants. Alert conference organizers if you notice a dangerous situation or someone in distress.</li><li>Participate in an authentic and active way. In doing so, you help to create <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> and make it your own.</li></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":3} -->
@@ -59,11 +59,11 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning conduct by any attendees of <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> and related events. All <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> venues may be shared with members of the public; please be respectful to all patrons of these locations.</p>
+<p>Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning conduct by any attendees of <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> and related events. All <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> platforms may be shared with members of the public; please be respectful to all patrons of these tools.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Harassment includes: offensive verbal comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.</p>
+<p>Harassment includes: offensive verbal comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images and links in public spaces (including presentation slides and virtual event text chat); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate contact, and unwelcome sexual attention.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
@@ -71,7 +71,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Unacceptable behavior will not be tolerated whether by other attendees, organizers, venue staff, sponsors, or other patrons of <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> venues.</p>
+<p>Unacceptable behavior will not be tolerated whether by other attendees, organizers, sponsors, or other patrons of <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> platforms.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -91,7 +91,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>The <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> team will be available to help participants contact venue security or local law enforcement, to provide escorts, or to otherwise assist those experiencing unacceptable behavior to feel safe for the duration of the conference. <span style="color: red; text-decoration: underline;">Volunteers will be wearing XXXXXXXXXXXXXXXXXXXXXXXX.</span> Any volunteer can connect you with a conference organizer. You can also come to the special registration desk in the lobby and ask for the organizers.</p>
+<p>The <span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> team will be available to help participants contact the platform moderators, or to otherwise assist those experiencing unacceptable behavior to feel safe for the duration of the conference. <span style="color: red; text-decoration: underline;">Volunteer’s screen name starts with “[V]”.</span> You can send a private message to them, and they will connect you with a conference organizer who has the control of the video conferencing software.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
@@ -99,7 +99,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>We expect all conference participants (sponsors, volunteers, speakers, attendees, and other guests) to abide by this code of conduct at all conference venues and conference-related social events.</p>
+<p>We expect all conference participants (sponsors, volunteers, speakers, attendees, and other guests) to abide by this code of conduct at all conference platforms and conference-related social events.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
@@ -107,7 +107,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><span style="color: red; text-decoration: underline;">Contact info here! Make sure this includes a way to access the organizers during the event.</span></p>
+<p><span style="color: red; text-decoration: underline;">Contact info here! Make sure this includes a way to access the organizers during the event. Having a virtual event, add some type of contact information that anyone can reach you during the event (such as Make WordPress Slack account or email address with an instant notification).</span></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -1,7 +1,3 @@
-<?php
-/** @var WordCamp_New_Site $this */
-
-?>
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
 <p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> Below is a boilerplate code of conduct that you can customize; another great example is the Ada Initiative <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">anti-harassment policy.</a></p>
 <!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -15,7 +15,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Purpose</h3>
+<h3>1. Purpose</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -31,7 +31,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Open Source Citizenship</h3>
+<h3>2. Open Source Citizenship</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -47,7 +47,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Expected Behavior</h3>
+<h3>3. Expected Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:list -->
@@ -55,7 +55,7 @@
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Unacceptable Behavior</h3>
+<h3>4. Unacceptable Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -67,7 +67,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Consequences Of Unacceptable Behavior</h3>
+<h3>5. Consequences Of Unacceptable Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -83,7 +83,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
+<h3>6. What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -95,7 +95,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Scope</h3>
+<h3>7. Scope</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -103,7 +103,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Contact Information</h3>
+<h3>8. Contact Information</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -111,7 +111,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>License And Attribution</h3>
+<h3>9. License And Attribution</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -1,7 +1,3 @@
-<?php
-/** @var WordCamp_New_Site $this */
-
-?>
 <!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
 <p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> Below is a boilerplate code of conduct that you can customize; another great example is the Ada Initiative <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">anti-harassment policy.</a></p>
 <!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -15,7 +15,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Purpose</h3>
+<h3>1. Purpose</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -31,7 +31,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Open Source Citizenship</h3>
+<h3>2. Open Source Citizenship</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -47,7 +47,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Expected Behavior</h3>
+<h3>3. Expected Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:list -->
@@ -55,7 +55,7 @@
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Unacceptable Behavior</h3>
+<h3>4. Unacceptable Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -67,7 +67,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Consequences Of Unacceptable Behavior</h3>
+<h3>5. Consequences Of Unacceptable Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -83,7 +83,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
+<h3>6. What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -95,7 +95,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Scope</h3>
+<h3>7. Scope</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -103,7 +103,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>Contact Information</h3>
+<h3>8. Contact Information</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -111,7 +111,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
-<h3>License And Attribution</h3>
+<h3>9. License And Attribution</h3>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -605,13 +605,6 @@ class WordCamp_New_Site {
 			),
 
 			array(
-				'title'   => __( 'Code of Conduct', 'wordcamporg' ),
-				'content' => $this->get_stub_content( 'page', 'code-of-conduct' ),
-				'status'  => 'publish',
-				'type'    => 'page',
-			),
-
-			array(
 				'title'   => __( 'Offline', 'wordcamporg' ),
 				'content' => $this->get_stub_content( 'page', 'offline', $wordcamp ),
 				'status'  => 'publish',
@@ -628,6 +621,22 @@ class WordCamp_New_Site {
 				'type'    => 'page',
 			),
 		);
+
+		if ( isset( $meta['Virtual event only'][0] ) && $meta['Virtual event only'][0] ) {
+			$pages[] = array(
+				'title'   => __( 'Code of Conduct', 'wordcamporg' ),
+				'content' => $this->get_stub_content( 'page', 'code-of-conduct-online' ),
+				'status'  => 'publish',
+				'type'    => 'page',
+			);
+		} else {
+			$pages[] = array(
+				'title'   => __( 'Code of Conduct', 'wordcamporg' ),
+				'content' => $this->get_stub_content( 'page', 'code-of-conduct' ),
+				'status'  => 'publish',
+				'type'    => 'page',
+			);
+		}
 
 		return $pages;
 	}
@@ -847,115 +856,5 @@ class WordCamp_New_Site {
 		}
 
 		return $pages;
-	}
-
-	/**
-	 * Get the default code of conduct
-	 *
-	 * @return string
-	 */
-	protected function get_code_of_conduct() {
-		ob_start();
-		?>
-
-		<ol>
-			<li>
-				<h3>Purpose</h3>
-
-				<p>
-					<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, preferred operating system, programming language, or text editor.
-				</p>
-
-				<p>This code of conduct outlines our expectations for participant behavior as well as the consequences for unacceptable behavior.</p>
-
-				<p>We invite all sponsors, volunteers, speakers, attendees, and other participants to help us realize a safe and positive conference experience for everyone.</p>
-			</li>
-
-			<li>
-				<h3>Open Source Citizenship</h3>
-
-				<p>A supplemental goal of this code of conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between what we do and the community at large.</p>
-
-				<p>In service of this goal,
-					<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> organizers will be taking nominations for exemplary citizens throughout the event and will recognize select participants after the conference on the website.
-				</p>
-
-				<p>If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
-					<span style="color: red; text-decoration: underline;">You can nominate someone at the Registration table or online at URL HERE.</span>
-				</p>
-			</li>
-
-			<li>
-				<h3>Expected Behavior</h3>
-
-				<ul>
-					<li>Be considerate, respectful, and collaborative.</li>
-					<li>Refrain from demeaning, discriminatory or harassing behavior and speech.</li>
-					<li>Be mindful of your surroundings and of your fellow participants. Alert conference organizers if you notice a dangerous situation or someone in distress.</li>
-					<li>Participate in an authentic and active way. In doing so, you help to create
-						<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> and make it your own.
-					</li>
-				</ul>
-			</li>
-
-			<li>
-				<h3>Unacceptable Behavior</h3>
-
-				<p>Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning conduct by any attendees of
-					<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> and related events. All
-					<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> venues may be shared with members of the public; please be respectful to all patrons of these locations.
-				</p>
-
-				<p>Harassment includes: offensive verbal comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.</p>
-			</li>
-
-			<li>
-				<h3>Consequences Of Unacceptable Behavior</h3>
-
-				<p>Unacceptable behavior will not be tolerated whether by other attendees, organizers, venue staff, sponsors, or other patrons of
-					<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> venues.</p>
-
-				<p>Anyone asked to stop unacceptable behavior is expected to comply immediately.</p>
-
-				<p>If a participant engages in unacceptable behavior, the conference organizers may take any action they deem appropriate, up to and including expulsion from the conference without warning or refund.</p>
-			</li>
-
-			<li>
-				<h3>What To Do If You Witness Or Are Subject To Unacceptable Behavior</h3>
-
-				<p>If you are subject to unacceptable behavior, notice that someone else is being subject to unacceptable behavior, or have any other concerns, please notify a conference organizer as soon as possible.</p>
-
-				<p>The
-					<span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> team will be available to help participants contact venue security or local law enforcement, to provide escorts, or to otherwise assist those experiencing unacceptable behavior to feel safe for the duration of the conference.
-					<span style="color: red; text-decoration: underline;">Volunteers will be wearing XXXXXXXXXXXXXXXXXXXXXXXX.</span> Any volunteer can connect you with a conference organizer. You can also come to the special registration desk in the lobby and ask for the organizers.
-				</p>
-			</li>
-
-			<li>
-				<h3>Scope</h3>
-
-				<p>We expect all conference participants (sponsors, volunteers, speakers, attendees, and other guests) to abide by this code of conduct at all conference venues and conference-related social events.</p>
-			</li>
-
-			<li>
-				<h3>Contact Information</h3>
-
-				<p>
-					<span style="color: red; text-decoration: underline;">Contact info here! Make sure this includes a way to access the organizers during the event.</span>
-				</p>
-			</li>
-
-			<li>
-				<h3>License And Attribution</h3>
-
-				<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at
-					<a href="http://opensourcebridge.org/about/code-of-conduct/">http://opensourcebridge.org/about/code-of-conduct/</a> and is released under a
-					<a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.
-				</p>
-			</li>
-		</ol>
-
-		<?php
-		return ob_get_clean();
 	}
 } // WordCamp_New_Site


### PR DESCRIPTION
Online only events use [slightly different wording](https://make.wordpress.org/community/handbook/virtual-events/online-code-of-conduct/) in the default Code of Conduct. This uses a separate stub with that wording when creating a new site if the "Virtual event only" box is checked for the WordCamp.

This also removes the `get_code_of_conduct` method from the `WordCamp_New_Site` class in favor of putting the content directly into the stub files.

Additionally, this converts the CoC content from a complex ordered list to simpler heading and paragraph blocks. This makes it easier for organizers to manage and customize the content and also eliminates some issues with extra line breaks.

Fixes #497 

### How to test the changes in this Pull Request:

1. In your local dev environment, make sure the "Virtual event only" box is checked for a WordCamp post and then generate a new site for it. Visit the new site's Dashboard and view the Code of Conduct page. It should have the online event wording (one easy way to spot the difference is that references to "venue" have been replaced with "platform" in the online version).
2. Delete the site, uncheck the "Virtual event only" box, and create a new site again. This time the wording for the CoC should be for a traditional in-person event (uses of "venue").
