### PR TITLE
Allow Google Fonts API v2

### DIFF
--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -257,7 +257,7 @@ class WordCamp_Fonts_Plugin {
 			$lines = explode( "\n", $input['google-web-fonts'] );
 			foreach ( $lines as $line ) {
 				$matches = array();
-				$url     = preg_match( '#fonts\.googleapis\.com/css\?family=[^\)\'"]+#', $line, $matches );
+				$url     = preg_match( '#fonts\.googleapis\.com/css2?\?family=[^\)\'"]+#', $line, $matches );
 
 				if ( $matches ) {
 					$url = esc_url_raw( 'http://' . $matches[0] );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Changed the Google Fonts URL validation to allow URLs from v2 API, which is currently the default one.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

<!-- List out anyone who helped with this task. -->
Props @wcgalicia

### Screenshots

![image](https://user-images.githubusercontent.com/49728/121914897-fa84d400-cd32-11eb-98e8-e05af2b23ab1.png)

### How to test the changes in this Pull Request:

1. Go to Google Fonts, choose any font and copy the @import code
2. Paste the code into the Fonts options page
3. The plugin remove the code (validation fails)

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
