### PR TITLE
Add a new Pilot Event CPT

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -72,7 +72,7 @@
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-organizer-reminders</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-remote-css</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-speaker-feedback</directory>
-			<directory suffix=".php">./public_html/wp-content/plugins/pilot-event/tests</directory>
+			<directory suffix=".php">./public_html/wp-content/plugins/pilot-event</directory>
 			<file>./public_html/wp-content/sunrise.php</file>
 		</include>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -55,6 +55,12 @@
 				./public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/
 			</directory>
 		</testsuite>
+
+		<testsuite name="WordCamp Pilot Event Post Type">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/pilot-event/tests/
+			</directory>
+		</testsuite>
 	</testsuites>
 
 	<coverage cacheDirectory=".phpunit/coverage-cache">
@@ -66,6 +72,7 @@
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-organizer-reminders</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-remote-css</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-speaker-feedback</directory>
+			<directory suffix=".php">./public_html/wp-content/plugins/pilot-event/tests</directory>
 			<file>./public_html/wp-content/sunrise.php</file>
 		</include>
 

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -14,7 +14,6 @@ function wcorg_include_common_plugins() {
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php';
 	}
 
-	
 	require_once __DIR__ . '/blocks/blocks.php';
 	require_once __DIR__ . '/theme-templates/bootstrap.php';
 	require_once __DIR__ . '/quickbooks/quickbooks.php';

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -14,6 +14,7 @@ function wcorg_include_common_plugins() {
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php';
 	}
 
+	
 	require_once __DIR__ . '/blocks/blocks.php';
 	require_once __DIR__ . '/theme-templates/bootstrap.php';
 	require_once __DIR__ . '/quickbooks/quickbooks.php';

--- a/public_html/wp-content/plugins/pilot-event/includes/post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/includes/post-type.php
@@ -5,6 +5,11 @@ namespace WordCampPilotEvents\PostType;
 defined( 'WPINC' ) || die();
 
 /**
+ * Constants.
+ */
+define( 'WCPT_PILOT_EVENT_SLUG', 'pilot_event' );
+
+/**
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\create_pilot_event_post_type' );

--- a/public_html/wp-content/plugins/pilot-event/includes/post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/includes/post-type.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WordCampPilotEvents\PostType;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\create_pilot_event_post_type' );
+
+/**
+ * Register the custom post type for Pilot WordCamp events.
+ *
+ * @return void
+ */
+function create_pilot_event_post_type() {
+    $labels = array(
+        'name'               => 'Pilot Events',
+        'singular_name'      => 'Pilot Event',
+        'menu_name'          => 'Pilot Events',
+        'name_admin_bar'     => 'Pilot Event',
+        'add_new'            => 'Add New',
+        'add_new_item'       => 'Add New Pilot Event',
+        'new_item'           => 'New Pilot Event',
+        'edit_item'          => 'Edit Pilot Event',
+        'view_item'          => 'View Pilot Event',
+        'all_items'          => 'All Pilot Events',
+        'search_items'       => 'Search Pilot Events',
+        'parent_item_colon'  => 'Parent Pilot Events:',
+        'not_found'          => 'No pilot events found.',
+        'not_found_in_trash' => 'No pilot events found in Trash.'
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'publicly_queryable' => true,
+        'show_ui'            => true,
+        'show_in_menu'       => true,
+        'show_in_rest'       => true,
+        'query_var'          => true,
+        'rewrite'            => array( 'slug' => 'pilot-event' ),
+        'capability_type'    => 'post',
+        'has_archive'        => true,
+        'hierarchical'       => false,
+        'menu_position'      => null,
+        'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+    );
+
+    register_post_type( 'pilot_event', $args );
+}

--- a/public_html/wp-content/plugins/pilot-event/includes/post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/includes/post-type.php
@@ -20,40 +20,40 @@ add_action( 'init', __NAMESPACE__ . '\create_pilot_event_post_type' );
  * @return void
  */
 function create_pilot_event_post_type() {
-    $labels = array(
-        'name'               => 'Pilot Events',
-        'singular_name'      => 'Pilot Event',
-        'menu_name'          => 'Pilot Events',
-        'name_admin_bar'     => 'Pilot Event',
-        'add_new'            => 'Add New',
-        'add_new_item'       => 'Add New Pilot Event',
-        'new_item'           => 'New Pilot Event',
-        'edit_item'          => 'Edit Pilot Event',
-        'view_item'          => 'View Pilot Event',
-        'all_items'          => 'All Pilot Events',
-        'search_items'       => 'Search Pilot Events',
-        'parent_item_colon'  => 'Parent Pilot Events:',
-        'not_found'          => 'No pilot events found.',
-        'not_found_in_trash' => 'No pilot events found in Trash.'
-    );
+	$labels = array(
+		'name'               => 'Pilot Events',
+		'singular_name'      => 'Pilot Event',
+		'menu_name'          => 'Pilot Events',
+		'name_admin_bar'     => 'Pilot Event',
+		'add_new'            => 'Add New',
+		'add_new_item'       => 'Add New Pilot Event',
+		'new_item'           => 'New Pilot Event',
+		'edit_item'          => 'Edit Pilot Event',
+		'view_item'          => 'View Pilot Event',
+		'all_items'          => 'All Pilot Events',
+		'search_items'       => 'Search Pilot Events',
+		'parent_item_colon'  => 'Parent Pilot Events:',
+		'not_found'          => 'No pilot events found.',
+		'not_found_in_trash' => 'No pilot events found in Trash.',
+	);
 
-    $args = array(
-        'labels'             => $labels,
-        'menu_icon'          => 'dashicons-wordpress',
-        'public'             => true,
-        'publicly_queryable' => true,
-        'show_ui'            => true,
-        'show_in_menu'       => true,
-        'show_in_rest'       => true,
-        'query_var'          => true,
-        'rewrite'            => array( 'slug' => 'pilot-event' ),
-        'capability_type'    => 'post',
-        'has_archive'        => true,
-        'hierarchical'       => false,
-        'menu_position'      => null,
-        'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
-        'menu_icon'             => 'dashicons-wordpress',
-    );
+	$args = array(
+		'labels'             => $labels,
+		'menu_icon'          => 'dashicons-wordpress',
+		'public'             => true,
+		'publicly_queryable' => true,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'show_in_rest'       => true,
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'pilot-event' ),
+		'capability_type'    => 'post',
+		'has_archive'        => true,
+		'hierarchical'       => false,
+		'menu_position'      => null,
+		'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+		'menu_icon'             => 'dashicons-wordpress',
+	);
 
-    register_post_type( WCPT_PILOT_EVENT_SLUG, $args );
+	register_post_type( WCPT_PILOT_EVENT_SLUG, $args );
 }

