### PR TITLE
Clarify "No comma" in payment amount description

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-general.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-general.php
@@ -4,7 +4,7 @@
 		$this->render_text_input( $post, esc_html__( 'Invoice Number', 'wordcamporg' ), 'invoice_number' );
 		$this->render_text_input( $post, esc_html__( 'Invoice date', 'wordcamporg' ), 'invoice_date', '', 'date' );
 		$this->render_text_input( $post, esc_html__( 'Requested date for payment/due by', 'wordcamporg' ), 'due_by', '', 'date' );
-		$this->render_text_input( $post, esc_html__( 'Amount', 'wordcamporg' ), 'payment_amount', esc_html__( 'No commas, thousands separators or currency symbols. Ex. 1234.56', 'wordcamporg' ) );
+		$this->render_text_input( $post, esc_html__( 'Amount', 'wordcamporg' ), 'payment_amount', esc_html__( 'No thousands separators or currency symbols. Use a period for the decimal separator. Ex. 1234.56', 'wordcamporg' ) );
 		$this->render_select_input( $post, esc_html__( 'Currency', 'wordcamporg' ), 'currency' );
 		$this->render_select_input( $post, esc_html__( 'Category', 'wordcamporg' ), 'payment_category' );
 	?>


### PR DESCRIPTION
In some languages, commas are used for decimal separators. We recently received a payment request omitting the comma, so the result request was 100 times more amount than intended (800,00 was changed to 80000, instead of 800.00). I think we should ask not to include thousands separators or currency symbols, and use a period for the decimal separator.