### PR TITLE
Automatically create Volunteer drafts when application submitted

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/css/editor.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/editor.css
@@ -43,3 +43,11 @@
 	margin-left: 0;
 	margin-right: 0;
 }
+
+.wc-panel-volunteer-info .components-base-control {
+	margin-bottom: 2em;
+}
+
+.wc-panel-volunteer-info .components-base-control:last-child {
+	margin-bottom: 0;
+}

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -115,6 +115,7 @@ function volunteer_personal_data_exporter( $email_address, $page ) {
 		'post_title'           => __( 'Volunteer Name', 'wordcamporg' ),
 		'_wcpt_user_id'        => __( 'WordPress.org Username', 'wordcamporg' ),
 		'_wcb_volunteer_email' => __( 'Email Address', 'wordcamporg' ),
+		'_wcb_volunteer_first_time' => __( 'First Time Volunteer', 'wordcamporg' ),
 	);
 
 	return _personal_data_exporter( 'wcb_volunteer', $props_to_export, $email_address, $page );

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -304,6 +304,21 @@ function register_volunteer_post_meta() {
 			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
 		)
 	);
+
+	register_post_meta(
+		'wcb_volunteer',
+		'_wcb_volunteer_first_time',
+		array(
+			'type'          => 'string',
+			'show_in_rest'  => array(
+				'schema' => array(
+					'context' => array( 'edit' ),
+				),
+			),
+			'single'        => true,
+			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+		)
+	);
 }
 
 /**

--- a/public_html/wp-content/plugins/wc-post-types/js/src/volunteer/panel-info.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/volunteer/panel-info.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { TextControl } from '@wordpress/components';
+import { RadioControl, TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import UsernameControl from '../components/username-control';
 export default function VolunteerInfoPanel() {
 	const [ email, setEmail ] = usePostMeta( '_wcb_volunteer_email', '' );
 	const [ username, setUsername ] = usePostMeta( '_wcpt_user_name', '' );
+	const [ firstTime, setFirstTime ] = usePostMeta( '_wcb_volunteer_first_time', false );
 
 	return (
 		<PluginDocumentSettingPanel
@@ -27,10 +28,22 @@ export default function VolunteerInfoPanel() {
 				value={ email }
 				onChange={ setEmail }
 			/>
+
 			<UsernameControl
 				label={ __( 'WordPress.org Username', 'wordcamporg' ) }
 				value={ username }
 				onChange={ setUsername }
+			/>
+
+			<RadioControl
+				label={ __( 'Is this the first time they have volunteered at a WordPress event?', 'wordcamporg' ) }
+				selected={ firstTime }
+				onChange={ ( value ) => setFirstTime( value ) }
+				options={ [
+					{ label: 'Yes', value: 'yes' },
+					{ label: 'No', value: 'no' },
+					{ label: 'Unsure', value: 'unsure' },
+				] }
 			/>
 		</PluginDocumentSettingPanel>
 	);

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
@@ -1,15 +1,27 @@
+<!-- wp:paragraph {"backgroundColor":"accent","textColor":"background","className":"has-accent-background-color has-background"} -->
+<p class="has-accent-background-color has-background has-background-color has-text-color"><em>Organizers Note:</em>
+	Submissions to this form will automatically create <code>draft</code>
+	<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=wcb_volunteer' ) ); ?>">Volunteer posts</a>.
+	You can use those to manage your volunteers, by publishing the ones that you accept, and deleting the ones that you don't.
+	Changing the <code>name</code>, <code>email</code>, <code>username</code>, or <code>first time volunteering</code> questions can break the automation, though.
+</p>
+<!-- /wp:paragraph -->
+
 <!-- wp:paragraph -->
 <p>Blurb with information for potential volunteers.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:jetpack/contact-form {"subject":"WordCamp Volunteer Application","hasFormSettingsSet":"yes"} -->
 <!-- wp:jetpack/field-name {"label":"Name","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email","required":true,"requiredText":"(required)","id":"volunteer-email"} /-->
 
-<!-- wp:jetpack/field-email {"label":"Email","required":true} /-->
+<!-- wp:jetpack/field-text {"label":"WordPress.org Username","requiredText":"(required)","id":"volunteer-username"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Skills / Interests / Experience (not necessary to volunteer)","required":true} /-->
 
 <!-- wp:jetpack/field-text {"label":"Number of Hours Available","required":true} /-->
+
+<!-- wp:jetpack/field-radio {"label":"Is this the first time you have volunteered at a WordPress event?","requiredText":"(required)","options":["Yes","No","Unsure"],"id":"first-time-volunteer"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Questions / Comments"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -733,6 +733,9 @@ class WordCamp_New_Site {
 				'content' => $this->get_stub_content( 'post', 'call-for-volunteers' ),
 				'status'  => 'draft',
 				'type'    => 'post',
+				'meta'    => array(
+					'wcfd-key' => 'call-for-volunteers',
+				),
 			),
 		);
 


### PR DESCRIPTION
See #887 

This makes it so that submitting the Call for Volunteers form will automatically create a `draft` Volunteer post. That cuts down on the amount of work that organizers need to do in order to use the post type.

It also adds a question to the form and CPT about if the person has volunteered at a WP event before.