### PR TITLE
Blocks: Add base Meta Link block with Session Slides and Session Video variations

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -34,6 +34,8 @@ function load_includes() {
 
 	// Blocks.
 	require_once $blocks_dir . 'avatar/controller.php';
+	require_once $blocks_dir . 'live-schedule/controller.php';
+	require_once $blocks_dir . 'meta-link/controller.php';
 	require_once $blocks_dir . 'organizers/controller.php';
 	require_once $blocks_dir . 'schedule/controller.php';
 	require_once $blocks_dir . 'session-date/controller.php';
@@ -42,7 +44,6 @@ function load_includes() {
 	require_once $blocks_dir . 'speaker-sessions/controller.php';
 	require_once $blocks_dir . 'speakers/controller.php';
 	require_once $blocks_dir . 'sponsors/controller.php';
-	require_once $blocks_dir . 'live-schedule/controller.php';
 
 	// Hooks.
 	require_once $hooks_dir . 'latest-posts/controller.php';

--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -130,7 +130,7 @@ add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
 
 /**
  * Determine whether a $post or a string contains a block type with set attributes.
- * Used to check for variations of generic blocks, e.g., video session-link block.
+ * Used to check for variations of generic blocks, e.g., session video meta-link block.
  *
  * @param string                  $block_name Full block type to look for.
  * @param array                   $attrs      Associative array of attribute-name => value.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/index.js
@@ -3,6 +3,7 @@
  */
 import * as avatar from './avatar';
 import * as liveSchedule from './live-schedule';
+import * as metaLink from './meta-link';
 import * as organizers from './organizers';
 import * as schedule from './schedule';
 import * as sessionDate from './session-date';
@@ -15,6 +16,7 @@ import * as sponsors from './sponsors';
 export const BLOCKS = [
 	avatar,
 	liveSchedule,
+	metaLink,
 	organizers,
 	schedule,
 	sessionDate,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/block.json
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/block.json
@@ -1,0 +1,33 @@
+{
+	"apiVersion": 2,
+	"name": "wordcamp/meta-link",
+	"title": "Meta Link",
+	"category": "wordcamp",
+	"description": "Display a link using a meta value.",
+	"textdomain": "wordcamporg",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"key": {
+			"type": "string"
+		},
+		"text": {
+			"type": "string"
+		},
+		"textAlign": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"editorScript": "wordcamp-blocks"
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/controller.php
@@ -1,0 +1,63 @@
+<?php
+namespace WordCamp\Blocks\MetaLink;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register block types and enqueue scripts.
+ *
+ * @return void
+ */
+function init() {
+	register_block_type_from_metadata(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+
+/**
+ * Renders the block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Returns an HTML link using the selected meta value as the URL.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_ID = $block->context['postId'];
+	$url     = get_post_meta( $post_ID, $attributes['key'], true );
+	$text    = $attributes['text'];
+
+	$classes = array_filter( array(
+		isset( $attributes['textAlign'] ) ? 'has-text-align-' . $attributes['textAlign'] : false,
+	) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+
+	return sprintf(
+		'<div %1$s><a href="%2$s">%3$s</a></div>',
+		$wrapper_attributes,
+		esc_url( $url ),
+		wp_kses_post( $text )
+	);
+}
+
+/**
+ * Enable the meta-link block & variations.
+ *
+ * @param array $data
+ * @return array
+ */
+function add_script_data( array $data ) {
+	$data['meta-link'] = true;
+
+	return $data;
+}
+add_filter( 'wordcamp_blocks_script_data', __NAMESPACE__ . '\add_script_data' );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/controller.php
@@ -46,6 +46,10 @@ function render( $attributes, $content, $block ) {
 	$url     = get_post_meta( $post_ID, $attributes['key'], true );
 	$text    = $attributes['text'];
 
+	if ( ! $url ) {
+		return '';
+	}
+
 	$classes = array_filter( array(
 		isset( $attributes['textAlign'] ) ? 'has-text-align-' . $attributes['textAlign'] : false,
 	) );

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/controller.php
@@ -32,6 +32,16 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$meta_keys = array_merge(
+		get_registered_meta_keys( 'post' ),
+		get_registered_meta_keys( 'post', $block->context['postType'] )
+	);
+	// If the meta value is not visible in the API, it should not be visible here. This prevents leaking data
+	// that should not be public.
+	if ( ! isset( $meta_keys[ $attributes['key'] ] ) || ! $meta_keys[ $attributes['key'] ]['show_in_rest'] ) {
+		return '';
+	}
+
 	$post_ID = $block->context['postId'];
 	$url     = get_post_meta( $post_ID, $attributes['key'], true );
 	$text    = $attributes['text'];

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/edit.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { AlignmentControl, BlockControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+export default function Edit( { attributes, setAttributes, context: { postId, postType } } ) {
+	const { key, text, textAlign } = attributes;
+	const url = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
+			const post = getEntityRecord( 'postType', postType, postId );
+			return post.meta[ key ];
+		},
+		[ key ]
+	);
+
+	const blockProps = useBlockProps( {
+		className: classnames( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
+	return (
+		<>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<div { ...blockProps }>
+				<RichText
+					tagName="a"
+					href={ url }
+					multiline={ false }
+					aria-label={ __( 'Link text', 'wordcamporg' ) }
+					value={ text }
+					onChange={ ( value ) => setAttributes( { text: value } ) }
+				/>
+			</div>
+		</>
+	);
+}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/edit.js
@@ -7,7 +7,14 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { AlignmentControl, BlockControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
@@ -38,6 +45,13 @@ export default function Edit( { attributes, setAttributes, context: { postId, po
 					} }
 				/>
 			</BlockControls>
+			{ ! url && (
+				<InspectorControls>
+					<Notice status="error" isDismissible={ false }>
+						{ __( 'The link for this content is missing. Add the URL in the Session tab.', 'wordcamporg' ) }
+					</Notice>
+				</InspectorControls>
+			) }
 			<div { ...blockProps }>
 				<RichText
 					tagName="a"

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+export const NAME = metadata.name;
+
+export const SETTINGS = {
+	...metadata,
+	icon: 'admin-links',
+	edit: edit,
+};
+
+if ( window.WordCampBlocks.hasOwnProperty( 'meta-link' ) ) {
+	registerBlockVariation( NAME, {
+		name: 'session-slides',
+		title: __( 'Session Slides', 'wordcamporg' ),
+		isDefault: true,
+		description: __( "Display a link to the session's slides.", 'wordcamporg' ),
+		attributes: {
+			key: '_wcpt_session_slides',
+			text: __( 'View Session Slides', 'wordcamporg' ),
+		},
+		isActive: ( blockAttributes ) => blockAttributes.key === '_wcpt_session_slides',
+	} );
+	registerBlockVariation( NAME, {
+		name: 'session-video',
+		title: __( 'Session Video', 'wordcamporg' ),
+		description: __( "Display a link to the session's video recording.", 'wordcamporg' ),
+		attributes: {
+			key: '_wcpt_session_video',
+			text: __( 'View Session Video', 'wordcamporg' ),
+		},
+		isActive: ( blockAttributes ) => blockAttributes.key === '_wcpt_session_video',
+	} );
+}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -871,7 +871,7 @@ class WordCamp_Post_Types_Plugin {
 			return $content;
 		}
 
-		// If the "Session Link" block is in the post content, with the slides key, we don't need to inject anything.
+		// If the "Meta Link" block is in the post content, with the slides key, we don't need to inject anything.
 		if ( has_block_with_attrs( 'wordcamp/meta-link', array( 'key' => '_wcpt_session_slides' ), $post ) ) {
 			return $content;
 		}
@@ -922,7 +922,7 @@ class WordCamp_Post_Types_Plugin {
 			return $content;
 		}
 
-		// If the "Session Link" block is in the post content, with the video key, we don't need to inject anything.
+		// If the "Meta Link" block is in the post content, with the video key, we don't need to inject anything.
 		if ( has_block_with_attrs( 'wordcamp/meta-link', array( 'key' => '_wcpt_session_video' ), $post ) ) {
 			return $content;
 		}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -11,6 +11,7 @@ require_once 'inc/privacy.php';
 require_once 'inc/deprecated.php';
 
 use function WordCamp\Post_Types\Utilities\get_avatar_or_image;
+use function WordCamp\Blocks\has_block_with_attrs;
 
 // Bitwise mask for the sessions CPT, to add endpoints to the session pages. This should be a unique power of 2
 // greater than the core-defined ep_masks, but could potentially conflict with another plugin.
@@ -870,6 +871,11 @@ class WordCamp_Post_Types_Plugin {
 			return $content;
 		}
 
+		// If the "Session Link" block is in the post content, with the slides key, we don't need to inject anything.
+		if ( has_block_with_attrs( 'wordcamp/meta-link', array( 'key' => '_wcpt_session_slides' ), $post ) ) {
+			return $content;
+		}
+
 		$site_id = get_current_blog_id();
 
 		if ( $site_id <= apply_filters( 'wcpt_session_post_slides_info_min_site_id', 699 ) && ! in_array( $site_id, $enabled_site_ids, true ) ) {
@@ -916,6 +922,11 @@ class WordCamp_Post_Types_Plugin {
 			return $content;
 		}
 
+		// If the "Session Link" block is in the post content, with the video key, we don't need to inject anything.
+		if ( has_block_with_attrs( 'wordcamp/meta-link', array( 'key' => '_wcpt_session_video' ), $post ) ) {
+			return $content;
+		}
+
 		$site_id = get_current_blog_id();
 
 		if ( $site_id <= apply_filters( 'wcpt_session_post_video_info_min_site_id', 699 ) && ! in_array( $site_id, $enabled_site_ids, true ) ) {
@@ -946,6 +957,11 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 
 		if ( ! $this->is_single_cpt_post( 'wcb_session' ) ) {
+			return $content;
+		}
+
+		// If the "Post Terms" block is in the post content, with the session category term, we don't need to inject anything.
+		if ( has_block_with_attrs( 'core/post-terms', array( 'term' => 'wcb_session_category' ), $post ) ) {
 			return $content;
 		}
 


### PR DESCRIPTION
See #743 — This adds two new blocks to display links to a session's slides and a session's video page, following the behavior of `add_slides_info_to_session_posts` & `add_video_info_to_session_posts`. This also updates those filters to omit the injected content if the relevant blocks are used in the content.

To create this block, I created a base block called "Meta Link", which outputs a link using a meta value as the URL. It checks that the meta key is valid, and that it has `show_in_rest = true` to avoid leaking data. The two Session * blocks are variations of the Meta Links, and provide the necessary meta_key. Session Slides is marked as "default", so the Meta Links block is never used directly.

Since we can't check just the single `has_block` in the content filters, I've also added a new function, `has_block_with_attrs`, which does a more thorough check of each block to find one matching the given attributes as well as blockType name.

### Screenshots

<img width="671" alt="Screen Shot 2022-04-12 at 1 38 39 PM" src="https://user-images.githubusercontent.com/541093/163021582-52f30155-de2e-436f-894a-fd9f2a98f61a.png">

### How to test the changes in this Pull Request:

1. Edit a Session post or a session Query Loop
2. Add the Session Slides or Session Video blocks
3. It should output a link, if the session has a value for that meta key
