### PR TITLE
Disable certain Jetpack modules which do not operate correctly on WordCamp.org

### DIFF
--- a/public_html/wp-content/mu-plugins/disable-modules.php
+++ b/public_html/wp-content/mu-plugins/disable-modules.php
@@ -1,0 +1,15 @@
+<?php
+namespace WordCamp\Jetpack_Tweaks\DisabledModules;
+
+defined( 'WPINC' ) || die();
+
+add_filter( 'jetpack_get_available_modules', __NAMESPACE__ . '\disable_modules' );
+function disable_modules( $modules ) {
+	// WordCamp infrastructure has monitoring in place which alerts those who can resolve downtime issues.
+	unset( $modules['monitor'] );
+
+	// Not supported on the WordCamp infrastructure.
+	unset( $modules['waf'] );
+
+	return $modules;
+}

--- a/public_html/wp-content/mu-plugins/disable-modules.php
+++ b/public_html/wp-content/mu-plugins/disable-modules.php
@@ -3,7 +3,12 @@ namespace WordCamp\Jetpack_Tweaks\DisabledModules;
 
 defined( 'WPINC' ) || die();
 
-add_filter( 'jetpack_get_available_modules', __NAMESPACE__ . '\disable_modules' );
+/**
+ * Disable Jetpack Modules which are not applicable to WordCamp.org.
+ *
+ * @param array $modules The Jetpack modules.
+ * @return array
+ */
 function disable_modules( $modules ) {
 	// WordCamp infrastructure has monitoring in place which alerts those who can resolve downtime issues.
 	unset( $modules['monitor'] );
@@ -13,3 +18,4 @@ function disable_modules( $modules ) {
 
 	return $modules;
 }
+add_filter( 'jetpack_get_available_modules', __NAMESPACE__ . '\disable_modules' );


### PR DESCRIPTION
This disables the Jetpack Downtime monitor, and the Firewall that's in Beta.

Jetpack Monitor alerts WordCamp site owners, and the WordCamp community team, but neither can do anything to resolve downtime issues. Our general infrastructure checks validate that WordCamp.org is operational.

Jetpack Firewall/WAF requires the ability to write to local files, which is not possible on the WordCamp infrastructure. We also have other server-level security measures in place.