### PR TITLE
Coming Soon: Sort pages by date before looking for form code

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -326,6 +326,8 @@ class WordCamp_Coming_Soon_Page {
 		$all_pages = get_posts( array(
 			'post_type'      => 'page',
 			'posts_per_page' => -1,
+			'orderby'        => 'date',
+			'order'          => 'ASC',
 		) );
 
 		foreach ( $all_pages as $page ) {


### PR DESCRIPTION
When looking for the form for Coming Soon, by default, pages are sorted by date descending, meaning the most recent page with a form will be used. The contact page is created when the site is created, so it will always be the oldest. If a later page is created for speaker submission, volunteering, etc, this form will be chosen first. The fix is to sort ascending, since we can safely assume the earliest page with a form is Contact.

Reported in slack: https://wordpress.slack.com/archives/C08M59V3P/p1677310384535199

Props danmaby, rmarks for helping debug.

### How to test the changes in this Pull Request:

1. Create a test site (or try with testing.wordcamp.org/2019)
2. Set it to Coming Soon mode
3. Check that the contact form renders on the Coming Soon page
4. Create a new page with a contact form on it
5. Check the Coming Soon page again, it should still have the contact form
