### PR TITLE
Update get_wordcamp calls to have the correct CPT.

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -20,9 +20,9 @@ function get_wordcamp_post_type() {
 	}
 
 	return WCPT_POST_TYPE_ID;
- }
+}
 
- /**
+/**
  * Retrieves the post type string of the wordcamp depending on the current network.
  *
  * @param string $post_type The post type to check.

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -278,7 +278,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
 	if ( empty( $query_options ) ) {
-		$wordcamps = $wpdb->get_results( "
+		$query = $wpdb->prepare( "
 			SELECT $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->postmeta.meta_value AS start_date
 			FROM $wpdb->posts
 				LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID
@@ -288,6 +288,9 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 				$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
 			ORDER BY `$wpdb->posts`.`ID` DESC
 		 ", get_wordcamp_post_type() );
+
+		 $wordcamps = $wpdb->get_results( $query );
+
 	} else {
 		// Default to standard query when query_options is sent.
 		$wordcamps = get_wordcamps( $query_options );

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -277,19 +277,17 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
-	$post_type = get_wordcamp_post_type();
-
 	if ( empty( $query_options ) ) {
 		$wordcamps = $wpdb->get_results( "
 			SELECT $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->postmeta.meta_value AS start_date
 			FROM $wpdb->posts
 				LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID
 			WHERE
-				$wpdb->posts.post_type = '$post_type' AND
+				$wpdb->posts.post_type = '%s' AND
 				( $wpdb->posts.post_status <> 'trash' AND $wpdb->posts.post_status <> 'auto-draft' AND $wpdb->posts.post_status <> 'spam' ) AND
 				$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
 			ORDER BY `$wpdb->posts`.`ID` DESC
-		 " );
+		 ", get_wordcamp_post_type() );
 	} else {
 		// Default to standard query when query_options is sent.
 		$wordcamps = get_wordcamps( $query_options );

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -9,6 +9,20 @@ defined( 'WPINC' ) || die();
  */
 
 
+ /**
+  * Retrieves the post type string of the wordcamp depending on the current network.
+  *
+  * @return string
+  */
+ function get_wordcamp_post_type() {
+	if( defined( 'SITE_ID_CURRENT_SITE' ) && defined( 'EVENTS_NETWORK_ID' ) && SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
+		// Update to be he right cpt.
+		return WCPT_PILOT_EVENT_SLUG;
+	}
+
+	return WCPT_POST_TYPE_ID;
+ }
+
 /**
  * Retrieve `wordcamp` posts and their metadata.
  *
@@ -20,7 +34,7 @@ function get_wordcamps( $args = array() ) {
 	$args = wp_parse_args(
 		$args,
 		array(
-			'post_type'   => WCPT_POST_TYPE_ID,
+			'post_type'   => get_wordcamp_post_type(),
 			'post_status' => 'any',
 			'orderby'     => 'ID',
 			'numberposts' => -1,
@@ -51,7 +65,7 @@ function get_wordcamp_post( $site_id = null ) {
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
 	$wordcamp = get_posts( array(
-		'post_type'   => 'wordcamp',
+		'post_type'   => get_wordcamp_post_type(),
 		'post_status' => 'any',
 		'meta_key'    => '_site_id',
 		'meta_value'  => $site_id,
@@ -319,7 +333,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
  * @return string
  */
 function get_wordcamp_date_range( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || 'wordcamp' !== $wordcamp->post_type ) {
+	if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
 		return '';
 	}
 
