### PR TITLE
Restore query options when sent

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -289,7 +289,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 				<?php
 
 				echo esc_html( $wordcamp->post_title );
-				if ( ! empty( $wordcamp->start_date && false === strpos( $wordcamp->post_title, gmdate( 'Y', $wordcamp->start_date ) ) ) {
+				if ( ! empty( $wordcamp->start_date ) && false === strpos( $wordcamp->post_title, gmdate( 'Y', $wordcamp->start_date ) ) ) {
 					echo ' ' . esc_html( gmdate( 'Y', $wordcamp->start_date ) );
 				} else if ( ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) && false === strpos( $wordcamp->post_title, gmdate( 'Y', $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ) ) {
 					// Catches when query_options is sent, since format is different.

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -252,7 +252,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 	global $wpdb;
 
 	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
-	
+
 	if ( empty( $query_options ) {
 		$wordcamps = $wpdb->get_results( "
 			SELECT $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->postmeta.meta_value AS start_date
@@ -266,7 +266,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 		 " );
 	} else {
 		// Default to standard query when query_options is sent.
-		$wordcamps = get_wordcamps( $query_options );	
+		$wordcamps = get_wordcamps( $query_options );
 	}
 	restore_current_blog();
 

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -253,7 +253,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 
 	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
 
-	if ( empty( $query_options ) {
+	if ( empty( $query_options ) ) {
 		$wordcamps = $wpdb->get_results( "
 			SELECT $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->postmeta.meta_value AS start_date
 			FROM $wpdb->posts

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -252,18 +252,22 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 	global $wpdb;
 
 	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
-
-	$wordcamps = $wpdb->get_results( "
-		SELECT $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->postmeta.meta_value AS start_date
-		FROM $wpdb->posts
-			LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID
-		WHERE
-			$wpdb->posts.post_type = 'wordcamp' AND
-			( $wpdb->posts.post_status <> 'trash' AND $wpdb->posts.post_status <> 'auto-draft' AND $wpdb->posts.post_status <> 'spam' ) AND
-			$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
-		ORDER BY `$wpdb->posts`.`ID` DESC
-	 " );
-
+	
+	if ( empty( $query_options ) {
+		$wordcamps = $wpdb->get_results( "
+			SELECT $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->postmeta.meta_value AS start_date
+			FROM $wpdb->posts
+				LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID
+			WHERE
+				$wpdb->posts.post_type = 'wordcamp' AND
+				( $wpdb->posts.post_status <> 'trash' AND $wpdb->posts.post_status <> 'auto-draft' AND $wpdb->posts.post_status <> 'spam' ) AND
+				$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
+			ORDER BY `$wpdb->posts`.`ID` DESC
+		 " );
+	} else {
+		// Default to standard query when query_options is sent.
+		$wordcamps = get_wordcamps( $query_options );	
+	}
 	restore_current_blog();
 
 	wp_enqueue_script( 'select2' );
@@ -285,10 +289,12 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 				<?php
 
 				echo esc_html( $wordcamp->post_title );
-				if ( ! empty( $wordcamp->start_date ) ) {
+				if ( ! empty( $wordcamp->start_date && false === strpos( $wordcamp->post_title, gmdate( 'Y', $wordcamp->start_date ) ) ) {
 					echo ' ' . esc_html( gmdate( 'Y', $wordcamp->start_date ) );
+				} else if ( ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) && false === strpos( $wordcamp->post_title, gmdate( 'Y', $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ) ) {
+					// Catches when query_options is sent, since format is different.
+					echo ' ' . esc_html( gmdate( 'Y', $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) );
 				}
-
 				?>
 			</option>
 		<?php endforeach; ?>


### PR DESCRIPTION
Returns the query_options when sent to function.

Also added an additional check before outputting the date, since often it would be seen as `Community Summit 2023 2023` when the date was in the post title.

Fixes #836


Props @iandunn 