### PR TITLE
CampTix: Ensure camptix scripts are loaded in the footer

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/class-payment-options.php
@@ -34,7 +34,8 @@ class Payment_Options extends CampTix_Addon {
 			'payment_options',
 			plugins_url( 'js/payment-options.js', __FILE__ ),
 			array( 'stripe-checkout', 'camptix' ),
-			filemtime( __DIR__ . '/js/payment-options.js' )
+			filemtime( __DIR__ . '/js/payment-options.js' ),
+			true
 		);
 
 		wp_register_style(

--- a/public_html/wp-content/plugins/camptix-invoices/admin/js/camptix-invoices.js
+++ b/public_html/wp-content/plugins/camptix-invoices/admin/js/camptix-invoices.js
@@ -1,12 +1,22 @@
-jQuery( document ).ready( function ($) {
+/* global jQuery */
 
-	$(document).on( 'change', '#camptix-need-invoice', toggleInvoiceDetailsForm );
-	function toggleInvoiceDetailsForm() {
-		var $camptixInvoiceDetailsForm = $( '.camptix-invoice-details' );
-		$camptixInvoiceDetailsForm.toggle();
-		var $camptixInvoiceDetailsFormFields = $camptixInvoiceDetailsForm.find( 'input,textarea,select' );
-		var required = $camptixInvoiceDetailsFormFields.eq(0).prop( 'required' );
-		$camptixInvoiceDetailsFormFields.prop( 'required', ! required );
+jQuery( document ).ready( function( $ ) {
+	function toggleInvoiceDetailsForm( showForm ) {
+		const $camptixInvoiceDetailsForm = $( '.camptix-invoice-details' );
+		const $camptixInvoiceDetailsFormFields = $camptixInvoiceDetailsForm.find( 'input,textarea,select' );
+
+		if ( showForm ) {
+			$camptixInvoiceDetailsForm.show();
+			$camptixInvoiceDetailsFormFields.prop( 'required', true );
+		} else {
+			$camptixInvoiceDetailsForm.hide();
+			$camptixInvoiceDetailsFormFields.prop( 'required', false );
+		}
 	}
 
-});
+	$( document ).on( 'change', '#camptix-need-invoice', function( event ) {
+		toggleInvoiceDetailsForm( event.target.checked );
+	} );
+
+	toggleInvoiceDetailsForm( $( '#camptix-need-invoice' ).prop( 'checked' ) );
+} );


### PR DESCRIPTION
Currently, the payment options script is not set to load in the footer, so when it's added to the page, it pulls `camptix.js` up into the header. The `camptix.js` script expects to be called in the footer though, and some code will silently fail, like the URL formatting.

Moving this down also affected the `camptix-invoice` script, so that's been refactored to check the status of the checkbox, rather than `toggle` the default state (because with this change, it ended up in the opposite state).

Fixes #773.
Props @mrfoxtalbot.

⚠️  I've tried testing this, but I don't know if there will be other cascade effects for other camptix addons.

### Screenshots

URL validation

https://user-images.githubusercontent.com/541093/170320109-08c3cba2-078b-40f6-9b7e-9c0ee96e1a8c.mp4

If you add a company, when you click out it becomes obvious it should be a URL:

https://user-images.githubusercontent.com/541093/170320501-f162a9f5-4215-4c8e-b56b-5b7a370f7717.mp4

### How to test the changes in this Pull Request:

_If you have a WordCamp sandbox, sync this to your sandbox and try using the WordCamp Europe ticket form, start from step 5._

1. Enable up payments (can be sandboxed)
2. Create a ticket
3. Add a website/URL question to the ticket
4. Set a price on the ticket
5. Go to the tickets page and buy a ticket
6. Try adding any value to the website field
7. When you click out of it, it should prepend `http://` to the value
8. Delete it, try adding another value with `http://` or `https://` already set
9. When you click out of it, it should leave the value alone
10. Click through the rest of the purchase process

Enable the CampTix Invoices plugin, turn invoices on in Tickets > Setup > Invoices.

1. Try buying a ticket
2. Toggle on & off the invoice checkbox
3. The fields should display correctly, and are required when they're visible
