### PR TITLE
Camptix: Load JS in footer.

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -478,7 +478,8 @@ class CampTix_Plugin {
 			'camptix',
 			plugins_url( 'camptix.js', __FILE__ ),
 			array( 'jquery' ),
-			filemtime( __DIR__ . '/camptix.js' )
+			filemtime( __DIR__ . '/camptix.js' ),
+			true
 		);
 
 		wp_localize_script( 'camptix', 'camptix_l10n', array(


### PR DESCRIPTION
I noticed while testing #730 that the issue on WordCamp Geneve's site was only a problem on sites using the Twenty Twenty-Two theme. I think this has to do with how block themes render content, the code that enqueued `camptix` was run earlier. So on classic themes, the camptix.js file was punted to the footer scripts queue because the header scripts were already output, but in a block theme, the script was enqueued in time to make the header queue.

This file is intended to be [output in the footer](https://github.com/WordPress/wordcamp.org/blob/f92cff647c8864fca3ca2e4159ab108b6d37f510/public_html/wp-content/plugins/camptix/camptix.js#L23), so I've updated the script registration to ensure that.

### How to test the changes in this Pull Request:

1. Load the tickets page on a WordCamp using a classic theme
2. View source, and search for `camptix.js`, it should be near the bottom of the page
3. Load the tickets page on a WordCamp using Twenty Twenty Two
4. View source, and search for `camptix.js`, it should be near the bottom of the page
