### PR TITLE
Payments: Add a button to download budget CSV

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
@@ -111,6 +111,12 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
         <?php settings_fields( 'wcb_budget_noop' ); ?>
         <input type="hidden" name="_wcb_budget_data" value="<?php echo esc_attr( json_encode( $budget ) ); ?>" />
 
+        <?php if ( current_user_can( WordCamp_Budgets::ADMIN_CAP ) ) : ?>
+        <p class="submit" style="padding-bottom:0">
+            <?php submit_button( esc_html__( 'Download CSV', 'wordcamporg' ), 'button-link', 'wcb-budget-download-csv', false ); ?>
+        </p>
+        <?php endif; ?>
+
         <?php if ( $budget['status'] == 'draft' && current_user_can( WordCamp_Budgets::ADMIN_CAP ) ) : ?>
         <p class="submit">
             <?php submit_button( esc_html__( 'Save Draft', 'wordcamporg' ), 'secondary', 'wcb-budget-save-draft', false ); ?>


### PR DESCRIPTION
This adds a button to the budget actions area to download a CSV of the current budget view. It exports the fields that are displayed in the "Expenses" and "Income" tables on the budget page.

~This is in draft mode until I can confirm this is the expected solution.~

~Eventual reviewing note— the first commit is a coding-standards cleanup, no other changes were done there. The second has the functionality changes.~ This PR is based on #890, which contains the coding standards changes.

### Screenshots

Currently, the download button appears below the data tables, above the other action buttons for the budget (if available), and it downloads a CSV of the budget.

On an approved budget:
<img width="308" alt="Screenshot 2023-05-31 at 2 08 26 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/861da3fc-d041-48cd-b622-e420f4eab2fa">

On a working budget:
<img width="617" alt="Screenshot 2023-05-31 at 2 08 54 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/47c2d5cd-87ec-4e6d-aefa-ca8fbf433d81">

On click, it kicks off a download of a CSV, named `budget_wordcamp-name_YYYY-MM-DD.csv`. This looks like:

<img width="809" alt="Screenshot 2023-05-31 at 1 51 28 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/bdb01596-c62f-49ac-bebf-e05b26080704">

### How to test the changes in this Pull Request:

View the budget of a WordCamp— I used `https://testing.wordcamp.org/2019/wp-admin/admin.php?page=wordcamp-budget` for testing, and try downloading the CSV. It should match the current tab (if you download on the approved tab, it should download the approved budget, and working should download the working budget).
