### PR TITLE
Update Code of Conduct attibution link to version from archive.org

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -111,5 +111,5 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://opensourcebridge.org/about/code-of-conduct/">http://opensourcebridge.org/about/code-of-conduct/</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
+<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">at the following link [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
 <!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -111,5 +111,5 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">at the following link [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
+<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">Open Source Bridge 2018 [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
 <!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -111,5 +111,5 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://opensourcebridge.org/about/code-of-conduct/">http://opensourcebridge.org/about/code-of-conduct/</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
+<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">at the following link [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
 <!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -111,5 +111,5 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">at the following link [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
+<p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">Open Source Bridge 2018 [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR updates the Code of Conduct broken attribution link in the page stubs.  

In [Help Scout conversation 121219](https://secure.helpscout.net/conversation/1643492982/121219/), it was reported that the Code of Conduct attribution link was broken.  It seems that the Open Source Bridge website is down (the conference wrapped up in 2018 and the site seems to have gone down in 2019).  It was suggested to use the archived link from archive.org 