### PR TITLE
Schedule Block: Add setting to toggle schedule timezones

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -43,7 +43,10 @@
 		]
 	},
 	"eslintConfig": {
-		"extends": "../../../../.eslintrc.js"
+		"extends": "../../../../.eslintrc.js",
+		"globals": {
+			"WordCampBlocks": "readonly"
+		}
 	},
 	"jest": {
 		"preset": "@wordpress/jest-preset-default",

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -178,6 +178,12 @@ function get_attributes_schema() {
 			'type'    => 'boolean',
 			'default' => true,
 		),
+
+		'useClientTimezone' => array(
+			'type'    => 'boolean',
+			// This should default to true when the event is virtual.
+			'default' => is_wordcamp_virtual( get_wordcamp_post() ),
+		),
 	);
 
 	return $schema;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -59,6 +59,7 @@ add_action( 'init', __NAMESPACE__ . '\init' );
 function enable_js_block_registration( $data ) {
 	$data['schedule'] = array(
 		'timezone' => wp_timezone_string(),
+		'adminUrl' => admin_url(),
 	);
 
 	return $data;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -48,20 +48,18 @@ add_action( 'init', __NAMESPACE__ . '\init' );
 /**
  * Enable registration of the block on the JavaScript side.
  *
- * This only exists to pass the `enabledBlocks` test in `blocks.js`. We don't actually need to populate the
- * `WordCampBlocks.schedule` property with anything on the back end, because all of the necessary data has
- * to be fetched on the fly in `fetchScheduleData`.
- *
- * See `pass_global_data_to_front_end()` for details on front- vs back-end data sourcing.
- *
- * @todo There's probably an elegant way to avoid the need for a workaround, by refactoring `blocks.js`.
+ * In the backend, all schedule, track, and settings data is fetched via `fetchScheduleData`. The only thing
+ * we need to pass directly is the timezone. For the frontend, this value is overwritten by
+ * `pass_global_data_to_front_end` with data to set up the schedule without requiring extra API requests.
  *
  * @param array $data
  *
  * @return array
  */
 function enable_js_block_registration( $data ) {
-	$data['schedule'] = array();
+	$data['schedule'] = array(
+		'timezone' => wp_timezone_string(),
+	);
 
 	return $data;
 }
@@ -101,6 +99,7 @@ function pass_global_data_to_front_end() {
 		'allTracks'     => get_all_tracks(),
 		'allCategories' => get_all_categories(),
 		'settings'      => get_settings(),
+		'timezone'      => wp_timezone_string(),
 	);
 
 	// The rest request in get_all_sessions changes the global $post value.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/front-end.js
@@ -48,7 +48,7 @@ function ScheduleGridWithContext( props ) {
  */
 function getScheduleGrdProps( element ) {
 	const { attributes: rawAttributes } = element.dataset;
-	const { allCategories, allTracks, settings } = rawScheduleData;
+	const { allCategories, allSessions, allTracks, settings } = rawScheduleData;
 	let parsedAttributes = {};
 	let derivedSessions = [];
 
@@ -56,7 +56,7 @@ function getScheduleGrdProps( element ) {
 		parsedAttributes = JSON.parse( decodeURIComponent( rawAttributes ) );
 
 		derivedSessions = getDerivedSessions(
-			rawScheduleData.allSessions,
+			allSessions,
 			allCategories,
 			allTracks,
 			parsedAttributes

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/front-end.js
@@ -9,15 +9,6 @@ import './front-end.scss';
 // See `pass_global_data_to_front_end()` for details on front- vs back-end data sourcing.
 const rawScheduleData = window.WordCampBlocks.schedule || {};
 
-/*
- * todo
- *
- * this file is being loading in the editor, but should only load on the front end.
- * probably a similar problem mentioned in render_callback -- https://github.com/WordPress/gutenberg/issues/18394
- * --, so maybe conditionally register it if on the front end?
- * `wp_using_themes() && ! wcorg_is_rest_api_request()` ? - https://wordpress.stackexchange.com/a/360401/3898
- */
-
 /**
  * Wrap ScheduleGrid with a Context provider.
  *

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -33,8 +33,31 @@ export default function ScheduleInspectorControls( {
 	setAttributes,
 	settings,
 } ) {
-	const { showCategories, chooseSpecificDays, chosenDays, chooseSpecificTracks, chosenTrackIds } = attributes;
+	const {
+		showCategories,
+		chooseSpecificDays,
+		chosenDays,
+		chooseSpecificTracks,
+		chosenTrackIds,
+		useClientTimezone,
+	} = attributes;
 	const displayedDays = getDisplayedDays( allSessions );
+
+	const clientTimezoneHelpText = __(
+		'Sessions will be shown using the local timezone of the viewer. This is best for virtual WordCamps or livestreams.',
+		'wordcamporg'
+	);
+
+	const siteTimezoneHelpText = createInterpolateElement(
+		__(
+			'Sessions will be shown using the site timezone. This uses the same timezone for everyone. <a>Set the site timezone.</a>',
+			'wordcamporg'
+		),
+		{
+			// eslint-disable-next-line jsx-a11y/anchor-has-content -- See 21441-gutenberg
+			a: <a href="/wp-admin/options-general.php" />,
+		}
+	);
 
 	return (
 		<InspectorControls>
@@ -45,6 +68,15 @@ export default function ScheduleInspectorControls( {
 					onChange={ ( value ) => setAttributes( { showCategories: value } ) }
 				/>
 
+				<ToggleControl
+					label={ __( "Use visitor's timezone", 'wordcamporg' ) }
+					help={ useClientTimezone ? clientTimezoneHelpText : siteTimezoneHelpText }
+					checked={ useClientTimezone }
+					onChange={ ( value ) => setAttributes( { useClientTimezone: value } ) }
+				/>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Filters', 'wordcamporg' ) } initialOpen={ true }>
 				<ChooseSpecificDays
 					chooseSpecificDays={ chooseSpecificDays }
 					displayedDays={ displayedDays }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -26,9 +26,13 @@ import { DATE_SLUG_FORMAT } from './data';
  * @param {Array}    props.settings
  * @return {Element}
  */
-export default function ScheduleInspectorControls(
-	{ attributes, allSessions, allTracks, setAttributes, settings }
-) {
+export default function ScheduleInspectorControls( {
+	attributes,
+	allSessions,
+	allTracks,
+	setAttributes,
+	settings,
+} ) {
 	const { showCategories, chooseSpecificDays, chosenDays, chooseSpecificTracks, chosenTrackIds } = attributes;
 	const displayedDays = getDisplayedDays( allSessions );
 
@@ -95,7 +99,8 @@ function ChooseSpecificDays( { chooseSpecificDays, displayedDays, chosenDays, da
 	const pleaseAssignDates = createInterpolateElement(
 		__( "There aren't any days to display. Please assign dates to <a>your sessions</a>.", 'wordcamporg' ),
 		{
-			a: <a href={ '/wp-admin/edit.php?post_type=wcb_session' } >#21441-gutenberg</a>,
+			// eslint-disable-next-line jsx-a11y/anchor-has-content -- See 21441-gutenberg
+			a: <a href={ '/wp-admin/edit.php?post_type=wcb_session' } />,
 		}
 	);
 
@@ -110,15 +115,14 @@ function ChooseSpecificDays( { chooseSpecificDays, displayedDays, chosenDays, da
 					/>
 				</legend>
 
-				{ chooseSpecificDays && displayedDays.length === 0 &&
+				{ chooseSpecificDays && displayedDays.length === 0 && (
 					<div className="notice notice-warning has-no-dates">
-						<p>
-							{ pleaseAssignDates }
-						</p>
+						<p>{ pleaseAssignDates }</p>
 					</div>
-				}
+				) }
 
-				{ chooseSpecificDays && displayedDays.length > 0 &&
+				{ chooseSpecificDays &&
+					displayedDays.length > 0 &&
 					displayedDays.map( ( day ) => {
 						return (
 							<CheckboxControl
@@ -126,17 +130,9 @@ function ChooseSpecificDays( { chooseSpecificDays, displayedDays, chosenDays, da
 								label={ format( dateFormat, day ) }
 								checked={ chosenDays.includes( day ) }
 								onChange={ ( isChecked ) => {
-									/*
-									 * Use `.from()` because `setAttributes()` needs a new array to determine if
-									 * it's changed or not.
-									 */
-									const newDays = Array.from( chosenDays );
-
-									if ( isChecked ) {
-										newDays.push( day );
-									} else {
-										newDays.splice( newDays.indexOf( day ), 1 ); // Remove from the array.
-									}
+									const newDays = isChecked
+										? [ ...chosenDays, day ]
+										: chosenDays.filter( ( i ) => day !== i );
 
 									setAttributes( { chosenDays: newDays } );
 								} }
@@ -168,12 +164,16 @@ function ChooseSpecificTracks( { chooseSpecificTracks, allTracks, chosenTrackIds
 	const pleaseAssignTracks = createInterpolateElement(
 		__( "There aren't any tracks to display, but you can <a>create some</a>.", 'wordcamporg' ),
 		{
-			a: <a href={ '/wp-admin/edit-tags.php?taxonomy=wcb_track&post_type=wcb_session' } >#21441-gutenberg</a>,
+			// eslint-disable-next-line jsx-a11y/anchor-has-content -- See 21441-gutenberg
+			a: <a href={ '/wp-admin/edit-tags.php?taxonomy=wcb_track&post_type=wcb_session' } />,
 		}
 	);
 
 	// See `fetchScheduleData()` for details on track sorting.
-	const tracksArrangedAlpha = __( 'Notes: Tracks are arranged alphabetically, according to their slug.', 'wordcamporg' );
+	const tracksArrangedAlpha = __(
+		'Notes: Tracks are arranged alphabetically, according to their slug.',
+		'wordcamporg'
+	);
 
 	return (
 		<div className="wordcamp-schedule__control-container">
@@ -187,15 +187,14 @@ function ChooseSpecificTracks( { chooseSpecificTracks, allTracks, chosenTrackIds
 					/>
 				</legend>
 
-				{ chooseSpecificTracks && allTracks.length === 0 &&
+				{ chooseSpecificTracks && allTracks.length === 0 && (
 					<div className="notice notice-warning has-no-tracks">
-						<p>
-							{ pleaseAssignTracks }
-						</p>
+						<p>{ pleaseAssignTracks }</p>
 					</div>
-				}
+				) }
 
-				{ chooseSpecificTracks && allTracks.length > 0 &&
+				{ chooseSpecificTracks &&
+					allTracks.length > 0 &&
 					allTracks.map( ( track ) => {
 						return (
 							<CheckboxControl
@@ -203,13 +202,9 @@ function ChooseSpecificTracks( { chooseSpecificTracks, allTracks, chosenTrackIds
 								label={ decodeEntities( stripTags( track.name ) ) }
 								checked={ chosenTrackIds.includes( track.id ) }
 								onChange={ ( isChecked ) => {
-									const newTracks = Array.from( chosenTrackIds ); // setAttributes() needs a new array to determine if it's changed or not.
-
-									if ( isChecked ) {
-										newTracks.push( track.id );
-									} else {
-										newTracks.splice( newTracks.indexOf( track.id ), 1 ); // Remove from the array.
-									}
+									const newTracks = isChecked
+										? [ ...chosenTrackIds, track.id ]
+										: chosenTrackIds.filter( ( id ) => track.id !== id );
 
 									setAttributes( { chosenTrackIds: newTracks } );
 								} }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -55,7 +55,7 @@ export default function ScheduleInspectorControls( {
 		),
 		{
 			// eslint-disable-next-line jsx-a11y/anchor-has-content -- See 21441-gutenberg
-			a: <a href="/wp-admin/options-general.php" />,
+			a: <a href={ `${ WordCampBlocks.schedule.adminUrl }options-general.php` } />,
 		}
 	);
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/inspector-controls.js
@@ -3,7 +3,7 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { CheckboxControl, PanelBody, ToggleControl } from '@wordpress/components';
-import { format } from '@wordpress/date';
+import { date, format } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -13,7 +13,7 @@ const { stripTags } = wp.sanitize;
 /**
  * Internal dependencies
  */
-import { DATE_SLUG_FORMAT } from './data';
+import { DATE_SLUG_FORMAT, SITE_TIMEZONE } from './data';
 
 /**
  * Render the inspector Controls for the Schedule block.
@@ -105,7 +105,9 @@ export default function ScheduleInspectorControls( {
 function getDisplayedDays( sessions ) {
 	let uniqueDays = sessions.reduce( ( accumulatingDays, session ) => {
 		if ( session.derived.startTime ) {
-			accumulatingDays[ format( DATE_SLUG_FORMAT, session.derived.startTime ) ] = true;
+			accumulatingDays[
+				date( DATE_SLUG_FORMAT, session.derived.startTime, SITE_TIMEZONE )
+			] = true;
 		}
 
 		return accumulatingDays;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/schedule-grid.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { format } from '@wordpress/date';
 import { __, _x } from '@wordpress/i18n';
 import { createContext, useContext } from '@wordpress/element';
+import { date, format } from '@wordpress/date';
 import { decodeEntities } from '@wordpress/html-entities';
 
 const { stripTags } = wp.sanitize;
@@ -42,13 +42,13 @@ export function ScheduleGrid( { sessions } ) {
 
 	const groupedSessions = groupSessionsByDate( sessions );
 
-	Object.keys( groupedSessions ).sort().forEach( ( date ) => {
-		const sessionsGroup = groupedSessions[ date ];
+	Object.keys( groupedSessions ).sort().forEach( ( day ) => {
+		const sessionsGroup = groupedSessions[ day ];
 
 		scheduleDays.push(
 			<ScheduleDay
-				key={ date }
-				localDate={ date }
+				key={ day }
+				localDate={ day }
 				sessions={ sessionsGroup }
 			/>
 		);
@@ -77,11 +77,11 @@ function groupSessionsByDate( sessions ) {
 			return groups;
 		}
 
-		const date = format( 'Y-m-d', session.derived.startTime );
+		const day = date( 'Y-m-d', session.derived.startTime, session.derived.timezone );
 
-		if ( date ) {
-			groups[ date ] = groups[ date ] || [];
-			groups[ date ].push( session );
+		if ( day ) {
+			groups[ day ] = groups[ day ] || [];
+			groups[ day ].push( session );
 		}
 
 		return groups;
@@ -126,8 +126,8 @@ function ScheduleDay( { localDate, sessions } ) {
 	const sectionId = `wordcamp-schedule__day-${ formattedDate }-tracks-${ formattedTrackIds }`;
 
 	const startEndTimes = sessions.reduce( ( accumulatingTimes, session ) => {
-		accumulatingTimes.push( session.derived.startTime );
-		accumulatingTimes.push( session.derived.endTime );
+		accumulatingTimes.push( date( 'dHi', session.derived.startTime, session.derived.timezone ) );
+		accumulatingTimes.push( date( 'dHi', session.derived.endTime, session.derived.timezone ) );
 
 		return accumulatingTimes;
 	}, [] );
@@ -386,9 +386,7 @@ function renderGridTemplateRows( startEndTimes ) {
 	startEndTimes.sort(); // Put them in chronological order.
 
 	const timeList = startEndTimes.reduce( ( accumulatingTimes, time ) => {
-		const formattedTime = format( 'dHi', time );
-
-		return accumulatingTimes += `[time-${ formattedTime }] auto `;
+		return accumulatingTimes += `[time-${ time }] auto `;
 	}, '' );
 
 	const templateRows = `

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/session.js
@@ -7,9 +7,9 @@ import { isEqual } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { format } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement, useContext } from '@wordpress/element';
+import { date } from '@wordpress/date';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Dashicon } from '@wordpress/components';
 
@@ -35,7 +35,7 @@ export function Session( { session, displayedTracks, showCategories, overlapsAno
 	const { renderEnvironment, settings } = useContext( ScheduleGridContext );
 	const { time_format: timeFormat } = settings;
 	const { id, slug, title, link: permalink, meta: { _wcpt_session_type: type } } = session;
-	const { assignedCategories, assignedTracks, startTime, endTime } = session.derived;
+	const { assignedCategories, assignedTracks, startTime, endTime, timezone } = session.derived;
 	const displayedTrackIds = displayedTracks.map( ( track ) => track.id );
 
 	const displayedAssignedTracks = assignedTracks.filter(
@@ -88,8 +88,8 @@ export function Session( { session, displayedTracks, showCategories, overlapsAno
 	`;
 
 	const gridRow = `
-		time-${ format( 'dHi', startTime ) } /
-		time-${ format( 'dHi', endTime ) }
+		time-${ date( 'dHi', startTime, timezone ) } /
+		time-${ date( 'dHi', endTime, timezone ) }
 	`;
 
 	return (
@@ -111,8 +111,8 @@ export function Session( { session, displayedTracks, showCategories, overlapsAno
 			</h4>
 
 			<p>
-				{ format( timeFormat, startTime ) } -
-				{ format( timeFormat, endTime ) }
+				{ date( timeFormat, startTime, timezone ) } -
+				{ date( timeFormat, endTime, timezone ) }
 			</p>
 
 			{ speakers.length > 0 && renderSpeakers( speakers, renderEnvironment ) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -6,14 +6,15 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { format } from '@wordpress/date';
+import { date } from '@wordpress/date';
 import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Session } from './session';
+import { getTimezone } from './utils/date';
 import { ScheduleGridContext } from './schedule-grid';
+import { Session } from './session';
 import { sortBySlug } from './data';
 
 /**
@@ -32,6 +33,7 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 	const overlappingSessionIds = overlappingSessions.map( ( session ) => session.id );
 	const timeGroups = [];
 	const timeSlots = Object.keys( sessionsByTimeSlot ).sort();
+	const timezone = getTimezone( attributes );
 
 	for ( let i = 0; i < timeSlots.length; i++ ) {
 		const currentSlot = timeSlots[ i ];
@@ -41,8 +43,8 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 		const endTime = parseInt( timeSlots[ i + 1 ] ) || 0;
 
 		const gridRow = `
-			time-${ format( 'dHi', startTime ) } /
-			time-${ format( 'dHi', endTime ) }
+			time-${ date( 'dHi', startTime, timezone ) } /
+			time-${ date( 'dHi', endTime, timezone ) }
 		`;
 
 		const classes = classnames(
@@ -50,10 +52,9 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 			sessionsByTimeSlot[ currentSlot ].length ? 'has-sessions' : 'is-empty'
 		);
 
-		const date = new Date( startTime );
 		timeGroups.push(
 			<h3 key={ startTime } className={ classes } style={ { gridRow } }>
-				{ date.toLocaleTimeString( [], { timeZoneName: 'short', hour: 'numeric', minute: '2-digit' } ) }
+				{ date( 'g:i a T', startTime, timezone ) }
 			</h3>
 		);
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/utils/date.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/utils/date.js
@@ -8,13 +8,3 @@
 export function getTimezone( { useClientTimezone = false } = {} ) {
 	return useClientTimezone ? Intl.DateTimeFormat().resolvedOptions().timeZone : WordCampBlocks.schedule.timezone;
 }
-
-/**
- * Get the timezone set in `derived` on a list of sessions.
- *
- * @param {Array} sessions
- * @return {string}
- */
-export function getTimezoneFromSessions( sessions ) {
-	return sessions[ 0 ]?.derived?.timezone || WordCampBlocks.schedule.timezone;
-}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/utils/date.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/utils/date.js
@@ -1,0 +1,20 @@
+/**
+ * Get the timezone to use depending on a `useClientTimezone` property.
+ *
+ * @param {Object}  props
+ * @param {boolean} props.useClientTimezone
+ * @return {string}
+ */
+export function getTimezone( { useClientTimezone = false } = {} ) {
+	return useClientTimezone ? Intl.DateTimeFormat().resolvedOptions().timeZone : WordCampBlocks.schedule.timezone;
+}
+
+/**
+ * Get the timezone set in `derived` on a list of sessions.
+ *
+ * @param {Array} sessions
+ * @return {string}
+ */
+export function getTimezoneFromSessions( sessions ) {
+	return sessions[ 0 ]?.derived?.timezone || WordCampBlocks.schedule.timezone;
+}


### PR DESCRIPTION
This PR adds a new setting (attribute) to the schedule block, "Use visitor's timezone." When toggled on, this will display the sessions using the client timezone, and when toggled off, it will use the site's timezone.

The toggle will default to showing client timezone when the WordCamp is "virtual only", and site timezone when the WordCamp is in-person. Hopefully this way the schedules default to what's expected for each camp, and if an in-person WC with a livestream wants to add a local-timezone schedule, they can do that by changing the toggle.

Fixes #753.

### Screenshots

I've split up the attributes into "Display Settings" and "Filters", and the new attribute is part of Display Settings.

<img width="282" alt="" src="https://user-images.githubusercontent.com/541093/169911207-614e8029-bacd-4ab8-9826-5289c8204ce0.png">

In this example, my local timezone is EDT, and the site's timezone is PDT (America/Vancouver). When toggled in the editor the schedule updates (assuming a different timezone). The "Choose specific days" option will always use the site timezone to prevent unexpected behavior when selecting dates — if this used the local timezone you could end up with a different set of sessions for different visitors.

Using site timezone
<img width="1475" alt="" src="https://user-images.githubusercontent.com/541093/169911537-ba237769-c6b5-4c87-8e19-7444717e53d4.png">

Using visitor's timezone
<img width="1488" alt="" src="https://user-images.githubusercontent.com/541093/169911540-b846b6cd-b4b6-42d8-b4a1-99232239102d.png">

### How to test the changes in this Pull Request:

1. Set your site timezone to something different than your current timezone
2. Set up some sessions, try to think of edge cases (ex, a session that's a different day depending on the site/client timezone)
3. Add the schedule block to a page
4. Toggle the timezone setting on & off, the schedule preview should change
5. Make sure you can still select specific days/tracks/etc
6. View the schedule on the frontend, it should use the correct timezone
