### PR TITLE
Blocks: Add custom content block patterns

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/blocks.php
+++ b/public_html/wp-content/mu-plugins/blocks/blocks.php
@@ -51,6 +51,9 @@ function load_includes() {
 	// Hooks.
 	require_once $hooks_dir . 'latest-posts/controller.php';
 
+	// Patterns.
+	require_once PLUGIN_DIR . 'patterns.php';
+
 	// Variations.
 	require_once $variations_dir . 'sessions-list/controller.php';
 }

--- a/public_html/wp-content/mu-plugins/blocks/patterns.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns.php
@@ -12,7 +12,7 @@ add_action( 'init', __NAMESPACE__ . '\register_patterns', 5 ); // Register our p
  * Register the patterns in the `./patterns/` directory. This matches the core
  * theme behavior to register patterns in a theme's `./patterns/` directory.
  *
- * See_register_theme_block_patterns().
+ * See _register_theme_block_patterns().
  *
  * The pattern fields include:
  *   - Title            (required)

--- a/public_html/wp-content/mu-plugins/blocks/patterns.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns.php
@@ -1,0 +1,162 @@
+<?php
+namespace WordCamp\Blocks\Patterns;
+
+use WP_Block_Patterns_Registry;
+
+/**
+ * Actions & filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\register_patterns', 5 ); // Register our patterns early, so they're first in the list.
+
+/**
+ * Register the patterns in the `./patterns/` directory. This matches the core
+ * theme behavior to register patterns in a theme's `./patterns/` directory.
+ *
+ * See_register_theme_block_patterns().
+ *
+ * The pattern fields include:
+ *   - Title            (required)
+ *   - Slug             (required)
+ *   - Description
+ *   - Viewport Width
+ *   - Inserter         (yes/no)
+ *   - Categories       (comma-separated values)
+ *   - Keywords         (comma-separated values)
+ *   - Block Types      (comma-separated values)
+ *   - Post Types       (comma-separated values)
+ *   - Template Types   (comma-separated values)
+ */
+function register_patterns() {
+	// Set up some categories (?).
+	register_block_pattern_category( 'wordcamp', array( 'label' => _x( 'WordCamp', 'Block pattern category', 'wordcamporg' ) ) );
+
+	$default_headers = array(
+		'title'         => 'Title',
+		'slug'          => 'Slug',
+		'description'   => 'Description',
+		'viewportWidth' => 'Viewport Width',
+		'inserter'      => 'Inserter',
+		'categories'    => 'Categories',
+		'keywords'      => 'Keywords',
+		'blockTypes'    => 'Block Types',
+		'postTypes'     => 'Post Types',
+		'templateTypes' => 'Template Types',
+	);
+
+	$dirpath = __DIR__ . '/patterns/';
+	if ( ! is_dir( $dirpath ) || ! is_readable( $dirpath ) ) {
+		return;
+	}
+
+	if ( file_exists( $dirpath ) ) {
+		$files = glob( $dirpath . '*.php' );
+		if ( $files ) {
+			foreach ( $files as $file ) {
+				$pattern_data = get_file_data( $file, $default_headers );
+
+				if ( empty( $pattern_data['slug'] ) ) {
+					_doing_it_wrong(
+						'register_patterns',
+						esc_html(
+							sprintf(
+								/* translators: %s: file name. */
+								__( 'Could not register file "%s" as a block pattern ("Slug" field missing)', 'wordcamp' ),
+								$file
+							)
+						),
+						''
+					);
+					continue;
+				}
+
+				if ( ! preg_match( '/^[A-z0-9\/_-]+$/', $pattern_data['slug'] ) ) {
+					_doing_it_wrong(
+						'register_patterns',
+						esc_html(
+							sprintf(
+								/* translators: %1s: file name; %2s: slug value found. */
+								__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")', 'wordcamp' ),
+								$file,
+								$pattern_data['slug']
+							)
+						),
+						''
+					);
+				}
+
+				if ( WP_Block_Patterns_Registry::get_instance()->is_registered( $pattern_data['slug'] ) ) {
+					continue;
+				}
+
+				// Title is a required property.
+				if ( ! $pattern_data['title'] ) {
+					_doing_it_wrong(
+						'register_patterns',
+						esc_html(
+							sprintf(
+								/* translators: %1s: file name; %2s: slug value found. */
+								__( 'Could not register file "%s" as a block pattern ("Title" field missing)', 'wordcamp' ),
+								$file
+							)
+						),
+						''
+					);
+					continue;
+				}
+
+				// For properties of type array, parse data as comma-separated.
+				foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes', 'templateTypes' ) as $property ) {
+					if ( ! empty( $pattern_data[ $property ] ) ) {
+						$pattern_data[ $property ] = array_filter(
+							preg_split(
+								'/[\s,]+/',
+								(string) $pattern_data[ $property ]
+							)
+						);
+					} else {
+						unset( $pattern_data[ $property ] );
+					}
+				}
+
+				// Parse properties of type int.
+				foreach ( array( 'viewportWidth' ) as $property ) {
+					if ( ! empty( $pattern_data[ $property ] ) ) {
+						$pattern_data[ $property ] = (int) $pattern_data[ $property ];
+					} else {
+						unset( $pattern_data[ $property ] );
+					}
+				}
+
+				// Parse properties of type bool.
+				foreach ( array( 'inserter' ) as $property ) {
+					if ( ! empty( $pattern_data[ $property ] ) ) {
+						$pattern_data[ $property ] = in_array(
+							strtolower( $pattern_data[ $property ] ),
+							array( 'yes', 'true' ),
+							true
+						);
+					} else {
+						unset( $pattern_data[ $property ] );
+					}
+				}
+
+				//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+				$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', 'wordcamp' );
+				if ( ! empty( $pattern_data['description'] ) ) {
+					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+					$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'wordcamp' );
+				}
+
+				// The actual pattern content is the output of the file.
+				ob_start();
+				include $file;
+				$pattern_data['content'] = ob_get_clean();
+				if ( ! $pattern_data['content'] ) {
+					continue;
+				}
+
+				register_block_pattern( $pattern_data['slug'], $pattern_data );
+			}
+		}
+	}
+}

