### PR TITLE
Merge https://meta.trac.wordpress.org/changeset/11498 to fix Meetup authentication

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
+++ b/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
@@ -1,0 +1,10 @@
+<?php
+
+if ( empty( $_GET['code'] ) || empty( $_GET['state'] ) || 'meetup-oauth' !== $_GET['state'] ) {
+	return;
+}
+
+add_action( 'admin_init', function () {
+	// Store the new meetup oauth tokens.
+	( new WordCamp\Utilities\Meetup_OAuth2_Client() )->get_oauth_token();
+} );

--- a/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
+++ b/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
@@ -4,7 +4,10 @@ if ( empty( $_GET['code'] ) || empty( $_GET['state'] ) || 'meetup-oauth' !== $_G
 	return;
 }
 
-add_action( 'admin_init', function () {
-	// Store the new meetup oauth tokens.
-	( new WordCamp\Utilities\Meetup_OAuth2_Client() )->get_oauth_token();
-} );
+add_action(
+	'admin_init',
+	function () {
+		// Store the new meetup oauth tokens.
+		( new WordCamp\Utilities\Meetup_OAuth2_Client() )->get_oauth_token();
+	}
+);


### PR DESCRIPTION
See #697

Meetup.com removed the authentication handler we were using, which allowed for server-to-server authentication without a human present.

The new handler requires a human to process the authentication, which is uglier than it should be, as the client was built with the expectation of being run either in a CLI environment, or as part of another process.

This hacky PR fixes the auth to the point it works, but it's not ideal in any shape or form.

> During the Meetup.com REST API > GraphQL migration, part of the authentication layer was deactivated, switch authentication methods.
>
> This commit is very not-preferential-approach, but works, which is better than the code in production :)
>
> A human is required to go through the oAuth flow, rather than letting the code perform the login, which is why this is somewhat ugly.
