### PR TITLE
When exporting content, only export public & custom status posts

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -224,7 +224,14 @@ function get_wc_posts( $post_type, $email_address, $page ) {
 		'posts_per_page' => $number,
 		'paged'          => $page,
 		'post_type'      => $post_type,
-		'post_status'    => 'any',
+		'post_status'    => get_post_stati(
+			array(
+				'public'   => 1,
+				'_builtin' => false,
+			),
+			'names',
+			'or'
+		),
 		'orderby'        => 'ID',
 		'order'          => 'ASC',
 	];


### PR DESCRIPTION
The current Exporters export all content, even if it's been removed from public view.

Some WordCamp data is required to be retained, per the privacy policy, but should not be accessible via the Export process nor prevent erasures proceeding, if it's been made publicly unavailable.

PR for GitHub action purposes.