### PR TITLE
WC Fonts: Register imported google fonts for use in the editor

### DIFF
--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -1,8 +1,9 @@
 <?php
-
 /*
  * Plugin Name: WordCamp.org Fonts
  */
+
+require_once __DIR__ . '/wc-google-fonts-provider.php';
 
 class WordCamp_Fonts_Plugin {
 	protected $options;
@@ -19,6 +20,7 @@ class WordCamp_Fonts_Plugin {
 		add_action( 'wp_head',            array( $this, 'wp_head_google_web_fonts' ) );
 		add_action( 'wp_head',            array( $this, 'wp_head_font_awesome'     ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_core_fonts'       ) );
+		add_action( 'init',               array( $this, 'register_fonts_for_editor' ) );
 	}
 
 	/**
@@ -49,8 +51,10 @@ class WordCamp_Fonts_Plugin {
 			return;
 		}
 
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		printf( '<style>%s</style>', $this->options['google-web-fonts'] );
+		if ( ! wp_is_block_theme() ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			printf( '<style>%s</style>', $this->options['google-web-fonts'] );
+		}
 	}
 
 	/**
@@ -309,6 +313,96 @@ class WordCamp_Fonts_Plugin {
 		$output['dashicons'] = isset( $input['dashicons'] ) && $input['dashicons'] ? true : false;
 
 		return $output;
+	}
+
+	/**
+	 * Register the google fonts into WordPress so they can be used in the Site Editor.
+	 */
+	public function register_fonts_for_editor() {
+		if ( ! function_exists( 'wp_register_fonts' ) ) {
+			return;
+		}
+
+		if ( ! isset( $this->options['google-web-fonts'] ) || empty( $this->options['google-web-fonts'] ) ) {
+			return;
+		}
+
+		$lines = explode( "\n", $this->options['google-web-fonts'] );
+		$fonts = array();
+		foreach ( $lines as $line ) {
+			if ( preg_match( '#https?://fonts\.googleapis\.com/css2?\?family=[^\)\'"]+#', $line, $matches ) ) {
+				$url = $matches[0];
+				$query = explode( '&', wp_parse_url( $url, PHP_URL_QUERY ) );
+
+				// Multiple families can be added to one URL, so we need to loop over to parse them.
+				// We can't just use wp_parse_str because each `family` will overwrite the previous.
+				foreach ( $query as $family ) {
+					// Make sure we're working with a `family=` value and not `display=` or anything else.
+					if ( ! str_starts_with( $family, 'family=' ) ) {
+						continue;
+					}
+					$details = explode( ':', $family );
+					$name = str_replace( 'family=', '', $details[0] );
+					$styles = $details[1] ?? '';
+
+					$variations = array(
+						array(
+							'font-family' => urldecode( $name ),
+							'provider'    => 'wordcamp-google',
+						),
+					);
+
+					if ( str_contains( $styles, '@' ) ) {
+						$variations = array_map(
+							function( $var ) use ( $name ) {
+								$variation = array(
+									'font-family' => urldecode( $name ),
+									'provider'    => 'wordcamp-google',
+								);
+								if ( isset( $var['ital'] ) ) {
+									$variation['font-style']  = '0' === $var['ital'] ? 'normal' : 'italic';
+								}
+								if ( isset( $var['wght'] ) ) {
+									$variation['font-weight'] = str_replace( '..', ' ', $var['wght'] );
+								}
+								return $variation;
+							},
+							$this->parse_google_font_variations( $styles )
+						);
+					}
+
+					$fonts[ urldecode( $name ) ] = $variations;
+				}
+			}
+		}
+
+		wp_register_fonts( $fonts );
+		wp_enqueue_fonts( array_keys( $fonts ) );
+	}
+
+	/**
+	 * Parse the google font options.
+	 *
+	 * Converts the string in a google fonts URL into an array of variations.
+	 * For example, `ital,wght@0,700;1,700` should return:
+	 * [
+	 *   [ 'ital' => 0, 'wght' => '700' ],
+	 *   [ 'ital' => 1, 'wght' => '700' ],
+	 * ]
+	 */
+	public function parse_google_font_variations( $styles ) {
+		list( $props, $values ) = explode( '@', $styles );
+		$props = explode( ',', $props );
+		$values = explode( ';', $values );
+
+		$result = array();
+		foreach ( $values as $i => $value ) {
+			$style = explode( ',', $value );
+			foreach ( $props as $j => $prop ) {
+				$result[ $i ][ $prop ] = $style[ $j ];
+			}
+		}
+		return $result;
 	}
 }
 

--- a/public_html/wp-content/plugins/wc-fonts/wc-google-fonts-provider.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-google-fonts-provider.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Google Fonts provider for WP Fonts API.
+ *
+ * Eventually this should be supported by core, and this file can be deprecated.
+ */
+
+if ( ! class_exists( 'WP_Fonts_Provider' ) ) {
+	return;
+}
+
+add_action(
+	'init',
+	function() {
+		if ( function_exists( 'wp_fonts' ) ) {
+			wp_fonts()->register_provider( 'wordcamp-google', 'WC_Fonts_Provider_Google' );
+		}
+	}
+);
+
+class WC_Fonts_Provider_Google extends WP_Fonts_Provider {
+
+	/**
+	 * The provider's unique ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'wordcamp-google';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if (
+			function_exists( 'is_admin' ) && ! is_admin() &&
+			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'style' )
+		) {
+			$this->style_tag_atts = array( 'type' => 'text/css' );
+		}
+	}
+
+	/**
+	 * Build the `@import` statement for Google's font API.
+	 *
+	 * @return string The `@font-face` CSS.
+	 */
+	public function get_css() {
+		$css = '';
+
+		foreach ( $this->fonts as $font ) {
+			$font_style = $font['font-style'] ?? 'normal';
+			$font_weight = $font['font-weight'] ?? '400';
+			// Rebuild the google font URL to explicitly load the enqueued font.
+			$css .= sprintf(
+				'@import url("https://fonts.googleapis.com/css2?family=%1$s:ital,wght@%2$s,%3$s");',
+				urlencode( $font['font-family'] ),
+				'normal' === $font_style ? '0' : '1',
+				str_replace( ' ', '..', $font_weight )
+			);
+		}
+
+		return $css;
+	}
+}


### PR DESCRIPTION
Use the (experimental?) Fonts API to load selected Google Fonts in block-based themes.

When fonts are loaded via the WordCamp Fonts admin screen, there's no easy way to use them in the editor. The Typography settings don't know about these fonts, and without being able to update the theme.json, a user can't add them.

With this PR, if a site is using a block theme and the user has added a google font to Appearance > Fonts, the font is registered & enqueued using the Fonts API (rather than output in `wp_head`). It's also loaded into the editor, and listed in the available Typography > Font Family options. When selected, Gutenberg automatically applies style or class, and the font is used.

_While this does touch the use of google fonts, this PR does not address anything in #739._

**Tech details**

- This only works for Google Fonts because we can parse out the individual fonts.
- I've created a new font provider called "wordcamp-google" because by default only local fonts are supported. It's prefixed in case a core provider (or another plugin like Jetpack*) eventually adds Google support.
- It's necessary to enqueue all the fonts, core/GB doesn't currently have a mechanism to load only the fonts in use… but that's not any different than how `wp_head_google_web_fonts` already works.
- This works best with variable fonts, but as far as I can tell GB does not restrict the weight/style to just the registered values - for example, Rubik Pixels only has 400 weight, no italics, but you can still set it to "Black (900) Italic". The browser faux-italicizes & faux-bolds it. I think this is a core limitation, and not something we need to address. 

*&nbsp;Jetpack does have [a beta Google Fonts feature](https://jetpack.com/support/google-fonts/), but it's pulling from a small subset of fonts.

### Screenshots

This example uses the following settings to load Comfortaa (variable), Tilt Warp (default), Open Sans (normal & italic, 300 weight), & Rubik Pixels (default).

```css
@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@400..700');
@import url('https://fonts.googleapis.com/css2?family=Tilt+Warp');
@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;1,300&family=Rubik+Pixels&family=Tilt+Warp&display=swap');
```

| | Editor | Front end |
|---|---|---|
| Site editor, setting the default font for all text | ![editor-site](https://user-images.githubusercontent.com/541093/231868122-08d444c6-48b2-4a77-bf04-48968069f280.png) | ![frontend-sitewide](https://user-images.githubusercontent.com/541093/231868125-51b20a2f-27a7-4489-8045-34dde34cd89f.png) |
| Post editor, setting fonts on a specific block | ![editor-post](https://user-images.githubusercontent.com/541093/231868117-f49b856c-887e-430e-9ce6-d855a74ec3ed.png) | ![frontend-post](https://user-images.githubusercontent.com/541093/231868123-c2b183f8-44ba-4f9f-89ed-01f654956cae.png) |

### How to test the changes in this Pull Request:

1. Go to google fonts and grab some `@import` URLs
2. Using a block theme (TT2 or TT3), put those in Appearance > Fonts
3. Load up the editor and try to change the typography of any element
4. The editor preview should match the front end
5. Switch to a non-block theme
6. The fonts are still loaded on the front end (but are not applied to anything without custom CSS)

There are checks in place to make sure this does not break if GB is accidentally disabled.