### PR TITLE
Automate updating of sponsors from Multi Event Sponsors

### DIFF
--- a/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
+++ b/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
@@ -35,7 +35,7 @@ function disable_editors_by_post_type( $editors, $post_type ) {
 		'wcb_session',
 		'wcb_speaker',
 		// 'wcb_sponsor',
-		// 'mes'
+		'mes', // Metaboxes not converted yet, but has other custom Gutenberg UI.
 		'wcb_organizer',
 	);
 
@@ -50,7 +50,7 @@ function disable_editors_by_post_type( $editors, $post_type ) {
 
 	// Currently not necessary to set on these post types, they don't support gutenberg. This is either because
 	// they don't support the `editor`, or they have `public`/`show_in_rest` set to false:
-	// WCPT_MEETUP_SLUG, \MES_Sponsor::POST_TYPE_SLUG, Payment CPTs, CampTix CPTs.
+	// WCPT_MEETUP_SLUG, Payment CPTs, CampTix CPTs.
 
 	if ( in_array( $post_type, $gutenberg_only ) ) {
 		$editors['classic_editor'] = false;

--- a/public_html/wp-content/plugins/multi-event-sponsors/css/multi-event-sponsor.css
+++ b/public_html/wp-content/plugins/multi-event-sponsors/css/multi-event-sponsor.css
@@ -1,0 +1,20 @@
+.push-to-active-camps {
+	padding: 16px; /* Mimic what Gutenberg applies to panels inside sidebars. */
+}
+
+.interface-complementary-area .push-to-active-camps p:not(:first-of-type) {
+	margin-top: 1em;
+}
+
+.push-to-active-camps .components-spinner {
+	display: block;
+	margin: 0 auto;
+}
+
+.push-to-active-camps .notice {
+	margin: 1em 0;
+}
+
+.push-to-active-camps .disclaimer {
+	font-style: italic;
+}

--- a/public_html/wp-content/plugins/multi-event-sponsors/javascript/index.js
+++ b/public_html/wp-content/plugins/multi-event-sponsors/javascript/index.js
@@ -56,7 +56,7 @@ function PushToActiveCamps( { adminUrl } ) {
 
 			<p className="disclaimer">
 				{ createInterpolateElement(
-					__( 'This wont push to sites that were created before this post; for that please <a>edit their WordCamp post</a> and <code>Push new sponsors to site</code>.', 'wordcamporg' ),
+					__( "This won't push to sites that were created before this post; for that please <a>edit their WordCamp post</a> and <code>Push new sponsors to site</code>.", 'wordcamporg' ),
 					{
 						a: <a href={ adminUrl + 'edit.php?post_type=wordcamp' } >#21441-gutenberg</a>,
 						code: <code />,

--- a/public_html/wp-content/plugins/multi-event-sponsors/javascript/index.js
+++ b/public_html/wp-content/plugins/multi-event-sponsors/javascript/index.js
@@ -1,0 +1,177 @@
+/* global MultiEventSponsor */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Dashicon, Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { PluginSidebar } from '@wordpress/edit-post';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { decodeEntities } from '@wordpress/html-entities';
+
+const { stripTags } = wp.sanitize;
+
+/*
+ * Render the main view for the sidebar.
+ */
+function PushToActiveCamps( { adminUrl } ) {
+	const [ loading, setLoading ] = useState( false );
+	const [ result, setResult ] = useState( null );
+
+	const sourcePost = useSelect(
+		( select ) => {
+			// This doesn't update until the `Update` button is saved, but that's good enough for our uses.
+			return select( 'core/editor' ).getCurrentPost();
+		}
+	);
+
+	const isDirty = useSelect(
+		( select ) => {
+			return select( 'core/editor' ).isEditedPostDirty();
+		}
+	);
+
+	if ( isDirty && result !== null ) {
+		// Make sure the UI doesn't show results from a previous push once the current changes are saved.
+		setResult( null );
+	}
+
+	return (
+		<PluginSidebar
+			name="push-to-active-camps"
+			className="push-to-active-camps"
+			title="Push to Active Camps"
+			icon={ <Dashicon icon="heart" /> }
+		>
+			<p>
+				{ sprintf(
+					// translators: Title of the post
+					__( 'This will copy the title/content/etc of this post to all of its corresponding %s posts on active WordCamp sites (except regional camps).', 'wordcamporg' ),
+					decodeEntities( stripTags( sourcePost.title ) )
+				) }
+			</p>
+
+			<p className="disclaimer">
+				{ createInterpolateElement(
+					__( 'This wont push to sites that were created before this post; for that please <a>edit their WordCamp post</a> and <code>Push new sponsors to site</code>.', 'wordcamporg' ),
+					{
+						a: <a href={ adminUrl + 'edit.php?post_type=wordcamp' } >#21441-gutenberg</a>,
+						code: <code />,
+					}
+				) }
+			</p>
+
+			{ loading &&
+				<Spinner />
+			}
+
+			{ isDirty &&
+				<div className={ `notice notice-error inline` }>
+					<p>
+						{ __( 'Please save or discard the current changes before pushing the post to other sites.', 'wordcamporg' ) }
+					</p>
+				</div>
+			}
+
+			{ ! loading && ! isDirty &&
+				<PushButton
+					sponsorId={ sourcePost.id }
+					setLoading={ setLoading }
+					setResult={ setResult }
+				/>
+			}
+
+			{ ! loading && ! isDirty && null !== result &&
+				<Result result={ result } />
+			}
+		</PluginSidebar>
+	);
+}
+
+/*
+ * Render the <button>, and make the API request when it's clicked.
+ */
+function PushButton( { sponsorId, setLoading, setResult } ) {
+	async function postRequest() {
+		setLoading( true );
+
+		let result = null;
+
+		const fetchParams = {
+			path: '/multi-event-sponsors/v1/push-to-active-camps',
+			method: 'POST',
+			data: {
+				sponsorId,
+			},
+		};
+
+		try {
+			result = await apiFetch( fetchParams );
+		} catch ( error ) {
+			result = {
+				success: false,
+				error: error.message ?? __( 'An unknown error occurred, please try again or ask the maintenance developer for help.', 'wordcamporg' ),
+			};
+		} finally {
+			setResult( result );
+			setLoading( false );
+		}
+	}
+
+	return (
+		<Button isSecondary onClick={ postRequest }>
+			{ __( 'Push to Active WordCamps', 'wordcamporg' ) }
+		</Button>
+	);
+}
+
+/*
+ * Render the result of a push.
+ */
+function Result( { result } ) {
+	const { success, edited_posts, error } = result;
+
+	return (
+		<div id="push-to-active-camps__result">
+			<div className={ `notice inline notice-${ success ? 'success' : 'error' }` }>
+				<p>
+					{ success
+						? _x( 'Success!', 'admin notice', 'wordcamporg' )
+						: _x( 'Error: ', 'admin notice', 'wordcamporg' ) + error
+					}
+				</p>
+			</div>
+
+			{ success && edited_posts.length > 0 &&
+				<div className="notice notice-warning">
+					<p>
+						{ __( 'These sites have already edited the post, so they were skipped to avoid overwriting their changes.', 'wordcamporg' ) }
+					</p>
+
+					<ul className="ul-disc">
+						{ edited_posts.map( ( { edit_url, site_name } ) => {
+							return (
+								<li key={ edit_url }>
+									<a href={ edit_url }>
+										{ site_name }
+									</a>
+								</li>
+							);
+						} ) }
+					</ul>
+				</div>
+			}
+		</div>
+	);
+}
+
+registerPlugin( 'push-to-active-camps', {
+	render: () => {
+		return (
+			<PushToActiveCamps adminUrl={ MultiEventSponsor.admin_url } />
+		);
+	} }
+);

--- a/public_html/wp-content/plugins/multi-event-sponsors/javascript/index.js
+++ b/public_html/wp-content/plugins/multi-event-sponsors/javascript/index.js
@@ -43,7 +43,7 @@ function PushToActiveCamps( { adminUrl } ) {
 		<PluginSidebar
 			name="push-to-active-camps"
 			className="push-to-active-camps"
-			title="Push to Active Camps"
+			title={ __( 'Push to Active Camps', 'wordcamporg' ) }
 			icon={ <Dashicon icon="heart" /> }
 		>
 			<p>

--- a/public_html/wp-content/plugins/multi-event-sponsors/package.json
+++ b/public_html/wp-content/plugins/multi-event-sponsors/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "multi-event-sponsors",
+	"version": "0.1.0",
+	"license": "GPL-2.0-or-later",
+	"eslintConfig": {
+		"extends": "../../../../.eslintrc.js"
+	},
+	"scripts": {
+		"build": "wp-scripts build javascript/index.js --output-path=build",
+		"start": "wp-scripts start javascript/index.js --output-path=build --hot",
+		"lint:js": "wp-scripts lint-js",
+		"packages-update": "wp-scripts packages-update"
+	},
+	"devDependencies": {
+		"@wordpress/icons": "^7.0.1",
+		"@wordpress/scripts": "^22.0.1"
+	}
+}

--- a/public_html/wp-content/plugins/multi-event-sponsors/views/template-region-dropdown.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/views/template-region-dropdown.php
@@ -23,6 +23,14 @@
 <?php if ( $site_id && ! $protected ) : ?>
 	<label>
 		<input type="checkbox" name="<?php echo esc_attr( $cb_push_name ); ?>" value="1" />
-		Push sponsors to site
+		Push new sponsors to site
 	</label>
+
+	<br />
+	<em>That won't push updates from existing sponsors. For that, please <a href="<?php echo esc_url( admin_url( 'edit.php?post_type=mes' ) ); ?>">Edit a sponsor</a> and click the
+	<span class="dashicons dashicons-heart">
+		<span class="screen-reader-text">heart</span>
+	</span>
+	icon in the toolbar.</em>
+
 <?php endif;

--- a/public_html/wp-content/plugins/multi-event-sponsors/webpack.config.js
+++ b/public_html/wp-content/plugins/multi-event-sponsors/webpack.config.js
@@ -1,0 +1,33 @@
+const fileSystem = require( 'fs' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const rootDirectory = process.cwd().replace( 'public_html/wp-content/plugins/multi-event-sponsors', '' );
+
+module.exports = {
+	...defaultConfig,
+
+	devServer: {
+		...defaultConfig.devServer,
+
+		static: {
+			directory: rootDirectory + 'public_html/',
+		},
+
+		// This may need to change if we ever use this on subdomains.
+		host: 'central.wordcamp.test',
+
+		// This is needed to work outside of wp-env, but may need to be expanded to account for more environments.
+		//
+		// `all` can't be used for security, though.
+		// See https://github.com/WordPress/gutenberg/pull/28273#issuecomment-1036439982
+		// See https://github.com/webpack/webpack-dev-server/issues/887#issuecomment-302801375
+		allowedHosts: [ 'localhost', '127.0.0.1', 'central.wordcamp.test' ],
+
+		server: {
+			type: 'https',
+			options: {
+				key: fileSystem.readFileSync( rootDirectory + '.docker/wordcamp.test.key.pem' ),
+				cert: fileSystem.readFileSync( rootDirectory + '.docker/wordcamp.test.pem' ),
+			},
+		},
+	},
+};

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -814,7 +814,7 @@ class WordCamp_New_Site {
 	 *
 	 * @return array
 	 */
-	protected function get_stub_me_sponsors_meta( $assigned_sponsor ) {
+	public static function get_stub_me_sponsors_meta( $assigned_sponsor ) {
 		$sponsor_meta    = array( '_mes_id' => $assigned_sponsor->ID );
 		$meta_field_keys = array(
 			'company_name', 'website', 'first_name', 'last_name', 'email_address', 'phone_number',


### PR DESCRIPTION
Fixes #736 

This adds a heart dashicon to Gutenbergs toolbar on Multi Event Sponsor pages (because that's the icon we use to represent sponsors). When you click it, a sidebar opens. From there you can click a button to push the current MES post out to active camps. 

That triggers an API request, which switches to each camp and updates the post if it hasn't been edited by the organizers.

The sidebar is not a very good UX for this, but it seems like the least-bad option, given [the lack of a proper slot in Gutenberg](https://github.com/WordPress/gutenberg/issues/16988#issuecomment-1055738184).

