### PR TITLE
Add question about having Contributor Day to WordCamp application

### DIFF
--- a/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
@@ -1321,6 +1321,49 @@ function render_wordcamp_application_form( $countries, $prefilled_fields ) {
 
 				<div class="PDF_questionDivide" id="pd-divider-29"></div>
 
+				<div class="PDF_question" id="pd-question-36">
+					<div class="qNumber">
+						Q.36
+					</div>
+
+					<div class="qContent">
+						<div class="qText">
+							Are you planning to hold a Contributor Day?
+						</div>
+
+						<div class="PDF_QT400">
+							<ul>
+								<li>
+									<input type="radio" name="q_contributor_day"
+										value="Yes, before session day(s)" id="q_contributor_day_1" />
+
+									<label for="q_contributor_day_1">Yes, before session day(s)</label>
+								</li>
+								<li>
+									<input type="radio" name="q_contributor_day"
+										value="Yes, during session day(s)" id="q_contributor_day_2" />
+
+									<label for="q_contributor_day_2">Yes, during session day(s)</label>
+								</li>
+								<li>
+									<input type="radio" name="q_contributor_day"
+										value="Yes, after session day(s)" id="q_contributor_day_3" />
+
+									<label for="q_contributor_day_3">Yes, after session day(s)</label>
+								</li>
+								<li>
+									<input type="radio" name="q_contributor_day"
+										value="No" id="q_contributor_day_4" />
+
+									<label for="q_contributor_day_4">No</label>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<div class="PDF_questionDivide" id="pd-divider-36"></div>
+
 				<div class="PDF_question" id="pd-question-35">
 					<div class="qNumber">
 						Q.35

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -153,6 +153,7 @@ class WordCamp_Application extends Event_Application {
 			'q_4236565_slack_username'                   => '',
 			'where_find_online'                          => '',
 			'q_1079098_anything_else'                    => '',
+			'q_contributor_day'                          => '',
 
 			// Bonus.
 			'q_1079112_best_describes_you'               => '',
@@ -238,6 +239,10 @@ class WordCamp_Application extends Event_Application {
 				$data['q_1079060_country'] ? $countries[ $data['q_1079060_country'] ]['name'] : ''
 			)
 		);
+
+		if ( false !== strpos( $data['q_contributor_day'], 'Yes' ) ) {
+			add_post_meta( $post_id, 'Contributor Day', true );
+		}
 
 		if ( 'It would be an online event' === $data['q_in_person_online'] ) {
 			add_post_meta( $post_id, 'Virtual event only', true );


### PR DESCRIPTION
Since WordCamps might have Contributor Day and we have fields for that on the WordCamp tracker, we should ask about that also during the application process. Right now the Deputy vetting the application or mentoring WordCamp needs to ask this in order to get the tracker data to reflect the right situation.

This PR adds a question about organising Contributor Day and options to choose at which point of the WordCamp they are planning to have it.

Fixes #276

### Screenshots

[Screenshot before the field was added](https://cln.sh/u4NWHFaJ3xPGXWXULlHc).
[Screenshot after the field was added](https://cln.sh/jRTmvGfQq9lBYPpMfJBR).

### How to test the changes in this Pull Request:

1. Go to the WordCamp Organiser application page
2. Fill out and submit the application, new field should be visible
3. Check the application on WordCamp tracker, Contributor Day checkbox is checked and original application rows contain the answer
