### PR TITLE
Block Patterns: Add general block patterns

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/patterns/header-centered-with-menu.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/header-centered-with-menu.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Title: Centered header with menu
+ * Slug: wordcamp/header-centered-with-menu
+ * Categories: header
+ * Block Types: core/template-part/header
+ */
+
+?>
+<!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull"><!-- wp:site-title {"textAlign":"center","style":{"typography":{"fontSize":"3rem"}}} /-->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">November 16–17. 2023 • City Conference Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css","className":"alignfull is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity alignfull is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"center"}} /-->
+
+<!-- wp:separator {"opacity":"css","className":"alignfull is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity alignfull is-style-wide"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/header-with-button.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/header-with-button.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Title: Short header with button
+ * Slug: wordcamp/header-with-button
+ * Categories: header
+ * Block Types: core/template-part/header
+ */
+
+?>
+<!-- wp:group {"align":"full"} -->
+<div class="wp-block-group alignfull"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"blockGap":"0.5em"}}} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"x-large"} /-->
+
+<!-- wp:paragraph {"align":"left","fontSize":"small"} -->
+<p class="has-text-align-left has-small-font-size"><em>November 16–17. 2023 • City Conference Center</em></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center"} -->
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","textColor":"background"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-background-color has-primary-background-color has-text-color has-background wp-element-button">Buy tickets</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:separator {"opacity":"css","className":"alignfull is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity alignfull is-style-wide"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-bottom-left.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-bottom-left.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Hero with bottom left content
+ * Slug: wordcamp/hero-cover-bottom-left
+ * Categories: call-to-action
+ * Block Types: core/cover
+ */
+
+?>
+<!-- wp:cover {"url":"https://testing.wordcamp.org/2017/files/2022/04/49627086572_50a19a83c3_k.jpg","dimRatio":50,"overlayColor":"contrast","minHeight":100,"minHeightUnit":"vh","contentPosition":"bottom left","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40"}}},"textColor":"base"} -->
+<div class="wp-block-cover alignfull is-light has-custom-content-position is-position-bottom-left has-base-color has-text-color" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40);min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="https://testing.wordcamp.org/2017/files/2022/04/49627086572_50a19a83c3_k.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"typography":{"fontSize":"4rem"}},"textColor":"background"} -->
+<h2 class="wp-block-heading has-background-color has-text-color" style="font-size:4rem"><strong>WordCamp Location</strong></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"textColor":"background"} -->
+<p class="has-background-color has-text-color">November 16–17 2023</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Buy tickets</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div></div>
+<!-- /wp:cover -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-center-left.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-center-left.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Hero with center left content
+ * Slug: wordcamp/hero-cover-center-left
+ * Categories: call-to-action
+ * Block Types: core/cover
+ */
+
+?>
+<!-- wp:cover {"url":"https://testing.wordcamp.org/2017/files/2022/04/3697251818_a01eb42c64_k.jpg","dimRatio":50,"overlayColor":"contrast","minHeight":100,"minHeightUnit":"vh","contentPosition":"center left","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"textColor":"base"} -->
+<div class="wp-block-cover alignfull is-light has-custom-content-position is-position-center-left has-base-color has-text-color" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="https://testing.wordcamp.org/2017/files/2022/04/3697251818_a01eb42c64_k.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"typography":{"fontSize":"4rem"}},"textColor":"background"} -->
+<h2 class="wp-block-heading has-background-color has-text-color" style="font-size:4rem"><strong>WordCamp Location</strong></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"textColor":"background"} -->
+<p class="has-background-color has-text-color">November 16–17 2023</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Buy tickets</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div></div>
+<!-- /wp:cover -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-centered.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Title: Hero with centered content
+ * Slug: wordcamp/hero-cover-centered
+ * Categories: call-to-action
+ * Block Types: core/cover
+ */
+
+?>
+<!-- wp:cover {"overlayColor":"tertiary","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><span aria-hidden="true" class="wp-block-cover__background has-tertiary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
+<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><strong>WordCamp Location</strong></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">November 16–17 2023</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background wp-element-button">Register</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div></div>
+<!-- /wp:cover -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-top-left.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/hero-cover-top-left.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Hero with top left content
+ * Slug: wordcamp/hero-cover-top-left
+ * Categories: call-to-action
+ * Block Types: core/cover
+ */
+
+?>
+<!-- wp:cover {"url":"https://testing.wordcamp.org/2017/files/2022/04/48047658306_ed53ebb492_k.jpg","dimRatio":50,"overlayColor":"contrast","focalPoint":{"x":0.5,"y":0.5},"minHeight":100,"minHeightUnit":"vh","contentPosition":"top left","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|70","left":"var:preset|spacing|40"}}},"textColor":"base"} -->
+<div class="wp-block-cover alignfull is-light has-custom-content-position is-position-top-left has-base-color has-text-color" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--40);min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim"></span><img class="wp-block-cover__image-background" alt="" src="https://testing.wordcamp.org/2017/files/2022/04/48047658306_ed53ebb492_k.jpg" style="object-position:50% 50%" data-object-fit="cover" data-object-position="50% 50%"/><div class="wp-block-cover__inner-container"><!-- wp:heading {"textColor":"background"} -->
+<h2 class="wp-block-heading has-background-color has-text-color"><strong>WordCamp Location</strong></h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"textColor":"background"} -->
+<p class="has-background-color has-text-color">November 16–17 2023</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Buy tickets</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div></div>
+<!-- /wp:cover -->


