### PR TITLE
Prevent leaks from tagline when on Coming Soon mode

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -20,6 +20,7 @@ class WordCamp_Coming_Soon_Page {
 		add_action( 'admin_notices',              array( $this, 'block_new_post_admin_notice'     )        );
 		add_filter( 'get_post_metadata',          array( $this, 'jetpack_dont_email_post_to_subs' ), 10, 4 );
 		add_filter( 'publicize_should_publicize_published_post', array( $this, 'jetpack_prevent_publicize' ) );
+		add_filter( 'document_title_parts',       array( $this, 'force_empty_tagline' ) );
 
 		add_image_size( 'wccsp_image_medium_rectangle', 500, 300 );
 	}
@@ -538,6 +539,23 @@ class WordCamp_Coming_Soon_Page {
 		}
 
 		return $should_publicize;
+	}
+
+	/**
+	 * Prevent any dates or locations being leaked out by tagline while site is on Coming Soon mode.
+	 *
+	 * @param  array $parts The document title parts.
+	 *
+	 * @return array        The document title parts.
+	 */
+	public function force_empty_tagline( $parts ) {
+		$settings = $GLOBALS['WCCSP_Settings']->get_settings();
+
+		if ( 'on' === $settings['enabled'] ) {
+			$parts['tagline'] = '';
+		}
+
+		return $parts;
 	}
 
 } // end WordCamp_Coming_Soon_Page.


### PR DESCRIPTION
Some WordCamps, like WCEU and other flagships, do update the site tagline to contain the location and dates when they are still in the Coming Soon mode. The location and dates can leak this way and be found too early, before the announcement of the next edition.

This PR fixes that, by forcing the site tagline to be empty when Coming Soon mode is on.

Fixes #779 

Props @vertizio

### How to test the changes in this Pull Request:

1. Go to the WordCamp site admin site
2. Update the tagline on `options-general.php`
3. Ensure that the Coming Soon mode is enabled
4. Visit the site on private browsing
5. `title` tag does not contain the just updated tagline
6. Disable the Coming Soon mode
7. Reload the site on private browsing
8. `title` tag contains the tagline
