### PR TITLE
Docker: Update MySQL base to stay with debian OS

### DIFF
--- a/.docker/Dockerfile.mysql
+++ b/.docker/Dockerfile.mysql
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7-debian
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
Fixes #830 — The official MySQL image has changed to a default of Oracle Linux, which causes the `apt-get` commands to fail. Switching to the debian image explicitly will keep the current behavior working.

Props @2ndkauboy for the report.

### How to test the changes in this Pull Request:

1. Build the docker images with `docker compose build --pull`
2. The build should complete successfully.
