### PR TITLE
Docker: Add configuration for `events.wordpress.org` network

### DIFF
--- a/.docker/config/nginx.conf
+++ b/.docker/config/nginx.conf
@@ -17,7 +17,7 @@ server {
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
 
-	server_name wordcamp.test;
+	server_name wordcamp.test events.wordpress.test;
 	ssl_certificate /etc/ssl/certs/wordcamp.test.pem;
 	ssl_certificate_key /etc/ssl/private/wordcamp.test.key.pem;
 	ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
@@ -47,6 +47,12 @@ server {
 	}
 
 	rewrite ^/files/(.*)$ /wp-includes/ms-files.php?file=$1;
+
+	# Map URLs like https://events.wordpress.test/barcelona/2023/diversity-day/ to the correct file.
+	if ( $host = "events.wordpress.test" ) {
+		rewrite "/[\w-]+/\d{4}/[\w-]+/wp-(admin|content|includes)(.*)" /wp-$1$2 last;
+		rewrite "/[\w-]+/\d{4}/[\w-]+/wp-(.*).php(.*)" /wp-$1.php$2 last;
+	}
 
 	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf)$ {
 		root /usr/src/public_html;

--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -24,9 +24,9 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 	brew install mkcert
 	brew install nss
 	mkcert -install
-	mkcert -cert-file wordcamp.test.pem -key-file wordcamp.test.key.pem wordcamp.test *.wordcamp.test buddycamp.test *.buddycamp.test
+	mkcert -cert-file wordcamp.test.pem -key-file wordcamp.test.key.pem wordcamp.test *.wordcamp.test buddycamp.test *.buddycamp.test events.wordpress.test
 	```
-	
+
 	_Using zsh? You may see `zsh: no matches found: *.wordcamp.test` running the final cert command above. Try prefixing the final command with `noglob`, i.e. `noglob mkcert -cert-file ...`_
 
 1. Clone WordPress into the **public_html/mu** directory and check out the latest version's branch.

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -38,22 +38,34 @@ $table_prefix = 'wc_'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 /*
  * Multisite
  */
-if ( 'buddycamp.test' === $_SERVER['HTTP_HOST'] || '.buddycamp.test' === substr( $_SERVER['HTTP_HOST'], strlen( $_SERVER['HTTP_HOST'] ) - 14, 14 ) ) {
-	$wcorg_domain_current_site = 'buddycamp.test';
-} else {
-	$wcorg_domain_current_site = 'wordcamp.test';
+const WORDCAMP_ROOT_BLOG_ID = 5;
+const EVENTS_ROOT_BLOG_ID   = 47;
+
+switch ( $_SERVER['HTTP_HOST'] ) {
+	case 'events.wordpress.test':
+		define( 'SITE_ID_CURRENT_SITE',  2 );
+		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID ); // events.wordpress.test.
+		define( 'DOMAIN_CURRENT_SITE',   'events.wordpress.test' );
+		define( 'SUBDOMAIN_INSTALL',     false );
+		define( 'NOBLOGREDIRECT',        'https://events.wordpress.test' );
+		define( 'CLI_HOSTNAME_OVERRIDE', 'events.wordpress.test' );
+		break;
+
+	case 'wordcamp.test':
+	case 'buddycamp.test':
+	default:
+		define( 'SITE_ID_CURRENT_SITE',  1 );
+		define( 'BLOG_ID_CURRENT_SITE',  WORDCAMP_ROOT_BLOG_ID ); // central.wordcamp.test.
+		define( 'DOMAIN_CURRENT_SITE',   'buddycamp.test' === $_SERVER['HTTP_HOST'] ? 'buddycamp.test' : 'wordcamp.test' );
+		define( 'SUBDOMAIN_INSTALL',     true );
+		define( 'NOBLOGREDIRECT',        'https://central.wordcamp.test' );
+		define( 'CLI_HOSTNAME_OVERRIDE', 'wordcamp.test' );
+		break;
 }
 
-define( 'WP_ALLOW_MULTISITE',   true ); // Temporary workaround for https://github.com/Automattic/wp-super-cache/issues/97.
-define( 'MULTISITE',            true );
-define( 'SUBDOMAIN_INSTALL',    true );
-define( 'DOMAIN_CURRENT_SITE',  $wcorg_domain_current_site );
-define( 'PATH_CURRENT_SITE',    '/' );
-define( 'SITE_ID_CURRENT_SITE',  1 );
-define( 'BLOG_ID_CURRENT_SITE',  5 ); // central.wordcamp.test.
-define( 'NOBLOGREDIRECT',       'https://central.wordcamp.test' );
-define( 'SUNRISE',               true );
-define( 'CLI_HOSTNAME_OVERRIDE', 'wordcamp.test' );
+define( 'MULTISITE',         true );
+define( 'SUNRISE',           true );
+define( 'PATH_CURRENT_SITE', '/' );
 
 
 /*


### PR DESCRIPTION
See #910
Broken off of #907

This adds some of the configuation needed for to create sites on the new Events network. More work will be needed in #910, but this gets us started.

