### PR TITLE
Themes: Add support for `comment_type = 'comment'` in the WordCamp themes

### DIFF
--- a/public_html/wp-content/themes/wordcamp-base-v2/lib/utils/twentyten-functions.php
+++ b/public_html/wp-content/themes/wordcamp-base-v2/lib/utils/twentyten-functions.php
@@ -301,6 +301,7 @@ if ( ! function_exists( 'twentyten_comment' ) ) :
 		$GLOBALS['comment'] = $comment;
 		switch ( $comment->comment_type ) :
 			case '':
+			case 'comment':
 				?>
 	<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
 		<div id="comment-<?php comment_ID(); ?>">

--- a/public_html/wp-content/themes/wordcamp-base/lib/utils/twentyten-functions.php
+++ b/public_html/wp-content/themes/wordcamp-base/lib/utils/twentyten-functions.php
@@ -302,6 +302,7 @@ if ( ! function_exists( 'twentyten_comment' ) ) :
 		$GLOBALS['comment'] = $comment;
 		switch ( $comment->comment_type ) :
 			case '':
+			case 'comment':
 				?>
 	<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
 		<div id="comment-<?php comment_ID(); ?>">

--- a/public_html/wp-content/themes/wordcamp-central-2012/functions.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/functions.php
@@ -563,7 +563,8 @@ class WordCamp_Central_Theme {
 
 		switch ( $comment->comment_type ) :
 			case '':
-			case 'comment': ?>
+			case 'comment':
+				?>
 				<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
 					<div id="comment-<?php comment_ID(); ?>" class="comment-container">
 						<div class="comment-author vcard">

--- a/public_html/wp-content/themes/wordcamp-central-2012/functions.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/functions.php
@@ -562,7 +562,8 @@ class WordCamp_Central_Theme {
 		$GLOBALS['comment'] = $comment;
 
 		switch ( $comment->comment_type ) :
-			case '': ?>
+			case '':
+			case 'comment': ?>
 				<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
 					<div id="comment-<?php comment_ID(); ?>" class="comment-container">
 						<div class="comment-author vcard">


### PR DESCRIPTION
Themes: Add support for `comment_type = 'comment'` in the WordCamp themes

See https://core.trac.wordpress.org/ticket/49236 for where `comment_type` changed from `''` to `'comment'`.

### How to test the changes in this Pull Request:

1. View https://central.wordcamp.org/news/2020/04/07/wordcamp-europe-2020-is-moving-online/
2. See Comments displayed.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
