### PR TITLE
Sessions: Add wcpt_session_duration default value

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -129,7 +129,7 @@ function register_session_post_meta() {
 			'show_in_rest'  => true,
 			'single'        => true,
 			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
-			'default'       => 50,
+			'default'       => 50 * MINUTE_IN_SECONDS,
 		)
 	);
 	register_post_meta(

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -129,6 +129,7 @@ function register_session_post_meta() {
 			'show_in_rest'  => true,
 			'single'        => true,
 			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+			'default'       => 50,
 		)
 	);
 	register_post_meta(


### PR DESCRIPTION
This PR adds a default value to the Session block's duration.  This is untested as I don't have a local environment setup.

Fixes #682
Props @coreymckrill 

### How to test the changes in this Pull Request:
Test using details in the [bug report](https://github.com/WordPress/wordcamp.org/issues/682#issue-908371121).