### PR TITLE
Add Volunteer post type

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -43,7 +43,7 @@ function get_previous_components() {
 		);
 
 		if ( $short_descriptions ) {
-			$short_descriptions = trim( $short_descriptions );
+			$short_descriptions = array_map( 'trim', (array) $short_descriptions );
 		}
 
 		foreach ( $short_descriptions as $description ) {

--- a/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
+++ b/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
@@ -37,6 +37,7 @@ function disable_editors_by_post_type( $editors, $post_type ) {
 		// 'wcb_sponsor',
 		'mes', // Metaboxes not converted yet, but has other custom Gutenberg UI.
 		'wcb_organizer',
+		'wcb_volunteer',
 	);
 
 	/*

--- a/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
@@ -88,13 +88,13 @@ class WordCamp_Post_Types_Plugin_Back_Compat {
 			<p>
 			<?php while ( $speakers->have_posts() ) :
 				$speakers->the_post(); ?>
-			<?php
+				<?php
 				$href  = '#' . esc_attr( $post->post_name );
 				$title = esc_attr( get_the_title() );
 				echo "<a href='$href' title='$title'>";
 				echo get_avatar( get_post_meta( get_the_ID(), '_wcb_speaker_email', true ), 48 );
 				echo '</a>';
-			?>
+				?>
 			<?php endwhile; ?>
 			</p>
 		</div>

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -37,6 +37,11 @@ function register_personal_data_exporters( $exporters ) {
 		'callback'               => __NAMESPACE__ . '\organizer_personal_data_exporter',
 	);
 
+	$exporters['wcb_volunteer'] = array(
+		'exporter_friendly_name' => __( 'WordCamp Volunteer Data', 'wordcamporg' ),
+		'callback'               => __NAMESPACE__ . '\volunteer_personal_data_exporter',
+	);
+
 	return $exporters;
 }
 
@@ -94,6 +99,25 @@ function organizer_personal_data_exporter( $email_address, $page ) {
 	];
 
 	return _personal_data_exporter( 'wcb_organizer', $props_to_export, $email_address, $page );
+}
+
+
+/**
+ * Finds and exports personal data in the Volunteer post type.
+ *
+ * @param string $email_address
+ * @param int    $page
+ *
+ * @return array
+ */
+function volunteer_personal_data_exporter( $email_address, $page ) {
+	$props_to_export = array(
+		'post_title'           => __( 'Volunteer Name', 'wordcamporg' ),
+		'_wcpt_user_id'        => __( 'WordPress.org Username', 'wordcamporg' ),
+		'_wcb_volunteer_email' => __( 'Email Address', 'wordcamporg' ),
+	);
+
+	return _personal_data_exporter( 'wcb_volunteer', $props_to_export, $email_address, $page );
 }
 
 /**
@@ -190,6 +214,11 @@ function register_personal_data_erasers( $erasers ) {
 		'callback'               => __NAMESPACE__ . '\organizer_personal_data_eraser',
 	);
 
+	$erasers['wcb_volunteer'] = array(
+		'exporter_friendly_name' => __( 'WordCamp Volunteer Data', 'wordcamporg' ),
+		'callback'               => __NAMESPACE__ . '\volunteer_personal_data_eraser',
+	);
+
 	return $erasers;
 }
 
@@ -205,6 +234,13 @@ function sponsor_personal_data_eraser( $email_address, $page ) {
 
 
 function organizer_personal_data_eraser( $email_address, $page ) {
+	// @todo
+}
+
+/**
+ * Erases personal data in the Volunteer post type.
+ */
+function volunteer_personal_data_eraser( $email_address, $page ) {
 	// @todo
 }
 
@@ -287,6 +323,31 @@ function get_wc_posts( $post_type, $email_address, $page ) {
 			} else {
 				$query_args = [];
 			}
+			break;
+
+		case 'wcb_volunteer':
+			$meta_query = array(
+				array(
+					'key'   => '_wcb_volunteer_email',
+					'value' => $email_address,
+				),
+			);
+
+			$user = get_user_by( 'email', $email_address );
+
+			if ( $user instanceof WP_User ) {
+				$meta_query[] = array(
+					array(
+						'key'   => '_wcpt_user_id',
+						'value' => $user->ID,
+						'type'  => 'NUMERIC',
+					),
+				);
+
+				$meta_query['relation'] = 'OR';
+			}
+
+			$query_args['meta_query'] = $meta_query;
 			break;
 	}
 

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -54,12 +54,12 @@ function register_personal_data_exporters( $exporters ) {
  * @return array
  */
 function speaker_personal_data_exporter( $email_address, $page ) {
-	$props_to_export = [
+	$props_to_export = array(
 		'post_title'         => __( 'Speaker Name', 'wordcamporg' ),
 		'post_content'       => __( 'Speaker Bio', 'wordcamporg' ),
 		'_wcb_speaker_email' => __( 'Gravatar Email', 'wordcamporg' ),
 		'_wcpt_user_id'      => __( 'WordPress.org Username', 'wordcamporg' ),
-	];
+	);
 
 	return _personal_data_exporter( 'wcb_speaker', $props_to_export, $email_address, $page );
 }
@@ -73,13 +73,13 @@ function speaker_personal_data_exporter( $email_address, $page ) {
  * @return array
  */
 function sponsor_personal_data_exporter( $email_address, $page ) {
-	$props_to_export = [
+	$props_to_export = array(
 		'_wcpt_sponsor_company_name'  => __( 'Company Name', 'wordcamporg' ),
 		'_wcpt_sponsor_first_name'    => __( 'First Name', 'wordcamporg' ),
 		'_wcpt_sponsor_last_name'     => __( 'Last Name', 'wordcamporg' ),
 		'_wcpt_sponsor_email_address' => __( 'Email Address', 'wordcamporg' ),
 		'_wcpt_sponsor_phone_number'  => __( 'Phone Number', 'wordcamporg' ),
-	];
+	);
 
 	return _personal_data_exporter( 'wcb_sponsor', $props_to_export, $email_address, $page );
 }
@@ -93,10 +93,10 @@ function sponsor_personal_data_exporter( $email_address, $page ) {
  * @return array
  */
 function organizer_personal_data_exporter( $email_address, $page ) {
-	$props_to_export = [
+	$props_to_export = array(
 		'post_title'    => __( 'Organizer Name', 'wordcamporg' ),
 		'_wcpt_user_id' => __( 'WordPress.org Username', 'wordcamporg' ),
-	];
+	);
 
 	return _personal_data_exporter( 'wcb_organizer', $props_to_export, $email_address, $page );
 }
@@ -131,7 +131,7 @@ function volunteer_personal_data_exporter( $email_address, $page ) {
 function _personal_data_exporter( $post_type, array $props_to_export, $email_address, $page ) {
 	$page = (int) $page;
 
-	$exporters   = apply_filters( 'wp_privacy_personal_data_exporters', [] );
+	$exporters   = apply_filters( 'wp_privacy_personal_data_exporters', array() );
 	$group_label = $exporters[ $post_type ]['exporter_friendly_name'] ?: sprintf( __( '%s Data', 'wordcamporg' ), $post_type );
 
 	$data_to_export = array();
@@ -139,17 +139,17 @@ function _personal_data_exporter( $post_type, array $props_to_export, $email_add
 	$post_query = get_wc_posts( $post_type, $email_address, $page );
 
 	if ( is_wp_error( $post_query ) ) {
-		return [
-			'data' => [],
+		return array(
+			'data' => array(),
 			'done' => true,
-		];
+		);
 	}
 
 	foreach ( (array) $post_query->posts as $post ) {
-		$post_data_to_export = [];
+		$post_data_to_export = array();
 
 		foreach ( $props_to_export as $key => $label ) {
-			if ( in_array( $key, [ 'post_title', 'post_content' ], true ) ) {
+			if ( in_array( $key, array( 'post_title', 'post_content' ), true ) ) {
 				$value = $post->$key;
 			} else {
 				$value = get_post_meta( $post->ID, $key, true );
@@ -166,29 +166,29 @@ function _personal_data_exporter( $post_type, array $props_to_export, $email_add
 			}
 
 			if ( ! empty( $value ) ) {
-				$post_data_to_export[] = [
+				$post_data_to_export[] = array(
 					'name'  => $label,
 					'value' => $value,
-				];
+				);
 			}
 		}
 
 		if ( ! empty( $post_data_to_export ) ) {
-			$data_to_export[] = [
+			$data_to_export[] = array(
 				'group_id'    => $post_type,
 				'group_label' => $group_label,
 				'item_id'     => "{$post_type}-{$post->ID}",
 				'data'        => $post_data_to_export,
-			];
+			);
 		}
 	}
 
 	$done = $post_query->max_num_pages <= $page;
 
-	return [
+	return array(
 		'data' => $data_to_export,
 		'done' => $done,
-	];
+	);
 }
 
 /**
@@ -256,7 +256,7 @@ function volunteer_personal_data_eraser( $email_address, $page ) {
 function get_wc_posts( $post_type, $email_address, $page ) {
 	$number = 20;
 
-	$query_args = [
+	$query_args = array(
 		'posts_per_page' => $number,
 		'paged'          => $page,
 		'post_type'      => $post_type,
@@ -270,58 +270,59 @@ function get_wc_posts( $post_type, $email_address, $page ) {
 		),
 		'orderby'        => 'ID',
 		'order'          => 'ASC',
-	];
+	);
 
 	switch ( $post_type ) {
-		case 'wcb_speaker' :
-			$meta_query = [
-				[
+		case 'wcb_speaker':
+			$meta_query = array(
+				array(
 					'key'   => '_wcb_speaker_email',
 					'value' => $email_address,
-				],
-			];
+				),
+			);
 
 			$user = get_user_by( 'email', $email_address );
 
 			if ( $user instanceof WP_User ) {
-				$meta_query[] = [
-					[
+				$meta_query[] = array(
+					array(
 						'key'   => '_wcpt_user_id',
 						'value' => $user->ID,
 						'type'  => 'NUMERIC',
-					],
-				];
+					),
+				);
 
 				$meta_query['relation'] = 'OR';
 			}
 
 			$query_args['meta_query'] = $meta_query;
 			break;
-		case 'wcb_sponsor' :
-			$meta_query = [
-				[
+		case 'wcb_sponsor':
+			$meta_query = array(
+				array(
 					'key'   => '_wcpt_sponsor_email_address',
 					'value' => $email_address,
-				],
-			];
+				),
+			);
 
 			$query_args['meta_query'] = $meta_query;
 			break;
-		case 'wcb_organizer' :
+
+		case 'wcb_organizer':
 			$user = get_user_by( 'email', $email_address );
 
 			if ( $user instanceof WP_User ) {
-				$meta_query = [
-					[
+				$meta_query = array(
+					array(
 						'key'   => '_wcpt_user_id',
 						'value' => $user->ID,
 						'type'  => 'NUMERIC',
-					],
-				];
+					),
+				);
 
 				$query_args['meta_query'] = $meta_query;
 			} else {
-				$query_args = [];
+				$query_args = array();
 			}
 			break;
 

--- a/public_html/wp-content/plugins/wc-post-types/js/src/volunteer/index.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/volunteer/index.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import VolunteerInfoPanel from './panel-info';
+
+registerPlugin( 'wordcamp-volunteer-settings', {
+	render: () => <VolunteerInfoPanel />,
+	icon: '',
+} );

--- a/public_html/wp-content/plugins/wc-post-types/js/src/volunteer/panel-info.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/volunteer/panel-info.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import usePostMeta from '../components/hooks/use-post-meta';
+import UsernameControl from '../components/username-control';
+
+export default function VolunteerInfoPanel() {
+	const [ email, setEmail ] = usePostMeta( '_wcb_volunteer_email', '' );
+	const [ username, setUsername ] = usePostMeta( '_wcpt_user_name', '' );
+
+	return (
+		<PluginDocumentSettingPanel
+			name="wordcamp/volunteer-info"
+			className="wc-panel-volunteer-info"
+			title={ __( 'Volunteer Info', 'wordcamporg' ) }
+		>
+			<TextControl
+				label={ __( 'Email Address', 'wordcamporg' ) }
+				type="email"
+				value={ email }
+				onChange={ setEmail }
+			/>
+			<UsernameControl
+				label={ __( 'WordPress.org Username', 'wordcamporg' ) }
+				value={ username }
+				onChange={ setUsername }
+			/>
+		</PluginDocumentSettingPanel>
+	);
+}

--- a/public_html/wp-content/plugins/wc-post-types/package.json
+++ b/public_html/wp-content/plugins/wc-post-types/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wc-post-types",
 	"version": "1.0.0",
-	"description": "Sessions, Speakers, Sponsors and much more.",
+	"description": "Custom post types for Sessions, Speakers, Sponsors, Organizers, Volunteers.",
 	"author": "WordCamp Team",
 	"license": "GPL-2.0-or-later",
 	"private": true,

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -275,7 +275,7 @@ class WordCamp_Post_Types_Plugin {
 		if ( 'wcb_session' == $post_type ) {
 			wp_enqueue_script( 'wcb-session-meta' );
 
-			$session_time = false;
+			$session_time         = false;
 			$most_recent_sessions = get_posts( array(
 				'post_type'   => 'wcb_session',
 				'orderby'     => 'modified',
@@ -289,7 +289,7 @@ class WordCamp_Post_Types_Plugin {
 
 			if ( ! $session_time ) {
 				$wordcamp_start_date = get_wordcamp_post()->meta['Start Date (YYYY-mm-dd)'][0];
-				$session_time = ( isset( $wordcamp_start_date ) ) ? $wordcamp_start_date : 0;
+				$session_time        = ( isset( $wordcamp_start_date ) ) ? $wordcamp_start_date : 0;
 			}
 
 			$settings = array(
@@ -334,7 +334,7 @@ class WordCamp_Post_Types_Plugin {
 		$full_path   = __DIR__ . '/' . $path;
 		$deps_path   = __DIR__ . '/' . str_replace( '.js', '.asset.php', $path );
 		$script_info = file_exists( $deps_path )
-			? require( $deps_path )
+			? require $deps_path
 			: array(
 				'dependencies' => array(),
 				'version' => filemtime( $full_path ),
@@ -1919,7 +1919,7 @@ class WordCamp_Post_Types_Plugin {
 
 			case 'wcb_session_time':
 				$session_time = absint( get_post_meta( get_the_ID(), '_wcpt_session_time', true ) );
-				$output = '&mdash;';
+				$output       = '&mdash;';
 				if ( $session_time ) {
 					$output = sprintf(
 						/* translators: 1: A date; 2: A time; */

--- a/public_html/wp-content/plugins/wc-post-types/webpack.config.js
+++ b/public_html/wp-content/plugins/wc-post-types/webpack.config.js
@@ -8,5 +8,6 @@ module.exports = {
 		sessions: path.resolve( __dirname, 'js/src/session/index.js' ),
 		speakers: path.resolve( __dirname, './js/src/speaker/index.js' ),
 		organizers: path.resolve( __dirname, 'js/src/organizer/index.js' ),
+		volunteers: path.resolve( __dirname, 'js/src/volunteer/index.js' ),
 	},
 };


### PR DESCRIPTION
See #887
See #550 

This adds a new custom post type for volunteers, similar to the post type for organizers and speakers. This will let us gather some stats on the success of pilot events, automatically grant profile badges, etc.

Automation with the `Call for Volunteers` form can be added in a subsequent PR (similar to how it works for speakers).