### PR TITLE
Ensure that special accommodations and allergy emails go only to unique addresses

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -331,6 +331,8 @@ class Accommodations_Field extends CampTix_Addon {
 			$support_email,
 		);
 
+		$recipients = array_unique( $recipients );
+
 		foreach ( $recipients as $recipient ) {
 			if ( $support_email === $recipient ) {
 				// Make sure the email to WordCamp Central is in English.


### PR DESCRIPTION
Prevent duplicate emails when the lead organiser and city email addresses are the same.

Fixes #877, See #947
