### PR TITLE
Add default empty select on Camptix country field

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/field-country.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-country.php
@@ -38,6 +38,10 @@ class CampTix_Addon_Country_Field extends CampTix_Addon {
 			name="<?php echo esc_attr( $name ); ?>"
 			<?php if ( $required ) echo 'required'; ?>
 		>
+			<option value="" disabled <?php selected( '', $user_value ); ?>>
+				-- <?php esc_html_e( 'Select', 'wordcamporg' ); ?> --
+			</option>
+
 			<?php foreach ( $countries as $country ) : ?>
 				<option value="<?php echo esc_attr( $country ); ?>" <?php selected( $country, $user_value ); ?>>
 					<?php echo esc_html( $country ); ?>


### PR DESCRIPTION
Adds option "-- Select --" with empty value to the country select field on Camptix. The option is disabled always and selected if the attendee hasn't selected any other value during the purchase. This forces the attendees to select a proper country if the field is required, thus making the field values more reliable.

Fixes #434

Props @NobNob

### Screenshots

<img width="609" alt="image" src="https://user-images.githubusercontent.com/415544/148628816-bcd274c5-0620-4744-bd41-2d4860f3aade.png">

1. Add tickets and configure Camptix to allow purchases
2. Add the Country field to the ticket questions without making it required
3. Purchase a ticket without choosing any option on the country field
4. Check the attendee data either on the dashboard or via attendee information edit link -> field should be in select state
5. Purchase a ticket and choose some country on the field
6. Check the attendee data either on the dashboard or via attendee information edit link -> field should have selected country
