### PR TITLE
Blocks: Add a "Speaker Sessions" block for use in Query Loop

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -37,6 +37,7 @@ function load_includes() {
 	require_once $blocks_dir . 'organizers/controller.php';
 	require_once $blocks_dir . 'schedule/controller.php';
 	require_once $blocks_dir . 'sessions/controller.php';
+	require_once $blocks_dir . 'speaker-sessions/controller.php';
 	require_once $blocks_dir . 'speakers/controller.php';
 	require_once $blocks_dir . 'sponsors/controller.php';
 	require_once $blocks_dir . 'live-schedule/controller.php';

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
@@ -6,6 +6,7 @@ import * as liveSchedule from './live-schedule';
 import * as organizers from './organizers';
 import * as schedule from './schedule';
 import * as sessions from './sessions';
+import * as speakerSessions from './speaker-sessions';
 import * as speakers from './speakers';
 import * as sponsors from './sponsors';
 
@@ -15,6 +16,7 @@ export const BLOCKS = [
 	organizers,
 	schedule,
 	sessions,
+	speakerSessions,
 	speakers,
 	sponsors,
 ];

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
@@ -17,14 +17,15 @@ import { arrayTokenReplace, tokenSplit } from '../../i18n';
  * Fetch the details for a session as a human-readable string, in array-parts from `arrayTokenReplace`. This can be
  * passed to any react component and renders as text in the element on the browser.
  *
- * @param {Object} session
+ * @param {Object}  session
+ * @param {boolean} allTracks
  * @return {Array}
  */
-export function getSessionDetails( session ) {
-	const terms = get( session, '_embedded[\'wp:term\']', [] ).flat();
+export function getSessionDetails( session, allTracks = false ) {
+	const terms = get( session, "_embedded['wp:term']", [] ).flat();
 
 	if ( session.session_track.length ) {
-		const [ firstTrack ] = terms.filter( ( term ) => 'wcb_track' === term.taxonomy );
+		const tracks = terms.filter( ( term ) => 'wcb_track' === term.taxonomy );
 
 		return arrayTokenReplace(
 			/* translators: 1: A date; 2: A time; 3: A location; */
@@ -32,7 +33,7 @@ export function getSessionDetails( session ) {
 			[
 				session.session_date_time.date,
 				session.session_date_time.time,
-				firstTrack.name.trim(),
+				allTracks ? tracks.map( ( { name } ) => name.trim() ).join( ', ' ) : tracks[ 0 ].name.trim(),
 			]
 		);
 	}
@@ -40,10 +41,7 @@ export function getSessionDetails( session ) {
 	return arrayTokenReplace(
 		/* translators: 1: A date; 2: A time; */
 		tokenSplit( __( '%1$s at %2$s', 'wordcamporg' ) ),
-		[
-			session.session_date_time.date,
-			session.session_date_time.time,
-		]
+		[ session.session_date_time.date, session.session_date_time.time ]
 	);
 }
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
@@ -46,3 +46,21 @@ export function getSessionDetails( session ) {
 		]
 	);
 }
+
+/**
+ * Sort callback for ordering sessions by time, ascending (past -> future).
+ *
+ * @param {Object} sessionA
+ * @param {Object} sessionB
+ * @return {number}
+ */
+export function sortSessionByTime( sessionA, sessionB ) {
+	// If no meta values found, keep the same sort order.
+	if ( ! sessionA.meta?._wcpt_session_time || ! sessionB.meta?._wcpt_session_time ) {
+		return 0;
+	}
+	if ( sessionA.meta._wcpt_session_time < sessionB.meta._wcpt_session_time ) {
+		return -1;
+	}
+	return 1;
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/block.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/block.json
@@ -1,0 +1,29 @@
+{
+	"apiVersion": 2,
+	"name": "wordcamp/speaker-sessions",
+	"title": "Speaker Sessions",
+	"category": "wordcamp",
+	"description": "Display the sessions attached to the current speaker.",
+	"textdomain": "wordcamporg",
+	"usesContext": [ "postId", "postType", "queryId" ],
+	"attributes": {
+		"hasSessionDetails": {
+			"type": "boolean",
+			"default": false
+		},
+		"isLink": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"supports": {
+		"align": [ "left", "right", "center" ],
+		"color": {
+			"text": true,
+			"background": true
+		},
+		"html": false
+	},
+	"editorScript": "wordcamp-blocks",
+	"style": "wordcamp-blocks"
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -54,14 +54,23 @@ function render( $attributes, $content, $block ) {
 
 		if ( isset( $attributes['hasSessionDetails'] ) && $attributes['hasSessionDetails'] ) {
 			$tracks = get_the_terms( $session, 'wcb_track' );
-			$session_li .= '<p class="wordcamp-speakers__session-info">';
+			$session_li .= '<p class="wordcamp-speaker-sessions__session-info">';
 			if ( ! is_wp_error( $tracks ) && ! empty( $tracks ) ) {
 				$session_li .= sprintf(
 					/* translators: 1: session date; 2: session time; 3: session track; */
 					esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
 					esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
 					esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
-					esc_html( implode( ', ', wp_list_pluck( $tracks, 'name' ) ) )
+					implode( ', ', array_map( // phpcs:ignore -- escaped below.
+						function ( $track ) {
+							return sprintf(
+								'<span class="wordcamp-speaker-sessions__track slug-%s">%s</span>',
+								esc_attr( $track->slug ),
+								esc_html( $track->name )
+							);
+						},
+						$tracks
+					) )
 				);
 			} else {
 				$session_li .= sprintf(

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -1,0 +1,95 @@
+<?php
+namespace WordCamp\Blocks\SpeakerSessions;
+
+use function WordCamp\Blocks\Speakers\get_speaker_sessions;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register block types and enqueue scripts.
+ *
+ * @return void
+ */
+function init() {
+	register_block_type_from_metadata(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+
+/**
+ * Renders the block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Returns the avatar for the current post.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_ID  = $block->context['postId'];
+	$sessions = get_speaker_sessions( array( $post_ID ) );
+
+	// Speaker has no sessions.
+	if ( ! isset( $sessions[ $post_ID ] ) || count( $sessions[ $post_ID ] ) < 1 ) {
+		return '';
+	}
+
+	$content = '';
+	foreach ( $sessions[ $post_ID ] as $session ) {
+		$session_li = '<li><p>';
+		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+			$session_li .= sprintf( '<a href="%1$s">%2$s</a>', get_the_permalink( $session->ID ), get_the_title( $session->ID ) );
+		} else {
+			$session_li .= get_the_title( $session->ID );
+		}
+		$session_li .= '</p>';
+
+		if ( isset( $attributes['hasSessionDetails'] ) && $attributes['hasSessionDetails'] ) {
+			$tracks = get_the_terms( $session, 'wcb_track' );
+			$session_li .= '<p class="wordcamp-speakers__session-info">';
+			if ( ! is_wp_error( $tracks ) && ! empty( $tracks ) ) {
+				$session_li .= sprintf(
+					/* translators: 1: session date; 2: session time; 3: session track; */
+					esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
+					esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
+					esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
+					esc_html( implode( ', ', wp_list_pluck( $tracks, 'name' ) ) )
+				);
+			} else {
+				$session_li .= sprintf(
+					/* translators: 1: session date; 2: session time; */
+					esc_html__( '%1$s at %2$s', 'wordcamporg' ),
+					esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
+					esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) )
+				);
+			}
+			$session_li .= '</p>';
+		}
+
+		$session_li .= '</li>';
+		$content .= $session_li;
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return "<ul $wrapper_attributes>$content</ul>";
+}
+/**
+ * Enable the speaker-sessions block.
+ *
+ * @param array $data
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['speaker-sessions'] = true;
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
@@ -57,7 +57,7 @@ export default function( { attributes, setAttributes, context: { postId } } ) {
 							) }
 						</p>
 						{ hasSessionDetails && (
-							<p className="wordcamp-speakers__session-info">{ getSessionDetails( session ) }</p>
+							<p className="wordcamp-speakers__session-info">{ getSessionDetails( session, true ) }</p>
 						) }
 					</li>
 				) ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getSessionDetails, sortSessionByTime } from '../sessions/utils';
+
+export default function( { attributes, setAttributes, context: { postId } } ) {
+	const { hasSessionDetails, isLink } = attributes;
+	const blockProps = useBlockProps();
+	const sessions = useSelect( ( select ) => {
+		const { getEntityRecords } = select( coreStore );
+		const _sessions =
+			getEntityRecords( 'postType', 'wcb_session', {
+				wc_meta_key: '_wcpt_speaker_id',
+				wc_meta_value: postId,
+				_embed: true,
+			} ) || [];
+
+		_sessions.sort( sortSessionByTime );
+
+		return _sessions;
+	}, [] );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wordcamporg' ) }>
+					<ToggleControl
+						label={ __( 'Show session details', 'wordcamporg' ) }
+						help={ __( 'Show the date, time, and track (if set).', 'wordcamporg' ) }
+						onChange={ () => setAttributes( { hasSessionDetails: ! hasSessionDetails } ) }
+						checked={ hasSessionDetails }
+					/>
+					<ToggleControl
+						label={ __( 'Link to session', 'wordcamporg' ) }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+						checked={ isLink }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<ul { ...blockProps }>
+				{ sessions.map( ( session ) => (
+					<li key={ session.id }>
+						<p>
+							{ isLink ? (
+								<a href={ session.link }>{ session.title.rendered }</a>
+							) : (
+								session.title.rendered
+							) }
+						</p>
+						{ hasSessionDetails && (
+							<p className="wordcamp-speakers__session-info">{ getSessionDetails( session ) }</p>
+						) }
+					</li>
+				) ) }
+			</ul>
+		</>
+	);
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
@@ -57,7 +57,7 @@ export default function( { attributes, setAttributes, context: { postId } } ) {
 							) }
 						</p>
 						{ hasSessionDetails && (
-							<p className="wordcamp-speakers__session-info">{ getSessionDetails( session, true ) }</p>
+							<p className="wordcamp-speaker-sessions__session-info">{ getSessionDetails( session, true ) }</p>
 						) }
 					</li>
 				) ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.scss
@@ -1,0 +1,5 @@
+.wp-block-wordcamp-speaker-sessions {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/index.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import './edit.scss';
+
+export const NAME = metadata.name;
+
+export const SETTINGS = {
+	...metadata,
+	icon: 'list-view',
+	edit: edit,
+};

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/controller.php
@@ -142,6 +142,7 @@ function get_speaker_sessions( array $speaker_ids ) {
 		'posts_per_page' => -1,
 		'meta_key'       => '_wcpt_session_time',
 		'orderby'        => 'meta_value_num',
+		'order'          => 'ASC',
 	);
 
 	$session_posts = get_posts( $session_args );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-list.js
@@ -21,6 +21,7 @@ import {
 } from '../../components';
 import { filterEntities } from '../../data';
 import { arrayTokenReplace, tokenSplit } from '../../i18n';
+import { sortSessionByTime } from '../sessions/utils';
 
 /**
  * Component for the section of each speaker post that displays information about relevant sessions.
@@ -36,6 +37,8 @@ function SpeakerSessions( { speaker, tracks } ) {
 	if ( ! sessions.length ) {
 		return null;
 	}
+
+	sessions.sort( sortSessionByTime );
 
 	return (
 		<div className="wordcamp-speakers__sessions">


### PR DESCRIPTION
When using the Query Loop block, it's possible to show a list of speakers, with name, bio, etc - but there was no block for listing the speaker's session(s). This adds a new block "Speaker Sessions" which can be used in the context of a speaker Query Loop to list out the session, time, & tracks. It's intended to mirror the function of the "Session Information" toggle on the Speakers block.

See #695 for a previous Query Loop helper block.

### Screenshots

Block settings:
<img width="288" alt="inspector" src="https://user-images.githubusercontent.com/541093/160207426-3687a926-1588-49a6-b155-65db803b8993.png">

No link, no details:
<img width="498" alt="block-none" src="https://user-images.githubusercontent.com/541093/160207639-934d8a4f-efd1-4f13-b453-450a1cf8131d.png">

With link & details:
<img width="501" alt="block" src="https://user-images.githubusercontent.com/541093/160207421-972d780b-5039-4f3f-a6d9-be86f6d8338a.png">

In use in a Query Loop:

| Editor | Frontend |
|----|----|
| <img width="881" alt="editor" src="https://user-images.githubusercontent.com/541093/160207423-2c859956-8431-4503-80b8-b30bf836d796.png"> | <img width="1019" alt="frontend" src="https://user-images.githubusercontent.com/541093/160207425-3dc1a3c2-18a9-4f50-9097-907a97eed1f5.png"> |

### How to test the changes in this Pull Request:

1. Add a Query Loop, set it to show Speakers
2. Add various blocks in the Post Template container, including this Speaker Sessions one
3. Configure it as you want
4. Everything should work as expected
5. The editor preview should match the frontend
