### PR TITLE
Blocks: Add Session meta blocks: Session Speakers, Session Date & Time, Categories, Tracks

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -36,6 +36,7 @@ function load_includes() {
 	require_once $blocks_dir . 'avatar/controller.php';
 	require_once $blocks_dir . 'organizers/controller.php';
 	require_once $blocks_dir . 'schedule/controller.php';
+	require_once $blocks_dir . 'session-speakers/controller.php';
 	require_once $blocks_dir . 'sessions/controller.php';
 	require_once $blocks_dir . 'speaker-sessions/controller.php';
 	require_once $blocks_dir . 'speakers/controller.php';

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -36,6 +36,7 @@ function load_includes() {
 	require_once $blocks_dir . 'avatar/controller.php';
 	require_once $blocks_dir . 'organizers/controller.php';
 	require_once $blocks_dir . 'schedule/controller.php';
+	require_once $blocks_dir . 'session-date/controller.php';
 	require_once $blocks_dir . 'session-speakers/controller.php';
 	require_once $blocks_dir . 'sessions/controller.php';
 	require_once $blocks_dir . 'speaker-sessions/controller.php';

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -22,4 +23,24 @@ const enabledBlocks = BLOCKS.filter( ( block ) =>
 
 enabledBlocks.forEach( ( { NAME, SETTINGS } ) => {
 	registerBlockType( NAME, SETTINGS );
+} );
+
+/*
+ * Register the Tracks and Categories as variations on Post Terms.
+ * See https://github.com/WordPress/gutenberg/blob/41325b983feabcc46615cd6b1a8a5efe64c5a9f0/packages/block-library/src/post-terms/variations.js.
+ */
+wp.blocks.registerBlockVariation( 'core/post-terms', {
+	name: 'wcb_track',
+	title: __( 'Session Tracks', 'wordcamporg' ),
+	description: __( "Display a session's tracks.", 'wordcamporg' ),
+	attributes: { term: 'wcb_track' },
+	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_track',
+} );
+
+wp.blocks.registerBlockVariation( 'core/post-terms', {
+	name: 'wcb_session_category',
+	title: __( 'Session Categories', 'wordcamporg' ),
+	description: __( "Display a session's categories.", 'wordcamporg' ),
+	attributes: { term: 'wcb_session_category' },
+	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_session_category',
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
@@ -5,6 +5,7 @@ import * as avatar from './avatar';
 import * as liveSchedule from './live-schedule';
 import * as organizers from './organizers';
 import * as schedule from './schedule';
+import * as sessionDate from './session-date';
 import * as sessionSpeakers from './session-speakers';
 import * as sessions from './sessions';
 import * as speakerSessions from './speaker-sessions';
@@ -16,6 +17,7 @@ export const BLOCKS = [
 	liveSchedule,
 	organizers,
 	schedule,
+	sessionDate,
 	sessionSpeakers,
 	sessions,
 	speakerSessions,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
@@ -5,6 +5,7 @@ import * as avatar from './avatar';
 import * as liveSchedule from './live-schedule';
 import * as organizers from './organizers';
 import * as schedule from './schedule';
+import * as sessionSpeakers from './session-speakers';
 import * as sessions from './sessions';
 import * as speakerSessions from './speaker-sessions';
 import * as speakers from './speakers';
@@ -15,6 +16,7 @@ export const BLOCKS = [
 	liveSchedule,
 	organizers,
 	schedule,
+	sessionSpeakers,
 	sessions,
 	speakerSessions,
 	speakers,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/block.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/block.json
@@ -1,0 +1,35 @@
+{
+	"apiVersion": 2,
+	"name": "wordcamp/session-date",
+	"title": "Session Date & Time",
+	"category": "wordcamp",
+	"description": "Display the date and time of the current session.",
+	"textdomain": "wordcamporg",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"format": {
+			"type": "string"
+		},
+		"showTimezone": {
+			"type": "boolean",
+			"default": true
+		},
+		"textAlign": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"editorScript": "wordcamp-blocks",
+	"style": "wordcamp-blocks"
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/controller.php
@@ -1,0 +1,67 @@
+<?php
+namespace WordCamp\Blocks\SessionDate;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register block types and enqueue scripts.
+ *
+ * @return void
+ */
+function init() {
+	register_block_type_from_metadata(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+
+/**
+ * Renders the block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Returns an HTML formatted date & time for the current session.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_ID = $block->context['postId'];
+	$date    = absint( get_post_meta( $post_ID, '_wcpt_session_time', true ) );
+	$format  = isset( $attributes['format'] ) ? $attributes['format'] : __( 'F j, Y g:i a' );
+
+	if ( isset( $attributes['showTimezone'] ) && $attributes['showTimezone'] ) {
+		$format .= ' T';
+	}
+
+	$classes = array_filter( array(
+		isset( $attributes['textAlign'] ) ? 'has-text-align-' . $attributes['textAlign'] : false,
+	) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+
+	return sprintf(
+		'<div %1$s><time dateTime="%2$s">%3$s</time></div>',
+		$wrapper_attributes,
+		esc_html( wp_date( 'c', $date ) ),
+		esc_html( wp_date( $format, $date ) )
+	);
+}
+
+/**
+ * Enable the session-date block.
+ *
+ * @param array $data
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['session-date'] = true;
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/edit.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { uniq } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { AlignmentControl, BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { dateI18n, __experimentalGetSettings as getDateSettings } from '@wordpress/date'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+export default function Edit( { attributes, setAttributes, context: { postId, postType } } ) {
+	const { format, showTimezone, textAlign } = attributes;
+	const date = useSelect( ( select ) => {
+		const { getEntityRecord } = select( coreStore );
+		const session = getEntityRecord( 'postType', postType, postId );
+		return session.meta._wcpt_session_time * 1000; // Convert from s to ms.
+	}, [] );
+
+	const { formats } = getDateSettings();
+	const defaultFormat = formats.datetime;
+
+	const formatOptions = uniq( [
+		...Object.values( formats ),
+		_x( 'D g:i A', 'short weekday name with time', 'wordcamporg' ),
+		_x( 'l g:i A', 'long weekday name with time', 'wordcamporg' ),
+		_x( 'M j, Y g:i A', 'medium date format with time', 'wordcamporg' ),
+		_x( 'n/j/Y g:i A', 'short date format with time', 'wordcamporg' ),
+	] ).map( ( formatOption ) => ( {
+		value: formatOption,
+		label: dateI18n( formatOption, date || new Date() ),
+	} ) );
+
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
+	const displayFormat = ( format || defaultFormat ) + ( showTimezone ? ' T' : '' );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wordcamporg' ) }>
+					<SelectControl
+						label={ __( 'Date Format', 'wordcamporg' ) }
+						value={ format || defaultFormat }
+						options={ formatOptions }
+						onChange={ ( value ) => setAttributes( { format: value } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Show Timezone', 'wordcamporg' ) }
+						checked={ showTimezone }
+						onChange={ () => setAttributes( { showTimezone: ! showTimezone } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<div { ...blockProps }>
+				<time dateTime={ dateI18n( 'c', date ) }>{ dateI18n( displayFormat, date ) }</time>
+			</div>
+		</>
+	);
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+export const NAME = metadata.name;
+
+export const SETTINGS = {
+	...metadata,
+	icon: 'clock',
+	edit: edit,
+};

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/block.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/block.json
@@ -13,10 +13,12 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"textAlign": {
+			"type": "string"
 		}
 	},
 	"supports": {
-		"align": [ "left", "right", "center" ],
 		"color": {
 			"text": true,
 			"background": true,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/block.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/block.json
@@ -24,7 +24,11 @@
 			"background": true,
 			"link": true
 		},
-		"html": false
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
 	},
 	"editorScript": "wordcamp-blocks",
 	"style": "wordcamp-blocks"

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/block.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/block.json
@@ -1,0 +1,29 @@
+{
+	"apiVersion": 2,
+	"name": "wordcamp/session-speakers",
+	"title": "Session Speakers",
+	"category": "wordcamp",
+	"description": "Display the speakers attached to the current session.",
+	"textdomain": "wordcamporg",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"byline": {
+			"type": "string"
+		},
+		"isLink": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"supports": {
+		"align": [ "left", "right", "center" ],
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"html": false
+	},
+	"editorScript": "wordcamp-blocks",
+	"style": "wordcamp-blocks"
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -1,0 +1,74 @@
+<?php
+namespace WordCamp\Blocks\SessionSpeakers;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register block types and enqueue scripts.
+ *
+ * @return void
+ */
+function init() {
+	register_block_type_from_metadata(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+
+/**
+ * Renders the block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Returns the avatar for the current post.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_ID  = $block->context['postId'];
+	$speaker_ids = get_post_meta( $post_ID, '_wcpt_speaker_id' );
+
+	// Session has no published speakers.
+	if ( ! is_array( $speaker_ids ) || empty( $speaker_ids ) ) {
+		return '';
+	}
+
+	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
+
+	$content = '';
+	if ( ! empty( $byline ) ) {
+		$content .= '<span class="wp-block-wordcamp-session-speakers__byline">' . esc_html( $byline ) . '</span>';
+	}
+
+	foreach ( $speaker_ids as $speaker_id ) {
+		$content .= '<span class="wp-block-wordcamp-session-speakers__name">';
+		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+			$content .= sprintf( '<a href="%1$s">%2$s</a>', get_the_permalink( $speaker_id ), get_the_title( $speaker_id ) );
+		} else {
+			$content .= get_the_title( $speaker_id );
+		}
+		$content .= '</span>';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return "<div $wrapper_attributes>$content</div>";
+}
+/**
+ * Enable the session-speakers block.
+ *
+ * @param array $data
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['session-speakers'] = true;
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -47,7 +47,7 @@ function render( $attributes, $content, $block ) {
 
 	$content = '';
 	if ( ! empty( $byline ) ) {
-		$content .= '<span class="wp-block-wordcamp-session-speakers__byline">' . esc_html( $byline ) . '</span>';
+		$content .= '<span class="wp-block-wordcamp-session-speakers__byline">' . wp_kses_post( $byline ) . '</span>';
 	}
 
 	foreach ( $speaker_ids as $speaker_id ) {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -41,6 +41,9 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
+	$classes = array_filter( array(
+		isset( $attributes['textAlign'] ) ? 'has-text-align-' . $attributes['textAlign'] : false,
+	) );
 
 	$content = '';
 	if ( ! empty( $byline ) ) {
@@ -57,7 +60,7 @@ function render( $attributes, $content, $block ) {
 		$content .= '</span>';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 	return "<div $wrapper_attributes>$content</div>";
 }
 /**

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+export default function( { attributes, setAttributes, context: { postId, postType }, isSelected } ) {
+	const { byline, isLink } = attributes;
+	const blockProps = useBlockProps();
+	const speakers = useSelect( ( select ) => {
+		const { getEntityRecord } = select( coreStore );
+		const session = getEntityRecord( 'postType', postType, postId );
+		return session.session_speakers || [];
+	}, [] );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wordcamporg' ) }>
+					<ToggleControl
+						label={ __( 'Link to speaker', 'wordcamporg' ) }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+						checked={ isLink }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				{ ( ! RichText.isEmpty( byline ) || isSelected ) && (
+					<RichText
+						className="wp-block-wordcamp-session-speakers__byline"
+						multiline={ false }
+						aria-label={ __( 'Session speaker byline text', 'wordcamporg' ) }
+						placeholder={ __( 'Presented by', 'wordcamporg' ) }
+						value={ byline }
+						onChange={ ( value ) => setAttributes( { byline: value } ) }
+					/>
+				) }
+				{ speakers.map( ( { id, name, link } ) => (
+					<span key={ id } className="wp-block-wordcamp-session-speakers__name">
+						{ isLink ? <a href={ link }>{ name }</a> : name }
+					</span>
+				) ) }
+			</div>
+		</>
+	);
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.js
@@ -1,20 +1,36 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 export default function( { attributes, setAttributes, context: { postId, postType }, isSelected } ) {
-	const { byline, isLink } = attributes;
-	const blockProps = useBlockProps();
+	const { byline, isLink, textAlign } = attributes;
 	const speakers = useSelect( ( select ) => {
 		const { getEntityRecord } = select( coreStore );
 		const session = getEntityRecord( 'postType', postType, postId );
 		return session.session_speakers || [];
 	}, [] );
+
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 
 	return (
 		<>
@@ -27,6 +43,14 @@ export default function( { attributes, setAttributes, context: { postId, postTyp
 					/>
 				</PanelBody>
 			</InspectorControls>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
 			<div { ...blockProps }>
 				{ ( ! RichText.isEmpty( byline ) || isSelected ) && (
 					<RichText

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.scss
@@ -1,0 +1,12 @@
+.wp-block-wordcamp-session-speakers__byline {
+	display: inline;
+	margin-right: 0.3em;
+}
+
+.wp-block-wordcamp-session-speakers__name::after {
+	content: ", ";
+}
+
+.wp-block-wordcamp-session-speakers__name:last-child::after {
+	content: "";
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/index.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import './edit.scss';
+
+export const NAME = metadata.name;
+
+export const SETTINGS = {
+	...metadata,
+	icon: 'megaphone',
+	edit: edit,
+};


### PR DESCRIPTION
See #743. 

- Session Speakers: modeled after the "Post Author" block, this lets you link to each speaker attached to a session.
- Session Date & Time: partially modeled after the "Post Date" block, this shows the session date and time, giving a variety of formats for display, with or without the timezone.
- Session Categories & Session Tracks: variations on the post-terms block, like categories & tags.

### Screenshots

| Editor | Frontend |
|----|----|
| <img width="1024" alt="editor" src="https://user-images.githubusercontent.com/541093/161145900-00e3e669-417c-4b20-85ff-0654ea7f6d6b.png"> | <img width="1021" alt="frontend" src="https://user-images.githubusercontent.com/541093/161145903-96c9920f-f05f-4b4a-b830-6db5db32e3e4.png"> |

| Details | Screenshot |
|-----|---|
| Session Speaker toolbar, the "Speaker" text is rich text editable | <img width="491" alt="speaker-toolbar" src="https://user-images.githubusercontent.com/541093/161145906-4bfb7d9a-298e-403b-b69c-2f5c8dbebd74.png"> |
| Session Speaker settings, can toggle the speaker link | <img width="293" alt="speaker-inspecor" src="https://user-images.githubusercontent.com/541093/161145905-88fb899a-858a-4c6e-8b92-ce8a1ed459f3.png"> |
| Session Date settings, can change the format & toggle the timezone (defaults on) | <img width="291" alt="date-inspector" src="https://user-images.githubusercontent.com/541093/161145893-563801d5-dc32-4838-8873-10b8081b1581.png"> |
| Session Date with a different format | <img width="349" alt="different-date-format" src="https://user-images.githubusercontent.com/541093/161145896-9b771fe5-6946-48ac-a3de-3f6373468eda.png"> |

### How to test the changes in this Pull Request:

1. Add a Query Loop with sessions, or edit a session
2. Add any of the Sessions ___ blocks
3. They should behave as you expect, and show the correct information
