### PR TITLE
Docker: Remove v1 of JSON API

### DIFF
--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -69,16 +69,6 @@
 					}
 				},
 				{
-					"name": "wordpress-plugin/json-rest-api",
-					"type": "wordpress-plugin",
-					"version": "1.2.5",
-					"source": {
-						"type": "svn",
-						"url": "https://plugins.svn.wordpress.org/json-rest-api/",
-						"reference": "tags/1.2.5/"
-					}
-				},
-				{
 					"name": "wordpress-meta/wporg-profiles-wp-activity-notifier",
 					"type": "wordpress-plugin",
 					"version": "1.1",
@@ -109,7 +99,6 @@
 		"wpackagist-plugin/gutenberg": "*",
 		"wpackagist-plugin/hyperdb": "dev-trunk",
 		"wpackagist-plugin/jetpack": "*",
-		"wordpress-plugin/json-rest-api": "1.2.5",
 		"wpackagist-plugin/liveblog": "*",
 		"wpackagist-plugin/public-post-preview": "*",
 		"wpackagist-plugin/pwa": "*",


### PR DESCRIPTION
It was removed from production in 78e6c9ae3cd32150780ca8b5d5f938600a58d75c.

xref https://wordpress.slack.com/archives/C08M59V3P/p1687994777208249?thread_ts=1687827168.561439&cid=C08M59V3P