### PR TITLE
Jetpack Tweaks: Decode child selectors `>` in Custom CSS

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/css-sanitization.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/css-sanitization.php
@@ -12,6 +12,7 @@ add_action( 'csstidy_optimize_postparse', __NAMESPACE__ . '\sanitize_csstidy_par
 add_action( 'admin_notices',              __NAMESPACE__ . '\notify_import_rules_stripped'  );
 add_action( 'csstidy_optimize_subvalue',  __NAMESPACE__ . '\sanitize_csstidy_subvalues'    );
 add_action( 'safecss_parse_pre',          __NAMESPACE__ . '\update_csstidy_safelist', 0    );
+add_filter( 'wp_get_custom_css',          __NAMESPACE__ . '\filter_custom_css' );
 
 /**
  * Sanitize CSS saved through the Core/Jetpack editor inside the Customizer
@@ -221,4 +222,17 @@ function update_csstidy_safelist() {
 	if ( ! empty( $GLOBALS['csstidy']['all_properties'] ) ) {
 		$GLOBALS['csstidy']['all_properties'] = array_merge( $GLOBALS['csstidy']['all_properties'], $properties_for_csstidy );
 	}
+}
+
+/**
+ * Replace encoded &gt; in CSS with a > so that CSS rules are valid.
+ *
+ * Remove this once the root issue is fixed in https://github.com/Automattic/jetpack/issues/21603.
+ *
+ * @param string $css CSS pulled in from the Custom CSS post type.
+ *
+ * @return string
+ */
+function filter_custom_css( $css ) {
+	return str_replace( '&gt;', '>', $css );
 }

--- a/public_html/wp-content/mu-plugins/tests/test-jetpack-css-sanitization.php
+++ b/public_html/wp-content/mu-plugins/tests/test-jetpack-css-sanitization.php
@@ -18,12 +18,21 @@ defined( 'WPINC' ) || die();
 class Test_Jetpack_CSS_Sanitization extends WP_UnitTestCase {
 
 	/**
-	 * Test that the angle bracket is not encoded.
+	 * Test that no selector characters are encoded.
 	 */
-	public function test_gt_not_encoded() {
+	public function test_selectors_not_encoded() {
 		$input = <<<CSS
-/* Child combinator syntax */
-.class > p {
+.class > p,
+p ~ span,
+h2 + p,
+col || td,
+.pseudo:visited,
+.pseudo::before,
+[title],
+a[href="https://example.org"],
+a[title*='an example'],
+span[data-emoji~=🐈‍⬛]
+span[attr$="한글"] {
 	color: lightcoral;
 }
 CSS;

--- a/public_html/wp-content/mu-plugins/tests/test-jetpack-css-sanitization.php
+++ b/public_html/wp-content/mu-plugins/tests/test-jetpack-css-sanitization.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_Jetpack_CSS_Sanitization
+ *
+ * @group mu-plugins
+ * @group jetpack-tweaks
+ * @group jetpack-css
+ *
+ * @package WordCamp\Tests
+ */
+class Test_Jetpack_CSS_Sanitization extends WP_UnitTestCase {
+
+	/**
+	 * Test that the angle bracket is not encoded.
+	 */
+	public function test_gt_not_encoded() {
+		$input = <<<CSS
+/* Child combinator syntax */
+.class > p {
+	color: lightcoral;
+}
+CSS;
+
+		$post = wp_update_custom_css_post( $input );
+		$this->assertNotWPError( $post );
+
+		$output = wp_get_custom_css();
+		$this->assertEquals( $input, $output );
+	}
+
+	/**
+	 * Test that HTML code is correcly stripped.
+	 */
+	public function test_html_not_allowed() {
+		$input = <<<CSS
+/* HTML-ish code should be stripped */
+<class> p {
+	color: lightcoral;
+}
+CSS;
+
+		$post = wp_update_custom_css_post( $input );
+		$this->assertNotWPError( $post );
+
+		$output = wp_get_custom_css();
+		$this->assertNotEquals( $input, $output );
+	}
+}


### PR DESCRIPTION
Fixes #678 — The `>` in CSS is encoded as `&gt;` when output on WordCamp sites, which is invalid CSS. This fix is very simple, just replace the `&gt;` with `>` again on output. The sanitization already strips out any HTML-like tags, so this should not introduce any security issues.

Props @megmorsie, @CdrMarks.

### How to test the changes in this Pull Request:

1. Open the Additional CSS panel in the Customizer
2. Add CSS with an angle bracket, like
	```css
	body > div {
		background: lightcoral;
	}
	```
3. It should apply correctly in the customizer, so any divs that are direct children of body should have a pink background now.
4. Save and exit the customizer, view the site
5. It should still have the background on the live site
6. Alternately, view `https://yoursite.wordcamp.org/?custom-css` and the CSS should be there, with the `>` not encoded.

I also added two simple tests, you can see it fail if you disable the filter, and pass again after the filter is enabled.