--- a/public_html/wp-content/mu-plugins/blocks/patterns/organizer-grid-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/organizer-grid-centered.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Title: Organizer grid, centered
+ * Slug: wordcamp/organizer-grid-centered
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":99,"pages":0,"offset":0,"postType":"wcb_organizer","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"namespace":"wordcamp/organizers-query","align":"wide","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
+<!-- wp:wordcamp/avatar {"align":"center","className":"is-style-rounded"} /-->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true,"fontSize":"x-large"} /-->
+
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:read-more {"content":"Read More"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/organizer-grid-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/organizer-grid-centered.php
@@ -3,6 +3,7 @@
  * Title: Organizer grid, centered
  * Slug: wordcamp/organizer-grid-centered
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/organizer-list-bio.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/organizer-list-bio.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Title: Organizer list with bio
+ * Slug: wordcamp/organizer-list-bio
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":"99","pages":0,"offset":0,"postType":"wcb_organizer","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"namespace":"wordcamp/organizers-query"} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"><!-- wp:spacer {"height":"35px"} -->
+<div style="height:35px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:wordcamp/avatar {"className":"is-style-rounded"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"80%"} -->
+<div class="wp-block-column" style="flex-basis:80%"><!-- wp:post-title /-->
+
+<!-- wp:post-content /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity is-style-wide"/>
+<!-- /wp:separator -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/organizer-list-bio.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/organizer-list-bio.php
@@ -3,6 +3,7 @@
  * Title: Organizer list with bio
  * Slug: wordcamp/organizer-list-bio
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/session-list-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/session-list-basic.php
@@ -3,6 +3,7 @@
  * Title: Session list with description
  * Slug: wordcamp/session-list-basic
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/session-list-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/session-list-basic.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Session list with description
+ * Slug: wordcamp/session-list-basic
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":99,"pages":0,"offset":0,"postType":"wcb_session","order":"asc","orderBy":"session_date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"wc_meta_key":"_wcpt_session_type","wc_meta_value":"session"},"displayLayout":{"type":"list"},"namespace":"wordcamp/sessions-query","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
+<!-- wp:group {"style":{"visualizers":{"padding":{"top":true,"right":true,"bottom":true,"left":true}}},"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dtypography\u002d\u002dfont-size\u002d\u002dhuge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
+
+<!-- wp:wordcamp/session-date /-->
+
+<!-- wp:post-content /-->
+
+<!-- wp:post-terms {"term":"wcb_track","fontSize":"small"} /-->
+
+<!-- wp:spacer {"height":"16px"} -->
+<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css","className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity alignwide is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":"16px"} -->
+<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/session-list-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/session-list-centered.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: Session list, centered
+ * Slug: wordcamp/session-list-centered
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":99,"pages":0,"offset":0,"postType":"wcb_session","order":"asc","orderBy":"session_date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"wc_meta_key":"_wcpt_session_type","wc_meta_value":"session"},"displayLayout":{"type":"list"},"namespace":"wordcamp/sessions-query","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
+<!-- wp:group {"style":{"visualizers":{"padding":{"top":true,"right":true,"bottom":true,"left":true}}},"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:post-terms {"term":"wcb_track","textAlign":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1px","fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} /-->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true,"align":"wide","fontSize":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dtypography\u002d\u002dfont-size\u002d\u002dhuge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
+
+<!-- wp:wordcamp/session-date {"textAlign":"center"} /-->
+
+<!-- wp:read-more {"content":"Read More"} /-->
+
+<!-- wp:spacer {"height":"16px"} -->
+<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css","className":"alignwide is-style-dots"} -->
+<hr class="wp-block-separator has-css-opacity alignwide is-style-dots"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":"16px"} -->
+<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/session-list-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/session-list-centered.php
@@ -3,6 +3,7 @@
  * Title: Session list, centered
  * Slug: wordcamp/session-list-centered
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-basic.php
@@ -3,6 +3,7 @@
  * Title: Basic speaker grid
  * Slug: wordcamp/speaker-grid-basic
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-basic.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Title: Basic speaker grid
+ * Slug: wordcamp/speaker-grid-basic
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":30,"pages":0,"offset":0,"postType":"wcb_speaker","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":2},"namespace":"wordcamp/speakers-query","align":"wide","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
+<!-- wp:columns {"style":{"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}}},"backgroundColor":"tertiary"} -->
+<div class="wp-block-columns has-tertiary-background-color has-background" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:column {"verticalAlignment":"center","width":"112px"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:112px"><!-- wp:wordcamp/avatar {"className":"is-style-default"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"66.66%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.66%"><!-- wp:post-title {"textAlign":"left","isLink":true,"fontSize":"x-large"} /-->
+
+<!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamp' ); ?>"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-bio.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-bio.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Title: Speaker grid with bio
+ * Slug: wordcamp/speaker-grid-bio
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":50,"pages":0,"offset":0,"postType":"wcb_speaker","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":2},"namespace":"wordcamp/speakers-query","align":"wide"} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"1rem","padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"},"margin":{"top":"20px","bottom":"20px"}},"border":{"style":"solid","width":"1px"}}} -->
+<div class="wp-block-group" style="border-style:solid;border-width:1px;margin-top:20px;margin-bottom:20px;padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:wordcamp/avatar {"size":128} /-->
+
+<!-- wp:post-title {"isLink":true} /-->
+
+<!-- wp:post-excerpt /-->
+
+<!-- wp:separator {"opacity":"css","className":"is-style-dots"} -->
+<hr class="wp-block-separator has-css-opacity is-style-dots"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-bio.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-bio.php
@@ -3,6 +3,7 @@
  * Title: Speaker grid with bio
  * Slug: wordcamp/speaker-grid-bio
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-centered.php
@@ -3,6 +3,7 @@
  * Title: Speaker grid, centered
  * Slug: wordcamp/speaker-grid-centered
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-centered.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Title: Speaker grid, centered
+ * Slug: wordcamp/speaker-grid-centered
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":99,"pages":0,"offset":0,"postType":"wcb_speaker","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"namespace":"wordcamp/speakers-query","align":"wide","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
+<!-- wp:wordcamp/avatar {"align":"center","className":"is-style-rounded"} /-->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true,"fontSize":"x-large"} /-->
+
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamp' ); ?>"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-basic.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Title: Basic speaker list
+ * Slug: wordcamp/speaker-list-basic
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"queryId":4,"query":{"perPage":99,"pages":0,"offset":0,"postType":"wcb_speaker","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"namespace":"wordcamp/speakers-query","layout":{"inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:wordcamp/avatar {"align":"center","className":"is-style-rounded"} /-->
+
+<!-- wp:post-title {"textAlign":"center"} /-->
+
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamp' ); ?>"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"50px"} -->
+<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css"} -->
+<hr class="wp-block-separator has-css-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":"50px"} -->
+<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-basic.php
@@ -3,6 +3,7 @@
  * Title: Basic speaker list
  * Slug: wordcamp/speaker-list-basic
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-bio.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-bio.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Title: Speaker list with bio
+ * Slug: wordcamp/speaker-list-bio
+ * Categories: wordcamp
+ */
+
+?>
+<!-- wp:query {"query":{"perPage":"99","pages":0,"offset":0,"postType":"wcb_speaker","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"namespace":"wordcamp/speakers-query"} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"20%"} -->
+<div class="wp-block-column" style="flex-basis:20%"><!-- wp:spacer {"height":"35px"} -->
+<div style="height:35px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:wordcamp/avatar {"className":"is-style-rounded"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"80%"} -->
+<div class="wp-block-column" style="flex-basis:80%"><!-- wp:post-title /-->
+
+<!-- wp:post-content /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity is-style-wide"/>
+<!-- /wp:separator -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-bio.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-bio.php
@@ -3,6 +3,7 @@
  * Title: Speaker list with bio
  * Slug: wordcamp/speaker-list-bio
  * Categories: wordcamp
+ * Block Types: core/query
  */
 
 ?>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/sponsor-grid-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/sponsor-grid-basic.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Title: Basic sponsor grid
+ * Slug: wordcamp/sponsor-grid-basic
+ * Categories: wordcamp
+ * Block Types: core/query
+ */
+
+?>
+<!-- wp:query {"queryId":2,"query":{"perPage":10,"pages":0,"offset":0,"postType":"wcb_sponsor","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3},"namespace":"wordcamp/sponsors-query"} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9","scale":"contain"} /-->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->


### PR DESCRIPTION
This adds some of the patterns suggested on #756 to all WordCamp sites, specifically those showing Organizers, Sessions, and Speakers, to a new category called "WordCamp".

See #756, uses block variations added in #879 & #754.

Props melchoyce.

### Screenshots

All the patterns available in the Pattern explorer:

| Block theme (TT3, customized) | Classic theme |
|---|---|
| ![](https://github.com/WordPress/wordcamp.org/assets/541093/c1899336-ec40-4723-834c-f5cd777667ff) | ![](https://github.com/WordPress/wordcamp.org/assets/541093/968cae63-884a-4dcb-ae1c-b0556fd635a2) |

<details>
<summary>Screenshots of individual patterns</summary>

| Editor | Frontend |
|---|---|
| ![editor-organizer-grid-centered](https://github.com/WordPress/wordcamp.org/assets/541093/69f528ab-6b6d-4749-9ac2-9090dfd5eb5e) | ![theme-organizer-grid-centered](https://github.com/WordPress/wordcamp.org/assets/541093/392d41af-507a-49a5-95b7-4881f5d28040) |
| ![editor-organizer-list-bio](https://github.com/WordPress/wordcamp.org/assets/541093/ea35f558-259b-48c0-8bed-1069731f2ed0) | ![theme-organizer-list-bio](https://github.com/WordPress/wordcamp.org/assets/541093/38787a29-038b-4a7f-8e38-b32efd059c84) |
| ![editor-session-list-basic](https://github.com/WordPress/wordcamp.org/assets/541093/58e66061-c8e2-47f0-8fe8-cac333128261) | ![theme-session-list-basic](https://github.com/WordPress/wordcamp.org/assets/541093/2828ad7e-6bb8-4c03-bb9b-1624842a5569) |
| ![editor-session-list-centered](https://github.com/WordPress/wordcamp.org/assets/541093/f89cfa7f-4c39-4ed8-8579-cbce45c61170) | ![theme-session-list-centered](https://github.com/WordPress/wordcamp.org/assets/541093/61d0ce3f-973b-4d29-bb89-bf3e1ce3aaab) |
| ![editor-speaker-grid-basic](https://github.com/WordPress/wordcamp.org/assets/541093/21cca1fe-8381-4f0c-819e-bd744257e5fa) | ![theme-speaker-grid-basic](https://github.com/WordPress/wordcamp.org/assets/541093/8702179c-c1c0-4591-bcb6-1bf08aad294f) |
| ![editor-speaker-grid-bio](https://github.com/WordPress/wordcamp.org/assets/541093/42b1eb29-c24a-4156-82a0-6e0477f9d243) | ![theme-speaker-grid-bio](https://github.com/WordPress/wordcamp.org/assets/541093/4a6433a4-98d9-42f6-b577-190c3b322e43) |
| ![editor-speaker-grid-centered](https://github.com/WordPress/wordcamp.org/assets/541093/037cdfbf-75f8-446c-af05-fc085da8f523) | ![theme-speaker-grid-centered](https://github.com/WordPress/wordcamp.org/assets/541093/8d77691c-5641-4b92-a3e6-da9db75c2481) |
| ![editor-speaker-list-basic](https://github.com/WordPress/wordcamp.org/assets/541093/c908da62-23b5-424a-8878-6170018942ed) | ![theme-speaker-list-basic](https://github.com/WordPress/wordcamp.org/assets/541093/fb246535-318a-4596-81e8-53c55db0ee30) |
| ![editor-speaker-list-bio](https://github.com/WordPress/wordcamp.org/assets/541093/4ac69411-1e8d-46ab-b295-8ec872054f74) | ![theme-speaker-list-bio](https://github.com/WordPress/wordcamp.org/assets/541093/6bfd630b-cd54-4b7c-8946-045502e6dc7f) |

</details>


### How to test the changes in this Pull Request:

1. Open the editor
2. Add a pattern
3. See the WordCamp category
4. Select it, add any pattern
5. It should load the pattern into the editor

Or

1. Open the editor
2. Add a Query Loop block
3. The starter templates available should use WordCamp content