--- a/public_html/wp-content/plugins/pilot-event/includes/post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/includes/post-type.php
@@ -39,6 +39,7 @@ function create_pilot_event_post_type() {
 
     $args = array(
         'labels'             => $labels,
+        'menu_icon'          => 'dashicons-wordpress',
         'public'             => true,
         'publicly_queryable' => true,
         'show_ui'            => true,
@@ -51,7 +52,8 @@ function create_pilot_event_post_type() {
         'hierarchical'       => false,
         'menu_position'      => null,
         'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+        'menu_icon'             => 'dashicons-wordpress',
     );
 
-    register_post_type( 'pilot_event', $args );
+    register_post_type( WCPT_PILOT_EVENT_SLUG, $args );
 }

--- a/public_html/wp-content/plugins/pilot-event/includes/post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/includes/post-type.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WordCampPilotEvents\PostType;
+namespace WordCamp\PilotEvents\PostType;
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/plugins/pilot-event/includes/post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/includes/post-type.php
@@ -38,21 +38,20 @@ function create_pilot_event_post_type() {
 	);
 
 	$args = array(
-		'labels'             => $labels,
-		'menu_icon'          => 'dashicons-wordpress',
-		'public'             => true,
-		'publicly_queryable' => true,
-		'show_ui'            => true,
-		'show_in_menu'       => true,
-		'show_in_rest'       => true,
-		'query_var'          => true,
-		'rewrite'            => array( 'slug' => 'pilot-event' ),
 		'capability_type'    => 'post',
 		'has_archive'        => true,
 		'hierarchical'       => false,
+		'labels'             => $labels,
+		'menu_icon'          => 'dashicons-wordpress',
 		'menu_position'      => null,
+		'public'             => true,
+		'publicly_queryable' => true,
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'pilot-event' ),
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'show_in_rest'       => true,
 		'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
-		'menu_icon'             => 'dashicons-wordpress',
 	);
 
 	register_post_type( WCPT_PILOT_EVENT_SLUG, $args );

