### PR TITLE
Camptix: Remove legacy lazy-loading for attendee avatars

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -120,18 +120,6 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 	 * Callback for the [camptix_attendees] shortcode.
 	 */
 	public function shortcode_attendees( $attr ) {
-		// Required scripts.
-		wp_enqueue_script( 'wp-util' ); // For wp.template().
-		if ( wp_script_is( 'jquery.spin', 'registered' ) ) {
-			wp_enqueue_script( 'jquery.spin' ); // Enqueue Jetpack's spinner script if available.
-		}
-		wp_enqueue_script( 'camptix' );
-
-		// Only print the JS template once.
-		if ( ! has_action( 'wp_print_footer_scripts', array( $this, 'avatar_js_template' ) ) ) {
-			add_action( 'wp_print_footer_scripts', array( $this, 'avatar_js_template' ) );
-		}
-
 		$attr = $this->sanitize_attendees_atts( $attr );
 
 		return $this->get_attendees_shortcode_content( $attr );
@@ -172,9 +160,9 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 
 		$cache_key = $this->generate_attendees_cache_key( $attr );
 
-		// Cache duration. Day for active sites, month for archived sites.
+		// Cache duration. 3 hours for active sites, day for archived sites.
 		$camptix_options = $camptix->get_options();
-		$cache_time      = ( $camptix_options['archived'] ) ? MONTH_IN_SECONDS : DAY_IN_SECONDS;
+		$cache_time      = ( $camptix_options['archived'] ) ? DAY_IN_SECONDS : HOUR_IN_SECONDS * 3;
 
 		// Timestamp for last change in Camptix purchases/profile edits.
 		$last_modified = $camptix->get_stats( 'last_modified' );
@@ -321,8 +309,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 						$first = get_post_meta( $attendee_id, 'tix_first_name', true );
 						$last  = get_post_meta( $attendee_id, 'tix_last_name', true );
 
-						// Avatar placeholder.
-						echo $this->get_avatar_placeholder( get_post_meta( $attendee_id, 'tix_email', true ) ); // phpcs:ignore
+						echo get_avatar( get_post_meta( $attendee_id, 'tix_email', true ) ); // phpcs:ignore
 						?>
 
 						<div class="tix-field tix-attendee-name">
@@ -378,52 +365,6 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 		wp_reset_postdata();
 
 		return ob_get_clean();
-	}
-
-	/**
-	 * Generate an avatar placeholder element with a data attribute that contains
-	 * the Gravatar hash so the real avatar can be loaded asynchronously.
-	 *
-	 * @param string $id_or_email
-	 *
-	 * @return string
-	 */
-	protected function get_avatar_placeholder( $id_or_email ) {
-		// @todo Allow customization of avatar and placeholder size
-		$size = 96;
-
-		return sprintf(
-			'<div
-                class="avatar avatar-placeholder"
-                data-url="%s"
-                data-url2x="%s"
-                data-size="%s"
-                data-alt="%s"
-                data-appear-top-offset="500"
-                ></div>',
-			get_avatar_url( $id_or_email ),
-			get_avatar_url( $id_or_email, array( 'size' => $size * 2 ) ),
-			$size,
-			''
-		);
-	}
-
-	/**
-	 * An Underscore.js template for the attendee avatar.
-	 */
-	public function avatar_js_template() {
-		?>
-		<script type="text/html" id="tmpl-tix-attendee-avatar">
-			<img
-					alt="{{ data.alt }}"
-					src="{{ data.url }}"
-					srcset="{{ data.url2x }} 2x"
-					class="avatar avatar-{{ data.size }} photo"
-					height="{{ data.size }}"
-					width="{{ data.size }}"
-			>
-		</script>
-		<?php
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -134,7 +134,10 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 	 * @return string     The cache key
 	 */
 	protected function generate_attendees_cache_key( $attr ) {
-		return 'camptix-attendees-' . md5( maybe_serialize( $attr ) );
+		// Increment this when the markup changes or there's some other reason to invalidate the cache on every site.
+		$cache_buster = 1;
+
+		return 'camptix-attendees-' . $cache_buster . '-' . md5( maybe_serialize( $attr ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.js
+++ b/public_html/wp-content/plugins/camptix/camptix.js
@@ -5,18 +5,6 @@
  */
 var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*"+encodeURIComponent(e).replace(/[\-\.\+\*]/g,"\\$&")+"\\s*\\=\\s*([^;]*).*$)|^.*$"),"$1"))||null},setItem:function(e,o,n,t,c,r){if(!e||/^(?:expires|max\-age|path|domain|secure)$/i.test(e))return!1;var s="";if(n)switch(n.constructor){case Number:s=1/0===n?"; expires=Fri, 31 Dec 9999 23:59:59 GMT":"; max-age="+n;break;case String:s="; expires="+n;break;case Date:s="; expires="+n.toUTCString()}return document.cookie=encodeURIComponent(e)+"="+encodeURIComponent(o)+s+(c?"; domain="+c:"")+(t?"; path="+t:"")+(r?"; secure":""),!0},removeItem:function(e,o,n){return e&&this.hasItem(e)?(document.cookie=encodeURIComponent(e)+"=; expires=Thu, 01 Jan 1970 00:00:00 GMT"+(n?"; domain="+n:"")+(o?"; path="+o:""),!0):!1},hasItem:function(e){return new RegExp("(?:^|;\\s*)"+encodeURIComponent(e).replace(/[\-\.\+\*]/g,"\\$&")+"\\s*\\=").test(document.cookie)},keys:function(){for(var e=document.cookie.replace(/((?:^|\s*;)[^\=]+)(?=;|$)|^\s*|\s*(?:\=[^;]*)?(?:\1|$)/g,"").split(/\s*(?:\=[^;]*)?;\s*/),o=0;o<e.length;o++)e[o]=decodeURIComponent(e[o]);return e}};
 
-/*
- * jQuery appear plugin
- *
- * Copyright (c) 2012 Andrey Sidorov
- * licensed under MIT license.
- *
- * https://github.com/morr/jquery.appear/
- *
- * Version: 0.3.6
- */
-!function(e){function r(r){return e(r).filter(function(){return e(this).is(":appeared")})}function t(){a=!1;for(var e=0,t=i.length;t>e;e++){var n=r(i[e]);if(n.trigger("appear",[n]),p[e]){var o=p[e].not(n);o.trigger("disappear",[o])}p[e]=n}}function n(e){i.push(e),p.push()}var i=[],o=!1,a=!1,f={interval:250,force_process:!1},u=e(window),p=[];e.expr[":"].appeared=function(r){var t=e(r);if(!t.is(":visible"))return!1;var n=u.scrollLeft(),i=u.scrollTop(),o=t.offset(),a=o.left,f=o.top;return f+t.height()<i||f-(t.data("appear-top-offset")||0)>i+u.height()||a+t.width()<n||a-(t.data("appear-left-offset")||0)>n+u.width()?!1:!0},e.fn.extend({appear:function(r){var i=e.extend({},f,r||{}),u=this.selector||this;if(!o){var p=function(){a||(a=!0,setTimeout(t,i.interval))};e(window).scroll(p).resize(p),o=!0}return i.force_process&&setTimeout(t,i.interval),n(u),e(u)}}),e.extend({force_appear:function(){return o?(t(),!0):!1}})}(function(){return"undefined"!=typeof module?require("jquery"):jQuery}());
-
 /**
  * CampTix Javascript
  *
@@ -166,68 +154,6 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 			} );
 		}
 	}
-
-	/**
-	 * Lazy load camptix_attendees avatars
-	 *
-	 * @uses jQuery appear plugin
-	 * @uses Jetpack's jquery.spin
-	 */
-	var lazyLoad = {
-		cache: {
-			$document:  $( document ),
-			$attendees: $( '.tix-attendee-list' )
-		},
-
-        /**
-		 * Initialize placeholders to be lazy-loaded into avatars.
-         */
-		init: function() {
-			// Dependencies
-			if ( lazyLoad.cache.$attendees.length < 1 ||
-				'undefined' === typeof $.fn.appear ||
-				'undefined' === typeof wp ) {
-				return;
-			}
-
-			var spinner = 'undefined' !== typeof $.fn.spin;
-
-			lazyLoad.avatarTemplate = wp.template( 'tix-attendee-avatar' );
-
-			lazyLoad.cache.$placeholders = lazyLoad.cache.$attendees.find( '.avatar-placeholder' );
-
-			lazyLoad.cache.$placeholders.appear({ interval: 500 });
-
-			lazyLoad.cache.$placeholders.one( 'appear', function(event) {
-				var $placeholder = $( event.target );
-
-				$placeholder.each(function() {
-					if ( spinner ) {
-						$( this ).spin( 'medium' );
-					}
-					lazyLoad.convertPlaceholder( $( this ) );
-				});
-			});
-
-			// Trigger appear event for the placeholders in the initial viewport
-			$.force_appear();
-		},
-
-        /**
-		 * Replace a placeholder with an instance of the avatar template.
-		 *
-         * @param {Object} $placeholder
-         */
-		convertPlaceholder: function( $placeholder ) {
-			var content = lazyLoad.avatarTemplate( $placeholder.data() );
-
-			if ( content ) {
-				$placeholder.after( content ).remove();
-			}
-		}
-	};
-
-	$( document ).ready( lazyLoad.init )
 
 }(jQuery));
 


### PR DESCRIPTION
Browser-based lazy loading for images has been built into WP since 5.4. We no longer need to use JavaScript and various jQuery scripts to accomplish this for the attendee avatars output by the Attendees shortcode.

This removes all the scripts and markup for our old homegrown lazy-loading scheme and just outputs the avatars via WP's `get_avatar` function. Core takes care of the rest.

This also changes the expiration for the cached attendee list markup to refresh every 3 hours instead of 24, as there have been a few complaints about that in the past when people wanted to see themselves show up on the attendees page.

(This refs #374, but only solves one of the bullet points therein.)

### How to test the changes in this Pull Request:

1. Upload the changed files to your wporg sandbox and then visit the attendees page on any WordCamp site.
2. You may need to also modify the `$force_refresh` value in the `get_attendees_shortcode_content` method to be `true` so that the new markup will load instead of the old markup that has avatar placeholders.
