### PR TITLE
Loop through queries in steps

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/field-tshirt.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-tshirt.php
@@ -130,11 +130,11 @@ class CampTix_Addon_Tshirt_Field extends CampTix_Addon {
 					'posts_per_page' => 1000,
 					'paged'          => $i,
 				) );
-				
+
 				if ( empty( $attendees ) ) {
 					break;
 				}
-				
+
 				foreach ( $attendees as $attendee ) {
 					if ( empty( $attendee->tix_questions[ $question->ID ] ) ) {
 						continue;

--- a/public_html/wp-content/plugins/camptix/addons/field-tshirt.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-tshirt.php
@@ -122,24 +122,32 @@ class CampTix_Addon_Tshirt_Field extends CampTix_Addon {
 			return $size_counts;
 		}
 
-		$attendees = get_posts( array(
-			'post_type'      => 'tix_attendee',
-			'posts_per_page' => 10000,
-		) );
-
 		foreach ( $questions as $question ) {
-			foreach ( $attendees as $attendee ) {
-				if ( empty( $attendee->tix_questions[ $question->ID ] ) ) {
-					continue;
+			// Loop around attendees in pages of 1000 to avoid memory issues.
+			for ( $i = 1; $i <= 10; $i++ ) {
+				$attendees = get_posts( array(
+					'post_type'      => 'tix_attendee',
+					'posts_per_page' => 1000,
+					'paged'          => $i,
+				) );
+				
+				if ( empty( $attendees ) ) {
+					break;
 				}
+				
+				foreach ( $attendees as $attendee ) {
+					if ( empty( $attendee->tix_questions[ $question->ID ] ) ) {
+						continue;
+					}
 
-				$size = $attendee->tix_questions[ $question->ID ];
+					$size = $attendee->tix_questions[ $question->ID ];
 
-				if ( empty( $size_counts[ $size ] ) ) {
-					$size_counts[ $size ] = 0;
+					if ( empty( $size_counts[ $size ] ) ) {
+						$size_counts[ $size ] = 0;
+					}
+
+					$size_counts[ $size ]++;
 				}
-
-				$size_counts[ $size ]++;
 			}
 		}
 


### PR DESCRIPTION
Instead of calling up to 10,000 attendees, loop through in blocks of 1,000

Should hopefully reduce memory consumption which is alerting.