@@ -353,7 +367,7 @@ function get_wordcamp_date_range( $wordcamp ) {
  * @return string
  */
 function get_wordcamp_location( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || 'wordcamp' !== $wordcamp->post_type ) {
+	if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
 		return;
 	}
 
@@ -374,7 +388,7 @@ function get_wordcamp_location( $wordcamp ) {
  * @return bool
  */
 function is_wordcamp_virtual( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || 'wordcamp' !== $wordcamp->post_type ) {
+	if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
 		return false;
 	}
 

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -333,7 +333,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
  * @return string
  */
 function get_wordcamp_date_range( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
+	if ( ! $wordcamp instanceof WP_Post || ( WCPT_POST_TYPE_ID !== $wordcamp->post_type && WCPT_PILOT_EVENT_SLUG !== $wordcamp->post_type ) ) {
 		return '';
 	}
 
@@ -367,7 +367,7 @@ function get_wordcamp_date_range( $wordcamp ) {
  * @return string
  */
 function get_wordcamp_location( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
+	if ( ! $wordcamp instanceof WP_Post || ( WCPT_POST_TYPE_ID !== $wordcamp->post_type && WCPT_PILOT_EVENT_SLUG !== $wordcamp->post_type ) ) {
 		return;
 	}
 
@@ -388,7 +388,7 @@ function get_wordcamp_location( $wordcamp ) {
  * @return bool
  */
 function is_wordcamp_virtual( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
+	if ( ! $wordcamp instanceof WP_Post || ( WCPT_POST_TYPE_ID !== $wordcamp->post_type && WCPT_PILOT_EVENT_SLUG !== $wordcamp->post_type ) ) {
 		return false;
 	}
 

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -9,12 +9,12 @@ defined( 'WPINC' ) || die();
  */
 
 
- /**
-  * Retrieves the post type string of the wordcamp depending on the current network.
-  *
-  * @return string
-  */
- function get_wordcamp_post_type() {
+/**
+ * Retrieves the post type string of the wordcamp depending on the current network.
+ *
+ * @return string
+ */
+function get_wordcamp_post_type() {
 	if( defined( 'SITE_ID_CURRENT_SITE' ) && defined( 'EVENTS_NETWORK_ID' ) && SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
 		// Update to be he right cpt.
 		return WCPT_PILOT_EVENT_SLUG;

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -286,10 +286,11 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 				$wpdb->posts.post_type = %s AND
 				( $wpdb->posts.post_status <> 'trash' AND $wpdb->posts.post_status <> 'auto-draft' AND $wpdb->posts.post_status <> 'spam' ) AND
 				$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
-			ORDER BY `$wpdb->posts`.`ID` DESC
-		 ", get_wordcamp_post_type() );
+			ORDER BY `$wpdb->posts`.`ID` DESC",
+			get_wordcamp_post_type()
+		);
 
-		 $wordcamps = $wpdb->get_results( $query );
+		$wordcamps = $wpdb->get_results( $query );  // phpcs:ignore -- Prepared above.
 
 	} else {
 		// Default to standard query when query_options is sent.

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -15,7 +15,7 @@ defined( 'WPINC' ) || die();
  * @return string
  */
 function get_wordcamp_post_type() {
-	if( defined( 'WCPT_PILOT_EVENT_SLUG' ) && defined( 'SITE_ID_CURRENT_SITE' ) && defined( 'EVENTS_NETWORK_ID' ) && SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
+	if( SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
 		return WCPT_PILOT_EVENT_SLUG;
 	}
 

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -5,11 +5,17 @@ use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_YEAR_D
 defined( 'WPINC' ) || die();
 
 /*
- * Helper functions related to the `wordcamp` post type.
+ * Helper functions related to retrieving WordCamp event data.
+ *
+ * These functions retrieve data for both WCPT_POST_TYPE_ID and WCPT_PILOT_EVENT_SLUG post types,
+ * which are both considered WordCamps but have different custom post types due to network
+ * separation and functionality.
+ *
+ * @see https://github.com/WordPress/wordcamp.org/pull/937
  */
 
 /**
- * Retrieves the post type string of the wordcamp depending on the current network.
+ * Retrieves the WordCamp event post type string depending on the current network.
  *
  * @return string
  */
@@ -22,11 +28,11 @@ function get_wordcamp_post_type() {
 }
 
 /**
- * Retrieves the post type string of the wordcamp depending on the current network.
+ * Returns true if the post type is a supported WordCamp event type.
  *
  * @param string $post_type The post type to check.
  *
- * @return string
+ * @return boolean
  */
 function is_valid_wordcamp_post_type( $post_type ) {
 	return ( defined( 'WCPT_POST_TYPE_ID' ) && WCPT_POST_TYPE_ID === $post_type ) ||
@@ -34,7 +40,7 @@ function is_valid_wordcamp_post_type( $post_type ) {
 }
 
 /**
- * Retrieve `wordcamp` posts and their metadata.
+ * Retrieves WordCamp posts and their metadata.
  *
  * @param array $args Optional. Extra arguments to pass to `get_posts()`.
  *
@@ -62,7 +68,7 @@ function get_wordcamps( $args = array() ) {
 }
 
 /**
- * Retrieves the `wordcamp` post and postmeta associated with the current site.
+ * Retrieves the WordCamp post and postmeta associated with the current site.
  *
  * @return false|WP_Post
  */
@@ -71,7 +77,7 @@ function get_wordcamp_post( $site_id = null ) {
 		$site_id = get_current_blog_id();
 	}
 
-	// Switch to central.wordcamp.org to get posts.
+	// Switch to the root network site to get posts.
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
 	$wordcamp = get_posts( array(
@@ -94,14 +100,14 @@ function get_wordcamp_post( $site_id = null ) {
 }
 
 /**
- * Find the site that corresponds to the given `wordcamp` post
+ * Find the site that corresponds to the given WordCamp post
  *
  * @param WP_Post $wordcamp_post
  *
  * @return mixed An integer if successful, or boolean false if failed
  */
 function get_wordcamp_site_id( $wordcamp_post ) {
-	// Switch to central.wordcamp.org to get post meta.
+	// Switch to the root network site to get post meta.
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 
 	$site_id = get_post_meta( $wordcamp_post->ID, '_site_id', true );
@@ -262,7 +268,7 @@ function wcorg_get_wordcamp_duration( WP_Post $wordcamp ) {
 }
 
 /**
- * Get a <select> dropdown of `wordcamp` posts with a select2 UI.
+ * Get a <select> dropdown of WordCamp posts with a select2 UI.
  *
  * The calling plugin is responsible for validating and processing the form, this just outputs a single field.
  *
@@ -351,7 +357,7 @@ function get_wordcamp_date_range( $wordcamp ) {
 		return '';
 	}
 
-	// Switch to central.wordcamp.org to get post meta.
+	// Switch to the root network site to get post meta.
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 	$start = (int) get_post_meta( $wordcamp->ID, 'Start Date (YYYY-mm-dd)', true );
 	$end   = (int) get_post_meta( $wordcamp->ID, 'End Date (YYYY-mm-dd)', true );
@@ -385,7 +391,7 @@ function get_wordcamp_location( $wordcamp ) {
 		return;
 	}
 
-	// Switch to central.wordcamp.org to get post meta.
+	// Switch to the root network site to get post meta.
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 	$venue   = get_post_meta( $wordcamp->ID, 'Venue Name', true );
 	$address = get_post_meta( $wordcamp->ID, 'Physical Address', true );
@@ -406,7 +412,7 @@ function is_wordcamp_virtual( $wordcamp ) {
 		return false;
 	}
 
-	// Switch to central.wordcamp.org to get post meta.
+	// Switch to the root network site to get post meta.
 	switch_to_blog( BLOG_ID_CURRENT_SITE );
 	$is_virtual = (bool) get_post_meta( $wordcamp->ID, 'Virtual event only', true );
 	restore_current_blog();

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -15,7 +15,7 @@ defined( 'WPINC' ) || die();
  * @return string
  */
 function get_wordcamp_post_type() {
-	if( SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
+	if ( SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
 		return WCPT_PILOT_EVENT_SLUG;
 	}
 

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -283,7 +283,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 			FROM $wpdb->posts
 				LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID
 			WHERE
-				$wpdb->posts.post_type = '%s' AND
+				$wpdb->posts.post_type = %s AND
 				( $wpdb->posts.post_status <> 'trash' AND $wpdb->posts.post_status <> 'auto-draft' AND $wpdb->posts.post_status <> 'spam' ) AND
 				$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
 			ORDER BY `$wpdb->posts`.`ID` DESC

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -15,7 +15,7 @@ defined( 'WPINC' ) || die();
  * @return string
  */
 function get_wordcamp_post_type() {
-	if( defined( 'SITE_ID_CURRENT_SITE' ) && defined( 'EVENTS_NETWORK_ID' ) && SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
+	if( defined( 'WCPT_PILOT_EVENT_SLUG' ) && defined( 'SITE_ID_CURRENT_SITE' ) && defined( 'EVENTS_NETWORK_ID' ) && SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
 		return WCPT_PILOT_EVENT_SLUG;
 	}
 
@@ -275,7 +275,9 @@ function wcorg_get_wordcamp_duration( WP_Post $wordcamp ) {
 function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(), $selected = 0 ) {
 	global $wpdb;
 
-	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
+	switch_to_blog( BLOG_ID_CURRENT_SITE );
+
+	$post_type = get_wordcamp_post_type();
 
 	if ( empty( $query_options ) ) {
 		$wordcamps = $wpdb->get_results( "
@@ -283,7 +285,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
 			FROM $wpdb->posts
 				LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID
 			WHERE
-				$wpdb->posts.post_type = 'wordcamp' AND
+				$wpdb->posts.post_type = '$post_type' AND
 				( $wpdb->posts.post_status <> 'trash' AND $wpdb->posts.post_status <> 'auto-draft' AND $wpdb->posts.post_status <> 'spam' ) AND
 				$wpdb->postmeta.meta_key = 'Start Date (YYYY-mm-dd)'
 			ORDER BY `$wpdb->posts`.`ID` DESC

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -8,7 +8,6 @@ defined( 'WPINC' ) || die();
  * Helper functions related to the `wordcamp` post type.
  */
 
-
 /**
  * Retrieves the post type string of the wordcamp depending on the current network.
  *
@@ -16,10 +15,10 @@ defined( 'WPINC' ) || die();
  */
 function get_wordcamp_post_type() {
 	if ( SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
-		return WCPT_PILOT_EVENT_SLUG;
+		return defined( 'WCPT_PILOT_EVENT_SLUG' ) ? WCPT_PILOT_EVENT_SLUG : '';
 	}
 
-	return WCPT_POST_TYPE_ID;
+	return defined( 'WCPT_POST_TYPE_ID' ) ? WCPT_POST_TYPE_ID : '';
 }
 
 /**
@@ -30,7 +29,8 @@ function get_wordcamp_post_type() {
  * @return string
  */
 function is_valid_wordcamp_post_type( $post_type ) {
-	return WCPT_POST_TYPE_ID === $post_type || WCPT_PILOT_EVENT_SLUG === $post_type;
+	return ( defined( 'WCPT_POST_TYPE_ID' ) && WCPT_POST_TYPE_ID === $post_type ) ||
+	( defined( 'WCPT_PILOT_EVENT_SLUG' ) && WCPT_PILOT_EVENT_SLUG === $post_type );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -16,12 +16,22 @@ defined( 'WPINC' ) || die();
  */
 function get_wordcamp_post_type() {
 	if( defined( 'SITE_ID_CURRENT_SITE' ) && defined( 'EVENTS_NETWORK_ID' ) && SITE_ID_CURRENT_SITE === EVENTS_NETWORK_ID ) {
-		// Update to be he right cpt.
 		return WCPT_PILOT_EVENT_SLUG;
 	}
 
 	return WCPT_POST_TYPE_ID;
  }
+
+ /**
+ * Retrieves the post type string of the wordcamp depending on the current network.
+ *
+ * @param string $post_type The post type to check.
+ *
+ * @return string
+ */
+function is_valid_wordcamp_post_type( $post_type ) {
+	return WCPT_POST_TYPE_ID === $post_type || WCPT_PILOT_EVENT_SLUG === $post_type;
+}
 
 /**
  * Retrieve `wordcamp` posts and their metadata.
@@ -333,7 +343,7 @@ function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(),
  * @return string
  */
 function get_wordcamp_date_range( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || ( WCPT_POST_TYPE_ID !== $wordcamp->post_type && WCPT_PILOT_EVENT_SLUG !== $wordcamp->post_type ) ) {
+	if ( ! $wordcamp instanceof WP_Post || ! is_valid_wordcamp_post_type( $wordcamp->post_type ) ) {
 		return '';
 	}
 
@@ -367,7 +377,7 @@ function get_wordcamp_date_range( $wordcamp ) {
  * @return string
  */
 function get_wordcamp_location( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || ( WCPT_POST_TYPE_ID !== $wordcamp->post_type && WCPT_PILOT_EVENT_SLUG !== $wordcamp->post_type ) ) {
+	if ( ! $wordcamp instanceof WP_Post || ! is_valid_wordcamp_post_type( $wordcamp->post_type ) ) {
 		return;
 	}
 
@@ -388,7 +398,7 @@ function get_wordcamp_location( $wordcamp ) {
  * @return bool
  */
 function is_wordcamp_virtual( $wordcamp ) {
-	if ( ! $wordcamp instanceof WP_Post || ( WCPT_POST_TYPE_ID !== $wordcamp->post_type && WCPT_PILOT_EVENT_SLUG !== $wordcamp->post_type ) ) {
+	if ( ! $wordcamp instanceof WP_Post || ! is_valid_wordcamp_post_type( $wordcamp->post_type ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
See #911, #936

With the events network up and running, there are various plugins that use the helper functions in `4-helpers-wcpt.php`. This PR removes the hardcoded `wordcamp` references in  so we can continue to use that code, but replace it with our soon-to-be minted pilot event post type in #911.

To be honest, I think this is necessary, but if it's not going in the right direction, let me know.

Requires #911 to work functionally but can be merged before.

## Alternate

We could alternatively write a new helper but that would require us update all the consuming plugins and that doesn't seem worth it right now.
