### PR TITLE
Speaker Feedback: Tweak rewrite handling during plugin activation

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -110,7 +110,10 @@ function activate_on_network() {
 function activate_on_current_site() {
 	add_feedback_page();
 	add_page_endpoint();
-	flush_rewrite_rules();
+
+	// Flushing the rewrite rules is buggy in the context of `switch_to_blog`.
+	// The rules will automatically get recreated on the next request to the site.
+	delete_option( 'rewrite_rules' );
 }
 
 /**


### PR DESCRIPTION
Calling `flush_rewrite_rules` within the context of `switch_to_blog` is problematic because it's not using an accurate site configuration, since it doesn't change which plugins are activated, etc. Instead, if we just delete the current rewrite rules from the database, WP will automatically regenerate them the next time there is a request to the site.
