### PR TITLE
Give option to show description below text field

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1804,12 +1804,20 @@ class CampTix_Plugin {
 	function field_text( $args ) {
 		?>
 		<input type="text" name="<?php echo esc_attr( $args['name'] ); ?>" value="<?php echo esc_attr( $args['value'] ); ?>" class="regular-text" />
+
+		<?php if ( isset( $args['description'] ) ) : ?>
+		<p class="description"><?php echo wp_kses_data( $args['description'] ); ?></p>
+		<?php endif; ?>
 		<?php
 	}
 
 	function field_textarea( $args ) {
 		?>
 		<textarea class="large-text" rows="5" name="<?php echo esc_attr( $args['name'] ); ?>"><?php echo esc_textarea( $args['value'] ); ?></textarea>
+
+		<?php if ( isset( $args['description'] ) ) : ?>
+		<p class="description"><?php echo wp_kses_data( $args['description'] ); ?></p>
+		<?php endif; ?>
 		<?php
 	}
 


### PR DESCRIPTION
Earlier, there was option to show description below field_yesno but there was no option to show description below field_text and field_textarea. This code will allow to show description below these fields. Some payment gateways needs to show description below fields.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #, See #

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. 
`$this->add_settings_field_helper( 'title', 'Title', [ $this, 'field_text' ], 'Description' );`

Above code in `payment_settings_fields ` function of Payment gateway integration class will now show Description below the text field

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
