### PR TITLE
Blocks: Fix compatibility issues with WordPress 5.6/Gutenberg 9.5

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
@@ -93,29 +93,10 @@ const fetchScheduleData = ( select, editorContext ) => {
 	}
 
 	// These must be kept in sync with `get_all_sessions()`.
-	const sessionArgs = {
-		/*
-		 * This doesn't include `session_cats_rendered` because we already need the category id/slug in other
-		 * places, so it's simpler to have single source of truth.
-		 */
-		_fields: [
-			'id',
-			'link',
-			'meta._wcpt_session_time',
-			'meta._wcpt_session_duration',
-			'meta._wcpt_session_type',
-			'session_category',
-			'session_speakers',
-			'session_track',
-			'slug',
-			'title',
-		],
-	};
+	const sessionArgs = {};
 
 	// These must be kept in sync with `get_all_tracks()`.
 	const trackArgs = {
-		_fields: [ 'id', 'name', 'slug' ],
-
 		/*
 		 * It's important that the order here match `getDisplayedTracks()`. The tracks must be sorted in a
 		 * predictable order, so that track spanning can be reliably detected; see
@@ -129,9 +110,7 @@ const fetchScheduleData = ( select, editorContext ) => {
 	};
 
 	// These must be kept in sync with `get_all_categories()`.
-	const categoryArgs = {
-		_fields: [ 'id', 'name', 'slug' ],
-	};
+	const categoryArgs = {};
 
 	const allSessions = getEntities( 'postType', 'wcb_session', sessionArgs );
 	const allTracks = getEntities( 'taxonomy', 'wcb_track', trackArgs );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
@@ -79,7 +79,7 @@ function groupSessionsByDate( sessions ) {
 			return groups;
 		}
 
-		const date = dateI18n( 'Ymd', session.derived.startTime );
+		const date = dateI18n( 'Y-m-d', session.derived.startTime );
 
 		if ( date ) {
 			groups[ date ] = groups[ date ] || [];
@@ -94,7 +94,7 @@ function groupSessionsByDate( sessions ) {
  * Render the schedule for a specific day.
  *
  * @param {Object} props
- * @param {string} props.localDate The day being displayed in Ymd format (in the site's timezone).
+ * @param {string} props.localDate The day being displayed in Y-m-d format (in the site's timezone).
  * @param {Array}  props.sessions  The sessions assigned to the displayed date.
  *
  * @return {Element}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -38,7 +38,9 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 	for ( let i = 0; i < timeSlots.length; i++ ) {
 		const currentSlot = timeSlots[ i ];
 		const startTime = parseInt( currentSlot );
-		const endTime = parseInt( timeSlots[ i + 1 ] );
+		// If this is the last session, this value is NaN, which date-fns cannot handle.
+		// Since this row is later removed (see below), fall back to any integer.
+		const endTime = parseInt( timeSlots[ i + 1 ] ) || 0;
 
 		const gridRow = `
 			time-${ dateI18n( 'Hi', startTime ) } /


### PR DESCRIPTION
I was testing Gutenberg 9.5 on wordcamp.org earlier today and found some date & api bugs.

- Dates: Moment had a wider range of permitted date formats, but now that wp.date uses date-fns, these unsupported dates fail and crash the block. Seen on the frontend, a page with the schedule block.
- API: At some point, the requests made by the schedule block stopped being understood by `getEntities`/`getEntityRecords`, and now always return null. Seen in the editor, the schedule block never stops "loading" even though the requests finish.

The fix for the first is straightforward, I don't think it has any unexpected side-effects. The second issue is "fixed" for now by removing `_fields`, in the interest of getting something working. I'll continue investigating the root issue, but this could be merged if we need a quick fix.

### How to test the changes in this Pull Request:

Update gutenberg to 9.5 (for the date issue). The API issue is visible on production currently (WP 5.6).

1. Have sessions on your site
2. Add a schedule block to a page
2. View the block in the editor, it should work.
3. Publish the page, the schedule should appear correct on the frontend
4. The dates & times should appear correct
