### PR TITLE
Coming Soon: Replace `jetpack_require_lib()` with it's replacement

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -199,8 +199,8 @@ class WordCamp_Coming_Soon_Page {
 	public function get_colors() {
 		$settings = $GLOBALS['WCCSP_Settings']->get_settings();
 
-		if ( ! class_exists( 'Jetpack_Color' ) && function_exists( 'jetpack_require_lib' ) ) {
-			jetpack_require_lib( 'class.color' );
+		if ( ! class_exists( 'Jetpack_Color' ) && defined( 'JETPACK__PLUGIN_DIR' ) ) {
+			include JETPACK__PLUGIN_DIR . '/_inc/lib/class.color.php';
 		}
 
 		// If they never changed from the old default background color, then use the new default.


### PR DESCRIPTION
Jetpack 11.9 has removed `jetpack_require_lib()` in preference for direct file inclusions.

See https://github.com/Automattic/jetpack/pull/28866

This PR is **untested**.

I have deliberately **not** included `file_exists` checks and instead just relying upon the Jetpack Constant and a PHP Warning to be triggered if this file is ever removed / renamed.