### PR TITLE
 Add instruction for arm64-arch based system to docker Readme

### DIFF
--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -55,6 +55,15 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
     docker compose up
 	```
 
+    _Using an Apple ARM64 chip? You may see `failed to solve: rpc error: code = Unknown desc =...` after running either of commands above. Try adding `platform: linux/amd64` to both `wordcamp.test` and `wordcamp.db` in `docker-compose.yaml`. This will instruct Docker to create an image based on the `linux/amd64` architecture instead of `linux/arm64`, i.e._ 
+    ```
+    build:
+        context: .docker
+        dockerfile: Dockerfile.php-fpm
+    platform: linux/amd64
+    ```
+
+
     This will provision the Docker containers and install 3rd-party plugins and themes used on WordCamp.org, if necessary. It could take some time depending upon the speed of your Internet connection. At the end of the process, you should see a message like this:
 
     ```bash

--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -89,7 +89,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 
 	If your browser warns you about the self-signed certificates, then the CA certificate is not properly installed. For Chrome, [manually add the CA cert to Keychain Access](https://deliciousbrains.com/ssl-certificate-authority-for-local-https-development/). For Firefox, import it to `Preferences > Certificates > Advanced > Authorities`.
 
-1. By default, docker will start with data defined in `.docker/wordcamp_dev.sql` and changes to data will be persisted across runs in `.docker/database`. To start with different database, delete `.docker/database` directory and replace the `.docker/wordcamp_dev.sql` file and run `docker compose up --build -d` again.
+1. By default, docker will start with data defined in `.docker/data/wordcamp_dev.sql` and changes to data will be persisted across runs in `.docker/database`. To start with different database, delete `.docker/database` directory and replace the `.docker/data/wordcamp_dev.sql` file and run `docker compose up --build -d` again.
 
 1. Optional: Install Git hooks to automate code inspections during pre-commit:
     ```bash


### PR DESCRIPTION
This PR will allow users with an arm64-arch-based system to run the setup steps successfully.