### PR TITLE
Docker local environment failed to build wordcamp.db service - public key is not available

### DIFF
--- a/.docker/Dockerfile.mysql
+++ b/.docker/Dockerfile.mysql
@@ -1,5 +1,6 @@
 FROM mysql:5.7
 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
 RUN apt-get update \
     && apt-get install -y \
         nano \


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds the public key that is missing / not available when the `wordcamp.db` service tries to run: 
```
RUN apt-get update \
    && apt-get install -y \
        nano \
        vim
```

### Output of docker-compose up --build

```
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Building wordcamp.db
[+] Building 4.6s (6/7)                                                                                                                                         
 => [internal] load build definition from Dockerfile.mysql                                                                                                 0.0s
 => => transferring dockerfile: 305B                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/mysql:5.7                                                                                               0.0s
 => CACHED [1/3] FROM docker.io/library/mysql:5.7                                                                                                          0.0s
 => [internal] load build context                                                                                                                          0.0s
 => => transferring context: 935.12kB                                                                                                                      0.0s
 => ERROR [2/3] RUN apt-get update     && apt-get install -y         nano         vim                                                                      4.5s
------                                                                                                                                                          
 > [2/3] RUN apt-get update     && apt-get install -y         nano         vim:                                                                                 
#5 0.324 Get:1 http://deb.debian.org/debian buster InRelease [122 kB]                                                                                           
#5 0.338 Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]                                                                    
#5 0.396 Get:3 http://repo.mysql.com/apt/debian buster InRelease [22.1 kB]                                                                                      
#5 0.409 Get:4 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]                                                                                  
#5 0.514 Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7911 kB]
#5 0.667 Get:6 http://security.debian.org/debian-security buster/updates/main amd64 Packages [318 kB]
#5 0.745 Err:3 http://repo.mysql.com/apt/debian buster InRelease
#5 0.745   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 467B942D3A79BD29
#5 3.019 Get:7 http://deb.debian.org/debian buster-updates/main amd64 Packages [8796 B]
#5 3.909 Reading package lists...
#5 4.497 W: GPG error: http://repo.mysql.com/apt/debian buster InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 467B942D3A79BD29
#5 4.497 E: The repository 'http://repo.mysql.com/apt/debian buster InRelease' is not signed.
------
executor failed running [/bin/sh -c apt-get update     && apt-get install -y         nano         vim]: exit code: 100
ERROR: Service 'wordcamp.db' failed to build : Build failed
```

### How to test the changes in this Pull Request:

1. Follow the instructions at https://github.com/WordPress/wordcamp.org/blob/production/.docker/readme.md
2. When you run `docker-compose up --build`, you should see the output above.
3. Edit `.docker/Dockerfile.mysql` on your local machine and add this line prior to line 3
```
RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29
```
4. Rerun `docker-compose up --build`
5. The `wordcamp.db` service successfully builds.

### Output after adding the key
```
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Building wordcamp.db
[+] Building 4.6s (6/7)                                                                                                                                         
 => [internal] load build definition from Dockerfile.mysql                                                                                                 0.0s
 => => transferring dockerfile: 305B                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/mysql:5.7                                                                                               0.0s
 => CACHED [1/3] FROM docker.io/library/mysql:5.7                                                                                                          0.0s
 => [internal] load build context                                                                                                                          0.0s
 => => transferring context: 935.12kB                                                                                                                      0.0s
 => [2/4] RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29                                                                    1.8s
 => [3/4] RUN apt-get update     && apt-get install -y         nano         vim                                                                            9.4s
 => [4/4] ADD data/wordcamp_dev.sql /docker-entrypoint-initdb.d/data.sql                                                                                   0.0s 
 => exporting to image                                                                                                                                     0.4s 
 => => exporting layers                                                                                                                                    0.4s 
 => => writing image sha256:374eb0d076eddcbd85036bdfba377469797898f88d1596fe6a046fc24a3dc407                                                               0.0s 
 => => naming to docker.io/library/wordcamptest_wordcamp.db                                                                                                0.0s
```