### PR TITLE
Budgets: Corrects Food & Beverage default expense category name

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -169,9 +169,9 @@ class WordCamp_Budget_Tool {
             array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Livestream', 'amount' => 0 ),
             array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Printing', 'amount' => 0 ),
             array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Badges', 'amount' => 0, 'link' => 'per-attendee' ),
-            array( 'type' => 'expense', 'category' => 'food-beverage', 'note' => 'Snacks', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'food-beverage', 'note' => 'Lunch', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'food-beverage', 'note' => 'Coffee', 'amount' => 0 ),
+            array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Snacks', 'amount' => 0 ),
+            array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Lunch', 'amount' => 0 ),
+            array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Coffee', 'amount' => 0 ),
             array( 'type' => 'expense', 'category' => 'swag', 'note' => 'T-shirts', 'amount' => 0 ),
             array( 'type' => 'expense', 'category' => 'speaker-event', 'note' => 'Speakers Dinner', 'amount' => 0, 'link' => 'per-speaker' ),
         );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -146,11 +146,14 @@ class WordCamp_Budget_Tool {
         return $budget;
     }
 
+	/**
+	 * Set the intial values for a new budget
+	 */
 	private static function _get_default_budget() {
 		return array(
 			array(
-				'type' => 'meta', 
-				'name' => 'attendees', 
+				'type' => 'meta',
+				'name' => 'attendees',
 				'value' => 0,
 			),
 			array(
@@ -177,7 +180,7 @@ class WordCamp_Budget_Tool {
 				'type' => 'meta',
 				'name' => 'currency',
 				'value' => 'USD',
-			 ),
+			),
 			array(
 				'type' => 'meta',
 				'name' => 'ticket-price',
@@ -197,13 +200,13 @@ class WordCamp_Budget_Tool {
 				'note' => 'Community Sponsorships',
 				'amount' => 0,
 			),
-			array( 
+			array(
 				'type' => 'income',
 				'category' => 'other',
 				'note' => 'Local Sponsorships',
 				'amount' => 0,
 			),
-			array( 
+			array(
 				'type' => 'income',
 				'category' => 'other',
 				'note' => 'Microsponsors',

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -147,34 +147,34 @@ class WordCamp_Budget_Tool {
     }
 
     private static function _get_default_budget() {
-        return array(
-            array( 'type' => 'meta', 'name' => 'attendees', 'value' => 0 ),
-            array( 'type' => 'meta', 'name' => 'days', 'value' => 0 ),
-            array( 'type' => 'meta', 'name' => 'tracks', 'value' => 0 ),
-            array( 'type' => 'meta', 'name' => 'speakers', 'value' => 0 ),
-            array( 'type' => 'meta', 'name' => 'volunteers', 'value' => 0 ),
-            array( 'type' => 'meta', 'name' => 'currency', 'value' => 'USD' ),
-            array( 'type' => 'meta', 'name' => 'ticket-price', 'value' => 0 ),
+	return array
+		array( 'type' => 'meta', 'name' => 'attendees', 'value' => 0 ),
+		array( 'type' => 'meta', 'name' => 'days', 'value' => 0 ),
+		array( 'type' => 'meta', 'name' => 'tracks', 'value' => 0 ),
+		array( 'type' => 'meta', 'name' => 'speakers', 'value' => 0 ),
+		array( 'type' => 'meta', 'name' => 'volunteers', 'value' => 0 ),
+		array( 'type' => 'meta', 'name' => 'currency', 'value' => 'USD' ),
+		array( 'type' => 'meta', 'name' => 'ticket-price', 'value' => 0 ),
 
-            array( 'type' => 'income', 'category' => 'other', 'note' => 'Tickets Income', 'amount' => 0, 'link' => 'ticket-price-x-attendees' ),
-            array( 'type' => 'income', 'category' => 'other', 'note' => 'Community Sponsorships', 'amount' => 0 ),
-            array( 'type' => 'income', 'category' => 'other', 'note' => 'Local Sponsorships', 'amount' => 0 ),
-            array( 'type' => 'income', 'category' => 'other', 'note' => 'Microsponsors', 'amount' => 0 ),
+		array( 'type' => 'income', 'category' => 'other', 'note' => 'Tickets Income', 'amount' => 0, 'link' => 'ticket-price-x-attendees' ),
+		array( 'type' => 'income', 'category' => 'other', 'note' => 'Community Sponsorships', 'amount' => 0 ),
+		array( 'type' => 'income', 'category' => 'other', 'note' => 'Local Sponsorships', 'amount' => 0 ),
+		array( 'type' => 'income', 'category' => 'other', 'note' => 'Microsponsors', 'amount' => 0 ),
 
-            array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Venue', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Wifi Costs', 'amount' => 0, 'link' => 'per-day' ),
-            array( 'type' => 'expense', 'category' => 'other', 'note' => 'Comped Tickets', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Video recording', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Projector rental', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Livestream', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Printing', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Badges', 'amount' => 0, 'link' => 'per-attendee' ),
-            array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Snacks', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Lunch', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Coffee', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'swag', 'note' => 'T-shirts', 'amount' => 0 ),
-            array( 'type' => 'expense', 'category' => 'speaker-event', 'note' => 'Speakers Dinner', 'amount' => 0, 'link' => 'per-speaker' ),
-        );
+		array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Venue', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Wifi Costs', 'amount' => 0, 'link' => 'per-day' ),
+		array( 'type' => 'expense', 'category' => 'other', 'note' => 'Comped Tickets', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Video recording', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Projector rental', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Livestream', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Printing', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Badges', 'amount' => 0, 'link' => 'per-attendee' ),
+		array( 'type' => 'expense', 'category' => 'food-beverages!', 'note' => 'Snacks', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Lunch', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Coffee', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'swag', 'note' => 'T-shirts', 'amount' => 0 ),
+		array( 'type' => 'expense', 'category' => 'speaker-event', 'note' => 'Speakers Dinner', 'amount' => 0, 'link' => 'per-speaker' ),
+	);
     }
 
     public static function render() {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -146,36 +146,153 @@ class WordCamp_Budget_Tool {
         return $budget;
     }
 
-    private static function _get_default_budget() {
-	return array
-		array( 'type' => 'meta', 'name' => 'attendees', 'value' => 0 ),
-		array( 'type' => 'meta', 'name' => 'days', 'value' => 0 ),
-		array( 'type' => 'meta', 'name' => 'tracks', 'value' => 0 ),
-		array( 'type' => 'meta', 'name' => 'speakers', 'value' => 0 ),
-		array( 'type' => 'meta', 'name' => 'volunteers', 'value' => 0 ),
-		array( 'type' => 'meta', 'name' => 'currency', 'value' => 'USD' ),
-		array( 'type' => 'meta', 'name' => 'ticket-price', 'value' => 0 ),
+	private static function _get_default_budget() {
+		return array(
+			array(
+				'type' => 'meta', 
+				'name' => 'attendees', 
+				'value' => 0,
+			),
+			array(
+				'type' => 'meta',
+				'name' => 'days',
+				'value' => 0,
+			),
+			array(
+				'type' => 'meta',
+				'name' => 'tracks',
+				'value' => 0,
+			),
+			array(
+				'type' => 'meta',
+				'name' => 'speakers',
+				'value' => 0,
+			),
+			array(
+				'type' => 'meta',
+				'name' => 'volunteers',
+				'value' => 0,
+			),
+			array(
+				'type' => 'meta',
+				'name' => 'currency',
+				'value' => 'USD',
+			 ),
+			array(
+				'type' => 'meta',
+				'name' => 'ticket-price',
+				'value' => 0,
+			),
 
-		array( 'type' => 'income', 'category' => 'other', 'note' => 'Tickets Income', 'amount' => 0, 'link' => 'ticket-price-x-attendees' ),
-		array( 'type' => 'income', 'category' => 'other', 'note' => 'Community Sponsorships', 'amount' => 0 ),
-		array( 'type' => 'income', 'category' => 'other', 'note' => 'Local Sponsorships', 'amount' => 0 ),
-		array( 'type' => 'income', 'category' => 'other', 'note' => 'Microsponsors', 'amount' => 0 ),
+			array(
+				'type' => 'income',
+				'category' => 'other',
+				'note' => 'Tickets Income',
+				'amount' => 0,
+				'link' => 'ticket-price-x-attendees',
+			),
+			array(
+				'type' => 'income',
+				'category' => 'other',
+				'note' => 'Community Sponsorships',
+				'amount' => 0,
+			),
+			array( 
+				'type' => 'income',
+				'category' => 'other',
+				'note' => 'Local Sponsorships',
+				'amount' => 0,
+			),
+			array( 
+				'type' => 'income',
+				'category' => 'other',
+				'note' => 'Microsponsors',
+				'amount' => 0,
+			),
 
-		array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Venue', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Wifi Costs', 'amount' => 0, 'link' => 'per-day' ),
-		array( 'type' => 'expense', 'category' => 'other', 'note' => 'Comped Tickets', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Video recording', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Projector rental', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Livestream', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Printing', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'signage-badges', 'note' => 'Badges', 'amount' => 0, 'link' => 'per-attendee' ),
-		array( 'type' => 'expense', 'category' => 'food-beverages!', 'note' => 'Snacks', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Lunch', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'food-beverages', 'note' => 'Coffee', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'swag', 'note' => 'T-shirts', 'amount' => 0 ),
-		array( 'type' => 'expense', 'category' => 'speaker-event', 'note' => 'Speakers Dinner', 'amount' => 0, 'link' => 'per-speaker' ),
-	);
-    }
+			array(
+				'type' => 'expense',
+				'category' => 'venue',
+				'note' => 'Venue',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'venue',
+				'note' => 'Wifi Costs',
+				'amount' => 0,
+				'link' => 'per-day',
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'other',
+				'note' => 'Comped Tickets',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'audio-visual',
+				'note' => 'Video recording',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'audio-visual',
+				'note' => 'Projector rental',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'audio-visual',
+				'note' => 'Livestream',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'signage-badges',
+				'note' => 'Printing',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'signage-badges',
+				'note' => 'Badges',
+				'amount' => 0,
+				'link' => 'per-attendee',
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'food-beverages!',
+				'note' => 'Snacks',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'food-beverages',
+				'note' => 'Lunch',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'food-beverages',
+				'note' => 'Coffee',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'swag',
+				'note' => 'T-shirts',
+				'amount' => 0,
+			),
+			array(
+				'type' => 'expense',
+				'category' => 'speaker-event',
+				'note' => 'Speakers Dinner',
+				'amount' => 0,
+				'link' => 'per-speaker',
+			),
+		);
+	}
 
     public static function render() {
         $budget = self::_get_budget();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR corrects a typo in [_get_default_budget()](https://github.com/WordPress/wordcamp.org/blob/055fd1a66f036da5211ba489dc80a65e3d3a8081/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php#L172) where the name for the Food & Beverage category doesn't match the name as defined in [get_payment_categories()](https://github.com/WordPress/wordcamp.org/blob/055fd1a66f036da5211ba489dc80a65e3d3a8081/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php#L587).

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #704.

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. In a new WordCamp site that hasn't interacted with their Budget yet, browse to /wp-admin/admin.php?page=wordcamp-budget
2. Scroll down to Snacks in the Expenses section.
3. See **Food & Beverage**.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
