### PR TITLE
Use new patterns for initial site content

### DIFF
--- a/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
@@ -2,4 +2,4 @@
 <p class="has-background" style="background-color:#eeeeee"><em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:wordcamp/organizers {"mode":"all"} /-->
+<!-- wp:pattern {"slug":"wordcamp/organizer-list-bio"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/organizers.php
@@ -1,5 +1,5 @@
-<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.</p>
+<!-- wp:paragraph {"style":{"color":{"background":"#eeeeee"}}} -->
+<p class="has-background" style="background-color:#eeeeee"><em>Organizers note:</em> You can enter content for this page in the Organizers menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/organizers {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
@@ -2,4 +2,4 @@
 <p class="has-background" style="background-color:#eeeeee"><em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:wordcamp/sessions {"mode":"all"} /-->
+<!-- wp:pattern {"slug":"wordcamp/session-list-basic"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sessions.php
@@ -1,5 +1,5 @@
-<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.</p>
+<!-- wp:paragraph {"style":{"color":{"background":"#eeeeee"}}} -->
+<p class="has-background" style="background-color:#eeeeee"><em>Organizers note:</em> You can enter content for this page in the Sessions menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/sessions {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
@@ -1,5 +1,5 @@
-<!-- wp:paragraph {"customBackgroundColor":"#eeeeee"} -->
-<p style="background-color:#eeeeee" class="has-background"><em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.</p>
+<!-- wp:paragraph {"style":{"color":{"background":"#eeeeee"}}} -->
+<p class="has-background" style="background-color:#eeeeee"><em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:wordcamp/speakers {"mode":"all"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/speakers.php
@@ -2,4 +2,4 @@
 <p class="has-background" style="background-color:#eeeeee"><em>Organizers note:</em> You can enter content for this page in the Speakers menu item in the sidebar.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:wordcamp/speakers {"mode":"all"} /-->
+<!-- wp:pattern {"slug":"wordcamp/speaker-grid-centered"} /-->

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
@@ -20,7 +20,7 @@
 <p>Blurb thanking sponsors</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:wordcamp/sponsors {"mode":"all"} /-->
+<!-- wp:pattern {"slug":"wordcamp/sponsor-grid-basic"} /-->
 
 <!-- wp:heading -->
 <h2 class="wp-block-heading">Interested in sponsoring WordCamp this year?</h2>

--- a/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/page/sponsors.php
@@ -1,9 +1,19 @@
-<!-- wp:list {"className":"has-background"} -->
-<ul class="has-background"><li><span class="has-inline-color has-accent-color"><strong><em>Organizers notes:</em> </strong></span></li><li><span class="has-inline-color has-accent-color">Multi-event sponsors have been automatically created in the Sponsors menu, but you'll need to remove the ones that don't apply to your specific event. To find out which ones apply, please visit the <a href="https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/fundraising/global-community-sponsorship-for-event-organizers/">Global Community Sponsorship</a> handbook page. After that, you should add the sponsors that are specific to your event. For non-English sites, make sure the URL below matches the Call for Sponsors page.</span></li><li><span class="has-inline-color has-accent-color">The "Call for Sponsors" post was created as a draft, but there is a link to it below. Please update the content of that post, and publish it, before you turn off Coming Soon mode. </span></li></ul>
-<!-- /wp:list -->
+<!-- wp:group {"style":{"color":{"background":"#eeeeee"},"spacing":{"padding":{"top":"1em","right":"1em","bottom":"1em","left":"1em"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="background-color:#eeeeee;padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em"><!-- wp:paragraph -->
+<p><strong><em>Organizers notes:</em></strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Multi-event sponsors have been automatically created in the Sponsors menu, but you'll need to remove the ones that don't apply to your specific event. To find out which ones apply, please visit the <a href="https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/fundraising/global-community-sponsorship-for-event-organizers/">Global Community Sponsorship</a> handbook page. After that, you should add the sponsors that are specific to your event. For non-English sites, make sure the URL below matches the Call for Sponsors page.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The "Call for Sponsors" post was created as a draft, but there is a link to it below. Please update the content of that post, and publish it, before you turn off Coming Soon mode.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:heading -->
-<h2>Our Sponsors</h2>
+<h2 class="wp-block-heading">Our Sponsors</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
@@ -13,7 +23,7 @@
 <!-- wp:wordcamp/sponsors {"mode":"all"} /-->
 
 <!-- wp:heading -->
-<h2>Interested in sponsoring WordCamp this year?</h2>
+<h2 class="wp-block-heading">Interested in sponsoring WordCamp this year?</h2>
 <!-- /wp:heading -->
 
 <?php
@@ -25,5 +35,5 @@
  */
 ?>
 <!-- wp:paragraph -->
-<p>Check out our <a href="<?php echo home_url( '/call-for-sponsors/' ); ?>">Call for Sponsors</a> post for details on how you can help make this year's WordCamp the best it can be!</p>
+<p>Check out our <a href="<?php echo esc_url( home_url( '/call-for-sponsors/' ) ); ?>">Call for Sponsors</a> post for details on how you can help make this year's WordCamp the best it can be!</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
This updates the stub content used when creating new WordCamp sites to use the patterns added in #760. Using block patterns works on classic and block themes, and when the pages are edited, the pattern is injected into the content so the organizers can fully customize the content.

The other blocks' syntax has also been updated to match the current syntax, and the organizer note on Sponsors was reformatted to a grey box like the other organizer notes.

See #754, #879, #760

This should be the last of this set of [FSE/block improvements](https://github.com/WordPress/wordcamp.org/projects/2). 

### Screenshots

By default, these won't show anything, since the content they would show doesn't exist yet. (The site I used to screenshot the content had organizers set up already.)

| organizers | sessions |
|---|---|
| ![](https://github.com/WordPress/wordcamp.org/assets/541093/9f0ee6e9-06b9-4e56-b250-017a1f8bf0e7) | ![](https://github.com/WordPress/wordcamp.org/assets/541093/5645293c-819e-4513-a02a-1ed1e14bd64e) |
| speakers | sponsors |
| ![](https://github.com/WordPress/wordcamp.org/assets/541093/419e74d6-1b5d-488d-a598-eca5b3b2ded8) | ![](https://github.com/WordPress/wordcamp.org/assets/541093/83af02bd-9e92-4304-bbf4-9aae01f45405) |

When edited, the pattern expands out to the pattern content:

![new-orgs-pattern](https://github.com/WordPress/wordcamp.org/assets/541093/6140e941-536d-478b-8a86-aec70c531ec6)

### How to test the changes in this Pull Request:

1. In your local dev environment, create or edit a WordCamp post, and check the box to create a new site
2. Go to the new site's dashboard, and view the newly created pages
3. The Organizers, Speakers, Sessions, and Sponsors pages should use the query loop variations
