### PR TITLE
Add exception for canonical URL

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -106,6 +106,10 @@ function get_latest_home_url( $current_domain, $current_path ) {
 	if ( ! $latest_site ) {
 		return false;
 	}
+	
+	if ( ( 'europe.wordcamp.org' === $latest_site[0]->domain ) && ( time() <= strtotime( '2023-06-20' ) ) ) {
+		$latest_site[0]->path = '/2023';
+	}
 
 	return set_url_scheme( trailingslashit( '//' . $latest_site[0]->domain . $latest_site[0]->path ) );
 }


### PR DESCRIPTION
Since a new site is already created for WCEU, it's already setting old sites to `/2024`. This fixes that temporarily.
