### PR TITLE
Change unencrypted Git protocol to https

### DIFF
--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -6,7 +6,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 
 1. Clone the repo:
     ```bash
-    git clone git@github.com:WordPress/wordcamp.org.git wordcamp.test
+    git clone https://github.com/WordPress/wordcamp.org.git wordcamp.test
     cd wordcamp.test
     ```
 


### PR DESCRIPTION
On March 15, 2022, GitHub [removed](https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/) the unencrypted Git protocol.  This PR changes the protocol to https.

### The error when accessing using the removed git protcol
```
$ git clone git@github.com:WordPress/wordcamp.org.git wordcamp.test
Cloning into 'wordcamp.test'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

### How to test the changes in this Pull Request:

1.  On your local machine, clone using this command:
> git clone https://github.com/WordPress/wordcamp.org.git wordcamp.test

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
