### PR TITLE
Use specific CSS class for slides link container in session posts

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -859,7 +859,7 @@ class WordCamp_Post_Types_Plugin {
 			return $content;
 		}
 
-		$session_slides_html  = '<div class="session-video">';
+		$session_slides_html  = '<div class="session-slides">';
 		$session_slides_html .= sprintf( __( '<a href="%s" target="_blank">View Session Slides</a>', 'wordcamporg' ), esc_url( $session_slides ) );
 		$session_slides_html .= '</div>';
 


### PR DESCRIPTION
This simple PR aims to use a specific class for session's slides link container. Currently the same `session-video` class is used both for slides and  video links in session pages.
 
<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

Props enrico-sorcinelli

### How to test the changes in this Pull Request:

1. Create a session
2. Add a slide link to session info metabox 
3. See new CSS class name in generated HTML page.
