### PR TITLE
Add KidsCamp to WordCamp application and tracker

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/wordcamp.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/wordcamp.css
@@ -956,6 +956,8 @@ SPECIFIC CSS STYLES FOR JANE
  #pd-divider-23,
 #pd-question-28,
  #pd-divider-28,
+#pd-question-38,
+ #pd-divider-38,
 .qNumber {
 	display: none;
 }

--- a/public_html/wp-content/plugins/wcpt/javascript/applications/wordcamp.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/applications/wordcamp.js
@@ -11,6 +11,7 @@ jQuery( document ).ready( function( $ ) {
 	questions[ "pd-question-22" ] = Array( "23" );
 	questions[ "pd-question-27" ] = Array( "28" );
 	questions[ "pd-question-35" ] = Array( "30" );
+	questions[ "pd-question-37" ] = Array( "38" );
 
 	var yesanswers                 = Array();
 	yesanswers[ "pd-question-6" ]  = Array( "Yes, more than one", "Yes, I've been to one" );
@@ -21,6 +22,7 @@ jQuery( document ).ready( function( $ ) {
 	yesanswers[ "pd-question-22" ] = Array( "Yes, I have co-organizers already" );
 	yesanswers[ "pd-question-27" ] = Array( "Yes, I know lots of local WordPress users/developers", "Yes, I know a couple of people who would be qualified" );
 	yesanswers[ "pd-question-35" ] = Array( "It would be an in-person event", "It would be both in-person and streamed online" );
+	yesanswers[ "pd-question-37" ] = Array( "Yes, before session day(s)", "Yes, during session day(s)", "Yes, after session day(s)" );
 
 	$( "input" ).click( function() {
 		qid = $( this ).closest( ".PDF_question" ).attr( "id" );

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -12,6 +12,7 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 		var createSiteCheckbox = $( '#wcpt_create-site-in-network' ),
 			$mentorUserName = $( '#wcpt_mentor_wordpress_org_user_name' ),
 			hasContributor = $( '#wcpt_contributor_day' ),
+			hasKidsCamp = $( '#wcpt_kidscamp' ),
 			$virtualEventCheckbox = $( '#wcpt_virtual_event_only' ),
 			$streamingSelection = $( '.field__type-select-streaming' );
 
@@ -22,6 +23,10 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 		// Contributor day info
 		hasContributor.change( self.toggleContributorInfo );
 		hasContributor.trigger( 'change' );
+
+		// KidsCamp day info
+		hasKidsCamp.change( self.toggleKidsCampInfo );
+		hasKidsCamp.trigger( 'change' );
 
 		// Date fields
 		$( '.date-field' ).datepicker( {
@@ -149,6 +154,25 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 			contributorInputElements.slideDown();
 		} else {
 			contributorInputElements.slideUp();
+		}
+
+	};
+
+	/**
+	 * Toggle the display of the KidsCamp Info fields
+	 *
+	 * @param {object} event
+	 */
+	self.toggleKidsCampInfo = function( event ) {
+
+		// Selects all the div enclosing input elements for kidscamp info,
+		// except for the one which has the checkbox with ID wcpt_kidscamp
+		var kidsCampInputElements = $( "#wcpt_kidscamp_info .inside .inside:not( :has( #wcpt_kidscamp ) )" );
+
+		if ( $( '#wcpt_kidscamp' ).is( ':checked' ) ) {
+			kidsCampInputElements.slideDown();
+		} else {
+			kidsCampInputElements.slideUp();
 		}
 
 	};

--- a/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
+++ b/public_html/wp-content/plugins/wcpt/views/applications/wordcamp/shortcode-application.php
@@ -1380,6 +1380,67 @@ function render_wordcamp_application_form( $countries, $prefilled_fields ) {
 
 				<div class="PDF_questionDivide" id="pd-divider-30"></div>
 
+				<div class="PDF_question" id="pd-question-37">
+					<div class="qNumber">
+						Q.37
+					</div>
+
+					<div class="qContent">
+						<div class="qText">
+							Are you planning to hold a KidsCamp?
+						</div>
+
+						<div class="PDF_QT400">
+							<ul>
+								<li>
+									<input type="radio" name="q_kidscamp"
+										value="Yes, before session day(s)" id="q_kidscamp_1" />
+
+									<label for="q_kidscamp_1">Yes, before session day(s)</label>
+								</li>
+								<li>
+									<input type="radio" name="q_kidscamp"
+										value="Yes, during session day(s)" id="q_kidscamp_2" />
+
+									<label for="q_kidscamp_2">Yes, during session day(s)</label>
+								</li>
+								<li>
+									<input type="radio" name="q_kidscamp"
+										value="Yes, after session day(s)" id="q_kidscamp_3" />
+
+									<label for="q_kidscamp_3">Yes, after session day(s)</label>
+								</li>
+								<li>
+									<input type="radio" name="q_kidscamp"
+										value="No" id="q_kidscamp_4" />
+
+									<label for="q_kidscamp_4">No</label>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<div class="PDF_questionDivide" id="pd-divider-37"></div>
+
+				<div class="PDF_question" id="pd-question-38">
+					<div class="qNumber">
+						Q.38
+					</div>
+
+					<div class="qContent">
+						<div class="qText">
+							Who will be the lead organizer for KidsCamp?
+						</div>
+
+						<div class="PDF_QT100">
+							<input maxlength="500" name="q_kidscamp_lead_organizer" class="large" type="text" title="Who will be the lead organizer for KidsCamp?" />
+						</div>
+					</div>
+				</div>
+
+				<div class="PDF_questionDivide" id="pd-divider-38"></div>
+
 				<div class="PDF_question" id="pd-question-32">
 					<div class="qNumber">
 						Q.32

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -153,6 +153,8 @@ class WordCamp_Application extends Event_Application {
 			'q_4236565_slack_username'                   => '',
 			'where_find_online'                          => '',
 			'q_1079098_anything_else'                    => '',
+			'q_kidscamp'                                 => '',
+			'q_kidscamp_lead_organizer'                  => '',
 
 			// Bonus.
 			'q_1079112_best_describes_you'               => '',
@@ -238,6 +240,10 @@ class WordCamp_Application extends Event_Application {
 				$data['q_1079060_country'] ? $countries[ $data['q_1079060_country'] ]['name'] : ''
 			)
 		);
+
+		if ( false !== strpos( $data['q_kidscamp'], 'Yes' ) ) {
+			add_post_meta( $post_id, 'KidsCamp', true );
+		}
 
 		if ( 'It would be an online event' === $data['q_in_person_online'] ) {
 			add_post_meta( $post_id, 'Virtual event only', true );

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -94,6 +94,14 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'advanced'
 			);
 
+			add_meta_box(
+				'wcpt_kidscamp_info',
+				__( 'KidsCamp Information', 'wordcamporg' ),
+				'wcpt_kidscamp_metabox',
+				WCPT_POST_TYPE_ID,
+				'advanced'
+			);
+
 		}
 
 		/**
@@ -403,6 +411,20 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					);
 					break;
 
+				case 'kidscamp':
+					// These fields names need to be unique, hence the 'Contributor' prefix on each one.
+					$retval = array(
+						'KidsCamp'                    => 'checkbox',
+						'KidsCamp Lead Organizer'     => 'text',
+						'KidsCamp Date (YYYY-mm-dd)'  => 'date',
+						'KidsCamp Venue Name'         => 'text',
+						'KidsCamp Venue Address'      => 'textarea',
+						'KidsCamp Venue Capacity'     => 'text',
+						'KidsCamp Venue Website URL'  => 'text',
+						'KidsCamp Venue Contact Info' => 'textarea',
+					);
+					break;
+
 				case 'wordcamp':
 					$retval = array(
 						'Start Date (YYYY-mm-dd)'           => 'date',
@@ -498,6 +520,15 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Contributor Venue Capacity'       => 'text',
 						'Contributor Venue Website URL'    => 'text',
 						'Contributor Venue Contact Info'   => 'textarea',
+
+						'KidsCamp'                         => 'checkbox',
+						'KidsCamp Lead Organizer'          => 'text',
+						'KidsCamp Date (YYYY-mm-dd)'       => 'date',
+						'KidsCamp Venue Name'              => 'text',
+						'KidsCamp Venue Address'           => 'textarea',
+						'KidsCamp Venue Capacity'          => 'text',
+						'KidsCamp Venue Website URL'       => 'text',
+						'KidsCamp Venue Contact Info'      => 'textarea',
 					);
 					break;
 
@@ -1176,6 +1207,14 @@ function wcpt_venue_metabox( $post, $metabox ) {
  */
 function wcpt_contributor_metabox( $post, $metabox ) {
 	$meta_keys = $GLOBALS['wordcamp_admin']->meta_keys( 'contributor' );
+	wcpt_metabox( $meta_keys, $metabox['id'] );
+}
+
+/**
+ * Displays KidsCamp metabox
+ */
+function wcpt_kidscamp_metabox( $post, $metabox ) {
+	$meta_keys = $GLOBALS['wordcamp_admin']->meta_keys( 'kidscamp' );
 	wcpt_metabox( $meta_keys, $metabox['id'] );
 }
 


### PR DESCRIPTION
WordCamp teams organise standalone KidsCamps or include it in their main event. To help know WordCamp applicants plans during the vetting, add questions about KidsCamp to the WordCamp organizer application. KidsCamp lead organiser question will be visible only when a yes answer is selected in the previous question.

Also add KidsCamp information fields to the WordCamp tracker, in order to help deputies and especially Youth Events working groups work.

Fixes #275
See #720 which is similar to this

Props @sunsand187

### Screenshots

<img width="703" alt="image" src="https://user-images.githubusercontent.com/415544/148630209-d7506795-089d-42c6-9f03-3f11d896ba31.png">

<img width="728" alt="image" src="https://user-images.githubusercontent.com/415544/148630219-8f861653-929a-4d0b-bb10-7986db1c0146.png">

### How to test the changes in this Pull Request:

1. Go to WordCamp organiser application page and start filling out the form
2. Select a yes answer to the question "Are you planning to hold a KidsCamp?"
3. Submit application
4. Go to WordCamp tracker to see the application, KidsCamp should be active and information fields visible
