### PR TITLE
Setup Pilot Events network and URL support

### DIFF
--- a/.docker/config/nginx.conf
+++ b/.docker/config/nginx.conf
@@ -52,6 +52,7 @@ server {
 	if ( $host = "events.wordpress.test" ) {
 		rewrite "/[\w-]+/\d{4}/[\w-]+/wp-(admin|content|includes)(.*)" /wp-$1$2 last;
 		rewrite "/[\w-]+/\d{4}/[\w-]+/wp-(.*).php(.*)" /wp-$1.php$2 last;
+		rewrite "/[\w-]+/\d{4}/[\w-]+/xmlrpc\.php" /xmlrpc.php last;
 	}
 
 	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf)$ {

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -38,13 +38,15 @@ $table_prefix = 'wc_'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 /*
  * Multisite
  */
+const WORDCAMP_NETWORK_ID   = 1;
 const WORDCAMP_ROOT_BLOG_ID = 5;
+const EVENTS_NETWORK_ID     = 2;
 const EVENTS_ROOT_BLOG_ID   = 47;
 
 switch ( $_SERVER['HTTP_HOST'] ) {
 	case 'events.wordpress.test':
-		define( 'SITE_ID_CURRENT_SITE',  2 );
-		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID ); // events.wordpress.test.
+		define( 'SITE_ID_CURRENT_SITE',  EVENTS_NETWORK_ID );
+		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID );
 		define( 'DOMAIN_CURRENT_SITE',   'events.wordpress.test' );
 		define( 'SUBDOMAIN_INSTALL',     false );
 		define( 'NOBLOGREDIRECT',        'https://events.wordpress.test' );
