### PR TITLE
Fix Jetpack fatals on update

### DIFF
--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -331,8 +331,12 @@ function wcorg_get_custom_css_url() {
 	 * This has side-effects because `add_hooks()` is called immediately, but it doesn't seem problematic because
 	 * it gets loaded on every front/back-end page anyway.
 	 */
-	require_once WP_PLUGIN_DIR . '/jetpack/modules/custom-css/custom-css-4.7.php';
-
+	if ( version_compare( JETPACK__VERSION, '11.6', '<' ) ) {
+		require_once JETPACK__PLUGIN_DIR . '/modules/custom-css/custom-css-4.7.php';
+	} else {
+		require_once JETPACK__PLUGIN_DIR . '/modules/custom-css/custom-css.php';
+	}
+	
 	ob_start();
 	Jetpack_Custom_CSS_Enhancements::wp_custom_css_cb();
 	$markup = ob_get_clean();

--- a/public_html/wp-content/themes/wordcamp-base/lib/structure/class-wcb-structure.php
+++ b/public_html/wp-content/themes/wordcamp-base/lib/structure/class-wcb-structure.php
@@ -42,7 +42,12 @@ class WCB_Structure extends WCB_Loader {
 		$grid = wcb_get_option('grid');
 
 		// Don't output CSS if Jetpack Custom CSS/RemoteCSS is set to 'replace' mode
-		require_once JETPACK__PLUGIN_DIR . '/modules/custom-css/custom-css-4.7.php';
+		if ( version_compare( JETPACK__VERSION, '11.6', '<' ) ) {
+			require_once JETPACK__PLUGIN_DIR . '/modules/custom-css/custom-css-4.7.php';
+		} else {
+			require_once JETPACK__PLUGIN_DIR . '/modules/custom-css/custom-css.php';
+		}
+
 		if ( Jetpack_Custom_CSS_Enhancements::skip_stylesheet() ) {
 			return;
 		}


### PR DESCRIPTION
Since Jetpack removed the 4.7 version in JP 11.6, updating Jetpack causes fatals due to these hardcoded includes no longer being in the plugin.

See: https://wordpress.slack.com/archives/GDDSW0WNS/p1673447878210639