### PR TITLE
Jetpack: Activate default modules for new sites

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/new-sites.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/new-sites.php
@@ -16,6 +16,7 @@ add_action( 'wcorg_connect_new_site',                          __NAMESPACE__ . '
 function default_jetpack_modules( $modules ) {
 	$modules = array_diff( $modules, array( 'widget-visibility' ) );
 	array_push( $modules, 'contact-form', 'shortcodes', 'custom-css', 'subscriptions' );
+	$modules = array_unique( $modules );
 
 	return $modules;
 }

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -432,6 +432,8 @@ class WordCamp_New_Site {
 		$this->set_default_options( $wordcamp, $meta );
 		$this->create_post_stubs( $wordcamp, $meta, $lead_organizer );
 
+		Jetpack::activate_default_modules( false, false, array(), false, false, false, false );
+
 		/**
 		 * Hook into the configuration process for a new WordCamp site.
 		 *


### PR DESCRIPTION
I noticed that the modules in `default_jetpack_modules()` weren't being activated when a new site is created. IIRC they used to be, but I'm not 100% sure of that. Either way, manually calling `Jetpack::activate_default_modules()` inside `configure_new_site()` fixes it.