### PR TITLE
Let's Encrypt: Only request certificates for WordCamp sites

### DIFF
--- a/public_html/wp-content/mu-plugins/lets-encrypt-helper.php
+++ b/public_html/wp-content/mu-plugins/lets-encrypt-helper.php
@@ -44,13 +44,17 @@ class WordCamp_Lets_Encrypt_Helper {
 
 		$tld     = get_top_level_domain();
 		$domains = array();
-		$blogs   = $wpdb->get_results( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
-			WHERE
-				`public`  = 1 AND
-				`deleted` = 0
-			ORDER BY `blog_id` ASC",
+		$blogs   = $wpdb->get_results(
+			$wpdb->prepare( "
+				SELECT `domain`, `path`
+				FROM `$wpdb->blogs`
+				WHERE
+					`site_id` = %d AND
+					`public`  = 1 AND
+					`deleted` = 0
+				ORDER BY `blog_id` ASC",
+				1
+			),
 			ARRAY_A
 		);
 


### PR DESCRIPTION
Sites on the new Events network will use the `wordpress.org` wildcard SSL.

See #906

`prepare()` is used because in a future commit `1` will be replaced with `EVENTS_NETWORK_ID`. See #907.

This needs to be deployed before #907, because creating the `events.wordpress.org` site triggered a Nagios alert from the Dehydrated client.

xref Slack `G0B1CF7E1/p1687372885952129`