### PR TITLE
Allow an attendee to have multiple flags, while preventing a flag being added multiple times.

### DIFF
--- a/public_html/wp-content/plugins/camptix-admin-flags/addons/admin-flags.php
+++ b/public_html/wp-content/plugins/camptix-admin-flags/addons/admin-flags.php
@@ -508,8 +508,10 @@ class CampTix_Admin_Flags_Addon extends CampTix_Addon {
 			wp_send_json_error( array( 'error' => 'Invalid attendee.' ) );
 		}
 
-		if ( 'enable' === $command ) {
-			update_post_meta( $attendee_id, 'camptix-admin-flag', $key );
+		$attendee_flags = (array) get_post_meta( $attendee_id, 'camptix-admin-flag' );
+
+		if ( 'enable' === $command && ! in_array( $key, $attendee_flags, true ) ) {
+			add_post_meta( $attendee_id, 'camptix-admin-flag', $key );
 		} elseif ( 'disable' === $command ) {
 			delete_post_meta( $attendee_id, 'camptix-admin-flag', $key );
 		}


### PR DESCRIPTION
See https://wordpress.slack.com/archives/C08M59V3P/p1678307726917039

Allow an attendee to have multiple flags, while preventing a flag being added multiple times.
Reverts 1579411c528b53d5f9500a70b4d59baeb28fae76

---

`add_post_meta()` was switched to `update_post_meta()` to account for a user having multiple post-meta's, such as `[ 'flag1', 'flag1', 'flag2' ]` but in doing so that removed the ability for an attendee to have multiple flags.

This reverts 1579411c528b53d5f9500a70b4d59baeb28fae76 but checks to see if the attendee has the flag before setting it again.

This is not an atomic operation, and the previous bug may still occur (especially when there's a higher than usual DB replication latency) but this should reduce it.