### PR TITLE
Expose AV Wrangler Name on WordCamp API

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -363,6 +363,7 @@ class WordCamp_Loader extends Event_Loader {
 			'Number of Anticipated Attendees',
 			'Organizer Name',
 			'WordPress.org Username',
+			'A/V Wrangler Name',
 			'Virtual event only',
 			'Host region',
 			'Venue Name',


### PR DESCRIPTION
WPTV team have asked to get the possible AV Wrangler's name of a WordCamp to help their work. This PR adds that info to the WordCamp REST API.

Fixes #302 

Props @ePascalC

### How to test the changes in this Pull Request:

1. Navigate to https://central.wordcamp.test/wp-json/wp/v2/wordcamps
2. Find a new "A/V Wrangler Name" field on each WordCamp item
3. Update some WordCamp data on Central and see that field reflected the change
