### PR TITLE
Add a redirect bypass for WC Asia 2023/24

### DIFF
--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -584,7 +584,7 @@ function get_canonical_year_url( $domain, $path ) {
 			break;
 
 		case "asia.wordcamp.$tld":
-			if ( time() <= strtotime( '2023-02-19' ) ) {
+			if ( time() <= strtotime( '2023-02-20' ) ) {
 				return "https://asia.wordcamp.$tld/2023/";
 			}
 			break;

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -582,6 +582,12 @@ function get_canonical_year_url( $domain, $path ) {
 				return "https://us.wordcamp.$tld/2023/";
 			}
 			break;
+
+		case "asia.wordcamp.$tld":
+			if ( time() <= strtotime( '2023-02-19' ) ) {
+				return "https://asia.wordcamp.$tld/2023/";
+			}
+			break;
 	}
 
 	$latest = $wpdb->get_row( $wpdb->prepare( "


### PR DESCRIPTION
This adds a date redirect bypass for asia.wordcamp.org similar to the US and EU flagships, so we can launch the 2024 site before the end of the 2023 event.