### PR TITLE
Update `get_sites()` calls in `mu-plugins` for Pilot Events

### DIFF
--- a/public_html/wp-content/mu-plugins/wp-cli-commands/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/miscellaneous.php
@@ -24,14 +24,17 @@ class WordCamp_CLI_Miscellaneous extends WP_CLI_Command {
 	 * : The ID of the newest site that the flag will be set on. If empty,
 	 * the flag will be applied to all sites.
 	 *
+	 * [<network>]
+	 * : The ID of the todo
+	 *
 	 * [--dry-run]
 	 * : Show a report, but don't perform the changes.
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp wc-misc set-skip-feature-flag wcb_viewport_initial_scale                  # Sets the flag on all sites
-	 * wp wc-misc set-skip-feature-flag wcb_viewport_initial_scale 437              # Sets the flag on all sites 1 through 437
-	 * wp wc-misc set-skip-feature-flag wcb_viewport_initial_scale 437 --dry-run    # Shows a report of what would happen for sites 1 through 437
+	 * wp wc-misc set-skip-feature-flag wcb_viewport_initial_scale --network=1                   # Sets the flag on all sites on WordCamp network
+	 * wp wc-misc set-skip-feature-flag wcb_viewport_initial_scale 437 --network=1               # Sets the flag on all sites 1 through 437 on WordCamp network
+	 * wp wc-misc set-skip-feature-flag wcb_viewport_initial_scale 1520 --network=2 --dry-run    # Shows a report of what would happen for sites 1 through 520 on Pilot Events network
 	 *
 	 * @subcommand set-skip-feature-flag
 	 *
@@ -42,6 +45,7 @@ class WordCamp_CLI_Miscellaneous extends WP_CLI_Command {
 		$flag_name   = $args[0];
 		$max_site_id = empty( $args[1] ) ? false : absint( $args[1] );
 		$dry_run     = isset( $assoc_args['dry-run'] );
+		$network     = $assoc_args['network'] ?? false;
 
 		$site_args = array( 'number' => 0 );
 		if ( $max_site_id ) {

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/miscellaneous.php
@@ -47,7 +47,9 @@ class WordCamp_CLI_Miscellaneous extends WP_CLI_Command {
 		if ( $max_site_id ) {
 			$site_args['site__in'] = range( 1, $max_site_id );
 		}
-		$sites = get_sites( $site_args );
+		$sites = get_sites( $site_args ); // want all networks, or just camps?
+		// probably will depend on the situation, so force the caller to specify
+		// error if network_in empty. or maybe make it more ergonomic and allow passing 'wordcamp' or 'pilot' ?
 
 		$notify  = new Bar( 'Applying flag', count( $sites ) );
 		$results = array();

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -801,6 +801,7 @@ function process_action_approve() {
 	}
 
 	$post->post_status = 'wcb-approved';
+	// this is just updating, but why use insert instead of update? maybe to skip some filters or something? should be documented.
 	wp_insert_post( $post );
 
 	WordCamp_Budgets::log(

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -300,6 +300,7 @@ function render_status_metabox( $post ) {
 	$allowed_submit_statuses         = WordCamp_Loader::get_after_contract_statuses();
 	$current_user_can_edit_request   = in_array( $post->post_status, $allowed_edit_statuses, true );
 	$current_user_can_submit_request = $wordcamp && in_array( $wordcamp->post_status, $allowed_submit_statuses, true );
+	// todo blocked on cpt. they may want different post statuses for the new cpt too? if so will have to update lots of stuff that uses that.
 
 	$invoice_url = '';
 	if ( current_user_can( 'manage_network' ) && ! empty( $post->_wcbsi_qbo_invoice_id ) ) {


### PR DESCRIPTION
WIP

See #906 

check all `get_sites()` because they include all networks by default. most queries will probably only want the wordcamp network, but it needs to be decided on a case by case basis because the context matters


### How to test the changes in this Pull Request:

1.
2.
3.