### PR DESCRIPTION
This adds the non-WordCamp specific content patterns from #756, header & hero patterns. The two header patterns will show up when creating header template parts, or in the Header category. The 4 hero patterns will show up in the Cover block suggestions, and are categorized as Call to Action.

Fixes #756 — if we want to add additional patterns, we can start a new issue/discussion, but for now this wraps up that issue.

Props @melchoyce

⚠️  This PR is built on #760, which adds the `patterns` folder & support for auto-registering files matching `patterns/*.php`.

### Screenshots

@melchoyce Could you check these out? I kept everything almost the same, but I removed some spacers in favor of padding & cover alignment.

| Editor | Frontend |
|---|---|
| ![editor-header-centered-with-menu](https://github.com/WordPress/wordcamp.org/assets/541093/8dc234fa-1097-4ee1-923c-1cb1ec29a6fc) | ![theme-header-centered-with-menu](https://github.com/WordPress/wordcamp.org/assets/541093/9e29f810-9bf6-4edb-aa93-d1417c6d53e5) |
| ![editor-header-with-button](https://github.com/WordPress/wordcamp.org/assets/541093/0ec90084-63ce-4f7b-8e7f-366fa69cbb87) | ![theme-header-with-button](https://github.com/WordPress/wordcamp.org/assets/541093/28d33681-96ad-4fe6-87b5-3a1ade87c95a) |
| ![editor-hero-cover-top-left](https://github.com/WordPress/wordcamp.org/assets/541093/65a8c1be-e902-49af-8597-9561b3892f15) | ![theme-hero-cover-top-left](https://github.com/WordPress/wordcamp.org/assets/541093/a9e8ade8-647d-4afe-8be0-c58df32722c2) |
| ![editor-hero-cover-center-left](https://github.com/WordPress/wordcamp.org/assets/541093/d37fb696-6fe3-48d6-94db-6da140d9c58b) | ![theme-hero-cover-center-left](https://github.com/WordPress/wordcamp.org/assets/541093/8004d236-1736-45e8-8ad9-9a67aacb7bdf) |
| ![editor-hero-cover-bottom-left](https://github.com/WordPress/wordcamp.org/assets/541093/5e33260b-2674-4caa-a3eb-866490ad80c1) | ![theme-hero-cover-bottom-left](https://github.com/WordPress/wordcamp.org/assets/541093/01258ef5-1132-4978-8311-a2546bb8d5e6) |
| ![editor-hero-cover-centered](https://github.com/WordPress/wordcamp.org/assets/541093/a4ad792a-d725-4ce6-84d1-41b480e09447) | ![theme-hero-cover-centered](https://github.com/WordPress/wordcamp.org/assets/541093/9e0ed733-d5ff-4e6b-8748-520bf0d67e9d) |

Options in the template editor:
<img width="782" alt="Screenshot 2023-05-22 at 2 11 38 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/8b6327cd-20f0-4dd4-a5fd-6ab1f62524ea">

### How to test the changes in this Pull Request:

1. Open the editor
2. Add a pattern
3. Select the Header or Call to Action category
4. The patterns should be available
5. Add one, it should insert as expected, no errors

1. In the site editor, create a new blank page template
2. Add a header template part, choose from existing options
3. The two header options should be available
4. Pick one, it should insert and create a header template part, no errors
