### PR TITLE
Add "In Progress" status to Planning Checklist

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks-data.php
+++ b/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks-data.php
@@ -673,7 +673,7 @@ function _reset_tasks() {
 
 		$args = array(
 			'post_type'   => Mentors\PREFIX . '_task',
-			'post_status' => Mentors\PREFIX . '_task_pending',
+			'post_status' => Mentors\PREFIX . '_task_incomplete',
 			'post_title'  => $l10n_id,
 			'menu_order'  => $order,
 			'meta_input'  => array(

--- a/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks.php
+++ b/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks.php
@@ -148,7 +148,7 @@ function register_tax() {
  */
 function register_status() {
 	$stati = array(
-		Mentors\PREFIX . '_task_incomplete'	=> esc_html__( 'Incomplete',  'wordcamporg' ),
+		Mentors\PREFIX . '_task_incomplete' => esc_html__( 'Incomplete',  'wordcamporg' ),
 		Mentors\PREFIX . '_task_pending'    => esc_html__( 'In progress',  'wordcamporg' ),
 		Mentors\PREFIX . '_task_complete'   => esc_html__( 'Complete', 'wordcamporg' ),
 		Mentors\PREFIX . '_task_skipped'    => esc_html__( 'Skipped',  'wordcamporg' ),

--- a/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks.php
+++ b/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks.php
@@ -148,8 +148,8 @@ function register_tax() {
  */
 function register_status() {
 	$stati = array(
-		Mentors\PREFIX . '_task_pending'    => esc_html__( 'Pending',  'wordcamporg' ),
-		Mentors\PREFIX . '_task_inprogress' => esc_html__( 'In Progress',  'wordcamporg' ),
+		Mentors\PREFIX . '_task_incomplete'	=> esc_html__( 'Incomplete',  'wordcamporg' ),
+		Mentors\PREFIX . '_task_pending'    => esc_html__( 'In progress',  'wordcamporg' ),
 		Mentors\PREFIX . '_task_complete'   => esc_html__( 'Complete', 'wordcamporg' ),
 		Mentors\PREFIX . '_task_skipped'    => esc_html__( 'Skipped',  'wordcamporg' ),
 	);

--- a/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks.php
+++ b/public_html/wp-content/plugins/wordcamp-mentors/includes/tasks.php
@@ -148,9 +148,10 @@ function register_tax() {
  */
 function register_status() {
 	$stati = array(
-		Mentors\PREFIX . '_task_pending'  => esc_html__( 'Pending',  'wordcamporg' ),
-		Mentors\PREFIX . '_task_complete' => esc_html__( 'Complete', 'wordcamporg' ),
-		Mentors\PREFIX . '_task_skipped'  => esc_html__( 'Skipped',  'wordcamporg' ),
+		Mentors\PREFIX . '_task_pending'    => esc_html__( 'Pending',  'wordcamporg' ),
+		Mentors\PREFIX . '_task_inprogress' => esc_html__( 'In Progress',  'wordcamporg' ),
+		Mentors\PREFIX . '_task_complete'   => esc_html__( 'Complete', 'wordcamporg' ),
+		Mentors\PREFIX . '_task_skipped'    => esc_html__( 'Skipped',  'wordcamporg' ),
 	);
 
 	foreach ( $stati as $id => $label ) {


### PR DESCRIPTION
Adds an "In Progress" status to Planning Checklist tool. Helps to filter by currently-being-worked-on tasks.

Fixes #539

Props @meaganhanes

### How to test the changes in this Pull Request:

1. Go to a planning checklist 
2. You'll see an "In Progress" on status dropdowns
