### PR TITLE
Blocks: Fix styles for ItemSelect component

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/package.json
+++ b/public_html/wp-content/mu-plugins/blocks/package.json
@@ -13,7 +13,6 @@
 	},
 	"dependencies": {
 		"classnames": "2.3.1",
-		"react-select": "5.2.2",
 		"rememo": "4.0.0"
 	},
 	"devDependencies": {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/organizer-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/organizer-select.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ItemSelect, Option, buildOptions } from '../../components';
+import { ItemSelect, buildOptions } from '../../components';
 
 /**
  * Component for selecting posts/terms for populating the block content.
@@ -101,7 +101,7 @@ class OrganizerSelect extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { label, icon, setAttributes } = this.props;
+		const { label, setAttributes } = this.props;
 
 		return (
 			<ItemSelect
@@ -109,19 +109,8 @@ class OrganizerSelect extends Component {
 				label={ label }
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
-				selectProps={ {
-					options: this.buildSelectOptions(),
-					isLoading: this.isLoading(),
-					formatOptionLabel: ( optionData, { context } ) => (
-						<Option
-							context={ context }
-							icon={ 'wcb_organizer_team' === optionData.type ? icon : null }
-							avatar={ optionData.avatar }
-							label={ optionData.label }
-							count={ optionData.count }
-						/>
-					),
-				} }
+				options={ this.buildSelectOptions() }
+				isLoading={ this.isLoading() }
 			/>
 		);
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sessions/session-select.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ItemSelect, Option, buildOptions } from '../../components';
+import { ItemSelect, buildOptions } from '../../components';
 
 /**
  * Component for selecting posts/terms for populating the block content.
@@ -107,7 +107,7 @@ class SessionSelect extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { icon, label, setAttributes } = this.props;
+		const { label, setAttributes } = this.props;
 
 		return (
 			<ItemSelect
@@ -115,19 +115,8 @@ class SessionSelect extends Component {
 				label={ label }
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
-				selectProps={ {
-					options: this.buildSelectOptions(),
-					isLoading: this.isLoading(),
-					formatOptionLabel: ( optionData, { context } ) => (
-						<Option
-							icon={ includes( [ 'wcb_track', 'wcb_session_category' ], optionData.type ) ? icon : null }
-							label={ optionData.label }
-							details={ optionData.details }
-							count={ optionData.count }
-							context={ context }
-						/>
-					),
-				} }
+				options={ this.buildSelectOptions() }
+				isLoading={ this.isLoading() }
 			/>
 		);
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speakers/speaker-select.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ItemSelect, Option, buildOptions } from '../../components';
+import { ItemSelect, buildOptions } from '../../components';
 
 /**
  * Component for selecting posts/terms for populating the block content.
@@ -101,7 +101,7 @@ class SpeakerSelect extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { label, icon, setAttributes } = this.props;
+		const { label, setAttributes } = this.props;
 
 		return (
 			<ItemSelect
@@ -109,19 +109,8 @@ class SpeakerSelect extends Component {
 				label={ label }
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
-				selectProps={ {
-					options: this.buildSelectOptions(),
-					isLoading: this.isLoading(),
-					formatOptionLabel: ( optionData, { context } ) => (
-						<Option
-							context={ context }
-							icon={ 'wcb_speaker_group' === optionData.type ? icon : null }
-							label={ optionData.label }
-							avatar={ optionData.avatar }
-							count={ optionData.count }
-						/>
-					),
-				} }
+				options={ this.buildSelectOptions() }
+				isLoading={ this.isLoading() }
 			/>
 		);
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/sponsor-select.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/sponsors/sponsor-select.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ItemSelect, Option, buildOptions } from '../../components';
+import { ItemSelect, buildOptions } from '../../components';
 
 /**
  * Component for selecting posts/terms for populating the block content.
@@ -101,7 +101,7 @@ class SponsorSelect extends Component {
 	 * @return {Element}
 	 */
 	render() {
-		const { label, icon, setAttributes } = this.props;
+		const { label, setAttributes } = this.props;
 
 		return (
 			<ItemSelect
@@ -109,18 +109,8 @@ class SponsorSelect extends Component {
 				label={ label }
 				value={ this.getCurrentSelectValue() }
 				onChange={ ( changed ) => setAttributes( changed ) }
-				selectProps={ {
-					options: this.buildSelectOptions(),
-					isLoading: this.isLoading(),
-					formatOptionLabel: ( optionData, { context } ) => (
-						<Option
-							context={ context }
-							icon={ 'wcb_sponsor_level' === optionData.type ? icon : null }
-							label={ optionData.label }
-							count={ optionData.count }
-						/>
-					),
-				} }
+				options={ this.buildSelectOptions() }
+				isLoading={ this.isLoading() }
 			/>
 		);
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/edit.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/edit.scss
@@ -6,7 +6,7 @@
 .wordcamp-item-select__select {
 	margin-bottom: 1em;
 
-	input[type="text"]:focus {
-		box-shadow: none;
+	select {
+		max-height: 40em;
 	}
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/edit.scss
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/edit.scss
@@ -4,64 +4,9 @@
 }
 
 .wordcamp-item-select__select {
-	flex-grow: 2;
 	margin-bottom: 1em;
 
 	input[type="text"]:focus {
 		box-shadow: none;
 	}
-}
-
-.wordcamp-item-select__option {
-	display: flex;
-	align-items: center;
-}
-
-.wordcamp-item-select__option-group-label {
-	color: #555d66;
-}
-
-.wordcamp-item-select__option-avatar,
-.wordcamp-item-select__option-icon-container {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.wordcamp-item-select__option-avatar {
-	flex: 0 0 50px;
-	height: 50px;
-	margin-right: 10px;
-}
-
-.wordcamp-item-select__option-icon-container {
-	flex: 0 0 24px;
-	height: 24px;
-	margin-right: 10px;
-	background-color: #f3f3f4;
-}
-
-.wordcamp-item-select__option-label {
-	margin: 0;
-	white-space: normal;
-}
-
-
-.wordcamp-item-select__option-label-count {
-	font-size: 0.6em;
-	display: inline-block;
-	border-radius: 50%;
-	background-color: #f3f3f4;
-	width: 2.2em;
-	height: 2.2em;
-	margin: 0 0.5em;
-	text-align: center;
-	line-height: 2.2;
-	vertical-align: text-top;
-}
-
-.wordcamp-item-select__option-label-details {
-	display: block;
-	color: #6c7781;
-	font-style: italic;
 }

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item-select/index.js
@@ -69,6 +69,7 @@ export function ItemSelect( { className, label, help, submitLabel, onChange, opt
 	const [ selectedOptions, setSelectedOptions ] = useState( null );
 	const currentValue = selectedOptions || value.map( ( item ) => item.type + ':' + item.value );
 	const id = `wordcamp-item-select-control-${ instanceId }`;
+	const length = options.reduce( ( acc = 0, group ) => acc + group.options.length, 0 );
 
 	if ( isLoading ) {
 		return null;
@@ -85,6 +86,9 @@ export function ItemSelect( { className, label, help, submitLabel, onChange, opt
 				value={ currentValue }
 				onChange={ ( newValue ) => {
 					setSelectedOptions( newValue || [] );
+				} }
+				style={ {
+					height: `${ length + 5 }em`,
 				} }
 			>
 				{ options.map( ( group, i ) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,7 +1062,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
@@ -1154,7 +1154,7 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^11.4.0", "@emotion/cache@^11.7.1":
+"@emotion/cache@^11.7.1":
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
   integrity sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==
@@ -1204,19 +1204,6 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
-
-"@emotion/react@^11.1.1":
-  version "11.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.7.1.tgz#3f800ce9b20317c13e77b8489ac4a0b922b2fe07"
-  integrity sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/cache" "^11.7.1"
-    "@emotion/serialize" "^1.0.2"
-    "@emotion/sheet" "^1.1.0"
-    "@emotion/utils" "^1.0.0"
-    "@emotion/weak-memoize" "^0.2.5"
-    hoist-non-react-statics "^3.3.1"
 
 "@emotion/react@^11.7.1":
   version "11.8.2"
@@ -2025,13 +2012,6 @@
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
   integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@^4.4.0":
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
-  integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
   dependencies:
     "@types/react" "*"
 
@@ -4726,14 +4706,6 @@ document.contains@^1.0.1:
   integrity sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==
   dependencies:
     define-properties "^1.1.3"
-
-dom-helpers@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
 
 dom-scroll-into-view@^1.2.1:
   version "1.2.1"
@@ -7503,11 +7475,6 @@ memize@^1.1.0:
   resolved "https://registry.yarnpkg.com/memize/-/memize-1.1.0.tgz#4a5a684ac6992a13b1299043f3e49b1af6a0b0d3"
   integrity sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==
 
-memoize-one@^5.0.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 meow@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
@@ -8653,7 +8620,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.8.1, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.8.1, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8892,19 +8859,6 @@ react-resize-aware@^3.1.0:
   resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.1.1.tgz#a428fd53f34dec3a52b68c923a6ebe51a192c63c"
   integrity sha512-M8IyVLBN8D6tEUss+bxQlWte3ZYtNEGhg7rBxtCVG8yEBjUlZwUo5EFLq6tnvTZXcgAbCLjsQn+NCoTJKumRYg==
 
-react-select@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.2.tgz#3d5edf0a60f1276fd5f29f9f90a305f0a25a5189"
-  integrity sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==
-  dependencies:
-    "@babel/runtime" "^7.12.0"
-    "@emotion/cache" "^11.4.0"
-    "@emotion/react" "^11.1.1"
-    "@types/react-transition-group" "^4.4.0"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-transition-group "^4.3.0"
-
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
@@ -8922,16 +8876,6 @@ react-test-renderer@^17.0.0, react-test-renderer@^17.0.2:
     react-is "^17.0.2"
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
-
-react-transition-group@^4.3.0:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
-  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react-with-direction@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Fixes #855 — Remove the `react-select` used in Organizers, Sessions, Speakers, and Sponsors blocks. This switches the behavior to simple multiple SelectControl.

The UX of react-select was nicer, when it was working, so a future iteration could bring back the token-style management of selected speakers.

### Screenshots

| Before | After |
|---|---|
| <img width="708" alt="Screenshot 2023-03-23 at 4 33 07 PM" src="https://user-images.githubusercontent.com/541093/227348193-a07b2115-8178-454a-9afb-3510b9aaac38.png"> | <img width="678" alt="" src="https://user-images.githubusercontent.com/541093/229635406-ecff4d27-6e09-4ff9-9ddc-caaa3449dd31.png"> |

The select section expands if there are a lot of options, maxing out at 40em:
<img width="862" alt="" src="https://user-images.githubusercontent.com/541093/229635405-88187e7d-f810-42e8-bb71-362af628cde6.png">

### How to test the changes in this Pull Request:

1. Add one of these blocks: Organizers, Sessions, Speakers, or Sponsors
2. Select some values
3. It should be possible to select 1 or many items
4. If you select something from one group (ex, Organizer Teams) selecting from other groups is disabled
5. Click the Select button
6. The block should update to display those selected people/sessions/sponsors
