### PR TITLE
Keep the path component when redirecting from the root-domain to a sub-path.

### DIFF
--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -111,7 +111,7 @@ function main() {
 	/*
 	 * This has to run before `get_canonical_year_url()`, because that function will redirect these requests to
 	 * the latest site instead of the intended one, and would strip out the request URI.
-	 * 
+	 *
 	 * This branch specifically only processes root-relative urls which are linked to from the same domain.
 	 */
 	if ( ! $redirect ) {

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -111,6 +111,8 @@ function main() {
 	/*
 	 * This has to run before `get_canonical_year_url()`, because that function will redirect these requests to
 	 * the latest site instead of the intended one, and would strip out the request URI.
+	 * 
+	 * This branch specifically only processes root-relative urls which are linked to from the same domain.
 	 */
 	if ( ! $redirect ) {
 		$redirect = get_corrected_root_relative_url( $domain, $path, $_SERVER['REQUEST_URI'], $_SERVER['HTTP_REFERER'] ?? '' );
@@ -128,6 +130,15 @@ function main() {
 	// Do this one last, because it sometimes executes a database query.
 	if ( ! $redirect ) {
 		$redirect = get_canonical_year_url( $domain, $path );
+
+		/*
+		 * Keep the path components if we requested the root site.
+		 * Eg. narnia.wordcamp.org/tickets => narnia.worcamp.org/{$latest_year}/tickets
+		 *     narnia.wordcamp.org/wp-login.php => narnia.wordcamp.org/{$latest_year}/wp-login.php
+		 */
+		if ( $redirect && '/' === $path ) {
+			$redirect .= ltrim( $_SERVER['REQUEST_URI'], '/' );
+		}
 
 		if ( $redirect ) {
 			$status_code = 302;


### PR DESCRIPTION
While testing some login changes, I ran into a slight issue - `asia.wordcamp.org/tickets` will redirect to `/2023/tickets` when linked to from asia.wordcamp.org, but not when linked to from outside.

This was intentional, links to `/tickets` should only be present on older sites which were migrated from `{year}.{city}.wordcamp.org` domains, but having the entire path of a request such as `asia.wordcamp.org/tickets` be lost during the redirect to `asia.wordcamp.org/2023/` feels slightly wrong. It would be better if it could retain that path component.

The above example is a contrived example, in my case I ran into it with `brisbane.wordcamp.org/wp-login.php` redirecting to `brisbane.wordcamp.org/2020/` and causing the remote-login code I was working on to fail. In my case, I'll fix this properly in a different manner, but brought up that supporting the above use-case would be worthwhile IMHO.

One downside of this would be that a link to `city.wordcamp.org/a-page-that-doesnt-exist` would end up on a 404 of `city.wordcamp.org/year/a-page-that-doesnt-exist` but I don't think that's a major concern.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Apply.
2. Request URL that redirects to current year
3. Observe "lost" path components.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
