### PR TITLE
WCPT: Update the wording of the Code of Conduct included in new sites

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -15,7 +15,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, preferred operating system, programming language, or text editor.</p>
+<p><span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, age, caste, social class, preferred operating system, programming language, or text editor, among other identifying characteristics.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -15,7 +15,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, preferred operating system, programming language, or text editor.</p>
+<p><span style="color: red; text-decoration: underline;">WordCamp YourCityName</span> believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, age, caste, social class, preferred operating system, programming language, or text editor, among other identifying characteristics.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
This changes the wording of the page stubs for both the in-person and online Code of Conduct pages to reflect the additions discussed here:

> The final update to the CoC in this instance will be this (changes in **bold**):
>
> > WordCamp CITYNAMEHERE believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, **age, caste, social class,** preferred operating system, programming language, or text editor, **among other identifying characteristics**.

https://make.wordpress.org/community/2020/06/18/pending-update-for-the-code-of-conduct/