--- a/public_html/wp-content/plugins/pilot-event/pilot-event.php
+++ b/public_html/wp-content/plugins/pilot-event/pilot-event.php
@@ -1,0 +1,43 @@
+<?php
+ /**
+ * Plugin name:       WordCamp Pilot Events
+ * Plugin URI:        https://github.com/WordPress/wordcamp.org
+ * Description:       [Experimental] Creates the custom post type for Pilot WordCamp events.
+ * Version:           0.1.0-beta
+ * Author:            WordPress.org
+ * Author URI:        http://wordpress.org/
+ * License:           GPLv2 or later
+ * Text Domain:       wordcamp
+ */
+
+namespace WordCampPilotEvents;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Constants.
+ */
+define( __NAMESPACE__ . '\PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+
+/**
+ * Actions and filters.
+ */
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_files' );
+
+/**
+ * Load the other PHP files for the plugin.
+ *
+ * @return void
+ */
+function load_files() {
+	require_once get_includes_path() . 'post-type.php';
+}
+
+/**
+ * Shortcut to the includes directory.
+ *
+ * @return string
+ */
+function get_includes_path() {
+	return PLUGIN_DIR . 'includes/';
+}

--- a/public_html/wp-content/plugins/pilot-event/pilot-event.php
+++ b/public_html/wp-content/plugins/pilot-event/pilot-event.php
@@ -10,7 +10,7 @@
   * Text Domain:       wordcamp
   */
 
-namespace WordCampPilotEvents;
+namespace WordCamp\PilotEvents;
 
 defined( 'WPINC' ) || die();
 

--- a/public_html/wp-content/plugins/pilot-event/pilot-event.php
+++ b/public_html/wp-content/plugins/pilot-event/pilot-event.php
@@ -1,14 +1,14 @@
 <?php
  /**
- * Plugin name:       WordCamp Pilot Events
- * Plugin URI:        https://github.com/WordPress/wordcamp.org
- * Description:       [Experimental] Creates the custom post type for Pilot WordCamp events.
- * Version:           0.1.0-beta
- * Author:            WordPress.org
- * Author URI:        http://wordpress.org/
- * License:           GPLv2 or later
- * Text Domain:       wordcamp
- */
+  * Plugin name:       WordCamp Pilot Events
+  * Plugin URI:        https://github.com/WordPress/wordcamp.org
+  * Description:       [Experimental] Creates the custom post type for Pilot WordCamp events.
+  * Version:           0.1.0-beta
+  * Author:            WordPress.org
+  * Author URI:        http://wordpress.org/
+  * License:           GPLv2 or later
+  * Text Domain:       wordcamp
+  */
 
 namespace WordCampPilotEvents;
 

--- a/public_html/wp-content/plugins/pilot-event/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/pilot-event/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WordCamp\PilotEvents\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugins that we'll need to be active for the tests
+ */
+function manually_load_plugins() {
+	require_once dirname( __DIR__ ) . '/pilot-event.php';
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/plugins/pilot-event/tests/test-post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/tests/test-post-type.php
@@ -7,7 +7,7 @@ use WP_UnitTestCase, WP_UnitTest_Factory;
 defined( 'WPINC' ) || die();
 
 /**
- *
+ * Tests the Pilot Events Post type.
  */
 class Test_PilotEvents_PostType extends WP_UnitTestCase {
 

--- a/public_html/wp-content/plugins/pilot-event/tests/test-post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/tests/test-post-type.php
@@ -7,14 +7,12 @@ use WP_UnitTestCase, WP_UnitTest_Factory;
 defined( 'WPINC' ) || die();
 
 /**
- * 
+ *
  */
 class Test_PilotEvents_PostType extends WP_UnitTestCase {
-    
-    /**
-	 * @covers WordCamp_New_Site::url_matches_expected_format
-	 *
-	 * @dataProvider data_url_matches_expected_format
+
+	/**
+	 * This is the first test! We passed!
 	 */
 	public function test_passes() : void {
 		$this->assertSame( true, true );

--- a/public_html/wp-content/plugins/pilot-event/tests/test-post-type.php
+++ b/public_html/wp-content/plugins/pilot-event/tests/test-post-type.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WordCamp\PilotEvents\Tests;
+use WordCamp_Post_Types_Plugin;
+use WP_UnitTestCase, WP_UnitTest_Factory;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * 
+ */
+class Test_PilotEvents_PostType extends WP_UnitTestCase {
+    
+    /**
+	 * @covers WordCamp_New_Site::url_matches_expected_format
+	 *
+	 * @dataProvider data_url_matches_expected_format
+	 */
+	public function test_passes() : void {
+		$this->assertSame( true, true );
+	}
+}


### PR DESCRIPTION
Alternate to #911, 
Closes #900 

This PR introduces a new Custom Post Type called "Pilot Event". It currently doesn't have much functionality since it isn't clear how much `wordcamp` functionality will be needed. It does include boilerplate test code which may not be needed for the testing the post type since it probably shouldn't contain too much logic. I can remove it if it's useless.

It's worth noting that changes made in #937 rely on this CPT working and is part of the reason why it should be merged in early.

I did [make the argument](https://github.com/WordPress/wordcamp.org/issues/900#issuecomment-1633494392) that we could go without a CPT but after a discussions with @iandunn, we agreed that the CPT is still probably the better way to go based on what we currently know about the project. 




### How to test the changes in this Pull Request:

1. Turn on the plugin
2. Click "Pilot Events"
3. Add a title
4. Click save
5. Expect to see it in the list.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
