### PR TITLE
Fix wordcamp.test success message

### DIFF
--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -49,7 +49,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
     This will provision the Docker containers and install 3rd-party plugins and themes used on WordCamp.org, if necessary. It could take some time depending upon the speed of your Internet connection. At the end of the process, you should see a message like this:
 
     ```bash
-    wordcamp.test_1  | Startup complete.
+    wordcamp.test_1  | NOTICE: ready to handle connections
     ```
    
     In this case the Docker environment will be running in the foreground. To stop the environment, use `CTRL + c`.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Updates the Docker readme with the correct success message after running `docker-compose up --build`.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #766 and [Slack](https://wordpress.slack.com/archives/C08M59V3P/p1652219592944999?thread_ts=1652217430.595639&cid=C08M59V3P).

<!-- List out anyone who helped with this task. -->
Props @ryelle 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<img width="892" alt="image" src="https://user-images.githubusercontent.com/3489003/167733241-21eebc85-b532-4677-ae3c-65e3df1210fc.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Follow the instructions at https://github.com/WordPress/wordcamp.org/blob/production/.docker/readme.md
2. When running `docker-compose up --build`, see the success message `NOTICE: ready to handle connections`

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
