### PR TITLE
Better UX for payment requests

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/css/wordcamp-budgets.css
+++ b/public_html/wp-content/plugins/wordcamp-payments/css/wordcamp-budgets.css
@@ -71,14 +71,6 @@ body.post-type-wcb_sponsor_invoice #save-action {
 	color: #dc3232;
 }
 
-/* Make room for the required field indicator (*) */
-body.post-type-wcp_payment_request input.large-text,
-body.post-type-wcp_payment_request input.regular-text,
-body.post-type-wcp_payment_request textarea.large-text,
-body.post-type-wcp_payment_request .meta-box-sortables select {
-	width: 95%;
-}
-
 @media screen and ( max-width: 782px ) {
 	body.post-type-wcp_payment_request .form-table td textarea {
 		display: inline;

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -11,6 +11,7 @@ jQuery( document ).ready( function( $ ) {
 			try {
 				app.registerEventHandlers();
 				wcb.setupSelect2( '#wcp_general_info select' );
+				wcb.setupSelect2( '#wcp_payment_details select' );
 				wcb.setupSelect2( '#vendor_country_iso3166' );
 				wcb.attachedFilesView = new wcb.AttachedFilesView( { el: $( '#row-files' ) } );
 				wcb.setupDatePicker( '#wcp_general_info' );

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -300,6 +300,7 @@ jQuery( document ).ready( function( $ ) {
 			this.collection.updateTotal();
 
 			wcb.setupDatePicker( '#wcbrr-expenses-container' );
+			wcb.setupSelect2( '#wcbrr_expenses select' );
 		}
 	} );
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -22,6 +22,7 @@ jQuery( document ).ready( function( $ ) {
 				wcb.attachedFilesView = new wcb.AttachedFilesView( { el: $( '#wcbrr_general_information' ) } );
 				wcb.setupSelect2( '#wcbrr_general_information select' );
 				wcb.setupSelect2( '#wcbrr-expenses-container select' );
+				wcb.setupSelect2( '#wcbrr_payment_information select' );
 			} catch ( exception ) {
 				wcb.log( exception );
 			}

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-country.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-country.php
@@ -9,6 +9,7 @@
 		<select
 			id="<?php echo esc_attr( $name ); ?>"
 			name="<?php echo esc_attr( $name ); ?>"
+			class="regular-text"
 			<?php __checked_selected_helper( $required, true, true, 'required' ); ?>
 		>
 			<option value=""><?php esc_html_e( '(None)', 'wordcamporg' ); ?></option>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-select.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-select.php
@@ -9,6 +9,7 @@
 		<select
 			id="<?php echo esc_attr( $name ); ?>"
 			name="<?php echo esc_attr( $name ); ?>"
+			class="regular-text"
 		    <?php __checked_selected_helper( $required, true, true, 'required' ); ?>
 		>
 			<option value="">

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-textarea.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-textarea.php
@@ -9,7 +9,7 @@
 		<textarea
 			id="<?php echo esc_attr( $name ); ?>"
 			name="<?php echo esc_attr( $name ); ?>"
-			class="large-text"
+			class="regular-text"
 		    <?php __checked_selected_helper( $required, true, true, 'required' ); ?>
 		><?php
 			echo esc_html( $text );

--- a/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-general-information.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/metabox-general-information.php
@@ -38,7 +38,7 @@ defined( 'WPINC' ) or die();
 				<?php _e( 'Currency:', 'wordcamporg' ) ?>
 			</label>
 
-			<select id="_wcbrr_currency" name="_wcbrr_currency">
+			<select id="_wcbrr_currency" name="_wcbrr_currency" class="regular-text">
 				<option value="">
 					<?php _e( '-- Select a Currency --', 'wordcamporg' ); ?>
 				</option>
@@ -61,7 +61,7 @@ defined( 'WPINC' ) or die();
 				<?php _e( 'Reason for Reimbursement:', 'wordcamporg' ); ?>
 			</label>
 
-			<select id="_wcbrr_reason" name="_wcbrr_reason">
+			<select id="_wcbrr_reason" name="_wcbrr_reason" class="regular-text">
 				<option value="">
 					<?php _e( '-- Select a Reason --', 'wordcamporg' ); ?>
 				</option>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/template-expense.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/reimbursement-request/template-expense.php
@@ -16,7 +16,7 @@ defined( 'WPINC' ) or die();
 				<?php _e( 'Category:', 'wordcamporg' ) ?>
 			</label>
 
-			<select id="_wcbrr_category_{{data.id}}" name="_wcbrr_category_{{data.id}}">
+			<select id="_wcbrr_category_{{data.id}}" name="_wcbrr_category_{{data.id}}" class="regular-text">
 				<option value="">
 					<?php _e( '-- Select a Category --', 'wordcamporg' ); ?>
 				</option>
@@ -77,6 +77,7 @@ defined( 'WPINC' ) or die();
 				rows="2"
 				cols="38"
 				id="_wcbrr_description_{{data.id}}"
+				class="regular-text"
 				name="_wcbrr_description_{{data.id}}"
 				maxlength="75"
 			    required


### PR DESCRIPTION
Payment requests; vendor payment and reimbursement requests do have select2 for some select fields but not for all. PR fixes that by adding select2 for all select field in payment request forms. At the same time, the width of all fields is normalised - some fields were wider than others previously. These improve the UX on forms.

Fixes #533 

### Screenshots

![](https://i.imgur.com/g2lZ9WL.png)
![](https://i.imgur.com/aUK9VH3.png)

**Old vendor payment view**
![](https://i.imgur.com/DOnK02n.png)

### How to test the changes in this Pull Request:

1. Log in to some WC site and go to the reimbursement request
2. Change the payment method selection and see that country has always select2
3. Add second expense and see that category has select2
4. Go to create a new vendor payment and enjoy form fields that are aligned

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
