### PR TITLE
Blocks: Schedule: Use the site's time format setting to display session time

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -58,8 +58,8 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  */
 function enable_js_block_registration( $data ) {
 	$data['schedule'] = array(
-		'timezone'   => wp_timezone_string(),
-		'adminUrl'   => admin_url(),
+		'timezone' => wp_timezone_string(),
+		'adminUrl' => admin_url(),
 	);
 
 	return $data;

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -58,8 +58,9 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  */
 function enable_js_block_registration( $data ) {
 	$data['schedule'] = array(
-		'timezone' => wp_timezone_string(),
-		'adminUrl' => admin_url(),
+		'timezone'   => wp_timezone_string(),
+		'adminUrl'   => admin_url(),
+		'timeFormat' => get_option( 'time_format', 'g:i a' ),
 	);
 
 	return $data;
@@ -101,6 +102,7 @@ function pass_global_data_to_front_end() {
 		'allCategories' => get_all_categories(),
 		'settings'      => get_settings(),
 		'timezone'      => wp_timezone_string(),
+		'timeFormat'    => get_option( 'time_format', 'g:i a' ),
 	);
 
 	// The rest request in get_all_sessions changes the global $post value.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/controller.php
@@ -60,7 +60,6 @@ function enable_js_block_registration( $data ) {
 	$data['schedule'] = array(
 		'timezone'   => wp_timezone_string(),
 		'adminUrl'   => admin_url(),
-		'timeFormat' => get_option( 'time_format', 'g:i a' ),
 	);
 
 	return $data;
@@ -102,7 +101,6 @@ function pass_global_data_to_front_end() {
 		'allCategories' => get_all_categories(),
 		'settings'      => get_settings(),
 		'timezone'      => wp_timezone_string(),
-		'timeFormat'    => get_option( 'time_format', 'g:i a' ),
 	);
 
 	// The rest request in get_all_sessions changes the global $post value.

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -34,6 +34,7 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 	const timeGroups = [];
 	const timeSlots = Object.keys( sessionsByTimeSlot ).sort();
 	const timezone = getTimezone( attributes );
+	const timeFormat = WordCampBlocks.schedule.timeFormat || 'g:i a T';
 
 	for ( let i = 0; i < timeSlots.length; i++ ) {
 		const currentSlot = timeSlots[ i ];
@@ -54,7 +55,7 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 
 		timeGroups.push(
 			<h3 key={ startTime } className={ classes } style={ { gridRow } }>
-				{ date( 'g:i a T', startTime, timezone ) }
+				{ date( timeFormat, startTime, timezone ) }
 			</h3>
 		);
 

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -34,7 +34,12 @@ export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
 	const timeGroups = [];
 	const timeSlots = Object.keys( sessionsByTimeSlot ).sort();
 	const timezone = getTimezone( attributes );
-	const timeFormat = WordCampBlocks.schedule.timeFormat || 'g:i a T';
+
+	let timeFormat = WordCampBlocks.schedule.timeFormat || 'g:i a';
+	// Append the timezone if it's not included.
+	if ( ! timeFormat.includes( 'T' ) ) {
+		timeFormat += ' T';
+	}
 
 	for ( let i = 0; i < timeSlots.length; i++ ) {
 		const currentSlot = timeSlots[ i ];

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/schedule/sessions.js
@@ -27,15 +27,14 @@ import { sortBySlug } from './data';
  * @return {Element}
  */
 export function Sessions( { sessions, displayedTracks, overlappingSessions } ) {
-	const { attributes } = useContext( ScheduleGridContext );
-
+	const { attributes, settings } = useContext( ScheduleGridContext );
 	const sessionsByTimeSlot = groupSessionsByTimeSlot( sessions );
 	const overlappingSessionIds = overlappingSessions.map( ( session ) => session.id );
 	const timeGroups = [];
 	const timeSlots = Object.keys( sessionsByTimeSlot ).sort();
 	const timezone = getTimezone( attributes );
 
-	let timeFormat = WordCampBlocks.schedule.timeFormat || 'g:i a';
+	let timeFormat = settings.time_format || 'g:i a';
 	// Append the timezone if it's not included.
 	if ( ! timeFormat.includes( 'T' ) ) {
 		timeFormat += ' T';


### PR DESCRIPTION
Use the time_format setting to display the scheduled session times. This is already used on the individual sessions in the block, so it makes sense to keep consistent and use it for the side time markers. Additionally this lets the site owners decide what format to use for times, for locales that don't use 12hr am/pm time.

Fixes #867 

### Screenshots

| Format | Editor | Front end |
|---|---|---|
| `g:i A` | <img width="1233" alt="g-i-a-editor" src="https://user-images.githubusercontent.com/541093/232083832-1b80faef-2d22-4cd5-934e-40a94bec935e.png"> | <img width="1239" alt="g-i-a-front" src="https://user-images.githubusercontent.com/541093/232083830-25a3389f-9d76-45f2-b258-829a16402a93.png"> |
| `H:i` | <img width="1238" alt="h-i-editor" src="https://user-images.githubusercontent.com/541093/232083825-48035f2a-b6a6-426f-a3ec-f3575a1a89e6.png"> | <img width="1233" alt="h-i-front" src="https://user-images.githubusercontent.com/541093/232083820-60653862-cca9-44bc-ba0a-27456d6c549c.png"> |

### How to test the changes in this Pull Request:

1. Set up sessions, add a schedule block to a page
2. The time should use the format in Settings > General > Time Format
    - All times on the schedule should use the format, inline in the session and along the side
    - The side time will have a timezone, even if the site's format does not
4. Change the format setting
5. Reload the block, and the time format should match your new format

