### PR TITLE
Format local dates instead of converting a second time

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
@@ -2,20 +2,13 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { __experimentalGetSettings, dateI18n, setSettings } from '@wordpress/date';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
 import { WC_BLOCKS_STORE } from '../../data';
 
-/*
- * Work around Gutenberg bug: https://github.com/WordPress/gutenberg/issues/22193
- *
- * @todo remove this when that's resolved, because it adds ~150k to the build.
- */
-import 'moment-timezone/moment-timezone-utils';
-setSettings( __experimentalGetSettings() );
 
 /*
  * Create an implicit "0" track when none formally exist.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
@@ -9,7 +9,6 @@ import { dateI18n } from '@wordpress/date';
  */
 import { WC_BLOCKS_STORE } from '../../data';
 
-
 /*
  * Create an implicit "0" track when none formally exist.
  *

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -3,7 +3,7 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { CheckboxControl, PanelBody, ToggleControl } from '@wordpress/components';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, format } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -62,7 +62,7 @@ export default function ScheduleInspectorControls(
 }
 
 /**
- * Get all of the dates that the given sessions are assigned to.
+ * Get all of the dates (in site/venue timezone) that the given sessions are assigned to.
  *
  * @param {Array} sessions
  *
@@ -124,7 +124,7 @@ function ChooseSpecificDays( { chooseSpecificDays, displayedDays, chosenDays, da
 						return (
 							<CheckboxControl
 								key={ day }
-								label={ dateI18n( dateFormat, day ) }
+								label={ format( dateFormat, day ) }
 								checked={ chosenDays.includes( day ) }
 								onChange={ ( isChecked ) => {
 									/*

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, format } from '@wordpress/date';
 import { __, _x } from '@wordpress/i18n';
 import { createContext, useContext } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -49,7 +49,7 @@ export function ScheduleGrid( { sessions } ) {
 		scheduleDays.push(
 			<ScheduleDay
 				key={ date }
-				date={ date }
+				localDate={ date }
 				sessions={ sessionsGroup }
 			/>
 		);
@@ -63,7 +63,7 @@ export function ScheduleGrid( { sessions } ) {
 }
 
 /**
- * Create an array of sessions, indexed by their date.
+ * Create an array of sessions, indexed by their date (according to the site's timezone).
  *
  * @param {Array} sessions
  *
@@ -94,17 +94,17 @@ function groupSessionsByDate( sessions ) {
  * Render the schedule for a specific day.
  *
  * @param {Object} props
- * @param {string} props.date     In a format acceptable by `wp.date.dateI18n()`.
- * @param {Array}  props.sessions
+ * @param {string} props.localDate The day being displayed in Ymd format (in the site's timezone).
+ * @param {Array}  props.sessions  The sessions assigned to the displayed date.
  *
  * @return {Element}
  */
-function ScheduleDay( { date, sessions } ) {
+function ScheduleDay( { localDate, sessions } ) {
 	const { attributes, allTracks, renderEnvironment, settings } = useContext( ScheduleGridContext );
 	const { chooseSpecificTracks, chosenTrackIds } = attributes;
 
 	const displayedTracks = getDisplayedTracks( sessions, allTracks, chooseSpecificTracks, chosenTrackIds );
-	const formattedDate = dateI18n( DATE_SLUG_FORMAT, date );
+	const formattedDate = format( DATE_SLUG_FORMAT, localDate );
 	const formattedTrackIds = chooseSpecificTracks ? displayedTracks.map( ( track ) => track.id ).join( '-' ) : 'all';
 
 	/*
@@ -145,7 +145,7 @@ function ScheduleDay( { date, sessions } ) {
 			</style>
 
 			<h2 className="wordcamp-schedule__date">
-				{ dateI18n( settings.date_format, date ) }
+				{ format( settings.date_format, localDate ) }
 			</h2>
 
 			{ 'editor' === renderEnvironment && renderOverlappingSessionsWarning( overlappingSessions ) }


### PR DESCRIPTION
_This shouldn't be merged until we install the version of Gutenberg that includes both https://github.com/WordPress/gutenberg/pull/25083 and https://github.com/WordPress/gutenberg/pull/22866._

---

Fixes #559

The dates are _already_ in the site timezone, so `dateI18n()` et al add the UTC offset a _second_ time. In some cases that would cross a date boundary, and the wrong date would be displayed.