### PR TITLE
Coming Soon Page: If WordCamp cancelled, replace the date with "Cancelled" text and remove Jetpack subscription form

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -279,6 +279,10 @@ class WordCamp_Coming_Soon_Page {
 	 * @return string|false
 	 */
 	public function get_dates() {
+		if ( 'wcpt-cancelled' === $this->get_status() ) {
+			return esc_html__( 'Cancelled', 'wordcamporg' );
+		}
+
 		$dates         = false;
 		$wordcamp_post = get_wordcamp_post();
 

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -173,14 +173,14 @@ class WordCamp_Coming_Soon_Page {
 	 */
 	public function get_template_variables() {
 		$variables = array(
-			'image_url'								=> $this->get_image_url(),
-			'background_url'					=> $this->get_bg_image_url(),
-			'dates'										=> $this->get_dates(),
-			'active_modules'					=> Jetpack::$instance->get_active_modules(),
-			'contact_form_shortcode'	=> $this->get_contact_form_shortcode(),
-			'colors'									=> $this->get_colors(),
-			'introduction'						=> $this->get_introduction(),
-			'status'									=> $this->get_status(),
+			'image_url'              => $this->get_image_url(),
+			'background_url'         => $this->get_bg_image_url(),
+			'dates'                  => $this->get_dates(),
+			'active_modules'         => Jetpack::$instance->get_active_modules(),
+			'contact_form_shortcode' => $this->get_contact_form_shortcode(),
+			'colors'                 => $this->get_colors(),
+			'introduction'           => $this->get_introduction(),
+			'status'                 => $this->get_status(),
 		);
 
 		return $variables;

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -180,6 +180,7 @@ class WordCamp_Coming_Soon_Page {
 			'contact_form_shortcode' => $this->get_contact_form_shortcode(),
 			'colors'                 => $this->get_colors(),
 			'introduction'           => $this->get_introduction(),
+			'status'								 => $this->get_status(),
 		);
 
 		return $variables;
@@ -370,6 +371,21 @@ class WordCamp_Coming_Soon_Page {
 		$settings = $GLOBALS['WCCSP_Settings']->get_settings();
 
 		return $settings['introduction'];
+	}
+
+	/**
+	 * Retrieve the WordCamp status.
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		$wordcamp_post = get_wordcamp_post();
+
+		if ( isset( $wordcamp_post->ID ) ) {
+			return $wordcamp_post->post_status;
+		}
+
+		return null;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -92,7 +92,7 @@ class WordCamp_Coming_Soon_Page {
 			return;
 		}
 
-		// TODO: Figure out an alternative here. 
+		// TODO: Figure out an alternative here.
 		//phpcs:ignore WordPress.PHP.DontExtract.extract_extract -- Not sure whats the alternative to this could be.
 		extract( $GLOBALS['WordCamp_Coming_Soon_Page']->get_template_variables() );
 
@@ -173,14 +173,14 @@ class WordCamp_Coming_Soon_Page {
 	 */
 	public function get_template_variables() {
 		$variables = array(
-			'image_url'              => $this->get_image_url(),
-			'background_url'         => $this->get_bg_image_url(),
-			'dates'                  => $this->get_dates(),
-			'active_modules'         => Jetpack::$instance->get_active_modules(),
-			'contact_form_shortcode' => $this->get_contact_form_shortcode(),
-			'colors'                 => $this->get_colors(),
-			'introduction'           => $this->get_introduction(),
-			'status'								 => $this->get_status(),
+			'image_url'								=> $this->get_image_url(),
+			'background_url'					=> $this->get_bg_image_url(),
+			'dates'										=> $this->get_dates(),
+			'active_modules'					=> Jetpack::$instance->get_active_modules(),
+			'contact_form_shortcode'	=> $this->get_contact_form_shortcode(),
+			'colors'									=> $this->get_colors(),
+			'introduction'						=> $this->get_introduction(),
+			'status'									=> $this->get_status(),
 		);
 
 		return $variables;

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/views/template-coming-soon.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/views/template-coming-soon.php
@@ -28,7 +28,7 @@
 					</h2>
 				<?php endif; ?>
 
-				<?php if ( in_array( 'subscriptions', $active_modules ) ) : ?>
+				<?php if ( 'wcpt-cancelled' !== $status && in_array( 'subscriptions', $active_modules ) ) : ?>
 					<div class="wccsp-subscription">
 						<?php echo do_shortcode( sprintf(
 							'[jetpack_subscription_form subscribe_text="" title="" subscribe_button="%s"]',


### PR DESCRIPTION
COVID-19 situation cancelled many WordCamps that were already in pre-planning and had a site in Coming Soon mode. Now those pages aren't really reflecting the state of the planning anymore. Community Team would like to those sites exists for a while at least, but for that content needs to be updated.

To reduce the amount of work that needs to be done for those sites pragmatically hiding the event dates and replacing it with "Cancelled" text string and removing Jetpack subscription module based on Central `wordcamp` CPT helps a lot. After that only the introduction text needs to be manually changed and possibly the page with contact form reverted to draft (which hides the form from Coming Soon page).

Fixes #543

Props @brandondove, @camikaos, courtneypk

### Screenshots

#### Before

![](https://i.imgur.com/WbVlhpu.png)

#### After
![](https://i.imgur.com/6UN6Lwx.png)

### How to test the changes in this Pull Request:

1. Change some existing WordCamp status to "Cancelled" on Central tracker
2. Enable "Coming Soon" mode on that WordCamp
3. Go to the WordCamp website
