### PR TITLE
Sessions: Use the TimePicker component for session times.

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/css/editor.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/editor.css
@@ -1,10 +1,18 @@
 
-.wordcamp-panel-session-info .components-base-control:first-of-type {
+.wordcamp-panel-session-info .components-base-control {
 	margin-bottom: 16px;
 }
 
-.wordcamp-panel-session-info .components-dropdown {
-	width: 100%;
+.wordcamp-panel-session-info .components-datetime__time {
+	padding-bottom: 0;
+}
+
+.wordcamp-panel-session-info .components-datetime__time .components-button,
+.wordcamp-panel-session-info .components-datetime__time input[type="number"],
+.wordcamp-panel-session-info .components-datetime__time select {
+	height: 30px;
+	margin-bottom: 0;
+	margin-top: 0;
 }
 
 .wordcamp-panel-session-info__duration-wrapper {
@@ -18,6 +26,7 @@
 }
 
 .wordcamp-panel-session-info__duration input {
+	-moz-appearance: textfield;
 	max-width: 3rem;
 }
 

--- a/public_html/wp-content/plugins/wc-post-types/js/src/components/date-control/index.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/components/date-control/index.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Date settings OK.
-import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
-import { BaseControl, Button, DateTimePicker, Dropdown } from '@wordpress/components';
+import { __experimentalGetSettings } from '@wordpress/date';
+import { BaseControl, TimePicker } from '@wordpress/components';
 
 export default function( { date, label, onChange } ) {
 	const settings = __experimentalGetSettings();
@@ -15,22 +15,11 @@ export default function( { date, label, onChange } ) {
 			.reverse()
 			.join( '' ) // Reverse the string and test for "a" not followed by a slash
 	);
-	const formattedDate = date && dateI18n( `${ settings.formats.date } ${ settings.formats.time }`, date );
 
 	return (
 		<BaseControl>
 			<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
-			<Dropdown
-				position="bottom left"
-				renderToggle={ ( { onToggle, isOpen } ) => (
-					<Button onClick={ onToggle } aria-expanded={ isOpen } isLink>
-						{ formattedDate }
-					</Button>
-				) }
-				renderContent={ () => (
-					<DateTimePicker currentDate={ date } onChange={ onChange } is12Hour={ is12HourTime } />
-				) }
-			/>
+			<TimePicker currentTime={ date } onChange={ onChange } is12Hour={ is12HourTime } />
 		</BaseControl>
 	);
 }


### PR DESCRIPTION
This displays a set of text inputs for the day and time of the session, including an indicator of timezone if your current TZ is different from the site's TZ. Previously, it was unclear once you closed the calendar dropdown what timezone the date was, this removes the ambiguity. The calendar dropdown is not as helpful for WordCamp sessions, since the majority of sessions happen over a set 1-3 day period, and the date field is pre-populated with the last-used date, so removing it should not have a negative effect on the UX.

This also fixes an issue with the duration fields in Firefox, where the arrows on the number input overlap the field content.

Fixes #689.

### Screenshots

Before/currently, no timezone indication & arrows overlap in duration/

<img width="268" alt="Screen Shot 2021-09-20 at 5 51 21 PM" src="https://user-images.githubusercontent.com/541093/134080704-ef980168-c487-4954-b106-8812470471af.png">

With the PR, if you're in the same timezone as the site, it doesn't mention the timezone.

<img width="276" alt="" src="https://user-images.githubusercontent.com/541093/134073787-70d06eb1-ca8d-4469-9586-7d713e0527a1.png">

But if you're not, it will tell you what timezone it's using.

<img width="276" alt="" src="https://user-images.githubusercontent.com/541093/134073784-cbb960c3-1d9f-4501-8ac4-e65628628209.png">

### How to test the changes in this Pull Request:

1. Check what timezone the site is using
2. Edit or create a session
3. In the Session tab, under Session Info, the Day & Time setting should be a set of input fields
4. If your site and local timezone are different, it should list the site timezone after the AM/PM fields