### PR TITLE
Jetpack Tweaks: Inject fieldset & legend into contact form fields

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -267,6 +267,12 @@ function inject_css_for_fieldset() {
 	font-weight: bold;
 	display: block;
 }
+.grunion-field-label span {
+	font-size: 85%;
+	margin-left: 0.25em;
+	font-weight: normal;
+	opacity: 0.45;
+}
 CSS;
 
 	wp_add_inline_style( 'grunion.css', $form_css );

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\Jetpack_Tweaks;
 use WP_Service_Worker_Caching_Routes, WP_Service_Worker_Scripts;
+use Grunion_Contact_Form;
 
 defined( 'WPINC' ) || die();
 
@@ -204,6 +205,14 @@ add_filter( 'jetpack_is_frontend', __NAMESPACE__ . '\workaround_is_frontend' );
  * @param int|null $post_id        Post ID.
  */
 function wrap_checkbox_radio_fieldset( $rendered_field, $field_label, $post_id ) {
+	// Get the current form style, if it's anything other than default, return early.
+	$class_name = Grunion_Contact_Form::$current_form->get_attribute( 'className' );
+	preg_match( '/is-style-([^\s]+)/i', $class_name, $matches );
+	$style = count( $matches ) >= 2 ? $matches[1] : 'default';
+	if ( 'default' !== $style ) {
+		return $rendered_field;
+	}
+
 	if (
 		str_contains( $rendered_field, 'grunion-checkbox-multiple-options' ) ||
 		str_contains( $rendered_field, 'grunion-radio-options' )

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -230,11 +230,11 @@ add_filter( 'grunion_contact_form_field_html', __NAMESPACE__ . '\wrap_checkbox_r
  */
 function inject_css_for_fieldset() {
 	$form_css = <<<CSS
-.contact-form fieldset {
+:where(.contact-form) fieldset {
 	border: none;
 	padding: 0;
 }
-.contact-form legend {
+:where(.contact-form) legend {
 	margin-bottom: 0.25em;
 	float: none;
 	font-weight: bold;

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -216,6 +216,15 @@ function wrap_checkbox_radio_fieldset( $rendered_field, $field_label, $post_id )
 		// replace only the first label, others are for the options.
 		$rendered_field = preg_replace( '/<label/', '<legend', $rendered_field, 1);
 		$rendered_field = preg_replace( '/<\/label>/', '</legend>', $rendered_field, 1);
+		// Pull out the legend text so we can create a separate visual element.
+		// See https://adrianroselli.com/2022/07/use-legend-and-fieldset.html.
+		if ( preg_match( '/<legend[^>]*>(.*)<\/legend>/i', $rendered_field, $matches ) ) {
+			$visible_label = sprintf(
+				'<div class="grunion-field-label" aria-hidden="true">%s</div>',
+				$matches[1]
+			);
+			$rendered_field = str_replace( $matches[0], $matches[0] . $visible_label, $rendered_field );
+		}
 	}
 	return $rendered_field;
 }
@@ -235,6 +244,15 @@ function inject_css_for_fieldset() {
 	padding: 0;
 }
 :where(.contact-form) legend {
+	position: absolute;
+	overflow: hidden;
+	clip: rect(0 0 0 0); 
+	clip-path: inset(50%);
+	width: 1px;
+	height: 1px;
+	white-space: nowrap; 
+}
+.grunion-field-label {
 	margin-bottom: 0.25em;
 	float: none;
 	font-weight: bold;


### PR DESCRIPTION
WordCamps use the Jetpack contact form for all forms on the site, from plain contact forms to calls for speakers, organizers, etc. When testing the forms for WCUS, @alexstine noticed that the Single Choice (Radio) & Multiple Choice (Checkbox) fields were not marked up correctly for screen reader users.

The upstream issue is being tracked here: https://github.com/Automattic/jetpack/issues/16685

Since these forms are widely used, I wanted to ship out a hotfix while we wait for the root issue to be fixed. The fix here is a bit hacky, based on string replacements, but I tried to keep each step straightforward. First, it wraps the field in a `fieldset`, then wraps the first label (the question) in a legend, which we hide visually. The legend text is then duplicated in an `aria-hidden` `div`, to avoid the browser default styles on legends (I grabbed [this method from Adrian Roselli](https://adrianroselli.com/2022/07/use-legend-and-fieldset.html)).

This change is only added to the two relevant fields, and only if the form style is default. The "animated" and "outline" style put the labels at the end of the field HTML, so it would require more careful manipulation, and the majority of sites I spot-checked used the default form style.

Props @alexstine

**Markup example**

The previous markup for a Single Choice (Radio) field (style & class attributes removed for easier reading):

```html
<div>
	<label>Will you be able to attend WordCamp US 2023 in person?</label>
	<div>
		<label><input type="radio" name="g549" value="Yes" required="" aria-required="true"> Yes</label>
		<label><input type="radio" name="g549" value="No" required="" aria-required="true"> No</label>
		<label><input type="radio" name="g549" value="Maybe/Unsure" required="" aria-required="true"> Maybe/Unsure</label>
	</div>
</div>
```

The new markup is:

```html
<fieldset>
	<legend>Will you be able to attend WordCamp US 2023 in person?</legend>
	<div aria-hidden="true">Will you be able to attend WordCamp US 2023 in person?</div>
	<div>
		<label><input type="radio" name="g549" value="Yes" required="" aria-required="true"> Yes</label>
		<label><input type="radio" name="g549" value="No" required="" aria-required="true"> No</label>
		<label><input type="radio" name="g549" value="Maybe/Unsure" required="" aria-required="true"> Maybe/Unsure</label>
	</div>
</fieldset>
```

**Screenshots**

There _should_ be no visual changes, but some customizations might not apply to the new visual field (that's why the text is slightly larger in Montclair's screenshot). I don't think that's major enough to block this fix though.

| | Before | After |
|---|---|---|
| Form on a block-based theme | ![before-us](https://user-images.githubusercontent.com/541093/234413127-f79f3c79-1f34-4e8d-b58f-c4af2c230aaa.png) | ![after-us](https://user-images.githubusercontent.com/541093/234414982-0703289c-6d4c-482f-8c2b-d25cb195a969.png) |
| Form on a classic theme | ![before-montclair](https://user-images.githubusercontent.com/541093/234413132-2082e1bd-1c2d-495a-913d-b4cfb73e013b.png) | ![after-montclair](https://user-images.githubusercontent.com/541093/234415094-c706c91a-ac4b-45c6-94b4-369407260ee2.png) |
| Form using "outline" style, no change | ![before-sylhet](https://user-images.githubusercontent.com/541093/234413130-2b3587fb-c3f6-435b-9519-d721b002c678.png) | ![after-sylhet](https://user-images.githubusercontent.com/541093/234413136-a0309293-ffca-4371-823a-f1ca9fc49d07.png) |

**How to test the changes in this Pull Request:**

1. Create a contact form
2. Add some fields, including radio & checkbox fields
3. They should display correctly
4. Try testing with a screen reader
5. When you hit the radio & multiple checkbox fields, each option should be associated with the question text
