### PR TITLE
Blocks: Check for post context values before using data

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/meta-link/edit.js
@@ -15,19 +15,12 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { Notice } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 
 export default function Edit( { attributes, setAttributes, context: { postId, postType } } ) {
 	const { key, text, textAlign } = attributes;
-	const url = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			const post = getEntityRecord( 'postType', postType, postId );
-			return post.meta[ key ];
-		},
-		[ key ]
-	);
+	const [ meta = {} ] = useEntityProp( 'postType', postType, 'meta', postId );
+	const url = meta[ key ] || '';
 
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -45,10 +38,13 @@ export default function Edit( { attributes, setAttributes, context: { postId, po
 					} }
 				/>
 			</BlockControls>
-			{ ! url && (
+			{ postId && postType && ! url && (
 				<InspectorControls>
 					<Notice status="error" isDismissible={ false }>
-						{ __( 'The link for this content is missing. Add the URL in the Session tab.', 'wordcamporg' ) }
+						{ __(
+							'The link for this content is missing. Add the URL in the Session tab.',
+							'wordcamporg'
+						) }
 					</Notice>
 				</InspectorControls>
 			) }

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-date/edit.js
@@ -11,16 +11,12 @@ import { __, _x } from '@wordpress/i18n';
 import { AlignmentControl, BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { dateI18n, __experimentalGetSettings as getDateSettings } from '@wordpress/date'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 
 export default function Edit( { attributes, setAttributes, context: { postId, postType } } ) {
 	const { format, showTimezone, textAlign } = attributes;
-	const date = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
-		const session = getEntityRecord( 'postType', postType, postId );
-		return session.meta._wcpt_session_time * 1000; // Convert from s to ms.
-	}, [] );
+	const [ meta = {} ] = useEntityProp( 'postType', postType, 'meta', postId );
+	const date = meta._wcpt_session_time;
 
 	const { formats } = getDateSettings();
 	const defaultFormat = formats.datetime;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/edit.js
@@ -15,16 +15,11 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 
 export default function( { attributes, setAttributes, context: { postId, postType }, isSelected } ) {
 	const { byline, isLink, textAlign } = attributes;
-	const speakers = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
-		const session = getEntityRecord( 'postType', postType, postId );
-		return session.session_speakers || [];
-	}, [] );
+	const [ speakers = [] ] = useEntityProp( 'postType', postType, 'session_speakers', postId );
 
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -62,11 +57,17 @@ export default function( { attributes, setAttributes, context: { postId, postTyp
 						onChange={ ( value ) => setAttributes( { byline: value } ) }
 					/>
 				) }
-				{ speakers.map( ( { id, name, link } ) => (
-					<span key={ id } className="wp-block-wordcamp-session-speakers__name">
-						{ isLink ? <a href={ link }>{ name }</a> : name }
+				{ postType && postId ? (
+					speakers.map( ( { id, name, link } ) => (
+						<span key={ id } className="wp-block-wordcamp-session-speakers__name">
+							{ isLink ? <a href={ link }>{ name }</a> : name }
+						</span>
+					) )
+				) : (
+					<span className="wp-block-wordcamp-session-speakers__name">
+						{ __( 'Speaker Name', 'wordcamporg' ) }
 					</span>
-				) ) }
+				) }
 			</div>
 		</>
 	);

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/edit.js
@@ -20,6 +20,18 @@ import { getSessionDetails, sortSessionByTime } from '../sessions/utils';
 export default function( { attributes, setAttributes, context: { postId } } ) {
 	const { hasSessionDetails, isLink, textAlign } = attributes;
 	const sessions = useSelect( ( select ) => {
+		if ( ! postId ) {
+			return [
+				{
+					id: 1,
+					title: { rendered: 'Session Name' },
+					link: '#',
+					session_date_time: { date: 'November 1, 2023', time: '10:15 am' },
+					session_track: [],
+				},
+			];
+		}
+
 		const { getEntityRecords } = select( coreStore );
 		const _sessions =
 			getEntityRecords( 'postType', 'wcb_session', {


### PR DESCRIPTION
If used in the post editor, these are valid and reflect the current post. If used in the template editor, these are null, and the block should display a placeholder value. This will display the placeholder value in the template editor regardless of sessions (published or not) on the site.

Fixes #829, fixes #832

### Screenshots

Speaker Sessions block in a speaker template:

![Screen Shot 2023-03-17 at 16 29 55](https://user-images.githubusercontent.com/541093/226033112-5f626416-3d75-4ce1-bc23-a72ec94fc00f.png)

Sessions blocks in a session template:

![Screen Shot 2023-03-17 at 16 30 28](https://user-images.githubusercontent.com/541093/226033119-d1a76662-9d01-44be-9d88-210587738a98.png)

### How to test the changes in this Pull Request:

1. Create or edit a template in the Site Editor, pick the "Single item: Speaker" or "Single item: Session" type
2. Add the "Session *" or "Speaker *" blocks to the template
3. They should work, no block or editor crashes
4. View some speakers/sessions on the frontend, they should use the template
