### PR TITLE
Add a Sessions List variation on the Query Loop block, with custom sort order

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -24,6 +24,7 @@ function load_includes() {
 	$blocks_dir     = PLUGIN_DIR . 'source/blocks/';
 	$components_dir = PLUGIN_DIR . 'source/components/';
 	$hooks_dir      = PLUGIN_DIR . 'source/hooks/';
+	$variations_dir = PLUGIN_DIR . 'source/variations/';
 
 	// Utilities.
 	require_once $includes_dir . 'definitions.php';
@@ -49,6 +50,9 @@ function load_includes() {
 
 	// Hooks.
 	require_once $hooks_dir . 'latest-posts/controller.php';
+
+	// Variations.
+	require_once $variations_dir . 'sessions-list/controller.php';
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_includes' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -12,6 +11,7 @@ import './edit.scss'; // Common styles for WordCamp Blocks.
 import { BLOCKS } from './blocks/'; // Trailing slash required to differentiate the folder from the file.
 // This attaches to the hook itself.
 import './hooks/latest-posts';
+import './variations';
 
 /*
  * When a block isn't enabled on the current site, it won't be registered by it's `controller.php`.
@@ -25,33 +25,3 @@ enabledBlocks.forEach( ( { NAME, SETTINGS } ) => {
 	registerBlockType( NAME, SETTINGS );
 } );
 
-/*
- * Register the custom taxonomies as variations on Post Terms.
- * See https://github.com/WordPress/gutenberg/blob/41325b983feabcc46615cd6b1a8a5efe64c5a9f0/packages/block-library/src/post-terms/variations.js.
- */
-registerBlockVariation( 'core/post-terms', {
-	name: 'wcb_track',
-	title: __( 'Session Tracks', 'wordcamporg' ),
-	description: __( "Display a session's tracks.", 'wordcamporg' ),
-	category: 'wordcamp',
-	attributes: { term: 'wcb_track' },
-	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_track',
-} );
-
-registerBlockVariation( 'core/post-terms', {
-	name: 'wcb_session_category',
-	title: __( 'Session Categories', 'wordcamporg' ),
-	description: __( "Display a session's categories.", 'wordcamporg' ),
-	category: 'wordcamp',
-	attributes: { term: 'wcb_session_category' },
-	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_session_category',
-} );
-
-registerBlockVariation( 'core/post-terms', {
-	name: 'wcb_organizer_team',
-	title: __( 'Organizer Teams', 'wordcamporg' ),
-	description: __( "Display an organizer's teams.", 'wordcamporg' ),
-	category: 'wordcamp',
-	attributes: { term: 'wcb_organizer_team' },
-	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_organizer_team',
-} );

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import './sessions-list';
+
+/*
+ * Register the custom taxonomies as variations on Post Terms.
+ * See https://github.com/WordPress/gutenberg/blob/41325b983feabcc46615cd6b1a8a5efe64c5a9f0/packages/block-library/src/post-terms/variations.js.
+ */
+registerBlockVariation( 'core/post-terms', {
+	name: 'wcb_track',
+	title: __( 'Session Tracks', 'wordcamporg' ),
+	description: __( "Display a session's tracks.", 'wordcamporg' ),
+	category: 'wordcamp',
+	attributes: { term: 'wcb_track' },
+	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_track',
+} );
+
+registerBlockVariation( 'core/post-terms', {
+	name: 'wcb_session_category',
+	title: __( 'Session Categories', 'wordcamporg' ),
+	description: __( "Display a session's categories.", 'wordcamporg' ),
+	category: 'wordcamp',
+	attributes: { term: 'wcb_session_category' },
+	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_session_category',
+} );
+
+registerBlockVariation( 'core/post-terms', {
+	name: 'wcb_organizer_team',
+	title: __( 'Organizer Teams', 'wordcamporg' ),
+	description: __( "Display an organizer's teams.", 'wordcamporg' ),
+	category: 'wordcamp',
+	attributes: { term: 'wcb_organizer_team' },
+	isActive: ( blockAttributes ) => blockAttributes.term === 'wcb_organizer_team',
+} );

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
@@ -1,0 +1,18 @@
+<?php
+namespace WordCamp\Blocks\Variations\Query;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Enable the hook by adding a value to the script data.
+ *
+ * @param array $data
+ *
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['hook-query'] = true;
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
@@ -4,6 +4,12 @@ namespace WordCamp\Blocks\Variations\Query;
 defined( 'WPINC' ) || die();
 
 /**
+ * Actions and filters.
+ */
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );
+add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\update_query_loop_vars' );
+
+/**
  * Enable the hook by adding a value to the script data.
  *
  * @param array $data
@@ -15,4 +21,22 @@ function add_script_data( array $data ) {
 
 	return $data;
 }
-add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );
+
+/**
+ * Filter the query loop arguments.
+ *
+ * Convert the "session_date" orderby value to real WP_Query args.
+ *
+ * @see WordCamp\Post_Types\REST_API\prepare_session_query_args.
+ *
+ * @param array $query Array containing parameters for `WP_Query` as parsed by the block context.
+ * @return array Updated query parameters.
+ */
+function update_query_loop_vars( $query ) {
+	if ( 'session_date' === $query['orderby'] ) {
+		$query['meta_key'] = '_wcpt_session_time';
+		$query['orderby']  = 'meta_value_num';
+	}
+
+	return $query;
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
@@ -7,7 +7,8 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );
-add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\update_query_loop_vars' );
+add_filter( 'pre_render_block', __NAMESPACE__ . '\pre_render_block', 10, 2 );
+add_filter( 'render_block', __NAMESPACE__ . '\post_render_block', 20, 2 );
 
 /**
  * Enable the hook by adding a value to the script data.
@@ -23,9 +24,39 @@ function add_script_data( array $data ) {
 }
 
 /**
- * Filter the query loop arguments.
+ * Attach the query modifications when starting to render this query block.
  *
- * Convert the "session_date" orderby value to real WP_Query args.
+ * @param string|null $pre_render The pre-rendered content. Default null.
+ * @param array       $block      The block being rendered.
+ * @return array Updated query parameters.
+ */
+function pre_render_block( $pre_render, $block ) {
+	if ( isset( $block['attrs']['namespace'] ) && 'wordcamp/sessions-query' === $block['attrs']['namespace'] ) {
+		add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\update_query_loop_vars' );
+	}
+
+	return $pre_render;
+}
+
+/**
+ * Remove the query modifications when starting to render this query block.
+ *
+ * @param string $block_content The block content.
+ * @param array  $block         The block being rendered.
+ * @return array Updated query parameters.
+ */
+function post_render_block( $block_content, $block ) {
+	if ( isset( $block['attrs']['namespace'] ) && 'wordcamp/sessions-query' === $block['attrs']['namespace'] ) {
+		remove_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\update_query_loop_vars', 10, 2 );
+	}
+
+	return $block_content;
+}
+
+/**
+ * Filter the query loop arguments when in a Sessions List variation.
+ *
+ * Only display regular sessions. Convert the "session_date" orderby value to real WP_Query args.
  *
  * @see WordCamp\Post_Types\REST_API\prepare_session_query_args.
  *
@@ -36,6 +67,24 @@ function update_query_loop_vars( $query ) {
 	if ( 'session_date' === $query['orderby'] ) {
 		$query['meta_key'] = '_wcpt_session_time';
 		$query['orderby']  = 'meta_value_num';
+	}
+
+	$meta_query = array(
+		'relation' => 'OR',
+		array(
+			'key' => '_wcpt_session_type',
+			'compare' => 'NOT EXISTS',
+		),
+		array(
+			'key' => '_wcpt_session_type',
+			'value' => 'session',
+		),
+	);
+
+	if ( isset( $query['meta_query'] ) && is_array( $query['meta_query'] ) ) {
+		$query['meta_query'][] = $meta_query;
+	} else {
+		$query['meta_query'] = array( $meta_query );
 	}
 
 	return $query;

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/controller.php
@@ -69,6 +69,7 @@ function update_query_loop_vars( $query ) {
 		$query['orderby']  = 'meta_value_num';
 	}
 
+	// Only show real sessions (not breaks, etc) in the Sessions List.
 	$meta_query = array(
 		'relation' => 'OR',
 		array(

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/index.js
@@ -35,6 +35,8 @@ registerBlockVariation( 'core/query', {
 			exclude: [],
 			sticky: '',
 			inherit: false,
+			wc_meta_key: '_wcpt_session_type',
+			wc_meta_value: 'session',
 		},
 	},
 	innerBlocks: [

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/index.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
+import { registerBlockVariation } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import OrderControl from './order-control';
+
+const NAMESPACE = 'wordcamp/sessions-query';
+const POST_TYPE = 'wcb_session';
+
+registerBlockVariation( 'core/query', {
+	name: NAMESPACE,
+	title: __( 'Sessions List', 'wordcamporg' ),
+	description: 'Display a list of sessions',
+	isActive: [ 'namespace' ],
+	attributes: {
+		namespace: NAMESPACE,
+		query: {
+			perPage: 10,
+			pages: 0,
+			offset: 0,
+			postType: POST_TYPE,
+			order: 'asc',
+			orderBy: 'session_date',
+			author: '',
+			search: '',
+			exclude: [],
+			sticky: '',
+			inherit: false,
+		},
+	},
+	innerBlocks: [
+		[
+			'core/post-template',
+			{},
+			[
+				[ 'core/post-title' ],
+				[ 'wordcamp/session-speakers' ],
+				[ 'core/post-excerpt' ],
+				[
+					'core/group',
+					{ layout: { type: 'flex', allowOrientation: false } },
+					[
+						[ 'core/paragraph', { content: __( 'Tracks:', 'wordcamporg' ) } ],
+						[ 'core/post-terms', { term: 'wcb_track' } ],
+					],
+				],
+				[
+					'core/group',
+					{ layout: { type: 'flex', allowOrientation: false } },
+					[
+						[ 'core/paragraph', { content: __( 'Time:', 'wordcamporg' ) } ],
+						[ 'wordcamp/session-date' ],
+					],
+				],
+			],
+		],
+		[ 'core/query-pagination' ],
+	],
+	// Omit `order` in favor of our custom OrderControl.
+	allowedControls: [ 'inherit', 'taxQuery', 'search' ],
+	scope: [ 'inserter' ],
+} );
+
+/**
+ * Inject the OrderControl component into the Sessions List query variation.
+ *
+ * @param {Function} BlockEdit Original component
+ * @return {Function}           Wrapped component
+ */
+const sessionQueryOrder = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { attributes, name, setAttributes } = props;
+		const { query = {}, namespace } = attributes;
+
+		if ( name !== 'core/query' || namespace !== NAMESPACE ) {
+			return <BlockEdit key="edit" { ...props } />;
+		}
+
+		const { order, orderBy } = query;
+		const updateQuery = ( newQuery ) => setAttributes( { query: { ...query, ...newQuery } } );
+
+		return (
+			<>
+				<BlockEdit key="edit" { ...props } />
+				<InspectorControls>
+					<PanelBody title={ __( 'Order by', 'wordcamporg' ) }>
+						<OrderControl order={ order } orderBy={ orderBy } onChange={ updateQuery } />
+					</PanelBody>
+				</InspectorControls>
+			</>
+		);
+	},
+	'withInspectorControls'
+);
+
+addFilter( 'editor.BlockEdit', 'wordcamp/session-query', sessionQueryOrder );

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/order-control.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/order-control.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const orderOptions = [
+	{
+		label: __( 'Newest to oldest', 'wordcamporg' ),
+		value: 'date/desc',
+	},
+	{
+		label: __( 'Oldest to newest', 'wordcamporg' ),
+		value: 'date/asc',
+	},
+	{
+		/* translators: label for ordering posts by title in ascending order */
+		label: __( 'A → Z', 'wordcamporg' ),
+		value: 'title/asc',
+	},
+	{
+		/* translators: label for ordering posts by title in descending order */
+		label: __( 'Z → A', 'wordcamporg' ),
+		value: 'title/desc',
+	},
+	{
+		label: __( 'Latest First', 'wordcamporg' ),
+		value: 'session_date/desc',
+	},
+	{
+		label: __( 'Earliest First', 'wordcamporg' ),
+		value: 'session_date/asc',
+	},
+];
+
+function OrderControl( { order, orderBy, onChange } ) {
+	return (
+		<SelectControl
+			hideLabelFromVision
+			label={ __( 'Order by', 'wordcamporg' ) }
+			value={ `${ orderBy }/${ order }` }
+			options={ orderOptions }
+			onChange={ ( value ) => {
+				const [ newOrderBy, newOrder ] = value.split( '/' );
+				onChange( { order: newOrder, orderBy: newOrderBy } );
+			} }
+		/>
+	);
+}
+
+export default OrderControl;

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -455,6 +455,22 @@ function prepare_session_query_args( $args, $request ) {
 			'key' => $request['wc_meta_key'],
 			'value' => $request['wc_meta_value'],
 		);
