### PR TITLE
Block: Speaker Sessions: Show sessions without set times

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/utils.js
@@ -6,42 +6,49 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
- */
-import { arrayTokenReplace, tokenSplit } from '../../i18n';
-
-/**
- * Fetch the details for a session as a human-readable string, in array-parts from `arrayTokenReplace`. This can be
- * passed to any react component and renders as text in the element on the browser.
+ * Fetch the details for a session as a human-readable string.
  *
  * @param {Object}  session
  * @param {boolean} allTracks
- * @return {Array}
+ * @return {string}
  */
 export function getSessionDetails( session, allTracks = false ) {
 	const terms = get( session, "_embedded['wp:term']", [] ).flat();
+	const hasDate = !! session.session_date_time?.date;
+	const hasTracks = !! session.session_track.length;
 
-	if ( session.session_track.length ) {
+	if ( ! hasDate && ! hasTracks ) {
+		return '';
+	}
+
+	if ( ! hasDate && hasTracks ) {
 		const tracks = terms.filter( ( term ) => 'wcb_track' === term.taxonomy );
 
-		return arrayTokenReplace(
-			/* translators: 1: A date; 2: A time; 3: A location; */
-			tokenSplit( __( '%1$s at %2$s in %3$s', 'wordcamporg' ) ),
-			[
-				session.session_date_time.date,
-				session.session_date_time.time,
-				allTracks ? tracks.map( ( { name } ) => name.trim() ).join( ', ' ) : tracks[ 0 ].name.trim(),
-			]
+		return sprintf(
+			/* translators: %s: Session track(s) */
+			__( 'In %s', 'wordcamporg' ),
+			allTracks ? tracks.map( ( { name } ) => name.trim() ).join( ', ' ) : tracks[ 0 ].name.trim()
+		);
+	} else if ( hasTracks ) {
+		const tracks = terms.filter( ( term ) => 'wcb_track' === term.taxonomy );
+
+		return sprintf(
+			/* translators: 1: A date; 2: A time; 3: Session track(s) */
+			__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
+			session.session_date_time.date,
+			session.session_date_time.time,
+			allTracks ? tracks.map( ( { name } ) => name.trim() ).join( ', ' ) : tracks[ 0 ].name.trim()
 		);
 	}
 
-	return arrayTokenReplace(
+	return sprintf(
 		/* translators: 1: A date; 2: A time; */
-		tokenSplit( __( '%1$s at %2$s', 'wordcamporg' ) ),
-		[ session.session_date_time.date, session.session_date_time.time ]
+		__( '%1$s at %2$s', 'wordcamporg' ),
+		session.session_date_time.date,
+		session.session_date_time.time
 	);
 }
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -75,11 +75,30 @@ function render( $attributes, $content, $block ) {
 		$session_li .= '</p>';
 
 		if ( isset( $attributes['hasSessionDetails'] ) && $attributes['hasSessionDetails'] ) {
-			$tracks = get_the_terms( $session, 'wcb_track' );
+			$tracks     = get_the_terms( $session, 'wcb_track' );
+			$has_date   = (bool) $session->_wcpt_session_time;
+			$has_tracks = ! is_wp_error( $tracks ) && ! empty( $tracks );
+
 			$session_li .= '<p class="wordcamp-speaker-sessions__session-info">';
-			if ( ! is_wp_error( $tracks ) && ! empty( $tracks ) ) {
+
+			if ( ! $has_date && $has_tracks ) {
 				$session_li .= sprintf(
-					/* translators: 1: session date; 2: session time; 3: session track; */
+					/* translators: %s: session tracks */
+					esc_html__( 'In %s', 'wordcamporg' ),
+					implode( ', ', array_map( // phpcs:ignore -- escaped below.
+						function ( $track ) {
+							return sprintf(
+								'<span class="wordcamp-speaker-sessions__track slug-%s">%s</span>',
+								esc_attr( $track->slug ),
+								esc_html( $track->name )
+							);
+						},
+						$tracks
+					) )
+				);
+			} else if ( $has_tracks ) {
+				$session_li .= sprintf(
+					/* translators: 1: session date; 2: session time; 3: session tracks */
 					esc_html__( '%1$s at %2$s in %3$s', 'wordcamporg' ),
 					esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
 					esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) ),
@@ -94,9 +113,9 @@ function render( $attributes, $content, $block ) {
 						$tracks
 					) )
 				);
-			} else {
+			} else if ( $has_date ) {
 				$session_li .= sprintf(
-					/* translators: 1: session date; 2: session time; */
+					/* translators: 1: session date; 2: session time */
 					esc_html__( '%1$s at %2$s', 'wordcamporg' ),
 					esc_html( wp_date( get_option( 'date_format' ), $session->_wcpt_session_time ) ),
 					esc_html( wp_date( get_option( 'time_format' ), $session->_wcpt_session_time ) )


### PR DESCRIPTION
Sessions without set times were not being shown in the Speaker Sessions block, because the query tried to sort by the meta value `_wcpt_session_time`, and if that didn't exist, the session was not returned. Instead, we switch to fetching sessions by attached speaker ID, which correctly returns all sessions, including those not yet scheduled (it will still only show published sessions).

In doing this, I realized the session details didn't handle sessions without time, so I've also updated the string-building logic for sessions without times.

### Screenshots

|  | Before | After |
|---|------|------|
| No time (editor) | <img width="705" alt="" src="https://user-images.githubusercontent.com/541093/162486514-1139576e-b716-4a16-ac02-392c5bc31ed1.png"> | <img width="702" alt="" src="https://user-images.githubusercontent.com/541093/162486506-933c2a22-2833-4468-b33c-73f500305451.png"> |
| No time (frontend) | <img width="700" alt="" src="https://user-images.githubusercontent.com/541093/162486512-2717b0db-afa7-4cdb-8fb2-4f3bf2d2f91f.png"> | <img width="701" alt="" src="https://user-images.githubusercontent.com/541093/162486492-5691c175-e806-4033-becf-a9d71a8e90b6.png"> |
| No track (editor) | <img width="701" alt="" src="https://user-images.githubusercontent.com/541093/162486513-9b1f1035-39a5-4bb4-a56b-16bce307a8df.png"> | <img width="724" alt="" src="https://user-images.githubusercontent.com/541093/162486502-7e3fe06f-a0e8-4444-b39b-264d85554d24.png"> |
| No track (frontend) | <img width="696" alt="" src="https://user-images.githubusercontent.com/541093/162486510-9aa70e30-0880-426e-aba9-3647b91fa69f.png"> | <img width="695" alt="" src="https://user-images.githubusercontent.com/541093/162486498-f9e6e971-cfb3-47ea-b7bd-253146268410.png"> |

