### PR TITLE
Prevent Camptix DB log overflow

### DIFF
--- a/public_html/wp-content/plugins/camptix/admin.css
+++ b/public_html/wp-content/plugins/camptix/admin.css
@@ -216,6 +216,10 @@
 	padding: 0;
 }
 
+#tix_db_log .tix-table {
+	table-layout: fixed;
+}
+
 .tix-revenue-summary .tix-sold,
 .tix-revenue-summary .tix-remaining,
 .tix-revenue-summary .tix-sub-total,


### PR DESCRIPTION
The Camptix BD log was not styled properly, since the contents of the `<pre>` spread some of the rows in the table way too wide. This PR fixes the styling, making the table look nicer.

Fixes #649 

Props faddah
