### PR TITLE
Sessions: Fix timezone offset in session time picker

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/js/src/components/date-control/index.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/components/date-control/index.js
@@ -2,8 +2,27 @@
  * WordPress dependencies
  */
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Date settings OK.
-import { __experimentalGetSettings } from '@wordpress/date';
+import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
 import { BaseControl, TimePicker } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+
+/**
+ * Using the site settings, generate the offset in ISO 8601 format (`+00:00`).
+ *
+ * For example, an offset of `-6` will return `'-06:00'`, and `'13.75'` will return `'+13:45'`.
+ *
+ * @param {Object}        root0        The site timezone settings.
+ * @param {string|number} root0.offset The offset in hours, as a string if it's fractional.
+ * @return {string}
+ */
+function getTimezoneOffset( { offset = 0 } ) {
+	return sprintf(
+		'%1$s%2$02d:%3$02d',
+		Number( offset ) < 0 ? '-' : '+',
+		Math.floor( Math.abs( offset ) ),
+		( Math.abs( offset ) % 1 ) * 60
+	);
+}
 
 export default function( { date, label, onChange } ) {
 	const settings = __experimentalGetSettings();
@@ -16,10 +35,24 @@ export default function( { date, label, onChange } ) {
 			.join( '' ) // Reverse the string and test for "a" not followed by a slash
 	);
 
+	// Remove the timezone info from the date. `TimePicker` uses an instance of moment that does not know about
+	// the site timezone, so passing it in causes an unexpected offset.
+	const dateNoTZ = dateI18n( 'Y-m-d\\TH:i:s', date, 'WP' );
+
 	return (
 		<BaseControl>
 			<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
-			<TimePicker currentTime={ date } onChange={ onChange } is12Hour={ is12HourTime } />
+			<TimePicker
+				currentTime={ dateNoTZ }
+				onChange={ ( dateValue ) => {
+					// dateValue is a tz-less string, so we need to add the site-timezone offset.
+					// Otherwise, `dateI18n` tries to use the browser timezone, which might not be the same.
+					const offset = getTimezoneOffset( settings.timezone );
+					const value = dateI18n( 'U', dateValue + offset );
+					onChange( value );
+				} }
+				is12Hour={ is12HourTime }
+			/>
 		</BaseControl>
 	);
 }

--- a/public_html/wp-content/plugins/wc-post-types/js/src/session/panel-info/index.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/session/panel-info/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getDate, gmdate } from '@wordpress/date';
 import { SelectControl, TextControl } from '@wordpress/components';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 
@@ -20,8 +19,6 @@ export default function SessionSettings() {
 	const [ type, setType ] = usePostMeta( '_wcpt_session_type', '' );
 	const [ video, setVideo ] = usePostMeta( '_wcpt_session_video', '' );
 
-	const start = getDate( time * 1000 );
-
 	return (
 		<PluginDocumentSettingPanel
 			name="wordcamp/session-info"
@@ -30,11 +27,8 @@ export default function SessionSettings() {
 		>
 			<DateControl
 				label={ __( 'Day & Time', 'wordcamporg' ) }
-				date={ start }
-				onChange={ ( dateValue ) => {
-					const value = gmdate( 'U', dateValue );
-					setStartTime( value );
-				} }
+				date={ time * 1000 }
+				onChange={ setStartTime }
 			/>
 
 			<SessionDuration value={ duration } onChange={ setDuration } />


### PR DESCRIPTION
Fixes #748 — The `TimePicker` component doesn't seem aware of the site timezone, so it's easier to remove the timezone data before passing the date though - and it matches how the post date component works. Previously to this change, the TimePicker would show the user-local time despite showing the site timezone, leading to confusion about scheduling.

Props @vertizio.

### Screenshots

This is the same session, no change to the time between screenshots. The session is scheduled for 9:45 PDT.

| Before | After |
|------|-----|
| <img width="280" alt="Screen Shot 2022-04-01 at 4 36 31 PM" src="https://user-images.githubusercontent.com/541093/161337791-b6e75116-e1d7-44a7-973d-a5cf7434ee8d.png"> | <img width="281" alt="Screen Shot 2022-04-01 at 4 35 43 PM" src="https://user-images.githubusercontent.com/541093/161337713-f962f361-e671-4ba6-8bd4-a6f853e1e06b.png"> |

### How to test the changes in this Pull Request:

1. Set your site's timezone to something different than your current timezone (or set your computer timezone differently)
2. Try editing a session
3. It should show the time in the site's timezone, and it should be correct
4. Saving a new time should work as expected
