### PR TITLE
Blocks: Return error when showing sessions inside session.

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/controller.php
@@ -35,6 +35,17 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  * @return string
  */
 function render( $attributes ) {
+	$current_post = get_post();
+
+	if ( 'revision' === $current_post->post_type ) {
+		$current_post = get_post( $current_post->post_parent );
+	}
+
+	// Showing sessions inside a session can lead to an infinite loop, and doesn't have any apparent use cases.
+	if ( 'wcb_session' === $current_post->post_type ) {
+		return '<div class="notice notice-error"> <p> This block can\'t be used inside a Session post. It\'s intended to be used in a page or post. </p> </div>';
+	}
+
 	$defaults   = wp_list_pluck( get_attributes_schema(), 'default' );
 	$attributes = wp_parse_args( $attributes, $defaults );
 	$sessions   = get_session_posts( $attributes );


### PR DESCRIPTION
If the Session block is added to a `wcb_session` post, it leads to an infinite loop when the current session is in the array returned by `get_session_posts()`.

I can't think of any use cases for doing that, I think it was just a misunderstanding of what the block does. Given that, it's probably best to prevent the block from being inserted into a Session post.

I didn't see a good way to do that via Gutenberg, though. `unregisterBlockType()` feels kind of clunky, and there may be cases where we need to leave it registered (like a loop of several posts where some can have the block and others can't). `hideBlockTypes()` would add it to the user's preferences permanently.

I ended up just returning an error message, but am open to a better way.

See https://wordpress.slack.com/archives/C08M59V3P/p1670236017716039