### PR TITLE
Blocks: Add Organizer Teams as a post terms variation

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -44,3 +44,11 @@ wp.blocks.registerBlockVariation( 'core/post-terms', {
 	attributes: { term: 'wcb_session_category' },
 	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_session_category',
 } );
+
+wp.blocks.registerBlockVariation( 'core/post-terms', {
+	name: 'wcb_organizer_team',
+	title: __( 'Organizer Teams', 'wordcamporg' ),
+	description: __( "Display an organizer's teams.", 'wordcamporg' ),
+	attributes: { term: 'wcb_organizer_team' },
+	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_organizer_team',
+} );


### PR DESCRIPTION
See #743 — Add another Post Terms variation for "Organizer Teams". Used to show the "Teams" taxonomy on organizers.

### Screenshots

<img width="287" alt="Screen Shot 2022-04-01 at 4 58 11 PM" src="https://user-images.githubusercontent.com/541093/161340463-245dd8cf-6890-4004-877f-0ae587ee48b8.png">

### How to test the changes in this Pull Request:

1. Edit an organizer post or add a Query Loop of organizers
2. Add the "Organizer Teams" block
3. If the organizer has a Team, it will show up.
