### PR TITLE
Add block templates for custom content type single views (Organizer, Speaker, etc)

### DIFF
--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_organizer.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_organizer.php
@@ -1,3 +1,10 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * Template: Single Organizer
+ */
+?>
+
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_organizer.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_organizer.php
@@ -1,0 +1,19 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)"><!-- wp:wordcamp/avatar {"className":"is-style-rounded"} /-->
+
+<!-- wp:post-title {"level":1} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+<!-- wp:spacer {"height":"0px","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}}} -->
+<div style="margin-bottom:var(--wp--preset--spacing--70);height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_session.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_session.php
@@ -1,0 +1,53 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:wordcamp/session-speakers {"byline":"<?php esc_html_e( 'Presented by', 'wordcamporg' ); ?>","isLink":true} /-->
+
+<!-- wp:wordcamp/session-date {"format":"l g:i A"} /-->
+
+<!-- wp:wordcamp/meta-link {"key":"_wcpt_session_video","text":"<?php esc_html_e( 'Play Session Video', 'wordcamporg' ); ?>"} /-->
+
+<!-- wp:wordcamp/meta-link {"key":"_wcpt_session_slides","text":"<?php esc_html_e( 'View Session Slides', 'wordcamporg' ); ?>"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+<!-- wp:spacer {"height":"0"} -->
+<div style="height:0" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:separator {"opacity":"css","align":"wide","className":"is-style-wide"} -->
+<hr class="wp-block-separator alignwide has-css-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|30"}},"fontSize":"small"} -->
+<div class="wp-block-columns alignwide has-small-font-size" style="margin-top:var(--wp--preset--spacing--30)"><!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5ch"}},"layout":{"type":"flex"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p><?php esc_html_e( 'Categories:', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:post-terms {"term":"wcb_session_category"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"0.5ch"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p><?php esc_html_e( 'Tracks:', 'wordcamporg' ); ?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:post-terms {"term":"wcb_track"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_session.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_session.php
@@ -1,3 +1,10 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * Template: Single Session
+ */
+?>
+
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_speaker.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_speaker.php
@@ -1,0 +1,23 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)"><!-- wp:wordcamp/avatar {"className":"is-style-rounded"} /-->
+
+<!-- wp:post-title {"level":1} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading"><?php esc_html_e( 'Sessions', 'wordcamporg' ); ?></h3>
+<!-- /wp:heading -->
+
+<!-- wp:wordcamp/speaker-sessions {"hasSessionDetails":true,"isLink":true,"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /--></div>
+<!-- /wp:group --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_speaker.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_speaker.php
@@ -1,3 +1,10 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * Template: Single Speaker
+ */
+?>
+
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_sponsor.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_sponsor.php
@@ -1,3 +1,10 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * Template: Single Sponsor
+ */
+?>
+
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_sponsor.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_sponsor.php
@@ -1,0 +1,17 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+
+<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"0px"}}}} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+<!-- wp:spacer {"height":"0px","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}}} -->
+<div style="margin-bottom:var(--wp--preset--spacing--70);height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -126,8 +126,7 @@ function add_offline_template_cachebuster( $entry ) {
  * @return WP_Block_Template[]
  */
 function inject_templates( $query_result, $query, $template_type ) {
-	// Don't affect older sites.
-	if ( ! wp_is_block_theme() || wcorg_skip_feature( 'wcpt_block_templates' ) ) {
+	if ( ! site_supports_block_templates() ) {
 		return $query_result;
 	}
 
@@ -180,8 +179,7 @@ function is_request_for_post_type( $query, $type ) {
  * @return WP_Block_Template|null
  */
 function inject_template( $block_template, $id, $template_type ) {
-	// Don't affect older sites.
-	if ( ! wp_is_block_theme() || wcorg_skip_feature( 'wcpt_block_templates' ) ) {
+	if ( ! site_supports_block_templates() ) {
 		return $query_result;
 	}
 
@@ -237,4 +235,14 @@ function get_wordcamp_block_template( $post_type = '' ) {
 	$template->content = _inject_theme_attribute_in_block_template_content( ob_get_clean() );
 
 	return $template;
+}
+
+
+/**
+ * Check whether this site supports and uses the new block templates.
+ *
+ * @return boolean
+ */
+function site_supports_block_templates() {
+	return wp_is_block_theme() && ! wcorg_skip_feature( 'wcpt_block_templates' );
 }

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -1,6 +1,12 @@
 <?php
 /**
  * Theme-agnostic front end HTML templates.
+ *
+ * Offline: Load a template to use for the "offline" PWA page.
+ *
+ * Block templates: Load special page templates for custom WordCamp content types.
+ * The templates are defined in this folder and loaded on all block-based themes
+ * (at the time of writing this, twentytwentytwo and twentytwentythree).
  */
 
 namespace WordCamp\Theme_Templates;
@@ -10,8 +16,13 @@ use WordCamp\Blocks\Utilities as BlockUtilities;
 
 defined( 'WPINC' ) || die();
 
-add_filter( 'template_include',                __NAMESPACE__ . '\inject_offline_template', 20 );  // After others because being offline transcends other templates.
+/**
+ * Actions & filters.
+ */
+add_filter( 'template_include', __NAMESPACE__ . '\inject_offline_template', 20 );  // After others because being offline transcends other templates.
 add_filter( 'wp_offline_error_precache_entry', __NAMESPACE__ . '\add_offline_template_cachebuster' );
+add_filter( 'get_block_templates', __NAMESPACE__ . '\inject_templates', 10, 3 );
+add_filter( 'get_block_template', __NAMESPACE__ . '\inject_template', 10, 3 );
 
 /**
  * Inject the offline template when the service worker pre-caches the response to offline requests.
@@ -104,4 +115,126 @@ function add_offline_template_cachebuster( $entry ) {
 	}
 
 	return $entry;
+}
+
+/**
+ * Inject the WC-specific templates into the available templates list.
+ *
+ * @param WP_Block_Template[] $query_result Array of found block templates.
+ * @param array               $query Arguments to retrieve templates.
+ * @param string              $template_type wp_template or wp_template_part.
+ * @return WP_Block_Template[]
+ */
+function inject_templates( $query_result, $query, $template_type ) {
+	// Don't affect older sites.
+	if ( ! wp_is_block_theme() || wcorg_skip_feature( 'wcpt_block_templates' ) ) {
+		return $query_result;
+	}
+
+	if ( 'wp_template' !== $template_type ) {
+		return $query_result;
+	}
+
+	$existing_templates = wp_list_pluck( $query_result, 'slug' );
+
+	foreach ( array( 'wcb_organizer', 'wcb_session', 'wcb_speaker', 'wcb_sponsor' ) as $type ) {
+		if (
+			// If there are no existing (user-created) templates.
+			! in_array( 'single-' . $type, $existing_templates, true ) &&
+			// and this request is either for all templates or just this specific post type.
+			( empty( $query ) || is_request_for_post_type( $query, $type) )
+		) {
+			$template = get_wordcamp_block_template( $type );
+			if ( $template ) {
+				$query_result[] = $template;
+			}
+		}
+	}
+
+	return $query_result;
+}
+
+/**
+ * Helper function to check the template query.
+ *
+ * @param array  $query Arguments to retrieve templates.
+ * @param string $type  A WordCamp post type slug.
+ * @return boolean
+ */
+function is_request_for_post_type( $query, $type ) {
+	if ( isset( $query['slug__in'] ) && in_array( 'single-' . $type, $query['slug__in'], true ) ) {
+		return true;
+	}
+	return isset( $query['post_type'] ) && $type === $query['post_type'];
+}
+
+/**
+ * Provide a custom template if the requested template is a WordCamp post type.
+ *
+ * If the local site has overwritten this to create a custom template, this
+ * filter never runs, so we don't need to worry about overriding a user template.
+ *
+ * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
+ * @param string                 $id             Template unique identifier (example: theme_slug//template_slug).
+ * @param array                  $template_type  Template type: `'wp_template'` or '`wp_template_part'`.
+ * @return WP_Block_Template|null
+ */
+function inject_template( $block_template, $id, $template_type ) {
+	// Don't affect older sites.
+	if ( ! wp_is_block_theme() || wcorg_skip_feature( 'wcpt_block_templates' ) ) {
+		return $query_result;
+	}
+
+	foreach ( array( 'wcb_organizer', 'wcb_session', 'wcb_speaker', 'wcb_sponsor' ) as $type ) {
+		// For example, this matches `twentytwentythree//single-wcb_organizer`.
+		if ( str_ends_with( $id, 'single-' . $type ) ) {
+			$template = get_wordcamp_block_template( $type );
+			if ( $template ) {
+				return $template;
+			}
+		}
+	}
+
+	return $block_template;
+}
+
+/**
+ * Get a template for a given WordCamp post type.
+ *
+ * These templates are local PHP files, so that we can support i18n.
+ *
+ * @param string $post_type
+ * @return WP_Block_Template|null
+ */
+function get_wordcamp_block_template( $post_type = '' ) {
+	$labels = array(
+		'wcb_organizer' => __( 'Single item: Organizer', 'wordcamporg' ),
+		'wcb_session' => __( 'Single item: Session', 'wordcamporg' ),
+		'wcb_speaker' => __( 'Single item: Speaker', 'wordcamporg' ),
+		'wcb_sponsor' => __( 'Single item: Sponsor', 'wordcamporg' ),
+	);
+
+	$template_file = __DIR__ . "/block-templates/single-{$post_type}.php";
+	if ( ! file_exists( $template_file ) ) {
+		return null;
+	}
+
+	$template = _build_block_template_result_from_file(
+		array(
+			'slug'  => "single-{$post_type}",
+			'path'  => $template_file,
+			'theme' => get_stylesheet(),
+			'type'  => 'wp_template',
+			'title' => $labels[ $post_type ] ?? '',
+		),
+		'wp_template'
+	);
+
+	// By default, the template is read directly from the file, which works for HTML.
+	// To allow php (i18n), we can overwrite the content property with output buffering.
+	ob_start();
+	include $template_file;
+	$template->content = _inject_theme_attribute_in_block_template_content( ob_get_clean() );
+
+	return $template;
 }

--- a/public_html/wp-content/plugins/wc-post-types/inc/utilities.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/utilities.php
@@ -77,3 +77,14 @@ function get_avatar_or_image( $post, $size, $alt = false ) {
 
 	return $avatar;
 }
+
+/**
+ * Check whether this site supports and uses the new block templates.
+ *
+ * If it does, the custom content is added via blocks, and does not need to be appended to `the_content`.
+ *
+ * @return boolean
+ */
+function site_supports_block_templates() {
+	return wp_is_block_theme() && ! wcorg_skip_feature( 'wcpt_block_templates' );
+}

--- a/public_html/wp-content/plugins/wc-post-types/inc/utilities.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/utilities.php
@@ -77,14 +77,3 @@ function get_avatar_or_image( $post, $size, $alt = false ) {
 
 	return $avatar;
 }
-
-/**
- * Check whether this site supports and uses the new block templates.
- *
- * If it does, the custom content is added via blocks, and does not need to be appended to `the_content`.
- *
- * @return boolean
- */
-function site_supports_block_templates() {
-	return wp_is_block_theme() && ! wcorg_skip_feature( 'wcpt_block_templates' );
-}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -10,7 +10,8 @@ require_once 'inc/favorite-schedule-shortcode.php';
 require_once 'inc/privacy.php';
 require_once 'inc/deprecated.php';
 
-use function WordCamp\Post_Types\Utilities\{ get_avatar_or_image, site_supports_block_templates };
+use function WordCamp\Post_Types\Utilities\get_avatar_or_image;
+use function WordCamp\Theme_Templates\site_supports_block_templates;
 use function WordCamp\Blocks\has_block_with_attrs;
 
 // Bitwise mask for the sessions CPT, to add endpoints to the session pages. This should be a unique power of 2

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -10,7 +10,7 @@ require_once 'inc/favorite-schedule-shortcode.php';
 require_once 'inc/privacy.php';
 require_once 'inc/deprecated.php';
 
-use function WordCamp\Post_Types\Utilities\get_avatar_or_image;
+use function WordCamp\Post_Types\Utilities\{ get_avatar_or_image, site_supports_block_templates };
 use function WordCamp\Blocks\has_block_with_attrs;
 
 // Bitwise mask for the sessions CPT, to add endpoints to the session pages. This should be a unique power of 2
@@ -760,7 +760,7 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$enabled_site_ids = apply_filters( 'wcpt_speaker_post_avatar_enabled_site_ids', array( 364 ) );    // 2014.sf
 
-		if ( ! $this->is_single_cpt_post( 'wcb_speaker') ) {
+		if ( site_supports_block_templates() || ! $this->is_single_cpt_post( 'wcb_speaker') ) {
 			return $content;
 		}
 
@@ -794,7 +794,7 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$enabled_site_ids = apply_filters( 'wcpt_session_post_speaker_info_enabled_site_ids', array( 364 ) );    // 2014.sf
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session') ) {
+		if ( site_supports_block_templates() || ! $this->is_single_cpt_post( 'wcb_session') ) {
 			return $content;
 		}
 
@@ -874,7 +874,7 @@ class WordCamp_Post_Types_Plugin {
 			)
 		);
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) ) {
+		if ( site_supports_block_templates() || ! $this->is_single_cpt_post( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -925,7 +925,7 @@ class WordCamp_Post_Types_Plugin {
 			)
 		);
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) ) {
+		if ( site_supports_block_templates() || ! $this->is_single_cpt_post( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -963,7 +963,7 @@ class WordCamp_Post_Types_Plugin {
 	public function add_session_categories_to_session_posts( $content ) {
 		global $post;
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) ) {
+		if ( site_supports_block_templates() || ! $this->is_single_cpt_post( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -1022,7 +1022,7 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$enabled_site_ids = apply_filters( 'wcpt_speaker_post_session_info_enabled_site_ids', array( 364 ) );    // 2014.sf
 
-		if ( ! $this->is_single_cpt_post( 'wcb_speaker') ) {
+		if ( site_supports_block_templates() || ! $this->is_single_cpt_post( 'wcb_speaker') ) {
 			return $content;
 		}
 


### PR DESCRIPTION
There are now 4 new templates that are pre-populated into sites using a block-based theme (Twenty Twenty-Two or Twenty Twenty-Three). The templates are for WC post types Organizer, Session, Speaker, and Sponsor. Each template contains the relevant blocks, for example Session includes "Session Speakers", "Session Date & Time", etc. The templates are available in the site editor, and can be customized to swap location, add colors, styles, etc.

Sites using these new templates also don't append the content to `the_content`, to prevent duplicate content.

When this is merged, I'll apply the `wcpt_block_templates` skip-flag to the current sites, so that only new sites will use these templates. This should prevent any unexpected changes on existing sites.

See #635.
Fixes #651 — Session page now has speaker, session date & time, link to slides, link to video, category, and tracks.
Fixes #745 — it does not detect if the template has these blocks, but instead if a site is using "block templates" for the content types, it won't inject that content. Current sites can opt into the block templates by contacting a dev in #meta-wordcamp.

### Tech notes

I decided to go the `mu-plugins` route rather than creating a child theme so that the templates would be available for both Twenty Twenty-Two and Twenty Twenty-Three. They're designed using the layout of TT3 but it still works with TT2. We should also see movement in the next few months to create a new starter theme, and I don't want to overwhelm organizers with new theme choices.

Additionally, this method allows for templates as `.php` files, so they can contain translations. A child theme would need to use the patterns workaround (like the wporg themes).

### Screenshots

The templates are available in the site editor:

<img src="https://user-images.githubusercontent.com/541093/227275873-8575d3ce-869d-433d-96a3-846c3903655e.png" alt="" width="600" />

|  | Organizer | Session | Speaker | Sponsor |
|---|---|---|---|---|
| TT2 Current sites | ![tt2-old-organizer](https://user-images.githubusercontent.com/541093/227267792-4408dcd2-4b64-4965-8437-ce7a89deb84e.png) | ![tt2-old-session](https://user-images.githubusercontent.com/541093/227267796-a5d87c7a-0d61-412c-956e-1ac6b89455c2.png) | ![tt2-old-speaker](https://user-images.githubusercontent.com/541093/227267799-71f26b3e-8e05-4727-a552-6bd67505f441.png) | ![tt2-old-sponsor](https://user-images.githubusercontent.com/541093/227267800-108758e0-f325-4348-8a93-141263c3aa60.png) |
| TT2 New sites | ![tt2-new-organizer](https://user-images.githubusercontent.com/541093/227267784-657de611-d696-4abe-a780-0f2004e60b84.png) | ![tt2-new-session](https://user-images.githubusercontent.com/541093/227268022-4a1de2a4-70bd-4dab-a633-c1a01b68c12e.png) | ![tt2-new-speaker](https://user-images.githubusercontent.com/541093/227267785-fe1dc111-4ea6-4cb6-90d5-c0a99c523081.png) | ![tt2-new-sponsor](https://user-images.githubusercontent.com/541093/227267787-3adb1a4b-8b5b-48d3-a795-da2d752c8985.png) |
| TT3 Current sites | ![tt3-old-organizer](https://user-images.githubusercontent.com/541093/227267817-adf3a6fb-0eb9-4305-b7a9-a1c17c58e42e.png) | ![tt3-old-session](https://user-images.githubusercontent.com/541093/227267819-cccd95c3-2412-4da2-8586-d08bbee11ab1.png) | ![tt3-old-speaker](https://user-images.githubusercontent.com/541093/227267822-e7053fda-059d-4130-aca1-5ae4810bb14a.png) | ![tt3-old-sponsor](https://user-images.githubusercontent.com/541093/227267825-695ea041-7f4e-4621-a434-a8e70f61f3cd.png) |
| TT3 New sites | ![tt3-new-organizer](https://user-images.githubusercontent.com/541093/227267802-a741688c-4d84-4db3-857d-2c810ddae35d.png) | ![tt3-new-session](https://user-images.githubusercontent.com/541093/227267805-784ba2b6-6fc5-48cb-8aa4-1c5d4bb794b1.png) | ![tt3-new-speaker](https://user-images.githubusercontent.com/541093/227267809-603ba21a-7d0c-4075-a7cd-4804bcf4dcaa.png) | ![tt3-new-sponsor](https://user-images.githubusercontent.com/541093/227267811-bd926188-778d-4a37-acc9-336e5b137e19.png) |
| Classic theme |  ![cs17-organizer](https://user-images.githubusercontent.com/541093/227271615-8bbf97aa-cf9b-4da5-b6c3-49ec995efcea.png) | ![cs17-session](https://user-images.githubusercontent.com/541093/227271623-90777c4f-ffc1-47c5-9e74-2b097a85e6a2.png) | ![cs17-speaker](https://user-images.githubusercontent.com/541093/227271624-e424b157-797d-4889-b7e1-0783da96529f.png) | ![cs17-sponsor](https://user-images.githubusercontent.com/541093/227271628-a29f5d00-f85b-4a99-87b5-4a14f8b01204.png) |
| In the site editor (TT3) | ![organizer](https://user-images.githubusercontent.com/541093/227275516-02e9b02d-3ab8-4213-8f36-5b8ef384253c.png) | ![session](https://user-images.githubusercontent.com/541093/227275519-f7b78a22-c0c0-45b1-ab7f-381782f25d20.png) | ![speaker](https://user-images.githubusercontent.com/541093/227275520-de0f3fae-bbcd-4980-a4ec-4b329bc20e1a.png) | ![sponsor](https://user-images.githubusercontent.com/541093/227275522-0ca92159-0455-40ad-be0a-5a73ae8235e4.png)

### How to test the changes in this Pull Request:

1. Set up some content on your test site
2. Use Twenty Twenty-Two or Twenty Twenty-Three
3. View a Organizer, Session, Speaker, or Sponsor - it should show the relevant meta fields
4. Go into the site editor, you should see these templates available
5. Try editing a template, it should save correctly
6. View it on the front end, your update should be there
7. Optionally create a new template file for a specific [post type], make sure that works

Try toggling the skip-flag: `wp --allow-root wc-misc skip-feature-flag unset wcpt_block_templates [site ID]`

If you've got the skip-flag enabled, it will not show these new templates and instead attach the meta fields into the `wp-block-post-content` block.

Try on a classic theme, there should be no change from production.
