### PR TITLE
Add First Time being a organizer/speaker/sponsor question to CPT

### DIFF
--- a/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor.php
@@ -391,7 +391,7 @@ class MES_Sponsor {
 
 		$text_fields = array(
 			'company_name', 'website', 'first_name', 'last_name', 'email_address', 'phone_number', 'twitter_handle',
-			'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country', 'first_time',
+			'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country',
 		);
 
 		foreach ( $text_fields as $field ) {

--- a/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor.php
@@ -391,7 +391,7 @@ class MES_Sponsor {
 
 		$text_fields = array(
 			'company_name', 'website', 'first_name', 'last_name', 'email_address', 'phone_number', 'twitter_handle',
-			'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country',
+			'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country', 'first_time',
 		);
 
 		foreach ( $text_fields as $field ) {

--- a/public_html/wp-content/plugins/wc-post-types/css/admin.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/admin.css
@@ -43,6 +43,7 @@
 
 li.wcpt-form-header {
 	display: table-caption;
+	width: max-content;
 	font-weight: 700;
 }
 

--- a/public_html/wp-content/plugins/wc-post-types/css/editor.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/editor.css
@@ -44,11 +44,13 @@
 	margin-right: 0;
 }
 
+.wc-panel-speaker-info .components-base-control,
 .wc-panel-organizer-info .components-base-control,
 .wc-panel-volunteer-info .components-base-control {
 	margin-bottom: 2em;
 }
 
+.wc-panel-speaker-info .components-base-control:last-child,
 .wc-panel-organizer-info .components-base-control:last-child,
 .wc-panel-volunteer-info .components-base-control:last-child {
 	margin-bottom: 0;

--- a/public_html/wp-content/plugins/wc-post-types/css/editor.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/editor.css
@@ -44,10 +44,12 @@
 	margin-right: 0;
 }
 
+.wc-panel-organizer-info .components-base-control,
 .wc-panel-volunteer-info .components-base-control {
 	margin-bottom: 2em;
 }
 
+.wc-panel-organizer-info .components-base-control:last-child,
 .wc-panel-volunteer-info .components-base-control:last-child {
 	margin-bottom: 0;
 }

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -80,6 +80,7 @@ function sponsor_personal_data_exporter( $email_address, $page ) {
 		'_wcpt_sponsor_last_name'     => __( 'Last Name', 'wordcamporg' ),
 		'_wcpt_sponsor_email_address' => __( 'Email Address', 'wordcamporg' ),
 		'_wcpt_sponsor_phone_number'  => __( 'Phone Number', 'wordcamporg' ),
+		'_wcpt_sponsor_first_time'    => __( 'First Time Sponsor', 'wordcamporg' ),
 	);
 
 	return _personal_data_exporter( 'wcb_sponsor', $props_to_export, $email_address, $page );

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -96,6 +96,7 @@ function organizer_personal_data_exporter( $email_address, $page ) {
 	$props_to_export = array(
 		'post_title'    => __( 'Organizer Name', 'wordcamporg' ),
 		'_wcpt_user_id' => __( 'WordPress.org Username', 'wordcamporg' ),
+		'_wcb_organizer_first_time' => __( 'First Time Organizer', 'wordcamporg' ),
 	);
 
 	return _personal_data_exporter( 'wcb_organizer', $props_to_export, $email_address, $page );

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -59,6 +59,7 @@ function speaker_personal_data_exporter( $email_address, $page ) {
 		'post_content'       => __( 'Speaker Bio', 'wordcamporg' ),
 		'_wcb_speaker_email' => __( 'Gravatar Email', 'wordcamporg' ),
 		'_wcpt_user_id'      => __( 'WordPress.org Username', 'wordcamporg' ),
+		'_wcb_speaker_first_time' => __( 'First Time Speaker', 'wordcamporg' ),
 	);
 
 	return _personal_data_exporter( 'wcb_speaker', $props_to_export, $email_address, $page );

--- a/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/privacy.php
@@ -80,7 +80,7 @@ function sponsor_personal_data_exporter( $email_address, $page ) {
 		'_wcpt_sponsor_last_name'     => __( 'Last Name', 'wordcamporg' ),
 		'_wcpt_sponsor_email_address' => __( 'Email Address', 'wordcamporg' ),
 		'_wcpt_sponsor_phone_number'  => __( 'Phone Number', 'wordcamporg' ),
-		'_wcpt_sponsor_first_time'    => __( 'First Time Sponsor', 'wordcamporg' ),
+		'_wcb_sponsor_first_time'     => __( 'First Time Sponsor', 'wordcamporg' ),
 	);
 
 	return _personal_data_exporter( 'wcb_sponsor', $props_to_export, $email_address, $page );

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -44,6 +44,20 @@ function register_sponsor_post_meta() {
 			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
 		)
 	);
+	register_post_meta(
+		'wcb_sponsor',
+		'_wcpt_sponsor_first_time',
+		array(
+			'type'          => 'string',
+			'show_in_rest'  => array(
+				'schema' => array(
+					'context' => array( 'edit' ),
+				),
+			),
+			'single'        => true,
+			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+		)
+	);
 }
 
 /**

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -106,6 +106,20 @@ function register_speaker_post_meta() {
 			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
 		)
 	);
+	register_post_meta(
+		'wcb_speaker',
+		'_wcb_speaker_first_time',
+		array(
+			'type'          => 'string',
+			'show_in_rest'  => array(
+				'schema' => array(
+					'context' => array( 'edit' ),
+				),
+			),
+			'single'        => true,
+			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+		)
+	);
 }
 
 /**

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -46,7 +46,7 @@ function register_sponsor_post_meta() {
 	);
 	register_post_meta(
 		'wcb_sponsor',
-		'_wcpt_sponsor_first_time',
+		'_wcb_sponsor_first_time',
 		array(
 			'type'              => 'string',
 			'show_in_rest'      => array(

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -48,14 +48,15 @@ function register_sponsor_post_meta() {
 		'wcb_sponsor',
 		'_wcpt_sponsor_first_time',
 		array(
-			'type'          => 'string',
-			'show_in_rest'  => array(
+			'type'              => 'string',
+			'show_in_rest'      => array(
 				'schema' => array(
 					'context' => array( 'edit' ),
 				),
 			),
-			'single'        => true,
-			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+			'single'            => true,
+			'auth_callback'     => __NAMESPACE__ . '\meta_auth_callback',
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_first_time_value',
 		)
 	);
 }
@@ -124,14 +125,15 @@ function register_speaker_post_meta() {
 		'wcb_speaker',
 		'_wcb_speaker_first_time',
 		array(
-			'type'          => 'string',
-			'show_in_rest'  => array(
+			'type'              => 'string',
+			'show_in_rest'      => array(
 				'schema' => array(
 					'context' => array( 'edit' ),
 				),
 			),
-			'single'        => true,
-			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+			'single'            => true,
+			'auth_callback'     => __NAMESPACE__ . '\meta_auth_callback',
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_first_time_value',
 		)
 	);
 }
@@ -272,14 +274,15 @@ function register_organizer_post_meta() {
 		'wcb_organizer',
 		'_wcb_organizer_first_time',
 		array(
-			'type'          => 'string',
-			'show_in_rest'  => array(
+			'type'              => 'string',
+			'show_in_rest'      => array(
 				'schema' => array(
 					'context' => array( 'edit' ),
 				),
 			),
-			'single'        => true,
-			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+			'single'            => true,
+			'auth_callback'     => __NAMESPACE__ . '\meta_auth_callback',
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_first_time_value',
 		)
 	);
 }
@@ -811,4 +814,21 @@ function add_larger_avatar_sizes( $sizes ) {
 	$sizes[] = 512;
 
 	return $sizes;
+}
+
+/**
+ * Sanitize the 'first_time' meta value before storing it.
+ *
+ * @param string $value The unsanitized meta value.
+ *
+ * @return string The sanitized meta value.
+ */
+function sanitize_first_time_value( $value ) {
+	$allowed_values = array( 'yes', 'no', 'unsure' );
+
+	if ( in_array( $value, $allowed_values, true ) ) {
+		return $value;
+	} else {
+		return 'unsure';
+	}
 }

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -240,6 +240,20 @@ function register_organizer_post_meta() {
 			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
 		)
 	);
+	register_post_meta(
+		'wcb_organizer',
+		'_wcb_organizer_first_time',
+		array(
+			'type'          => 'string',
+			'show_in_rest'  => array(
+				'schema' => array(
+					'context' => array( 'edit' ),
+				),
+			),
+			'single'        => true,
+			'auth_callback' => __NAMESPACE__ . '\meta_auth_callback',
+		)
+	);
 }
 
 /**

--- a/public_html/wp-content/plugins/wc-post-types/js/src/organizer/panel-info.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/organizer/panel-info.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { RadioControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import UsernameControl from '../components/username-control';
 
 export default function OrganizerInfoPanel() {
 	const [ username, setUsername ] = usePostMeta( '_wcpt_user_name', '' );
+	const [ firstTime, setFirstTime ] = usePostMeta( '_wcb_organizer_first_time', false );
 
 	return (
 		<PluginDocumentSettingPanel
@@ -23,6 +25,16 @@ export default function OrganizerInfoPanel() {
 				label={ __( 'WordPress.org Username', 'wordcamporg' ) }
 				value={ username }
 				onChange={ setUsername }
+			/>
+			<RadioControl
+				label={ __( 'Is this their first time being an organizer at a WordPress event?', 'wordcamporg' ) }
+				selected={ firstTime }
+				onChange={ ( value ) => setFirstTime( value ) }
+				options={ [
+					{ label: 'Yes', value: 'yes' },
+					{ label: 'No', value: 'no' },
+					{ label: 'Unsure', value: 'unsure' },
+				] }
 			/>
 		</PluginDocumentSettingPanel>
 	);

--- a/public_html/wp-content/plugins/wc-post-types/js/src/speaker/panel-info.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/speaker/panel-info.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { TextControl } from '@wordpress/components';
+import { RadioControl, TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import UsernameControl from '../components/username-control';
 export default function SpeakerInfoPanel() {
 	const [ email, setEmail ] = usePostMeta( '_wcb_speaker_email', '' );
 	const [ username, setUsername ] = usePostMeta( '_wcpt_user_name', '' );
+	const [ firstTime, setFirstTime ] = usePostMeta( '_wcb_speaker_first_time', false );
 
 	return (
 		<PluginDocumentSettingPanel
@@ -31,6 +32,16 @@ export default function SpeakerInfoPanel() {
 				label={ __( 'WordPress.org Username', 'wordcamporg' ) }
 				value={ username }
 				onChange={ setUsername }
+			/>
+			<RadioControl
+				label={ __( 'Is this their first time being a speaker at a WordPress event?', 'wordcamporg' ) }
+				selected={ firstTime }
+				onChange={ ( value ) => setFirstTime( value ) }
+				options={ [
+					{ label: 'Yes', value: 'yes' },
+					{ label: 'No', value: 'no' },
+					{ label: 'Unsure', value: 'unsure' },
+				] }
 			/>
 		</PluginDocumentSettingPanel>
 	);

--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
@@ -285,37 +285,37 @@
 	</li>
 
 	<li>
-		<label for="_wcpt_sponsor_first_time_yes">
+		<label for="_wcb_sponsor_first_time_yes">
 			<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
 		</label>
 		<input
 			type="radio"
-			id="_wcpt_sponsor_first_time_yes"
-			name="_wcpt_sponsor_first_time"
+			id="_wcb_sponsor_first_time_yes"
+			name="_wcb_sponsor_first_time"
 			value="yes"
 			<?php checked( $first_time, 'yes' ); ?>
 		/>
 	</li>
 	<li>
-		<label for="_wcpt_sponsor_first_time_no">
+		<label for="_wcb_sponsor_first_time_no">
 			<?php esc_html_e( 'No', 'wordcamporg' ); ?>
 		</label>
 		<input
 			type="radio"
-			id="_wcpt_sponsor_first_time_no"
-			name="_wcpt_sponsor_first_time"
+			id="_wcb_sponsor_first_time_no"
+			name="_wcb_sponsor_first_time"
 			value="no"
 			<?php checked( $first_time, 'no' ); ?>
 		/>
 	</li>
 	<li>
-		<label for="_wcpt_sponsor_first_time_unsure">
+		<label for="_wcb_sponsor_first_time_unsure">
 			<?php esc_html_e( 'I don\'t know', 'wordcamporg' ); ?>
 		</label>
 		<input
 			type="radio"
-			id="_wcpt_sponsor_first_time_unsure"
-			name="_wcpt_sponsor_first_time"
+			id="_wcb_sponsor_first_time_unsure"
+			name="_wcb_sponsor_first_time"
 			value="unsure"
 			<?php checked( $first_time, 'unsure' ); ?>
 		/>

--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
@@ -310,7 +310,7 @@
 	</li>
 	<li>
 		<label for="_wcpt_sponsor_first_time_unsure">
-			<?php esc_html_e( 'Unsure', 'wordcamporg' ); ?>
+			<?php esc_html_e( 'I don\'t know', 'wordcamporg' ); ?>
 		</label>
 		<input
 			type="radio"

--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
@@ -293,7 +293,7 @@
 			id="_wcpt_sponsor_first_time_yes"
 			name="_wcpt_sponsor_first_time"
 			value="yes"
-			<?php echo 'yes' === $first_time  ? 'checked' : ''; ?>
+			<?php checked( $first_time, 'yes' ); ?>
 		/>
 	</li>
 	<li>
@@ -305,7 +305,7 @@
 			id="_wcpt_sponsor_first_time_no"
 			name="_wcpt_sponsor_first_time"
 			value="no"
-			<?php echo 'no' === $first_time ? 'checked' : ''; ?>
+			<?php checked( $first_time, 'no' ); ?>
 		/>
 	</li>
 	<li>
@@ -317,7 +317,7 @@
 			id="_wcpt_sponsor_first_time_unsure"
 			name="_wcpt_sponsor_first_time"
 			value="unsure"
-			<?php echo 'unsure' === $first_time ? 'checked' : ''; ?>
+			<?php checked( $first_time, 'unsure' ); ?>
 		/>
 	</li>
 </ul>

--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
@@ -13,6 +13,7 @@
 /** @var string $state */
 /** @var string $zip_code */
 /** @var string $country */
