### PR TITLE
Disable Jetpack Simple Payments feature

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -8,7 +8,7 @@ defined( 'WPINC' ) || die();
 // Allow Photon to fetch images that are served via HTTPS.
 add_filter( 'jetpack_photon_reject_https',    '__return_false' );
 
-// Disable Simple Payments feature
+// Disable Simple Payments feature.
 add_filter( 'jetpack_disable_simple_payments', '__return_true' );
 
 /**

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -8,6 +8,9 @@ defined( 'WPINC' ) || die();
 // Allow Photon to fetch images that are served via HTTPS.
 add_filter( 'jetpack_photon_reject_https',    '__return_false' );
 
+// Disable Simple Payments feature
+add_filter( 'jetpack_disable_simple_payments', '__return_true' );
+
 /**
  * Filter the post types Jetpack has access to, and can synchronize with WordPress.com.
  *


### PR DESCRIPTION
Jetpack has a Simple Payments feature that registers a block and widget for adding PayPal/Stripe payment button. This feature isn't really needed on WordCamp.org as we sell only tickets with Camptix.

The feature is causing some issues when saving posts, so the easiest thing is just to disable it completely.

See https://wordpress.slack.com/archives/C08M59V3P/p1597998977062100

### How to test the changes in this Pull Request:

1. Go to block editor and try to search "Payments" block - shouldn't be there anymore
