### PR TITLE
Plugins: Add `permission_callback` to API registration

### DIFF
--- a/public_html/wp-content/mu-plugins/lets-encrypt-helper.php
+++ b/public_html/wp-content/mu-plugins/lets-encrypt-helper.php
@@ -27,8 +27,9 @@ class WordCamp_Lets_Encrypt_Helper {
 			'wordcamp-letsencrypt/v1',
 			'/domains-dehydrated',
 			array(
-				'methods'  => 'GET',
-				'callback' => array( __CLASS__, 'rest_callback_domains_dehydrated' ),
+				'methods'             => 'GET',
+				'callback'            => array( __CLASS__, 'rest_callback_domains_dehydrated' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 	}

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -399,9 +399,10 @@ function register_fav_sessions_email() {
 		'wc-post-types/v1',
 		'/email-fav-sessions/',
 		array(
-			'methods'  => WP_REST_Server::CREATABLE,
-			'callback' => 'send_favourite_sessions_email',
-			'args'     => array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => 'send_favourite_sessions_email',
+			'permission_callback' => '__return_true',
+			'args'                => array(
 				'email-address' => array(
 					'required'          => true,
 					'validate_callback' => function( $value, $request, $param ) {

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -85,25 +85,45 @@ class WordCamp_QBO {
 	 * Runs during rest_api_init.
 	 */
 	public static function rest_api_init() {
-		register_rest_route( 'wordcamp-qbo/v1', '/expense', array(
-			'methods'  => 'GET, POST',
-			'callback' => array( __CLASS__, 'rest_callback_expense' ),
-		) );
+		register_rest_route(
+			'wordcamp-qbo/v1',
+			'/expense',
+			array(
+				'methods'             => 'GET, POST',
+				'callback'            => array( __CLASS__, 'rest_callback_expense' ),
+				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+			)
+		);
 
-		register_rest_route( 'wordcamp-qbo/v1', '/invoice', array(
-			'methods'  => 'GET, POST',
-			'callback' => array( __CLASS__, 'rest_callback_invoice' ),
-		) );
+		register_rest_route(
+			'wordcamp-qbo/v1',
+			'/invoice',
+			array(
+				'methods'             => 'GET, POST',
+				'callback'            => array( __CLASS__, 'rest_callback_invoice' ),
+				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+			)
+		);
 
-		register_rest_route( 'wordcamp-qbo/v1', '/invoice_pdf', array(
-			'methods'  => 'GET',
-			'callback' => array( __CLASS__, 'rest_callback_invoice_pdf' ),
-		) );
+		register_rest_route(
+			'wordcamp-qbo/v1',
+			'/invoice_pdf',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( __CLASS__, 'rest_callback_invoice_pdf' ),
+				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+			)
+		);
 
-		register_rest_route( 'wordcamp-qbo/v1', '/paid_invoices', array(
-			'methods'  => 'GET',
-			'callback' => array( __CLASS__, 'rest_callback_paid_invoices' ),
-		) );
+		register_rest_route(
+			'wordcamp-qbo/v1',
+			'/paid_invoices',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( __CLASS__, 'rest_callback_paid_invoices' ),
+				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+			)
+		);
 	}
 
 	/**
@@ -112,10 +132,6 @@ class WordCamp_QBO {
 	 * @param WP_REST_Request $request
 	 */
 	public static function rest_callback_expense( $request ) {
-		if ( ! self::_is_valid_request( $request ) ) {
-			return new WP_Error( 'unauthorized', 'Unauthorized', array( 'status' => 401 ) );
-		}
-
 		self::load_options();
 		$oauth_header = self::qbo_client()->get_oauth_header();
 		$realm_id     = self::qbo_client()->get_realm_id();
@@ -318,10 +334,6 @@ class WordCamp_QBO {
 	 * @return int|WP_Error The invoice ID on success, or a WP_Error on failure
 	 */
 	public static function rest_callback_invoice( $request ) {
-		if ( ! self::_is_valid_request( $request ) ) {
-			return new WP_Error( 'unauthorized', 'Unauthorized', array( 'status' => 401 ) );
-		}
-
 		$invoice_id = self::create_invoice(
 			$request->get_param( 'wordcamp_name'     ),
 			$request->get_param( 'sponsor'           ),
@@ -668,10 +680,6 @@ class WordCamp_QBO {
 	 * @return string|WP_Error The filename on success, or a WP_Error on failure
 	 */
 	public static function rest_callback_invoice_pdf( $request ) {
-		if ( ! self::_is_valid_request( $request ) ) {
-			return new WP_Error( 'unauthorized', 'Unauthorized', array( 'status' => 401 ) );
-		}
-
 		$qbo_request = self::build_qbo_get_invoice_pdf_request( $request->get_param( 'invoice_id' ) );
 		$response    = wp_remote_get( $qbo_request['url'], $qbo_request['args'] );
 
@@ -1022,10 +1030,6 @@ class WordCamp_QBO {
 	 * @return array|WP_Error
 	 */
 	public static function rest_callback_paid_invoices( $wordcamp_request ) {
-		if ( ! self::_is_valid_request( $wordcamp_request ) ) {
-			return new WP_Error( 'unauthorized', 'Unauthorized', array( 'status' => 401 ) );
-		}
-
 		$qbo_request = self::build_qbo_paid_invoices_request( $wordcamp_request->get_param( 'invoice_ids' ) );
 
 		if ( is_wp_error( $qbo_request ) ) {

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -91,7 +91,7 @@ class WordCamp_QBO {
 			array(
 				'methods'             => 'GET, POST',
 				'callback'            => array( __CLASS__, 'rest_callback_expense' ),
-				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+				'permission_callback' => array( __CLASS__, 'is_valid_request' ),
 			)
 		);
 
@@ -101,7 +101,7 @@ class WordCamp_QBO {
 			array(
 				'methods'             => 'GET, POST',
 				'callback'            => array( __CLASS__, 'rest_callback_invoice' ),
-				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+				'permission_callback' => array( __CLASS__, 'is_valid_request' ),
 			)
 		);
 
@@ -111,7 +111,7 @@ class WordCamp_QBO {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( __CLASS__, 'rest_callback_invoice_pdf' ),
-				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+				'permission_callback' => array( __CLASS__, 'is_valid_request' ),
 			)
 		);
 
@@ -121,7 +121,7 @@ class WordCamp_QBO {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( __CLASS__, 'rest_callback_paid_invoices' ),
-				'permission_callback' => array( __CLASS__, '_is_valid_request' ),
+				'permission_callback' => array( __CLASS__, 'is_valid_request' ),
 			)
 		);
 	}
@@ -1122,7 +1122,7 @@ class WordCamp_QBO {
 	 *
 	 * @return bool True if valid, false if invalid.
 	 */
-	private static function _is_valid_request( $request ) {
+	public static function is_valid_request( $request ) {
 		if ( ! $request->get_header( 'authorization' ) ) {
 			return false;
 		}

--- a/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
+++ b/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
@@ -142,17 +142,14 @@ function register_customizer_components( $wp_customize ) {
  * Register the REST API endpoint for the Customizer to use to retriever the site list
  */
 function register_api_endpoints() {
-	if ( ! current_user_can( 'switch_themes' ) ) {
-		return;
-
-		// todo - use `permission_callback` instead
-	}
-
 	register_rest_route(
 		'wordcamp-site-cloner/v1',
 		'/sites',
 		array(
 			'methods'  => 'GET',
+			'permission_callback' => function() {
+				return current_user_can( 'switch_themes' );
+			},
 			'callback' => __NAMESPACE__ . '\sites_endpoint',
 		)
 	);


### PR DESCRIPTION
As of WP 5.5, API endpoints must set a permission_callback. If the endpoint is public, this can be `__return_true`. In other cases, the endpoint was being checked in the main callback, or before being registered, so that functionality was moved into the permission_callback.

### How to test the changes in this Pull Request:

1. Enable WP_DEBUG
2. Try requesting posts: `/wp-json/wp/v2/posts` (or editing a post in GB)
3. On the production branch, this triggers errors
4. This branch, no errors
5. Try requesting each endpoint changed, you should see no errors. Use [basic-auth plugin](https://github.com/WP-API/Basic-Auth) to test logged in access.

```
POST [city site]/wp-json/wc-post-types/v1/email-fav-sessions # public
GET [city site]/wp-json/wordcamp-site-cloner/v1/sites # private, admin-only

GET https://wordcamp.test/wp-json/wordcamp-letsencrypt/v1/domains-dehydrated # public, key check happens in callback
GET/POST https://wordcamp.test/wp-json/wordcamp-qbo/v1/expense # private, checks header authorization
GET/POST https://wordcamp.test/wp-json/wordcamp-qbo/v1/invoice
GET https://wordcamp.test/wp-json/wordcamp-qbo/v1/invoice_pdf
GET https://wordcamp.test/wp-json/wordcamp-qbo/v1/paid_invoices
```

Searching the codebase for `register_rest_route` also brings up [wordcamp-reports,](https://github.com/WordPress/wordcamp.org/blob/6f777b8613ec270f013d1b8273304ab65d38b5c8/public_html/wp-content/plugins/wordcamp-reports/index.php#L337) but it seems none of the reports register an endpoint.