### PR TITLE
Add redirect for events.wordcamp.test

### DIFF
--- a/public_html/wp-content/mu-plugins/events/redirects.php
+++ b/public_html/wp-content/mu-plugins/events/redirects.php
@@ -4,13 +4,13 @@ namespace WordCamp\Redirects;
 
 defined( 'WPINC' ) || die();
 
-add_action( 'init',  __NAMESPACE__ . '\redirect_subdomain' );
+add_action( 'init', __NAMESPACE__ . '\redirect_to_make_community' );
 
 /**
  * Redirects the root URL of the "events.wordpress.org" to "https://make.wordpress.org/community/events".
  */
-function redirect_subdomain() {
-	if ( 'events.wordcamp.test' === $_SERVER['HTTP_HOST'] && wp_using_themes() && ! defined( 'REST_REQUEST' ) ) {
+function redirect_to_make_community() {
+	if ( wp_using_themes() && ! defined( 'REST_REQUEST' ) ) {
 		$request_uri = $_SERVER['REQUEST_URI'];
 
 		if ( '/' === $request_uri ) {

--- a/public_html/wp-content/mu-plugins/events/redirects.php
+++ b/public_html/wp-content/mu-plugins/events/redirects.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WordCamp\Redirect;
+namespace WordCamp\Redirects;
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -19,6 +19,7 @@ if ( EVENTS_NETWORK_ID === SITE_ID_CURRENT_SITE ) {
 
 wcorg_include_individual_mu_plugins();
 wcorg_include_mu_plugin_folders();
+wcorg_include_events_network_mu_plugins();
 
 /**
  * Load individually-targeted files
@@ -28,9 +29,9 @@ wcorg_include_mu_plugin_folders();
 function wcorg_include_individual_mu_plugins() {
 	$shortcodes = dirname( __DIR__ ) . '/mu-plugins-private/wordcamp-shortcodes/wc-shortcodes.php';
 
-	require_once( __DIR__ . '/wp-cli-commands/bootstrap.php' );
-	require_once( __DIR__ . '/camptix-tweaks/camptix-tweaks.php' );
-	require_once( __DIR__ . '/blocks/blocks.php' );
+	require_once __DIR__ . '/wp-cli-commands/bootstrap.php';
+	require_once __DIR__ . '/camptix-tweaks/camptix-tweaks.php';
+	require_once __DIR__ . '/blocks/blocks.php';
 	require_once __DIR__ . '/quickbooks/quickbooks.php';
 	require_once __DIR__ . '/theme-templates/bootstrap.php';
 	require_once __DIR__ . '/virtual-embeds/virtual-embeds.php';
@@ -42,7 +43,7 @@ function wcorg_include_individual_mu_plugins() {
 	}
 
 	if ( is_file( $shortcodes ) ) {
-		require_once( $shortcodes );
+		require_once $shortcodes;
 	}
 }
 
@@ -61,9 +62,18 @@ function wcorg_include_mu_plugin_folders() {
 		if ( is_array( $plugins ) ) {
 			foreach ( $plugins as $plugin ) {
 				if ( is_file( $plugin ) ) {
-					require_once( $plugin );
+					require_once $plugin;
 				}
 			}
 		}
+	}
+}
+
+/**
+ * Load every mu-plugin that only runs on events network
+ */
+function wcorg_include_events_network_mu_plugins() {
+	if ( EVENTS_NETWORK_ID === SITE_ID_CURRENT_SITE ) {
+		require_once __DIR__ . '/events/redirects.php';
 	}
 }

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -14,6 +14,8 @@ if ( EVENTS_NETWORK_ID === SITE_ID_CURRENT_SITE ) {
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins/privacy-gdpr-exporter/privacy-gdpr-exporter.php';
 	}
 
+	require_once __DIR__ . '/events/redirects.php';
+
 	return;
 }
 

--- a/public_html/wp-content/mu-plugins/redirect.php
+++ b/public_html/wp-content/mu-plugins/redirect.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WordCamp\Redirect;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init',  __NAMESPACE__ . '\redirect_subdomain' );
+
+/**
+ * Redirects the root URL of the "events.wordpress.org" to "https://make.wordpress.org/community/events".
+ */
+function redirect_subdomain() {
+	if ( 'events.wordcamp.test' === $_SERVER['HTTP_HOST'] && wp_using_themes() && ! defined( 'REST_REQUEST' ) ) {
+		$request_uri = $_SERVER['REQUEST_URI'];
+
+		if ( '/' === $request_uri ) {
+			$new_url = 'https://make.wordpress.org/community/events';
+			wp_redirect( $new_url );
+			exit;
+		}
+	}
+}


### PR DESCRIPTION
See #894 

This PR adds a function that redirects the URL `events.wordpress.org` to https://make.wordpress.org/community/events/

**Screencast tested while sandboxed**

https://github.com/WordPress/wordcamp.org/assets/18050944/6c076567-5263-43a5-9786-c86460db1861





