### PR TITLE
Events: Add trailing slash to URL to avoid unnecessary redirect

### DIFF
--- a/public_html/wp-content/mu-plugins/events/redirects.php
+++ b/public_html/wp-content/mu-plugins/events/redirects.php
@@ -14,7 +14,7 @@ function redirect_to_make_community() {
 		$request_uri = $_SERVER['REQUEST_URI'];
 
 		if ( '/' === $request_uri ) {
-			$new_url = 'https://make.wordpress.org/community/events';
+			$new_url = 'https://make.wordpress.org/community/events/';
 			wp_redirect( $new_url );
 			exit;
 		}


### PR DESCRIPTION
Otherwise, after redirecting to `.../events`, the Make server would add an additional redirect to `.../events/`.
