### PR TITLE
CampTix: Remove camptix-mercadopago from Docker composer.json

### DIFF
--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -93,7 +93,6 @@
 		"wordpress-plugin/bbpress": "2.6.*",
 		"wpackagist-plugin/campt-indian-payment-gateway": "*",
 		"wordpress-plugin/camptix-bd-payments": "1.2",
-		"wpackagist-plugin/camptix-mercadopago": "*",
 		"wpackagist-plugin/camptix-pagseguro": "*",
 		"wpackagist-plugin/camptix-payfast-gateway": "*",
 		"wpackagist-plugin/camptix-trustcard": "*",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Composer was stopping, while running `docker-compose up --build`, because `camptix-mercadopago` was not found.  This was causing composer to not process the rest of the file.
`Root composer.json requires wpackagist-plugin/camptix-mercadopago, it could not be found in any version, there may be a typo in the package name.`

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #766

<!-- List out anyone who helped with this task. -->
Props @ryelle 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
See #766 

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Follow the instructions at https://github.com/WordPress/wordcamp.org/blob/production/.docker/readme.md
2. When running `docker-compose up --build`, you no longer see output about `camptix-mercadopago` being unavailable.