+
+		// If requesting only "session" types, also return null types, they're handled the same way.
+		if ( '_wcpt_session_type' === $request['wc_meta_key'] && 'session' === $request['wc_meta_value'] ) {
+			$meta_query = array(
+				'relation' => 'OR',
+				array(
+					'key' => '_wcpt_session_type',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key' => '_wcpt_session_type',
+					'value' => 'session',
+				),
+			);
+		}
+
 		if ( is_array( $args['meta_query'] ) ) {
 			$args['meta_query'][] = $meta_query;
 		} else {
@@ -464,7 +480,7 @@ function prepare_session_query_args( $args, $request ) {
 
 	if ( 'session_date' === $request['orderby'] ) {
 		$args['meta_key'] = '_wcpt_session_time';
-		$args['orderby'] = 'meta_value_num';
+		$args['orderby']  = 'meta_value_num';
 	}
 
 	return $args;

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -12,11 +12,21 @@ defined( 'WPINC' ) || die();
 
 require_once 'favorite-schedule-shortcode.php';
 
+/**
+ * Actions and filters.
+ */
 add_action( 'init', __NAMESPACE__ . '\register_sponsor_post_meta' );
 add_action( 'init', __NAMESPACE__ . '\register_speaker_post_meta' );
 add_action( 'init', __NAMESPACE__ . '\register_session_post_meta' );
 add_action( 'init', __NAMESPACE__ . '\register_organizer_post_meta' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_user_validation_route' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_additional_rest_fields' );
+add_filter( 'rest_wcb_session_query', __NAMESPACE__ . '\prepare_meta_query_args', 10, 2 );
+add_filter( 'rest_wcb_session_collection_params', __NAMESPACE__ . '\add_meta_collection_params', 10, 2 );
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_fav_sessions_email' );
+add_filter( 'rest_prepare_wcb_speaker', __NAMESPACE__ . '\link_speaker_to_sessions', 10, 2 );
+add_filter( 'rest_prepare_wcb_session', __NAMESPACE__ . '\link_session_to_speakers', 10, 2 );
+add_filter( 'rest_avatar_sizes', __NAMESPACE__ . '\add_larger_avatar_sizes' );
 
 /**
  * Registers post meta to the Sponsor post type.
@@ -431,8 +441,6 @@ function register_additional_rest_fields() {
 	);
 }
 
-add_action( 'rest_api_init', __NAMESPACE__ . '\register_additional_rest_fields' );
-
 /**
  * Validate simple meta query parameters in an API request and add them to the args passed to WP_Query.
  *
@@ -449,8 +457,6 @@ function prepare_meta_query_args( $args, $request ) {
 
 	return $args;
 }
-
-add_filter( 'rest_wcb_session_query', __NAMESPACE__ . '\prepare_meta_query_args', 10, 2 );
 
 /**
  * Add meta field schemas to Sessions collection parameters.
@@ -493,8 +499,6 @@ function add_meta_collection_params( $query_params, $post_type ) {
 
 	return $query_params;
 }
-
-add_filter( 'rest_wcb_session_collection_params', __NAMESPACE__ . '\add_meta_collection_params', 10, 2 );
 
 /**
  * Get the URLs for an avatar based on an email address or username.
@@ -573,7 +577,6 @@ function register_fav_sessions_email() {
 		)
 	);
 }
-add_action( 'rest_api_init', __NAMESPACE__ . '\register_fav_sessions_email' );
 
 /**
  * Link all sessions to the speaker in the `speakers` API endpoint
@@ -618,8 +621,6 @@ function link_speaker_to_sessions( $response, $post ) {
 	return $response;
 }
 
-add_filter( 'rest_prepare_wcb_speaker', __NAMESPACE__ . '\link_speaker_to_sessions', 10, 2 );
-
 /**
  * Link all speakers to the session in the `sessions` API endpoint
  *
@@ -645,8 +646,6 @@ function link_session_to_speakers( $response, $post ) {
 	return $response;
 }
 
-add_filter( 'rest_prepare_wcb_session', __NAMESPACE__ . '\link_session_to_speakers', 10, 2 );
-
 /**
  * Add larger avatar sizes to the API response.
  *
@@ -661,4 +660,3 @@ function add_larger_avatar_sizes( $sizes ) {
 
 	return $sizes;
 }
-add_filter( 'rest_avatar_sizes', __NAMESPACE__ . '\add_larger_avatar_sizes' );


### PR DESCRIPTION
See #797, Fixes #759

Create a block variation on the Query Loop block to show a list of sessions, called Sessions List. This new Query Loop is preset to show Sessions, only regular sessions (not breaks, etc), 10 per page, ordered from earliest to latest by session time. The variation also includes a template for showing session info.

The core "order" control is disabled, and a custom control which includes sorting by session time is used instead.

### Screenshots

| Editor | Frontend |
|---|---|
| ![editor](https://user-images.githubusercontent.com/541093/226744823-c63dc122-8137-426e-89cb-a74a0c12402a.png) | ![frontend](https://user-images.githubusercontent.com/541093/226744827-ec683cd2-2778-4a91-a82d-2f2ec94e6f3a.png) |

### How to test the changes in this Pull Request:

1. Set up some sessions in your test site
2. Add a Sessions List block
3. It should load up to 10 sessions using the structure in the block outline in the screenshot
4. Make sure it's not showing any "custom" session types
5. Edit the blocks, change the items in the post template
6. It should work as expected
7. Change the "Order By" filter on Sessions List
8. It should reload the sessions in the chosen order
9. Publish the page, and the sessions should be ordered correctly on the frontend too

