### PR TITLE
Fix mailcatcher install command on Docker build

### DIFF
--- a/.docker/Dockerfile.php-fpm
+++ b/.docker/Dockerfile.php-fpm
@@ -58,7 +58,7 @@ RUN chown www-data /etc/msmtprc
 RUN chmod 600 /etc/msmtprc
 
 # Install MailCatcher.
-RUN gem install mailcatcher --no-ri --no-rdoc
+RUN gem install mailcatcher --no-document
 
 # todo Maybe install phpMyAdmin?
 


### PR DESCRIPTION
On Docker build, mailcatcher is installed from gem. Previously there were options `--no-ri --no-rdoc` given, but those are deprecated and the build process didn't work as `gem install` failed. Changed the options to `--no-document` which seemed to do the same thing.

### How to test the changes in this Pull Request:

1. Try to run Docker build with `RUN gem install mailcatcher --no-ri --no-rdoc` > fails
2. Now run Docker build with `RUN gem install mailcatcher --no-document` > works
