### PR TITLE
Update Code of Conduct text

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct-online.php
@@ -113,3 +113,15 @@
 <!-- wp:paragraph -->
 <p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">Open Source Bridge 2018 [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>Statement about Socials or Supplemental Events (where applicable)</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Social and supplemental events are intended to provide networking and additional educational opportunities, as well as an opportunity to unwind after a full WordCamp. They should also be places where attendees can feel safe and secure.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>We want you to enjoy yourself at these events, and we want you to do so safely. If you experience a Code of Conduct violation, see a violation, are concerned about the well-being, safety or behavior of another attendee, or have a general question (we understand that violations are not always obvious!) contact us immediately by notifying a WordCamp organizer or emailing <a href="mailto:report@wordcamp.org">report@wordcamp.org</a>. For in-person events, if you need help or are unable to comfortably or safely remove yourself from a situation you do not want to be in, organizers will prioritize assisting you immediately and discretely. Some examples are: not feeling well; your transportation arrangements fall through; you are intoxicated, you are alone or with someone you do not trust, you are overwhelmed, you have experienced or witnessed a Code of Conduct violation. Please ask any nearby event volunteer or organizer to help you.</p>
+<!-- /wp:paragraph -->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/code-of-conduct.php
@@ -113,3 +113,15 @@
 <!-- wp:paragraph -->
 <p>This Code of Conduct is a direct swipe from the awesome work of Open Source Bridge, but with our event information substituted. The original is available at <a href="http://web.archive.org/web/20191206083557/http://opensourcebridge.org/about/code-of-conduct/">Open Source Bridge 2018 [archived]</a> and is released under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike</a> license.</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>Statement about Socials or Supplemental Events (where applicable)</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Social and supplemental events are intended to provide networking and additional educational opportunities, as well as an opportunity to unwind after a full WordCamp. They should also be places where attendees can feel safe and secure.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>We want you to enjoy yourself at these events, and we want you to do so safely. If you experience a Code of Conduct violation, see a violation, are concerned about the well-being, safety or behavior of another attendee, or have a general question (we understand that violations are not always obvious!) contact us immediately by notifying a WordCamp organizer or emailing <a href="mailto:report@wordcamp.org">report@wordcamp.org</a>. For in-person events, if you need help or are unable to comfortably or safely remove yourself from a situation you do not want to be in, organizers will prioritize assisting you immediately and discretely. Some examples are: not feeling well; your transportation arrangements fall through; you are intoxicated, you are alone or with someone you do not trust, you are overwhelmed, you have experienced or witnessed a Code of Conduct violation. Please ask any nearby event volunteer or organizer to help you.</p>
+<!-- /wp:paragraph -->


### PR DESCRIPTION
As per updates to https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/code-of-conduct/, the changes reflect these.

See: https://wordpress.slack.com/archives/C08M59V3P/p1678957621185289