### PR TITLE
Add email templates and email attendees about their allergy or accommodation

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -64,6 +64,10 @@ class Accommodations_Field extends CampTix_Addon {
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
+
+		// E-mail template
+		add_filter( 'camptix_custom_email_templates', array( $this, 'register_custom_email_templates' ) );
+		add_filter( 'camptix_default_options', array( $this, 'custom_email_template_default_values' ) );
 	}
 
 	/**
@@ -520,6 +524,35 @@ class Accommodations_Field extends CampTix_Addon {
 			$anonymized_value = wp_privacy_anonymize_data( $type );
 			update_post_meta( $post->ID, $key, $anonymized_value );
 		}
+	}
+
+	/**
+	 * Add an e-mail template for accessibility accommodations.
+	 *
+	 * @param array $templates
+	 *
+	 * @return array
+	 */
+	public function register_custom_email_templates( $templates ) {
+		$templates['email_template_accessibility_accommodations'] = array(
+			'title'           => __( 'Accessibility Accommodations', 'wordcamporg' ),
+			'callback_method' => 'field_textarea',
+		);
+
+		return $templates;
+	}
+
+	/**
+	 * Add the default e-mail template text for accessibility accommodations.
+	 *
+	 * @param array $options
+	 *
+	 * @return array
+	 */
+	public function custom_email_template_default_values( $options ) {
+		$options['email_template_accessibility_accommodations'] = __( "Hey there!\n\nWhen you registered your ticket, you answered 'Yes' to the question 'Do you have any accessibility needs, such as a sign language interpreter or wheelchair access, to participate in WordCamp?' If you made the choice by mistake, you can edit the ticket information from:\n\n[ticket_url]\n\nIf you do require an accessibility accommodation, would you be able to provide additional detail and anything related that we should be informed of by replying to this email?", 'wordcamporg' );
+
+		return $options;
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -62,6 +62,11 @@ class Allergy_Field extends CampTix_Addon {
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
+
+        // E-mail template
+		add_filter( 'camptix_custom_email_templates', array( $this, 'register_custom_email_templates' ) );
+        add_filter( 'camptix_default_options', array( $this, 'custom_email_template_default_values' ) );
+
 	}
 
 	/**
@@ -518,6 +523,35 @@ class Allergy_Field extends CampTix_Addon {
 			$anonymized_value = wp_privacy_anonymize_data( $type );
 			update_post_meta( $post->ID, $key, $anonymized_value );
 		}
+	}
+
+	/**
+	 * Add an e-mail template for life-threatening allergies.
+	 *
+	 * @param array $templates
+	 *
+	 * @return array
+	 */
+	public function register_custom_email_templates( $templates ) {
+		$templates['email_template_life_threatening_allergy'] = array(
+			'title'           => __( 'Life-threatening Allergy', 'wordcamporg' ),
+			'callback_method' => 'field_textarea',
+		);
+
+		return $templates;
+	}
+
+	/**
+	 * Add the default e-mail template text for life-threatening allergies.
+	 *
+	 * @param array $options
+	 *
+	 * @return array
+	 */
+	public function custom_email_template_default_values( $options ) {
+		$options['email_template_life_threatening_allergy'] = __( "Hey there!\n\nWhen you registered your ticket, you answered 'Yes' to the question 'Do you have a life-threatening allergy that would affect your experience at WordCamp?' If you made the choice by mistake, you can edit the ticket information from:\n\n[ticket_url]\n\nIf you do have a life-threatening allergy, would you be able to provide additional detail and anything related that we should be informed of by replying to this email?", 'wordcamporg' );
+
+        return $options;
 	}
 }
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR attempts to add two new fields to the list of email templates in CampTix.  While the additional textareas have been added and I'm able to save content and see the entered value appear again, I'm unable to correctly setup the default value for these new fields.  This is why this PR is still marked a Draft.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Attempts to Fix #764 

<!-- List out anyone who helped with this task. -->
Props

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

The new textareas
<img width="683" alt="image" src="https://user-images.githubusercontent.com/3489003/174083881-3d5dcfa7-fac5-42b1-ad14-f78611d8ae7d.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Apply the changes in my branch to production
2. Create a new WordCamp and its site.
3. Browse to the new site's Tickets > Setup > E-mail Templates (/wp-admin/edit.php?post_type=tix_ticket&page=camptix_options&tix_section=email-templates)
4. See two new fields (screenshot above) that are empty.  I was under the impression that the function `custom_email_template_default_values( $options )` in `public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php` and `public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php` would set these defaults.
5. Enter some text in the two blank textareas and click `Save Changes`.
6. See the same text shown in the textareas.
7. Click the `Reset Default` button.
8. Same as in step 4 above (the fields are empty, but I was expecting to see default values.)

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
