### PR TITLE
Fix speaker meta save

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -45,11 +45,12 @@ function register_speaker_post_meta() {
 		'wcb_speaker',
 		'_wcpt_user_id',
 		array(
-			'type'         => 'integer',
+			'type'          => 'integer',
 			// This is not set directly, but is set as a result of `_wcpt_user_name`.
 			// See update_wcorg_user_id() in wc-post-types.php.
-			'show_in_rest' => false,
-			'single'       => true,
+			'show_in_rest'  => false,
+			'single'        => true,
+			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
 		)
 	);
 	register_post_meta(
@@ -59,6 +60,7 @@ function register_speaker_post_meta() {
 			'type'              => 'string',
 			'single'            => true,
 			'show_in_rest'      => true,
+			'auth_callback'     => __NAMESPACE__ . '\meta_auth_callback',
 			'sanitize_callback' => function( $value ) {
 				$wporg_user = wcorg_get_user_by_canonical_names( $value );
 				if ( ! $wporg_user ) {
@@ -72,13 +74,14 @@ function register_speaker_post_meta() {
 		'wcb_speaker',
 		'_wcb_speaker_email',
 		array(
-			'type'         => 'string',
-			'show_in_rest' => array(
+			'type'          => 'string',
+			'show_in_rest'  => array(
 				'schema' => array(
 					'context' => array( 'edit' ),
 				),
 			),
-			'single'       => true,
+			'single'        => true,
+			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
 		)
 	);
 }
@@ -213,7 +216,7 @@ function register_organizer_post_meta() {
  * @param int    $object_id Object ID.
  */
 function meta_auth_callback( $allowed, $meta_key, $object_id ) {
-	if ( '_wcpt_' === substr( $meta_key, 0, 6 ) ) {
+	if ( '_wcpt_' === substr( $meta_key, 0, 6 ) || '_wcb_' === substr( $meta_key, 0, 5 ) ) {
 		return current_user_can( 'edit_post', $object_id );
 	}
 	return $allowed;


### PR DESCRIPTION
[See Slack discussion for full bug description](https://wordpress.slack.com/archives/C08M59V3P/p1597998977062100).

Looks like some `register_post_meta` calls were missing `auth_callback`. That caused issues with saving speaker username and email. Additionally, the `meta_auth_callback` just checked if the meta key contains `_wcpt_` but some new meta fields are prefixed with `_wcb_` and thus weren't authorized to edit by organizers.

Props nukaga

### How to test the changes in this Pull Request:

1. Without this patch, try to update the speaker WordPress.org username. You should end up with error similar to "Updating failed. Sorry, you are not allowed to edit the _wcpt_user_name custom field."
2. Apply patch and try to update the speaker WordPress.org username again. This time it should work.
