### PR TITLE
Fix special chars in "favorite sessions" emails

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -337,7 +337,7 @@ function generate_plaintext_fav_sessions( $sessions_rev, $fav_sessions_lookup ) 
 			}
 
 			$session              = get_post( $session_id );
-			$session_title        = apply_filters( 'the_title', $session->post_title );
+			$session_title        = html_entity_decode( apply_filters( 'the_title', $session->post_title ) );
 			$session_tracks       = get_the_terms( $session_id, 'wcb_track' );
 			$session_track_titles = is_array( $session_tracks ) ? implode( ', ', wp_list_pluck( $session_tracks, 'name' ) ) : '';
 


### PR DESCRIPTION
This change applies `html_entity_decode` to the session titles in the "Favorite sessions" email messages.

Fixes #665 

Props marcochiesi

### How to test the changes in this Pull Request:

1. Create a session that includes special character like `'`, `-`, `&`
2. In the frontend schedule page select the session and request to receive the list via email
3. Check the email received. The HTML entities, which previously were not rendered, should now be ok.