+/** @var string $first_time */
 /** @var array $available_countries */
 ?>
 <ul class="wcpt-form">
@@ -275,6 +276,49 @@
 		/>
 
 		<?php wcorg_required_indicator(); ?>
+	</li>
+</ul>
+
+<ul class="wcpt-form">
+	<li class="wcpt-form-header">
+		<?php esc_html_e( 'Is this their first time being a sponsor at a WordPress event?', 'wordcamporg' ); ?>
+	</li>
+
+	<li>
+		<label for="_wcpt_sponsor_first_time_yes">
+			<?php esc_html_e( 'Yes', 'wordcamporg' ); ?>
+		</label>
+		<input
+			type="radio"
+			id="_wcpt_sponsor_first_time_yes"
+			name="_wcpt_sponsor_first_time"
+			value="yes"
+			<?php echo 'yes' === $first_time  ? 'checked' : ''; ?>
+		/>
+	</li>
+	<li>
+		<label for="_wcpt_sponsor_first_time_no">
+			<?php esc_html_e( 'No', 'wordcamporg' ); ?>
+		</label>
+		<input
+			type="radio"
+			id="_wcpt_sponsor_first_time_no"
+			name="_wcpt_sponsor_first_time"
+			value="no"
+			<?php echo 'no' === $first_time ? 'checked' : ''; ?>
+		/>
+	</li>
+	<li>
+		<label for="_wcpt_sponsor_first_time_unsure">
+			<?php esc_html_e( 'Unsure', 'wordcamporg' ); ?>
+		</label>
+		<input
+			type="radio"
+			id="_wcpt_sponsor_first_time_unsure"
+			name="_wcpt_sponsor_first_time"
+			value="unsure"
+			<?php echo 'unsure' === $first_time ? 'checked' : ''; ?>
+		/>
 	</li>
 </ul>
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1235,6 +1235,7 @@ class WordCamp_Post_Types_Plugin {
 		$state           = get_post_meta( $sponsor->ID, '_wcpt_sponsor_state',           true );
 		$zip_code        = get_post_meta( $sponsor->ID, '_wcpt_sponsor_zip_code',        true );
 		$country         = get_post_meta( $sponsor->ID, '_wcpt_sponsor_country',         true );
+		$first_time      = get_post_meta( $sponsor->ID, '_wcb_sponsor_first_time',       true );
 
 		if ( $state === $this->get_sponsor_info_state_default_value() ) {
 			$state = '';
@@ -1358,7 +1359,7 @@ class WordCamp_Post_Types_Plugin {
 		}
 
 		if ( wp_verify_nonce( filter_input( INPUT_POST, 'wcpt-meta-sponsor-info' ), 'edit-sponsor-info' ) ) {
-			$text_values = array(
+			$text_values_wcpt = array(
 				'company_name',
 				'first_name',
 				'last_name',
@@ -1374,8 +1375,16 @@ class WordCamp_Post_Types_Plugin {
 				'country',
 			);
 
-			foreach ( $text_values as $id ) {
+			$text_values_wcb = array(
+				'first_time',
+			);
+
+			foreach ( $text_values_wcpt as $id ) {
 				$values[ $id ] = sanitize_text_field( filter_input( INPUT_POST, '_wcpt_sponsor_' . $id ) );
+			}
+
+			foreach ( $text_values_wcb as $id ) {
+				$values[ $id ] = sanitize_text_field( filter_input( INPUT_POST, '_wcb_sponsor_' . $id ) );
 			}
 
 			if ( empty( $values['state'] ) ) {
@@ -1389,7 +1398,9 @@ class WordCamp_Post_Types_Plugin {
 			$values['agreement']  = filter_input( INPUT_POST, '_wcpt_sponsor_agreement', FILTER_SANITIZE_NUMBER_INT );
 
 			foreach ( $values as $id => $value ) {
-				$meta_key = '_wcpt_sponsor_' . $id;
+				$meta_key = in_array($id, $text_values_wcb, true)
+					? '_wcb_sponsor_' . $id
+					: '_wcpt_sponsor_' . $id;
 
 				if ( empty( $value ) ) {
 					delete_post_meta( $post_id, $meta_key );

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
@@ -9,9 +9,9 @@
 <!-- wp:jetpack/contact-form {"subject":"WordCamp Speaker Request","hasFormSettingsSet":"yes"} -->
 <!-- wp:jetpack/field-name {"label":"Name","required":true} /-->
 
-<!-- wp:jetpack/field-email {"label":"Email Address","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email","required":true,"requiredText":"(required)","id":"speaker-email"} /-->
 
-<!-- wp:jetpack/field-text {"label":"WordPress.org Username","required":true} /-->
+<!-- wp:jetpack/field-text {"label":"WordPress.org Username","requiredText":"(required)","id":"speaker-username"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Your Bio","required":true} /-->
 
@@ -20,6 +20,8 @@
 <!-- wp:jetpack/field-textarea {"label":"Topic Description","required":true} /-->
 
 <!-- wp:jetpack/field-text {"label":"Intended Audience","required":true} /-->
+
+<!-- wp:jetpack/field-radio {"label":"Is this your first time being a speaker at a WordPress event?","requiredText":"(required)","options":["Yes","No","Unsure"],"id":"first-time-speaker"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Past Speaking Experience (not necessary to apply)"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-speakers.php
@@ -11,7 +11,7 @@
 
 <!-- wp:jetpack/field-email {"label":"Email","required":true,"requiredText":"(required)","id":"speaker-email"} /-->
 
-<!-- wp:jetpack/field-text {"label":"WordPress.org Username","requiredText":"(required)","id":"speaker-username"} /-->
+<!-- wp:jetpack/field-text {"label":"WordPress.org Username","requiredText":"(required)","id":"speaker-username","required":true} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Your Bio","required":true} /-->
 
@@ -21,7 +21,7 @@
 
 <!-- wp:jetpack/field-text {"label":"Intended Audience","required":true} /-->
 
-<!-- wp:jetpack/field-radio {"label":"Is this your first time being a speaker at a WordPress event?","requiredText":"(required)","options":["Yes","No","Unsure"],"id":"first-time-speaker"} /-->
+<!-- wp:jetpack/field-radio {"label":"Is this your first time being a speaker at a WordPress event?","options":["Yes","No","Unsure"],"id":"first-time-speaker"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Past Speaking Experience (not necessary to apply)"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
@@ -26,7 +26,7 @@
 
 <!-- wp:jetpack/field-textarea {"label":"Why Would you Like to Sponsor WordCamp?","required":true} /-->
 
-<!-- wp:jetpack/field-radio {"label":"Is this your first time being a sponsor at a WordPress event?","requiredText":"(required)","options":["Yes","No","Unsure"],"id":"first-time-sponsor"} /-->
+<!-- wp:jetpack/field-radio {"label":"Is this your first time being a sponsor at a WordPress event?","options":["Yes","No","Unsure"],"id":"first-time-sponsor"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Questions / Comments"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-sponsors.php
@@ -1,3 +1,12 @@
+<!-- wp:paragraph {"backgroundColor":"accent","textColor":"background","className":"has-accent-background-color has-background"} -->
+<p class="has-accent-background-color has-background has-background-color has-text-color"><em>Organizers Note:</em>
+	Submissions to this form will automatically create <code>draft</code>
+	<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=wcb_sponsor' ) ); ?>">Sponsor posts</a>.
+	You can use those to manage your sponsors, by publishing the ones that you accept, and deleting the ones that you don't.
+	Changing the <code>name</code>, <code>email</code>, <code>username</code>, or <code>first time sponsoring</code> questions can break the automation, though.
+</p>
+<!-- /wp:paragraph -->
+
 <!-- wp:paragraph -->
 <p>Blurb with information for potential sponsors.</p>
 <!-- /wp:paragraph -->
@@ -9,13 +18,15 @@
 
 <!-- wp:jetpack/field-url {"label":"Company Website","required":true} /-->
 
-<!-- wp:jetpack/field-email {"label":"Email","required":true} /-->
+<!-- wp:jetpack/field-email {"label":"Email","required":true,"requiredText":"(required)","id":"sponsor-email"} /-->
 
 <!-- wp:jetpack/field-telephone {"label":"Phone Number"} /-->
 
 <!-- wp:jetpack/field-select {"label":"Sponsorship Level","options":["Bronze","Silver","Gold"]} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Why Would you Like to Sponsor WordCamp?","required":true} /-->
+
+<!-- wp:jetpack/field-radio {"label":"Is this your first time being a sponsor at a WordPress event?","requiredText":"(required)","options":["Yes","No","Unsure"],"id":"first-time-sponsor"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Questions / Comments"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
+++ b/public_html/wp-content/plugins/wcpt/stubs/post/call-for-volunteers.php
@@ -21,7 +21,7 @@
 
 <!-- wp:jetpack/field-text {"label":"Number of Hours Available","required":true} /-->
 
-<!-- wp:jetpack/field-radio {"label":"Is this the first time you have volunteered at a WordPress event?","requiredText":"(required)","options":["Yes","No","Unsure"],"id":"first-time-volunteer"} /-->
+<!-- wp:jetpack/field-radio {"label":"Is this the first time you have volunteered at a WordPress event?","options":["Yes","No","Unsure"],"id":"first-time-volunteer"} /-->
 
 <!-- wp:jetpack/field-textarea {"label":"Questions / Comments"} /-->
 <!-- /wp:jetpack/contact-form -->

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -854,6 +854,9 @@ class WordCamp_New_Site {
 			$sponsor_meta[ "_wcpt_sponsor_$key" ] = get_post_meta( $assigned_sponsor->ID, "mes_$key", true );
 		}
 
+		// Always set the first-time sponsor value to 'no' for Multi Event (ME) Sponsors.
+		$sponsor_meta['_wcpt_sponsor_first_time'] = 'no';
+
 		restore_current_blog();
 
 		return $sponsor_meta;

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -735,6 +735,9 @@ class WordCamp_New_Site {
 				'content' => $this->get_stub_content( 'post', 'call-for-sponsors' ),
 				'status'  => 'draft',
 				'type'    => 'post',
+				'meta'    => array(
+					'wcfd-key' => 'call-for-sponsors',
+				),
 			),
 
 			array(

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -855,7 +855,7 @@ class WordCamp_New_Site {
 		}
 
 		// Always set the first-time sponsor value to 'no' for Multi Event (ME) Sponsors.
-		$sponsor_meta['_wcpt_sponsor_first_time'] = 'no';
+		$sponsor_meta['_wcb_sponsor_first_time'] = 'no';
 
 		restore_current_blog();
 

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -42,7 +42,7 @@ class WordCamp_Forms_To_Drafts {
 		?>
 
 		<style>
-			<?php require_once( __DIR__ . '/front-end.css' ); ?>
+			<?php require_once __DIR__ . '/front-end.css'; ?>
 		</style>
 
 		<?php
@@ -55,7 +55,7 @@ class WordCamp_Forms_To_Drafts {
 		if ( ! $this->form_requires_login( $this->get_current_form_id() ) ) {
 			return;
 		}
-		$deps_path = __DIR__ . '/build/inert.asset.php';
+		$deps_path   = __DIR__ . '/build/inert.asset.php';
 		$script_info = require $deps_path;
 
 		wp_enqueue_script(
@@ -472,8 +472,11 @@ class WordCamp_Forms_To_Drafts {
 		);
 
 		if ( $speaker_id ) {
+			$first_time = strtolower( $speaker['Is this your first time being a speaker at a WordPress event?'] ) ?? '';
+			$first_time = in_array( $first_time, array( 'yes', 'no', 'unsure' ), true ) ? $first_time : '';
 			update_post_meta( $speaker_id, '_wcb_speaker_email', $speaker['Email Address'] ?? '' );
 			update_post_meta( $speaker_id, '_wcpt_user_id',      $this->get_user_id_from_username( $speaker['WordPress.org Username'] ?? '' ) );
+			update_post_meta( $speaker_id, '_wcb_speaker_first_time', $first_time );
 		}
 
 		return $speaker_id;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #888

This PR adds First Time being an organizer/speaker/sponsor question to CPT and prepares CPT stub for form automation in order to allow the WordCamp Counts to retrieve the first_time value.

<!-- List out anyone who helped with this task. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
**Sponsor**
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/0fa8b86f-8c50-4cba-95e5-ca68dae500a1)
**Speaker**
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/65daf178-3d76-4449-aea1-1d8c6d80cd50)
**Organizer**
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/7949c863-09a5-4332-bbb7-2dc3f4541c90)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go to individual sites.
2. Go to Sponsors/Organizers/Speakers and click on anyone listed there.
3. You'll see the meta box questions as the above screenshots show.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->

### Questions
1. I'm curious if the timing for a volunteer/speaker/sponsor to fill in the first-time volunteer/speaker/sponsor can only be through the initial form that's created on a new website? If a user deletes this initial form, is there another way to retrieve it later?

2. Is the timing to fill in the first-time organizer only through the organizer's block editor page side panel? Is there a need to prepare an organizer stub for form automation?