@@ -54,8 +56,8 @@ switch ( $_SERVER['HTTP_HOST'] ) {
 	case 'wordcamp.test':
 	case 'buddycamp.test':
 	default:
-		define( 'SITE_ID_CURRENT_SITE',  1 );
-		define( 'BLOG_ID_CURRENT_SITE',  WORDCAMP_ROOT_BLOG_ID ); // central.wordcamp.test.
+		define( 'SITE_ID_CURRENT_SITE',  WORDCAMP_NETWORK_ID );
+		define( 'BLOG_ID_CURRENT_SITE',  WORDCAMP_ROOT_BLOG_ID );
 		define( 'DOMAIN_CURRENT_SITE',   'buddycamp.test' === $_SERVER['HTTP_HOST'] ? 'buddycamp.test' : 'wordcamp.test' );
 		define( 'SUBDOMAIN_INSTALL',     true );
 		define( 'NOBLOGREDIRECT',        'https://central.wordcamp.test' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -78,6 +78,7 @@
 	<!-- Exclude 3rd-party files -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>./public_html/mu/*</exclude-pattern>
 
 	<!-- Scan all (php) files in the current folder and subfolders -->
 	<file>.</file>

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -5,6 +5,12 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
+const WORDCAMP_NETWORK_ID   = 1;
+const WORDCAMP_ROOT_BLOG_ID = 5;
+const EVENTS_NETWORK_ID     = 2;
+const EVENTS_ROOT_BLOG_ID   = 47;
+const SITE_ID_CURRENT_SITE  = WORDCAMP_NETWORK_ID;
+
 define( 'WP_PLUGIN_DIR', __DIR__ . '/public_html/wp-content/plugins' );
 define( 'SUT_WPMU_PLUGIN_DIR', __DIR__ . '/public_html/wp-content/mu-plugins' ); // WPMU_PLUGIN_DIR will be in `WP_TESTS_DIR`.
 

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -2,10 +2,16 @@
 
 namespace WordCamp\Latest_Site_Hints;
 use function WordCamp\Sunrise\get_top_level_domain;
-
 use const WordCamp\Sunrise\{ PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH };
 
 defined( 'WPINC' ) || die();
+
+if ( EVENTS_NETWORK_ID === SITE_ID_CURRENT_SITE ) {
+	// @todo Remove this once https://github.com/WordPress/wordcamp.org/issues/906 is fixed.
+	// If it's needed on the Events network, the constants above will need to be moved to `sunrise.php`, or
+	// defined in `sunrise-events.php` with a pattern designed for Events sites.
+	return;
+}
 
 // Hook in before `WordPressdotorg\SEO\Canonical::rel_canonical_link()`, so that callback can be removed.
 add_action( 'wp_head', __NAMESPACE__ . '\canonical_link_past_home_pages_to_current_year', 9 );

--- a/public_html/wp-content/mu-plugins/lets-encrypt-helper.php
+++ b/public_html/wp-content/mu-plugins/lets-encrypt-helper.php
@@ -53,7 +53,7 @@ class WordCamp_Lets_Encrypt_Helper {
 					`public`  = 1 AND
 					`deleted` = 0
 				ORDER BY `blog_id` ASC",
-				1
+				WORDCAMP_NETWORK_ID
 			),
 			ARRAY_A
 		);

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -2,6 +2,12 @@
 
 defined( 'WPINC' ) || die();
 
+if ( EVENTS_NETWORK_ID === SITE_ID_CURRENT_SITE ) {
+	// @todo Remove this once https://github.com/WordPress/wordcamp.org/issues/906 is fixed.
+	// In the meantime it causes problems because of switch_to_blog().
+	return;
+}
+
 wcorg_include_individual_mu_plugins();
 wcorg_include_mu_plugin_folders();
 

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WordCamp\Sunrise\Events;
+use WP_Network, WP_Site;
+
+defined( 'WPINC' ) || die();
+
+/*
+ * Matches URLs of regular sites, but not the root site.
+ *
+ * For example, `events.wordpress.org/vancouver/2023/diversity-day/`.
+ *
+ */
+const PATTERN_EVENT_SITE = '
+	@ ^
+	/
+	( [\w-]+ )    # Capture the city.
+	/
+	( \d{4} )     # Capture the year.
+	/
+	( [\w-]+ )    # Capture the event type.
+	/?
+	@ix
+';
+
+set_network_and_site();
+
+
+/**
+ * Determine the current network and site.
+ *
+ * This is needed to achieve the `events.wordpress.org/{year}/{event-type}{city}` URL structure.
+ *
+ * @see https://paulund.co.uk/wordpress-multisite-with-nested-folder-paths
+ *
+ * phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- WP is designed in a way that requires this.
+ * That's the whole point of `sunrise.php`.
+ */
+function set_network_and_site() {
+	global $current_site, $current_blog, $blog_id, $site_id, $domain, $path, $public;
+
+	// Originally WP referred to networks as "sites" and sites as "blogs".
+	$current_site = WP_Network::get_instance( EVENTS_NETWORK_ID );
+	$site_id      = $current_site->id;
+	$path         = stripslashes( $_SERVER['REQUEST_URI'] );
+
+	if ( 1 === preg_match( PATTERN_EVENT_SITE, $path ) ) {
+		if ( is_admin() ) {
+			$path = preg_replace( '#(.*)/wp-admin/.*#', '$1/', $path );
+		}
+
+		list( $path ) = explode( '?', $path );
+
+		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 3 );
+
+	} else {
+		$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
+	}
+
+	$blog_id = $current_blog->id;
+	$domain  = $current_blog->domain;
+	$public  = $current_blog->public;
+}

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -154,15 +154,6 @@ function main() {
 }
 
 /**
- * Get the TLD for the current environment.
- *
- * @return string
- */
-function get_top_level_domain() {
-	return 'local' === WORDCAMP_ENVIRONMENT ? 'test' : 'org';
-}
-
-/**
  * Parse the `$wpdb->blogs` `domain` and `path` out of the requested URL.
  *
  * This is only an educated guess, and cannot work in all cases (e.g., `central.wordcamp.org/2020` (year archive

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -317,7 +317,7 @@ function get_domain_redirects() {
 		"2018.philly.wordcamp.$tld"               => "philadelphia.wordcamp.$tld/2018",
 		"2019.philly.wordcamp.$tld"               => "philadelphia.wordcamp.$tld/2019",
 
-		// city.wordcamp.org/year redirects
+		// city.wordcamp.org/year redirects.
 		"india.wordcamp.$tld/2020" => "india.wordcamp.$tld/2021",
 
 		/*
@@ -352,10 +352,8 @@ function get_city_slash_year_url( $domain, $request_uri ) {
 	$tld = get_top_level_domain();
 
 	$redirect_cities = array(
-		/*
-		 * These domains were created before the 2014 migration, and moved from `unsubdomactories_redirects()`
-		 * during the 2020 migration.
-		 */
+		// These domains were created before the 2014 migration, and moved from `unsubdomactories_redirects()`
+		// during the 2020 migration.
 		'barcelona', 'chicago', 'columbus', 'geneve', 'philly', 'philadelphia', 'publishers',
 		'athens', 'atlanta', 'austin', 'brighton', 'europe', 'nyc', 'newyork', 'organizers', 'rhodeisland', 'sf',
 		'cincinnati', 'dayton', 'denmark', 'finland', 'india', 'seattle', 'sunshinecoast', 'testing', 'varna',
@@ -363,8 +361,8 @@ function get_city_slash_year_url( $domain, $request_uri ) {
 		'mexico', 'mexicocity', 'colombia', 'saopaulo', 'iloilo', 'lima', 'pokhara',
 		'peoria', 'torino', 'aalborg', 'cebu', 'butwal', 'centroamerica', 'london', 'londonca',
 		'portland', 'portlandme', 'miami', 'mallorca', 'montreal', 'ottawa', 'bristol', 'cusco', 'niagara',
-		'saintpetersburg','zilina','wuerzburg', 'kolkata', 'montclair', 'telaviv', 'bucharest',
-		'lancasterpa','lancaster', 'peru', 'pune', 'lisboa', 'sevilla',
+		'saintpetersburg', 'zilina', 'wuerzburg', 'kolkata', 'montclair', 'telaviv', 'bucharest',
+		'lancasterpa', 'lancaster', 'peru', 'pune', 'lisboa', 'sevilla',
 		'us', 'dc', 'phoenix', 'slc', 'boston', 'orlando', 'melbourne',
 		'oc', 'vegas', 'capetown', 'victoria', 'birmingham', 'birminghamuk', 'maine',
 		'albuquerque', 'sacramento', 'calgary', 'porto', 'portoalegre', 'tampa',
@@ -373,8 +371,8 @@ function get_city_slash_year_url( $domain, $request_uri ) {
 		'biarritz', 'charleston', 'buenosaires', 'krakow', 'vienna', 'grandrapids', 'hamilton', 'minneapolis',
 		'stlouis', 'edinburgh', 'winnipeg', 'northcanton', 'sanantonio', 'prague',
 		'slovakia', 'salvador', 'maui', 'hamptonroads', 'houston', 'warsaw', 'belgrade', 'mumbai',
-		'belohorizonte',  'switzerland', 'romania', 'saratoga', 'fayetteville',
-		'bournemouth', 'hanoi',  'cologne', 'louisville', 'annarbor', 'manchester',
+		'belohorizonte', 'switzerland', 'romania', 'saratoga', 'fayetteville',
+		'bournemouth', 'hanoi', 'cologne', 'louisville', 'annarbor', 'manchester',
 		'laspenitas', 'israel', 'ventura', 'vancouver', 'auckland', 'norrkoping', 'netherlands',
 		'hamburg', 'nashville', 'connecticut', 'sheffield', 'wellington', 'omaha', 'milwaukee',
 		'riodejaneiro', 'wroclaw', 'santarosa', 'edmonton', 'kenya',
@@ -386,7 +384,6 @@ function get_city_slash_year_url( $domain, $request_uri ) {
 		'pittsburgh', 'nola', 'neo', 'antwerp', 'helsinki', 'vernon', 'frankfurt', 'bilbao',
 		'gdynia', 'lehighvalley', 'lahore', 'bratislava', 'okc', 'la', 'rochester', 'ogijima', 'asheville',
 
-
 		// These domains were created after the 2014 URL migration was reverted, but before the 2020 migration.
 		'rome', 'ahmedabad', 'alicante', 'asia', 'bangkok', 'bari', 'belfast', 'bengaluru', 'bern',
 		'bharatpur', 'bhopal', 'bhubaneswar', 'biratnagar', 'bogota', 'boise', 'bordeaux', 'brno', 'buea',
@@ -394,7 +391,7 @@ function get_city_slash_year_url( $domain, $request_uri ) {
 		'chiclana', 'colombo', 'davao', 'delhi', 'denpasar', 'dhaka', 'douala', 'dublin', 'dusseldorf',
 		'entebbe', 'floripa', 'nice', 'niigata', 'nijmegen', 'nis', 'noordnederland', 'nordic',
 		'geneva', 'glasgow', 'granada', 'guadalajara', 'guayaquil', 'halifax', 'haneda', 'harare', 'hongkong',
-		'ileife', 'irun', 'islamabad',  'jackson', 'johannesburg', 'jyvaskyla', 'kampala', 'kanpur',
+		'ileife', 'irun', 'islamabad', 'jackson', 'johannesburg', 'jyvaskyla', 'kampala', 'kanpur',
 		'karachi', 'kathmandu', 'kent', 'kigali', 'kochi', 'kosice', 'kotakinabalu', 'kualalumpur', 'kyiv',
 		'kyoto', 'lagos', 'laspalmas', 'laspalmasgc', 'lausanne', 'lille', 'littlerock', 'lodz',
 		'longbeach', 'lublin', 'madison', 'madrid', 'managua', 'manila', 'mannheim', 'marbella', 'marseille',

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -11,6 +11,10 @@ load_network_sunrise();
  */
 function load_network_sunrise() {
 	switch ( SITE_ID_CURRENT_SITE ) {
+		case EVENTS_NETWORK_ID:
+			require __DIR__ . '/sunrise-events.php';
+			break;
+
 		case WORDCAMP_NETWORK_ID:
 		default:
 			require __DIR__ . '/sunrise-wordcamp.php';

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WordCamp\Sunrise;
+defined( 'WPINC' ) || die();
+
+load_network_sunrise();
+
+
+/**
+ * Load the sunrise file for the current network.
+ */
+function load_network_sunrise() {
+	switch ( SITE_ID_CURRENT_SITE ) {
+		case WORDCAMP_NETWORK_ID:
+		default:
+			require __DIR__ . '/sunrise-wordcamp.php';
+			break;
+	}
+}
+
+/**
+ * Get the TLD for the current environment.
+ *
+ * @return string
+ */
+function get_top_level_domain() {
+	return 'local' === WORDCAMP_ENVIRONMENT ? 'test' : 'org';
+}


### PR DESCRIPTION
See #884 
See #885 

This handles the interdependent parts of those issues, which covers everything needed to create sites like `events.wordpress.test/barcelona/2023/diversity-day/`, and have requests routed appropriately.

### Testing

⚠️ Do this in a local environment, since more testing is needed before we test this on a w.org sandbox

- [ ] Update your `wp-config.php` and `nginx.conf` to be similar to the Docker files in #912. _( I haven't tested Docker yet, though, so more work may be needed in #910 to make it work )_
- [ ] Manually create sites for `events.wordpress.test` and `events.wordpress.test/vancouver/2023/diversity-day/`. You'll probably have to use `-` instead of `/` in the path when creating them, but then you can edit them to change to `/`.
- [ ] Add those hostnames to your `hosts` file
- [ ] Rerun `mkcert` to update your SSL certs with the new domain
- [ ] Manually change the `site_id` for those new sites in the `wp_blogs` table to be `2`
- [ ] Update `EVENTS_ROOT_BLOG_ID` values to match the blog you created above
- [ ] Don't activate any plugins. We'll have to do #886 and #906 before they'll work
- [ ] Visit the Vancouver site and make sure all the Core functionality works
- [ ] Visit Central and a regular site on the WordCamp network and make sure everything still works