### PR TITLE
Fix local docker environment

### DIFF
--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -10,8 +10,11 @@ wcorg_include_network_only_plugins();
  * Load mu-plugins that should run on all networks.
  */
 function wcorg_include_common_plugins() {
-	if ( 'local' !== WORDCAMP_ENVIRONMENT ) {
+	if ( file_exists( dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php' ) ) {
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php';
+	}
+
+	if ( 'local' !== WORDCAMP_ENVIRONMENT ) {
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-sso.php';
 	}
 }

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -10,9 +10,8 @@ wcorg_include_network_only_plugins();
  * Load mu-plugins that should run on all networks.
  */
 function wcorg_include_common_plugins() {
-	require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php';
-
 	if ( 'local' !== WORDCAMP_ENVIRONMENT ) {
+		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php';
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-sso.php';
 	}
 }


### PR DESCRIPTION
Commit https://github.com/WordPress/wordcamp.org/commit/3f48d5169848a3a24b0c1f0b61dac02ef74b2c94 broke the local Docker environment, since `mu-plugins-private` directory is not included in this public repository.

Moving the required private file inside environment check fixes things, but might have other consequences depending on what plugins are kept private.