### PR TITLE
Improve UX for disabled application popup

### DIFF
--- a/public_html/wp-content/plugins/wcpt/css/applications/common.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/common.css
@@ -54,12 +54,14 @@
 
 .wcfd-disabled-form #wcorg-login-message a {
 	color: #fff;
+	text-decoration: underline;
 }
 
 .wcfd-disabled-form #wcorg-login-message a:hover,
 .wcfd-disabled-form #wcorg-login-message a:focus,
 .wcfd-disabled-form #wcorg-login-message a:active {
-	color: #fff;
+	color: #eae7e7;
+	text-decoration: none;
 }
 
 .wcfd-overlay {


### PR DESCRIPTION
Add underline and slight hover effect to application disabled popup links.

Fixes #561

Props @CdrMarks 

### Screenshots

See before screenshot of the mentioned issue.

After screenshot

<img width="783" alt="image" src="https://user-images.githubusercontent.com/415544/148630462-cba9e0d2-60ee-4872-ace5-3331ab223700.png">

### How to test the changes in this Pull Request:

1. Launch private window in browser in order to be logged out
2. Navigate to WordCamp organiser application form
