### PR TITLE
CamptTx Attendee List: Fix margins

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.css
+++ b/public_html/wp-content/plugins/camptix/camptix.css
@@ -71,6 +71,8 @@ body.admin-bar #tix {
 #tix-attendees li {
 	float: left;
 	width: 50%;
+	margin-left: 0px;
+	margin-right: 0px;
 	margin-bottom: 20px;
 	height: 80px;
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR sets the margin-left and margin-right to 0px on li elements inside the `tix-attendees` id.

The width for a 2, 3, 4, or 5 column wide attendee list needs to take up 50%, 33%, 25%, and 20% respectively.  

The CSS in some of the themes available to WordCamp sites have a margin defined on all li elements.   For example, this [margin](https://github.com/WordPress/twentytwenty/blob/a9e73ab1b6db33a57bd6317ce9f319fbf37b23d1/style.css#L495) is applied on all li elements in the Twenty Twenty theme.  
`li { margin: 0.5rem 0 0 2rem; }` 

This was causing the attendee list margin to be narrower than needed to display as intended.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #713

<!-- List out anyone who helped with this task. -->
Props @dd32 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
Before the fix:
![image](https://user-images.githubusercontent.com/3489003/147205224-b44603af-2883-4d8b-be57-47b722c67406.png)

After the fix:
![image](https://user-images.githubusercontent.com/3489003/147206125-1270621e-3efd-44e7-8736-93141ec79359.png)

### How to test the changes in this Pull Request:

1. As a WordCamp site administrator, set your site's theme to Twenty Twenty.
2. Have at least 3 attendees visible on the site's Attendee page.
3. Browse to https://city.wordcamp.org/year/attendees/
Assumes the shortcode in places is `[camptix_attendees]`.
4. See three columns of attendees displayed.