### PR TITLE
Switch gallery images to use alt and title fields

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/header.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/header.php
@@ -117,9 +117,12 @@
 					$image_src = wp_get_attachment_image_src( $image->ID, 'wccentral-thumbnail-hero' );
 					if ( ! $image_src ) continue;
 					list( $src, $width, $height ) = $image_src;
+
+					$image_alt = get_post_meta( $image->ID, '_wp_attachment_image_alt', true );
+					$image_title = get_the_title( $image->ID );
 				?>
 				<div class="wc-hero-entry" style="position: absolute;">
-					<img src="<?php echo esc_url( $src ); ?>" width="<?php echo absint( $width ); ?>" height="<?php echo absint( $height ); ?>" alt="<?php echo esc_attr( $image->post_excerpt ); ?>" title="<?php echo esc_attr( $image->post_excerpt ); ?>" />
+					<img src="<?php echo esc_url( $src ); ?>" width="<?php echo absint( $width ); ?>" height="<?php echo absint( $height ); ?>" alt="<?php echo esc_attr( $image_alt ); ?>" title="<?php echo esc_attr( $image_title ); ?>" />
 					<?php if ( ! empty( $image->post_excerpt ) ) : ?>
 					<span class="wc-hero-caption"><?php echo esc_html( $image->post_excerpt ); ?></span>
 					<?php endif; ?>


### PR DESCRIPTION
Make use of alt and title fields associated with images, rather than only using caption field.

Fixes #856

Props @naokomc , @pkevan 