### PR TITLE
Refactor network plugin loading to handle WordCamps

### DIFF
--- a/public_html/wp-content/mu-plugins/events/redirects.php
+++ b/public_html/wp-content/mu-plugins/events/redirects.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WordCamp\Redirects;
+namespace Events\Redirects;
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -133,32 +133,6 @@ function wcorg_disable_network_activated_plugins_on_sites( $plugins ) {
 }
 add_filter( 'site_option_active_sitewide_plugins', 'wcorg_disable_network_activated_plugins_on_sites' );
 
-/**
- * Disable Global Terms on new sites.
- *
- * Global Terms is an old, largely unused, and undocumented feature of WordPress. It was used on WordPress.com
- * for many years, but even they turned it off around 2015. We don't know why it was ever enabled for
- * WordCamp.org.
- *
- * When it's enabled, the "local" terms are still created like normal, but the `term_id_filter` will override
- * their IDs at runtime, so that all sites use the same ID for the same slug, across sites _and_ across taxonomies.
- * Because the local terms still exist, it can (theoretically) be safely disabled without any consequences, and
- * then the local terms will be used instead.
- *
- * When term splitting was introduced in WP 4.2 - 4.4, though, it was not compatible with Global Terms, and any
- * term that was split while Global Terms is enabled will have the wrong IDs set, which causes bugs, like not
- * being able to assign shared terms to a post, and not being able to edit the name of a shared term. So, we're
- * turning it off for new sites.
- *
- * It's left on for old sites out of caution, since there could be some unforeseeable consequences or hassles
- * with turning it off for them.
- *
- * This will not retroactively fix any terms that have been split with the wrong ID, those need to be fixed
- * manually.
- */
-add_filter( 'global_terms_enabled', function() {
-	return wcorg_skip_feature( 'local_terms' );
-} );
 
 /**
  * Remove menu items on certain sites.
@@ -739,31 +713,6 @@ function debug_community_events_response( $response, $context, $transport, $requ
 }
 // Comment this out when not needed, but leave the code for future use.
 // add_action( 'http_api_debug', 'debug_community_events_response', 10, 5 );
-
-/**
- * Prevent permalink structures from starting with `%year%`
- *
- * See https://make.wordpress.org/community/2020/03/03/proposal-for-wordcamp-sites-seo-fixes/#comment-28213.
- * See `WordCamp\Sunrise\Tests\Test_Sunrise\data_get_canonical_year_url()`.
- *
- * @param string $new_value
- *
- * @return string
- */
-function wcorg_prevent_date_permalinks( $new_value ) {
-	if ( '/%year%' === substr( $new_value, 0, 7 ) ) {
-		wp_die(
-			'<p>' .
-			__( "WordCamp.org permalinks can't start with `%year%`, because that conflicts with our URL structure (`https://city.wordcamp.org/year`).", 'wordcamporg' ) .
-			'</p> <p>' .
-			__( 'Please add a prefix like `/news/`, or choose a different structure (like `%postname%`).', 'wordcamporg' ) .
-			'</p>'
-		);
-	}
-
-	return $new_value;
-}
-add_filter( 'pre_update_option_permalink_structure', 'wcorg_prevent_date_permalinks' );
 
 /**
  * Modify CLDR country data temporarily while awaiting an update to the data in the WP CLDR plugin.

--- a/public_html/wp-content/mu-plugins/wordcamp/multisite.php
+++ b/public_html/wp-content/mu-plugins/wordcamp/multisite.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WordCamp\Multisite;
+defined( 'WPINC' ) || die();
+
+
+add_filter( 'global_terms_enabled', __NAMESPACE__ . '\disable_global_terms' );
+
+
+/**
+ * Disable Global Terms on new sites.
+ *
+ * Global Terms is an old, largely unused, and undocumented feature of WordPress. It was used on WordPress.com
+ * for many years, but even they turned it off around 2015. We don't know why it was ever enabled for
+ * WordCamp.org.
+ *
+ * When it's enabled, the "local" terms are still created like normal, but the `term_id_filter` will override
+ * their IDs at runtime, so that all sites use the same ID for the same slug, across sites _and_ across taxonomies.
+ * Because the local terms still exist, it can (theoretically) be safely disabled without any consequences, and
+ * then the local terms will be used instead.
+ *
+ * When term splitting was introduced in WP 4.2 - 4.4, though, it was not compatible with Global Terms, and any
+ * term that was split while Global Terms is enabled will have the wrong IDs set, which causes bugs, like not
+ * being able to assign shared terms to a post, and not being able to edit the name of a shared term. So, we're
+ * turning it off for new sites.
+ *
+ * It's left on for old sites out of caution, since there could be some unforeseeable consequences or hassles
+ * with turning it off for them.
+ *
+ * This will not retroactively fix any terms that have been split with the wrong ID, those need to be fixed
+ * manually.
+ */
+function disable_global_terms() {
+	return wcorg_skip_feature( 'local_terms' );
+}

--- a/public_html/wp-content/mu-plugins/wordcamp/permalinks.php
+++ b/public_html/wp-content/mu-plugins/wordcamp/permalinks.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WordCamp\Permalinks;
+defined( 'WPINC' ) || die();
+
+add_filter( 'pre_update_option_permalink_structure', 'wcorg_prevent_date_permalinks' );
+
+
+/**
+ * Prevent permalink structures from starting with `%year%`
+ *
+ * See https://make.wordpress.org/community/2020/03/03/proposal-for-wordcamp-sites-seo-fixes/#comment-28213.
+ * See `WordCamp\Sunrise\Tests\Test_Sunrise\data_get_canonical_year_url()`.
+ *
+ * @param string $new_value
+ *
+ * @return string
+ */
+function wcorg_prevent_date_permalinks( $new_value ) {
+	if ( '/%year%' === substr( $new_value, 0, 7 ) ) {
+		wp_die(
+			'<p>' .
+			__( "WordCamp.org permalinks can't start with `%year%`, because that conflicts with our URL structure (`https://city.wordcamp.org/year`).", 'wordcamporg' ) .
+			'</p> <p>' .
+			__( 'Please add a prefix like `/news/`, or choose a different structure (like `%postname%`).', 'wordcamporg' ) .
+			'</p>'
+		);
+	}
+
+	return $new_value;
+}


### PR DESCRIPTION
See #906 

This creates a `mu-plugins/wordcamp` folder to compliment the `mu-plugins/events` folder that was added in #899. It also refactors `load-other-mu-plugins.php` to be more explicitly aware of the multiple networks, and organize the loaders according.

Files in those two folders are `require`'d with a `glob` to avoid having to add a lot of manual `require`'s in the future.

It also moves a few mu-plugins into the `wordcamp` folder that shouldn't run on the Events network.