### PR TITLE
Fix `composer/installers` not being an allowed plugin

### DIFF
--- a/.docker/bin/extra-setup.sh
+++ b/.docker/bin/extra-setup.sh
@@ -37,6 +37,7 @@ function do_extra_setup() {
 
   if [ ! -f $PKG_PATH/composer.lock ]; then
     echo "Installing additional plugins and themes... "
+    php composer.phar config --no-plugins allow-plugins.composer/installers true
     php composer.phar install
   fi
 }

--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -9,6 +9,9 @@
 	"config": {
 		"platform": {
 			"php": "7.2"
+		},
+		"allow-plugins": {
+			"composer/installers": true
 		}
 	},
 	"extra": {


### PR DESCRIPTION
When running the Docker command to build the `php-fpm` container, it fails at the `composer install` step. Running the Docker command a second time would not even fix it, as the `composer install` would not even run again.

This change makes sure that the composer plugin is always allowed and the install works.