### PR TITLE
Coming Soon mode: use edit_theme_options as required capability instead of administrator role

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-settings.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-settings.php
@@ -8,7 +8,7 @@
 
 class WCCSP_Settings {
 	protected $settings;
-	const REQUIRED_CAPABILITY = 'administrator';
+	const REQUIRED_CAPABILITY = 'edit_theme_options';
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
When the user is a trusted deputy, they are not able to see or modify Coming Soon mode settings because capability check was using `administrator` role instead of actual capability. Change that to `edit_theme_options` so trusted deputies can access the settings without adding themselves to the site with administrator role.

Fixes #547 
