### PR TITLE
Add first time participation measurement

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -277,6 +277,12 @@ class WordCamp_Counts extends Base {
 	public function compile_report_data( array $data ) {
 		$wordcamps = $this->prepare_data_for_display( $this->get_wordcamps() );
 
+		$first_time_template = array(
+			'yes'  => 0,
+			'no'    => 0,
+			'unsure' => 0,
+		);
+
 		$compiled_data = array(
 			'wordcamps' => array(),
 			'totals'    => array(
@@ -295,12 +301,12 @@ class WordCamp_Counts extends Base {
 				'volunteer'   => array(),
 			),
 			'first_times' => array(
-				'attendee'  => 0,
-				'organizer' => 0,
-				'session'   => 0,
-				'speaker'   => 0,
-				'sponsor'   => 0,
-				'volunteer' => 0,
+				'attendee'  => $first_time_template,
+				'organizer' => $first_time_template,
+				'session'   => $first_time_template,
+				'speaker'   => $first_time_template,
+				'sponsor'   => $first_time_template,
+				'volunteer' => $first_time_template,
 			),
 		);
 
@@ -314,12 +320,12 @@ class WordCamp_Counts extends Base {
 				'volunteer'   => 0,
 			),
 			'first_times' => array(
-				'attendee'  => 0,
-				'organizer' => 0,
-				'session'   => 0,
-				'speaker'   => 0,
-				'sponsor'   => 0,
-				'volunteer' => 0,
+				'attendee'  => $first_time_template,
+				'organizer' => $first_time_template,
+				'session'   => $first_time_template,
+				'speaker'   => $first_time_template,
+				'sponsor'   => $first_time_template,
+				'volunteer' => $first_time_template,
 			),
 		);
 
@@ -356,9 +362,9 @@ class WordCamp_Counts extends Base {
 
 			$compiled_data['wordcamps'][ $wordcamp_id ]['totals'][ $type ] ++;
 			$compiled_data['totals'][ $type ] ++;
-			if ( 'yes' === $first_time ) {
-				$compiled_data['wordcamps'][ $wordcamp_id ]['first_times'][ $type ] ++;
-				$compiled_data['first_times'][ $type ] ++;
+			if ( isset( $wordcamp_template['first_times'][ $type ] ) ) {
+				$compiled_data['wordcamps'][ $wordcamp_id ]['first_times'][ $type ][ $first_time ] ++;
+				$compiled_data['first_times'][ $type ][ $first_time ] ++;
 			}
 			if ( isset( $compiled_data['uniques'][ $type ] ) ) {
 				$compiled_data['uniques'][ $type ][] = $identifier;

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -598,7 +598,7 @@ class WordCamp_Counts extends Base {
 				'post_id'     => $sponsor->ID,
 				'type'        => 'sponsor',
 				'identifier'  => $this->get_sponsor_identifier( $sponsor->_wcpt_sponsor_website ),
-				'first_time'  => $sponsor->_wcpt_sponsor_first_time,
+				'first_time'  => $sponsor->_wcb_sponsor_first_time,
 			);
 
 			if ( $this->include_gender ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -598,6 +598,7 @@ class WordCamp_Counts extends Base {
 				'post_id'     => $sponsor->ID,
 				'type'        => 'sponsor',
 				'identifier'  => $this->get_sponsor_identifier( $sponsor->_wcpt_sponsor_website ),
+				'first_time'  => $sponsor->_wcpt_sponsor_first_time,
 			);
 
 			if ( $this->include_gender ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -573,6 +573,7 @@ class WordCamp_Counts extends Base {
 				'post_id'     => $speaker->ID,
 				'type'        => 'speaker',
 				'identifier'  => $speaker->_wcb_speaker_email,
+				'first_time'  => $speaker->_wcb_speaker_first_time,
 			);
 
 			if ( $this->include_gender ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -494,6 +494,7 @@ class WordCamp_Counts extends Base {
 				'post_id'     => $attendee->ID,
 				'type'        => 'attendee',
 				'identifier'  => $attendee->tix_email,
+				'first_time'  => $attendee->tix_first_time_attending_wp_event,
 			);
 
 			if ( $this->include_gender ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -313,6 +313,14 @@ class WordCamp_Counts extends Base {
 				'sponsor'   => 0,
 				'volunteer'   => 0,
 			),
+			'first_times' => array(
+				'attendee'  => 0,
+				'organizer' => 0,
+				'session'   => 0,
+				'speaker'   => 0,
+				'sponsor'   => 0,
+				'volunteer' => 0,
+			),
 		);
 
 		if ( $this->include_gender ) {
@@ -349,6 +357,7 @@ class WordCamp_Counts extends Base {
 			$compiled_data['wordcamps'][ $wordcamp_id ]['totals'][ $type ] ++;
 			$compiled_data['totals'][ $type ] ++;
 			if ( 'yes' === $first_time ) {
+				$compiled_data['wordcamps'][ $wordcamp_id ]['first_times'][ $type ] ++;
 				$compiled_data['first_times'][ $type ] ++;
 			}
 			if ( isset( $compiled_data['uniques'][ $type ] ) ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -518,6 +518,7 @@ class WordCamp_Counts extends Base {
 				'post_id'     => $organizer->ID,
 				'type'        => 'organizer',
 				'identifier'  => $organizer->_wcpt_user_id,
+				'first_time'  => $organizer->_wcb_organizer_first_time,
 			);
 
 			if ( $this->include_gender ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -130,6 +130,7 @@ class WordCamp_Counts extends Base {
 		'post_id'     => 0,
 		'type'        => '',
 		'gender'      => '',
+		'first_time'  => '',
 	);
 
 	/**
@@ -293,6 +294,14 @@ class WordCamp_Counts extends Base {
 				'sponsor'   => array(),
 				'volunteer'   => array(),
 			),
+			'first_times' => array(
+				'attendee'  => 0,
+				'organizer' => 0,
+				'session'   => 0,
+				'speaker'   => 0,
+				'sponsor'   => 0,
+				'volunteer' => 0,
+			),
 		);
 
 		$wordcamp_template = array(
@@ -335,9 +344,13 @@ class WordCamp_Counts extends Base {
 
 			$type       = $item['type'];
 			$identifier = $item['identifier'];
+			$first_time = $item['first_time'];
 
 			$compiled_data['wordcamps'][ $wordcamp_id ]['totals'][ $type ] ++;
 			$compiled_data['totals'][ $type ] ++;
+			if ( 'yes' === $first_time ) {
+				$compiled_data['first_times'][ $type ] ++;
+			}
 			if ( isset( $compiled_data['uniques'][ $type ] ) ) {
 				$compiled_data['uniques'][ $type ][] = $identifier;
 			}
@@ -592,6 +605,7 @@ class WordCamp_Counts extends Base {
 				'post_id'     => $volunteer->ID,
 				'type'        => 'volunteer',
 				'identifier'  => $volunteer->_wcpt_user_name,
+				'first_time'  => $volunteer->_wcb_volunteer_first_time,
 			);
 
 			if ( $this->include_gender ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -284,12 +284,14 @@ class WordCamp_Counts extends Base {
 				'session'   => 0,
 				'speaker'   => 0,
 				'sponsor'   => 0,
+				'volunteer' => 0,
 			),
 			'uniques'   => array(
 				'attendee'  => array(),
 				'organizer' => array(),
 				'speaker'   => array(),
 				'sponsor'   => array(),
+				'volunteer'   => array(),
 			),
 		);
 
@@ -300,6 +302,7 @@ class WordCamp_Counts extends Base {
 				'session'   => 0,
 				'speaker'   => 0,
 				'sponsor'   => 0,
+				'volunteer'   => 0,
 			),
 		);
 
@@ -314,6 +317,7 @@ class WordCamp_Counts extends Base {
 				'attendee'  => $gender_template,
 				'organizer' => $gender_template,
 				'speaker'   => $gender_template,
+				'volunteer'   => $gender_template,
 			);
 		}
 
@@ -573,6 +577,30 @@ class WordCamp_Counts extends Base {
 			$site_data[] = $data;
 
 			clean_post_cache( $sponsor );
+		}
+
+		$volunteers = new WP_Query( array(
+			'posts_per_page' => -1,
+			'post_type'      => 'wcb_volunteer',
+			'post_status'    => 'publish',
+		) );
+
+		foreach ( $volunteers->posts as $volunteer ) {
+			$data = array(
+				'wordcamp_id' => $wordcamp_id,
+				'site_id'     => $site_id,
+				'post_id'     => $volunteer->ID,
+				'type'        => 'volunteer',
+				'identifier'  => $volunteer->_wcpt_user_name,
+			);
+
+			if ( $this->include_gender ) {
+				$data['first_name'] = explode( ' ', $volunteer->post_title )[0];
+			}
+
+			$site_data[] = $data;
+
+			clean_post_cache( $volunteer );
 		}
 
 		restore_current_blog();

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -14,7 +14,8 @@ use DateTime;
 /** @var DateTime $end_date */
 /** @var string $statuses */
 
-$gender_legend = '<span class="description small"><span class="total">Total</span> / F / M / ?</span>';
+$gender_legend     = '<span class="description small">Gender: F / M / ?</span>';
+$first_time_legend = '<span class="description small">Y / N / ?</span>';
 
 ?>
 
@@ -42,44 +43,68 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>Type</td>
 			<td>Total</td>
 			<td>Unique</td>
-			<td>First time</td>
+			<td>First time<br><?php echo $first_time_legend; ?></td>
 		</tr>
 		<tr>
 			<td>Registered Attendees</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['attendee'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['attendee'] ); ?></td>
-			<td class="number"><?php echo number_format_i18n( $data['first_times']['attendee'] ); ?></td>
+			<td class="number">
+				<?php echo number_format_i18n( $data['first_times']['attendee']['yes'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['attendee']['no'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['attendee']['unsure'] ); ?>
+			</td>
 		</tr>
 		<tr>
 			<td>Organizers</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['organizer'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['organizer'] ); ?></td>
-			<td class="number"><?php echo number_format_i18n( $data['first_times']['organizer'] ); ?></td>
+			<td class="number">
+				<?php echo number_format_i18n( $data['first_times']['organizer']['yes'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['organizer']['no'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['organizer']['unsure'] ); ?>
+			</td>
 		</tr>
 		<tr>
 			<td>Sessions</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['session'] ); ?></td>
 			<td class="number">n/a</td>
-			<td class="number"><?php echo number_format_i18n( $data['first_times']['session'] ); ?></td>
+			<td class="number">
+				<?php echo number_format_i18n( $data['first_times']['session']['yes'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['session']['no'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['session']['unsure'] ); ?>
+			</td>
 		</tr>
 		<tr>
 			<td>Speakers</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['speaker'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['speaker'] ); ?></td>
-			<td class="number"><?php echo number_format_i18n( $data['first_times']['speaker'] ); ?></td>
+			<td class="number">
+				<?php echo number_format_i18n( $data['first_times']['speaker']['yes'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['speaker']['no'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['speaker']['unsure'] ); ?>
+			</td>
 		</tr>
 		<tr>
 			<td>Sponsors</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['sponsor'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['sponsor'] ); ?></td>
-			<td class="number"><?php echo number_format_i18n( $data['first_times']['sponsor'] ); ?></td>
+			<td class="number">
+				<?php echo number_format_i18n( $data['first_times']['sponsor']['yes'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['sponsor']['no'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['sponsor']['unsure'] ); ?>
+			</td>
 		</tr>
 
 		<tr>
 			<td>Volunteers</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['volunteer'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['volunteer'] ); ?></td>
-			<td class="number"><?php echo number_format_i18n( $data['first_times']['volunteer'] ); ?></td>
+			<td class="number">
+				<?php echo number_format_i18n( $data['first_times']['volunteer']['yes'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['volunteer']['no'] ); ?>
+				/ <?php echo number_format_i18n( $data['first_times']['volunteer']['unsure'] ); ?>
+			</td>
 		</tr>
 	</table>
 
@@ -141,9 +166,16 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>Speakers<?php if ( ! empty( $data['genders'] ) ) :
 				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
 			<td>Sponsors</td>
-			<td><?php if ( empty( $data['genders'] ) ) :
-				?>Volunteers (FT*)<?php else :
-					?>Volunteers<br /><?php echo $gender_legend; ?><?php endif; ?></td>
+			<td>
+				Volunteers
+				<br>
+				<span class="description small">First time: </span>
+				<?php echo $first_time_legend; ?>
+				<?php if ( ! empty( $data['genders'] ) ) : ?>
+					<br>
+					<?php echo $gender_legend; ?>
+				<?php endif; ?>
+			</td>
 		</tr>
 
 		<?php foreach ( $data['wordcamps'] as $event ) : ?>
@@ -188,9 +220,14 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 				</td>
 
 				<td class="number">
-					<span class="total"><?php echo number_format_i18n( $event['totals']['volunteer'] ) . ' (' . number_format_i18n( $event['first_times']['volunteer'] ) . ')'; ?></span>
+					<span class="total">Total: <?php echo number_format_i18n( $event['totals']['volunteer'] ); ?></span>
+					<br>
+					FT: <?php echo number_format_i18n( $event['first_times']['volunteer']['yes'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['volunteer']['no'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['volunteer']['unsure'] ); ?>
 					<?php if ( ! empty( $data['genders'] ) ) : ?>
-						/ <?php echo number_format_i18n( $event['genders']['volunteer']['female'] ); ?>
+						<br>
+						G: <?php echo number_format_i18n( $event['genders']['volunteer']['female'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['volunteer']['male'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['volunteer']['unknown'] ); ?>
 					<?php endif; ?>
@@ -198,7 +235,6 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			</tr>
 		<?php endforeach; ?>
 	</table>
-	<p class="table-abbrev-explainer">*FT = First Time</p>
 
 <?php else : ?>
 

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -69,11 +69,7 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 			<td>Sessions</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['session'] ); ?></td>
 			<td class="number">n/a</td>
-			<td class="number">
-				<?php echo number_format_i18n( $data['first_times']['session']['yes'] ); ?>
-				/ <?php echo number_format_i18n( $data['first_times']['session']['no'] ); ?>
-				/ <?php echo number_format_i18n( $data['first_times']['session']['unsure'] ); ?>
-			</td>
+			<td class="number">n/a</td>
 		</tr>
 		<tr>
 			<td>Speakers</td>

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -141,8 +141,9 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>Speakers<?php if ( ! empty( $data['genders'] ) ) :
 				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
 			<td>Sponsors</td>
-			<td>Volunteers<?php if ( ! empty( $data['genders'] ) ) :
-				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
+			<td><?php if ( empty( $data['genders'] ) ) :
+				?>Volunteers (FT*)<?php else :
+					?>Volunteers<br /><?php echo $gender_legend; ?><?php endif; ?></td>
 		</tr>
 
 		<?php foreach ( $data['wordcamps'] as $event ) : ?>
@@ -187,7 +188,7 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 				</td>
 
 				<td class="number">
-					<span class="total"><?php echo number_format_i18n( $event['totals']['volunteer'] ); ?></span>
+					<span class="total"><?php echo number_format_i18n( $event['totals']['volunteer'] ) . ' (' . number_format_i18n( $event['first_times']['volunteer'] ) . ')'; ?></span>
 					<?php if ( ! empty( $data['genders'] ) ) : ?>
 						/ <?php echo number_format_i18n( $event['genders']['volunteer']['female'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['volunteer']['male'] ); ?>
@@ -197,6 +198,7 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			</tr>
 		<?php endforeach; ?>
 	</table>
+	<p class="table-abbrev-explainer">*FT = First Time</p>
 
 <?php else : ?>
 

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -48,32 +48,38 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>Registered Attendees</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['attendee'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['attendee'] ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['first_times']['attendee'] ); ?></td>
 		</tr>
 		<tr>
 			<td>Organizers</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['organizer'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['organizer'] ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['first_times']['organizer'] ); ?></td>
 		</tr>
 		<tr>
 			<td>Sessions</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['session'] ); ?></td>
 			<td class="number">n/a</td>
+			<td class="number"><?php echo number_format_i18n( $data['first_times']['session'] ); ?></td>
 		</tr>
 		<tr>
 			<td>Speakers</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['speaker'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['speaker'] ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['first_times']['speaker'] ); ?></td>
 		</tr>
 		<tr>
 			<td>Sponsors</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['sponsor'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['sponsor'] ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['first_times']['sponsor'] ); ?></td>
 		</tr>
 
 		<tr>
 			<td>Volunteers</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['volunteer'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['volunteer'] ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['first_times']['volunteer'] ); ?></td>
 		</tr>
 	</table>
 

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -179,7 +179,11 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 					<?php echo $gender_legend; ?>
 				<?php endif; ?>
 			</td>
-			<td>Sponsors</td>
+			<td>Sponsors
+				<br>
+				<span class="description small">First time: </span>
+				<?php echo $first_time_legend; ?>
+			</td>
 			<td>
 				Volunteers
 				<br>
@@ -239,8 +243,12 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 					<?php endif; ?>
 				</td>
 
-				<td class="number total">
-					<?php echo number_format_i18n( $event['totals']['sponsor'] ); ?>
+				<td class="number">
+					<span class="total">Total: <?php echo number_format_i18n( $event['totals']['sponsor'] ); ?></span>
+					<br>
+					FT: <?php echo number_format_i18n( $event['first_times']['sponsor']['yes'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['sponsor']['no'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['sponsor']['unsure'] ); ?>
 				</td>
 
 				<td class="number">

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -154,8 +154,15 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 			<td>WordCamp</td>
 			<td>Date</td>
 			<td>Status</td>
-			<td>Registered Attendees<?php if ( ! empty( $data['genders'] ) ) :
-				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
+			<td>Registered Attendees
+				<br>
+				<span class="description small">First time: </span>
+				<?php echo $first_time_legend; ?>
+				<?php if ( ! empty( $data['genders'] ) ) : ?>
+					<br />
+					<?php echo $gender_legend; ?>
+				<?php endif; ?>	
+			</td>
 			<td>Organizers
 				<br>
 				<span class="description small">First time: </span>
@@ -199,9 +206,14 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 				<td><?php echo esc_html( $event['info']['Status'] ); ?></td>
 
 				<td class="number">
-					<span class="total"><?php echo number_format_i18n( $event['totals']['attendee'] ); ?></span>
+					<span class="total">Total: <?php echo number_format_i18n( $event['totals']['attendee'] ); ?></span>
+					<br>
+					FT: <?php echo number_format_i18n( $event['first_times']['attendee']['yes'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['attendee']['no'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['attendee']['unsure'] ); ?>
 					<?php if ( ! empty( $data['genders'] ) ) : ?>
-						/ <?php echo number_format_i18n( $event['genders']['attendee']['female'] ); ?>
+						<br>
+						G: <?php echo number_format_i18n( $event['genders']['attendee']['female'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['attendee']['male'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['attendee']['unknown'] ); ?>
 					<?php endif; ?>

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -35,13 +35,14 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 		</tr>
 	</table>
 
-	<h4>Totals and Uniques</h4>
+	<h4>Totals, Uniques and First times</h4>
 
 	<table class="striped widefat but-not-too-wide">
 		<tr>
 			<td>Type</td>
 			<td>Total</td>
 			<td>Unique</td>
+			<td>First time</td>
 		</tr>
 		<tr>
 			<td>Registered Attendees</td>
@@ -67,6 +68,12 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>Sponsors</td>
 			<td class="number"><?php echo number_format_i18n( $data['totals']['sponsor'] ); ?></td>
 			<td class="number"><?php echo number_format_i18n( $data['uniques']['sponsor'] ); ?></td>
+		</tr>
+
+		<tr>
+			<td>Volunteers</td>
+			<td class="number"><?php echo number_format_i18n( $data['totals']['volunteer'] ); ?></td>
+			<td class="number"><?php echo number_format_i18n( $data['uniques']['volunteer'] ); ?></td>
 		</tr>
 	</table>
 
@@ -112,10 +119,13 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>WordCamp</td>
 			<td>Date</td>
 			<td>Status</td>
-			<td>Registered Attendees<?php if ( ! empty( $data['genders'] ) ) : ?><br /><?php echo $gender_legend ?><?php endif; ?></td>
-			<td>Organizers<?php if ( ! empty( $data['genders'] ) ) : ?><br /><?php echo $gender_legend ?><?php endif; ?></td>
+			<td>Registered Attendees<?php if ( ! empty( $data['genders'] ) ) :
+				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
+			<td>Organizers<?php if ( ! empty( $data['genders'] ) ) :
+				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
 			<td>Sessions</td>
-			<td>Speakers<?php if ( ! empty( $data['genders'] ) ) : ?><br /><?php echo $gender_legend ?><?php endif; ?></td>
+			<td>Speakers<?php if ( ! empty( $data['genders'] ) ) :
+				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
 			<td>Sponsors</td>
 		</tr>
 

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -109,6 +109,14 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 				<td class="number"><?php echo number_format_i18n( $data['genders']['speaker']['male'] ); ?></td>
 				<td class="number"><?php echo number_format_i18n( $data['genders']['speaker']['unknown'] ); ?></td>
 			</tr>
+
+			<tr>
+				<td>Volunteers</td>
+				<td class="number"><?php echo number_format_i18n( $data['totals']['volunteer'] ); ?></td>
+				<td class="number"><?php echo number_format_i18n( $data['genders']['volunteer']['female'] ); ?></td>
+				<td class="number"><?php echo number_format_i18n( $data['genders']['volunteer']['male'] ); ?></td>
+				<td class="number"><?php echo number_format_i18n( $data['genders']['volunteer']['unknown'] ); ?></td>
+			</tr>
 		</table>
 	<?php endif; ?>
 
@@ -127,6 +135,8 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 			<td>Speakers<?php if ( ! empty( $data['genders'] ) ) :
 				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
 			<td>Sponsors</td>
+			<td>Volunteers<?php if ( ! empty( $data['genders'] ) ) :
+				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
 		</tr>
 
 		<?php foreach ( $data['wordcamps'] as $event ) : ?>
@@ -168,6 +178,15 @@ $gender_legend = '<span class="description small"><span class="total">Total</spa
 
 				<td class="number total">
 					<?php echo number_format_i18n( $event['totals']['sponsor'] ); ?>
+				</td>
+
+				<td class="number">
+					<span class="total"><?php echo number_format_i18n( $event['totals']['volunteer'] ); ?></span>
+					<?php if ( ! empty( $data['genders'] ) ) : ?>
+						/ <?php echo number_format_i18n( $event['genders']['volunteer']['female'] ); ?>
+						/ <?php echo number_format_i18n( $event['genders']['volunteer']['male'] ); ?>
+						/ <?php echo number_format_i18n( $event['genders']['volunteer']['unknown'] ); ?>
+					<?php endif; ?>
 				</td>
 			</tr>
 		<?php endforeach; ?>

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -160,11 +160,25 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 			<td>Status</td>
 			<td>Registered Attendees<?php if ( ! empty( $data['genders'] ) ) :
 				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
-			<td>Organizers<?php if ( ! empty( $data['genders'] ) ) :
-				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
+			<td>Organizers
+				<br>
+				<span class="description small">First time: </span>
+				<?php echo $first_time_legend; ?>
+				<?php if ( ! empty( $data['genders'] ) ) : ?>
+					<br />
+					<?php echo $gender_legend; ?>
+				<?php endif; ?>	
+			</td>
 			<td>Sessions</td>
-			<td>Speakers<?php if ( ! empty( $data['genders'] ) ) :
-				?><br /><?php echo $gender_legend; ?><?php endif; ?></td>
+			<td>Speakers
+				<br>
+				<span class="description small">First time: </span>
+				<?php echo $first_time_legend; ?>
+				<?php if ( ! empty( $data['genders'] ) ) : ?>
+					<br />
+					<?php echo $gender_legend; ?>
+				<?php endif; ?>
+			</td>
 			<td>Sponsors</td>
 			<td>
 				Volunteers
@@ -194,9 +208,14 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 				</td>
 
 				<td class="number">
-					<span class="total"><?php echo number_format_i18n( $event['totals']['organizer'] ); ?></span>
+					<span class="total">Total: <?php echo number_format_i18n( $event['totals']['organizer'] ); ?></span>
+					<br>
+					FT: <?php echo number_format_i18n( $event['first_times']['organizer']['yes'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['organizer']['no'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['organizer']['unsure'] ); ?>
 					<?php if ( ! empty( $data['genders'] ) ) : ?>
-						/ <?php echo number_format_i18n( $event['genders']['organizer']['female'] ); ?>
+						<br>
+						G: <?php echo number_format_i18n( $event['genders']['organizer']['female'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['organizer']['male'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['organizer']['unknown'] ); ?>
 					<?php endif; ?>
@@ -207,9 +226,14 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 				</td>
 
 				<td class="number">
-					<span class="total"><?php echo number_format_i18n( $event['totals']['speaker'] ); ?></span>
+					<span class="total">Total: <?php echo number_format_i18n( $event['totals']['speaker'] ); ?></span>
+					<br>
+					FT: <?php echo number_format_i18n( $event['first_times']['speaker']['yes'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['speaker']['no'] ); ?>
+					/ <?php echo number_format_i18n( $event['first_times']['speaker']['unsure'] ); ?>
 					<?php if ( ! empty( $data['genders'] ) ) : ?>
-						/ <?php echo number_format_i18n( $event['genders']['speaker']['female'] ); ?>
+						<br>
+						G: <?php echo number_format_i18n( $event['genders']['speaker']['female'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['speaker']['male'] ); ?>
 						/ <?php echo number_format_i18n( $event['genders']['speaker']['unknown'] ); ?>
 					<?php endif; ?>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #888

This PR introduces a measurement for first-time participation of organizers, sponsors, speakers, and volunteers into the WordCamp Counts table. It not only presents the total number of first-time participants but breaks down these figures for each individual event within a specified time period.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

![Screen Shot 2023-07-12 at 4 50 24 PM](https://github.com/WordPress/wordcamp.org/assets/18050944/7b1fa90e-ff59-4048-9c33-020e46243bb3)


### How to test the changes in this Pull Request:

1. Sandboxed.
2. WP Admin Dashboard => (Top-left side) Dashboard => Reports => [WordCamp Counts](https://central.wordcamp.org/wp-admin/index.php?page=wordcamp-reports&report=wordcamp-counts)
3. Select the desired date range and then click on `Show results`.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
