### PR TITLE
Speaker Feedback: Use the site's URL when redirecting feedback

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/assets/js/script.js
@@ -6,7 +6,7 @@
 		event.preventDefault();
 		var value = event.target[ 0 ].value;
 		// Use the fact that post IDs will redirect to the right page.
-		window.location = '/?p=' + value + '&sft_feedback=1#sft-feedback';
+		window.location = SpeakerFeedbackData.url + '/?p=' + value + '&sft_feedback=1#sft-feedback';
 	}
 
 	function onFormSubmit( event ) {

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -308,6 +308,7 @@ function enqueue_assets() {
 		);
 
 		$data = array(
+			'url'      => home_url(),
 			'messages' => array(
 				'submitSuccess'         => __( 'Feedback submitted.', 'wordcamporg' ),
 				'markedHelpful'         => __( 'Feedback marked as helpful.', 'wordcamporg' ),


### PR DESCRIPTION
When redirecting from the session form to the feedback form, we should use the site's real URL, which we get from the `SpeakerFeedbackData` global. This will keep the year subdirectory intact, rather than stripping the path down to the base `/`.

See https://wordpress.slack.com/archives/C037W5S7X/p1621790017184600
