### PR TITLE
Blocks: Improve date display for schedule & sessions across timezones

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/data.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { dateI18n } from '@wordpress/date';
+import { format } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -447,7 +447,7 @@ function filterSessionsByChosenDays( sessions, chosenDays ) {
 	}
 
 	return sessions.filter( ( session ) => {
-		const date = dateI18n( DATE_SLUG_FORMAT, session.derived.startTime );
+		const date = format( DATE_SLUG_FORMAT, session.derived.startTime );
 		return chosenDays.includes( date );
 	} );
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -3,7 +3,7 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { CheckboxControl, PanelBody, ToggleControl } from '@wordpress/components';
-import { dateI18n, format } from '@wordpress/date';
+import { format } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -68,7 +68,7 @@ export default function ScheduleInspectorControls(
  */
 function getDisplayedDays( sessions ) {
 	let uniqueDays = sessions.reduce( ( accumulatingDays, session ) => {
-		accumulatingDays[ dateI18n( DATE_SLUG_FORMAT, session.derived.startTime ) ] = true;
+		accumulatingDays[ format( DATE_SLUG_FORMAT, session.derived.startTime ) ] = true;
 
 		return accumulatingDays;
 	}, {} );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
@@ -386,7 +386,7 @@ function renderGridTemplateRows( startEndTimes ) {
 	startEndTimes.sort(); // Put them in chronological order.
 
 	const timeList = startEndTimes.reduce( ( accumulatingTimes, time ) => {
-		const formattedTime = format( 'Hi', time );
+		const formattedTime = format( 'dHi', time );
 
 		return accumulatingTimes += `[time-${ formattedTime }] auto `;
 	}, '' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dateI18n, format } from '@wordpress/date';
+import { format } from '@wordpress/date';
 import { __, _x } from '@wordpress/i18n';
 import { createContext, useContext } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -77,7 +77,7 @@ function groupSessionsByDate( sessions ) {
 			return groups;
 		}
 
-		const date = dateI18n( 'Y-m-d', session.derived.startTime );
+		const date = format( 'Y-m-d', session.derived.startTime );
 
 		if ( date ) {
 			groups[ date ] = groups[ date ] || [];
@@ -386,7 +386,7 @@ function renderGridTemplateRows( startEndTimes ) {
 	startEndTimes.sort(); // Put them in chronological order.
 
 	const timeList = startEndTimes.reduce( ( accumulatingTimes, time ) => {
-		const formattedTime = dateI18n( 'Hi', time );
+		const formattedTime = format( 'Hi', time );
 
 		return accumulatingTimes += `[time-${ formattedTime }] auto `;
 	}, '' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.js
@@ -88,8 +88,8 @@ export function Session( { session, displayedTracks, showCategories, overlapsAno
 	`;
 
 	const gridRow = `
-		time-${ format( 'Hi', startTime ) } /
-		time-${ format( 'Hi', endTime ) }
+		time-${ format( 'dHi', startTime ) } /
+		time-${ format( 'dHi', endTime ) }
 	`;
 
 	return (

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.js
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { dateI18n } from '@wordpress/date';
+import { format } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement, useContext } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -88,8 +88,8 @@ export function Session( { session, displayedTracks, showCategories, overlapsAno
 	`;
 
 	const gridRow = `
-		time-${ dateI18n( 'Hi', startTime ) } /
-		time-${ dateI18n( 'Hi', endTime ) }
+		time-${ format( 'Hi', startTime ) } /
+		time-${ format( 'Hi', endTime ) }
 	`;
 
 	return (
@@ -111,7 +111,8 @@ export function Session( { session, displayedTracks, showCategories, overlapsAno
 			</h4>
 
 			<p>
-				{ dateI18n( timeFormat, startTime ) } - { dateI18n( timeFormat, endTime ) }
+				{ format( timeFormat, startTime ) } -
+				{ format( timeFormat, endTime ) }
 			</p>
 
 			{ speakers.length > 0 && renderSpeakers( speakers, renderEnvironment ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -42,8 +42,8 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 		const endTime = parseInt( timeSlots[ i + 1 ] ) || 0;
 
 		const gridRow = `
-			time-${ format( 'Hi', startTime ) } /
-			time-${ format( 'Hi', endTime ) }
+			time-${ format( 'dHi', startTime ) } /
+			time-${ format( 'dHi', endTime ) }
 		`;
 
 		const classes = classnames(

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { dateI18n } from '@wordpress/date';
+import { format } from '@wordpress/date';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -42,8 +42,8 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 		const endTime = parseInt( timeSlots[ i + 1 ] ) || 0;
 
 		const gridRow = `
-			time-${ dateI18n( 'Hi', startTime ) } /
-			time-${ dateI18n( 'Hi', endTime ) }
+			time-${ format( 'Hi', startTime ) } /
+			time-${ format( 'Hi', endTime ) }
 		`;
 
 		const classes = classnames(
@@ -53,7 +53,7 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 
 		timeGroups.push(
 			<h3 key={ startTime } className={ classes } style={ { gridRow } }>
-				{ dateI18n( timeFormat, startTime ) }
+				{ format( timeFormat, startTime ) }
 			</h3>
 		);
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -26,8 +26,7 @@ import { sortBySlug } from './data';
  * @return {Element}
  */
 export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
-	const { attributes, settings } = useContext( ScheduleGridContext );
-	const { time_format: timeFormat } = settings;
+	const { attributes } = useContext( ScheduleGridContext );
 
 	const sessionsByTimeSlot = groupSessionsByTimeSlot( sessions );
 	const overlappingSessionIds = overlappingSessions.map( ( session ) => session.id );
@@ -51,9 +50,10 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 			sessionsByTimeSlot[ currentSlot ].length ? 'has-sessions' : 'is-empty'
 		);
 
+		const date = new Date( startTime );
 		timeGroups.push(
 			<h3 key={ startTime } className={ classes } style={ { gridRow } }>
-				{ format( timeFormat, startTime ) }
+				{ date.toLocaleTimeString( [], { timeZoneName: 'short', hour: 'numeric', minute: '2-digit' } ) }
 			</h3>
 		);
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/view.php
@@ -78,7 +78,7 @@ setup_postdata( $session );
 							/* translators: 1: A date; 2: A time; 3: A location; */
 							esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
 							esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-							esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
+							esc_html( wp_date( get_option( 'time_format' ) . ' T', $session->_wcpt_session_time ) ),
 							sprintf(
 								'<span class="wordcamp-sessions__track slug-%s">%s</span>',
 								esc_attr( $tracks[0]->slug ),
@@ -91,7 +91,7 @@ setup_postdata( $session );
 							/* translators: 1: A date; 2: A time; */
 							esc_html__( '%1$s at %2$s', 'wordcamporg' ),
 							esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-							esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) )
+							esc_html( wp_date( get_option( 'time_format' ) . ' T', $session->_wcpt_session_time ) )
 						);
 					endif; ?>
 				</div>

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/view.php
@@ -68,7 +68,7 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 										/* translators: 1: A date; 2: A time; 3: A location; */
 										esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
 										esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-										esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
+										esc_html( wp_date( get_option( 'time_format' ) . ' T', $session->_wcpt_session_time ) ),
 										esc_html( $tracks[0]->name )
 									);
 								?>
@@ -79,7 +79,7 @@ setup_postdata( $speaker ); // This is necessary for generating an excerpt from 
 										/* translators: 1: A date; 2: A time; */
 										esc_html__( '%1$s at %2$s', 'wordcamporg' ),
 										esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
-										esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) )
+										esc_html( wp_date( get_option( 'time_format' ) . ' T', $session->_wcpt_session_time ) )
 									);
 								?>
 							<?php endif; ?>


### PR DESCRIPTION
This PR iterates on how dates & times are displayed in the blocks.

1. Update the schedule block to use `format`, which will use the client's timezone to do all session-grouping, layout, and display. This ensures the schedule is always showing the viewers timezone, which makes more sense for online and regional WordCamps.
2. Prefix the grid rules with the numeric date. This fixes the issue in #562, which happened because the last session ended at 12:10 the following day, while the first session started at 12:10 -- this created 2 rules in the `grid-template-rows` for `time-0010`, but only the first was valid. The session spanned from that first start time to it's real start time, functionally the entire "day".
3. Add timezone strings to the sessions in the session and speaker blocks - this is more of a workaround, since these are rendered by PHP and we don't know the client timezone, but it's a small improvement.

Fixes #562, fixes #565, fixes #492.

~Note: I'm not sure if we could consider this as fixing 565 - once this PR is applied, it should be the case that session times are always either your (viewer's) time, or has a timezone identifier.~ Now that the schedule time also has a TZ displayed, it should always be clear what timezone you're seeing.

### Screenshots

Schedule block use the viewer's timezone. My browser timezone is EDT, the site's timezone is PDT.  The sessions start at 8:00 am PDT. On the left is Safari, which shows production, showing the ambiguous "8:00am" start time. On the right is Firefox showing my sandbox, correctly showing "11:00am". (it's still ambiguous, but most people will assume local time. Organizers can add a note above the schedule)

<img width="1073" alt="Screen Shot 2021-09-14 at 12 47 41 PM" src="https://user-images.githubusercontent.com/541093/133301069-140f9b16-93a4-4e6d-affa-146318db43c4.png">

Session overlapping (#562):

![schedule-overlap@0 5x](https://user-images.githubusercontent.com/541093/133304279-fe87abf4-722d-4ab2-a4af-3f1c5e429f63.png)

Sessions with timezones

<img width="391" alt="Screen Shot 2021-09-14 at 7 24 05 PM" src="https://user-images.githubusercontent.com/541093/133304766-c9e6644a-fdac-47d4-a19e-651403a4ab94.png">

### How to test the changes in this Pull Request:

1. Set up sessions and a schedule, pay attention to your site's timezone
2. View the schedule from various timezones, the schedule should reflect your current TZ.
3. View the speakers & sessions blocks with dates showing, they should include the site's timezone
