### PR TITLE
Prevent WordCamps disabling Coming Soon before they are in schedule

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
@@ -211,16 +211,6 @@ class WCCSP_Customizer {
 			return $validity;
 		}
 
-		/**
-		 * Short circuit when network admin is changing the value.
-		 *
-		 * On typical WordCamp site, at least some organisers do have administrator role so that
-		 * capability can not be used for this check.
-		 */
-		if ( in_array( 'manage_network', wp_get_current_user()->roles ) ) {
-			return $maybe_empty;
-		}
-
 		// Short circuit when deputy is changing the value.
 		if ( current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
 			return $validity;

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
@@ -206,8 +206,23 @@ class WCCSP_Customizer {
 	 * @return boolean           Status of the field validity.
 	 */
 	public function maybe_prevent_disable( $validity, $value ) {
-		// Coming soon page on is always valid.
+		// Short circuit when the value is on.
 		if ( 'on' === $value ) {
+			return $validity;
+		}
+
+		/**
+		 * Short circuit when network admin is changing the value.
+		 *
+		 * On typical WordCamp site, at least some organisers do have administrator role so that
+		 * capability can not be used for this check.
+		 */
+		if ( in_array( 'manage_network', wp_get_current_user()->roles ) ) {
+			return $maybe_empty;
+		}
+
+		// Short circuit when deputy is changing the value.
+		if ( current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
 			return $validity;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
@@ -44,6 +44,7 @@ class WCCSP_Customizer {
 				'type'              => 'option',
 				'capability'        => $GLOBALS['WCCSP_Settings']::REQUIRED_CAPABILITY,
 				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => array( $this, 'maybe_prevent_disable' ),
 			)
 		);
 
@@ -177,5 +178,44 @@ class WCCSP_Customizer {
 			1,
 			true
 		);
+	}
+
+	/**
+	 * Retrieve the WordCamp status.
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		$wordcamp_post = get_wordcamp_post();
+
+		if ( isset( $wordcamp_post->ID ) ) {
+			return $wordcamp_post->post_status;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Validate the wccsp_settings[enabled] and maybe prevent disabling the coming soon page.
+	 *
+	 * Non valid field prevents the save, thus also disabling the coming soon page.
+	 *
+	 * @param  boolean $validity Status of the field validity.
+	 * @param  string  $value    Field value.
+	 *
+	 * @return boolean           Status of the field validity.
+	 */
+	public function maybe_prevent_disable( $validity, $value ) {
+		// Coming soon page on is always valid.
+		if ( 'on' === $value ) {
+			return $validity;
+		}
+
+		// If WordCamp is not added to schedule, field is not valid.
+		if ( 'wcpt-scheduled' !== $this->get_status() ) {
+			return new WP_Error( 'wcpt-not-in-schedule', __( 'The Coming Soon page can not be turned off because WordCamp is not yet published in the schedule.' ) );
+		}
+
+		return $validity;
 	}
 }


### PR DESCRIPTION
Sometimes WordCamp organisers are eager to publish their WordCamp and website even before Central has approved their budget and added them to the schedule. Each organiser is told not to announce anything before the event is officially scheduled - on rare occasions, this is forgotten or ignored.

To avoid WordCamp going public too soon, this change prevents disabling Coming Soon mode before WordCamp is on the schedule.

Fixes #791 

### Screenshots

<img width="344" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/babc9fb6-9029-49ee-8703-fe35678b2f4b">

Coming Soon settings when a user tries to save (publish) off mode while WordCamp is not in `wcpt-scheduled` status.

### How to test the changes in this Pull Request:

1. Edit any WordCamp on Central, and change the status to something else than "WordCamp Scheduled"
2. Open the dashboard of that WordCamp and open Coming Soon settings
3. If the Coming Soon is off, turn it on and publish
4. Try to turn the setting back to off, you should see the error message
5. Change the status back to "WordCamp Scheduled" on Central
6. Publishing with Coming Soon off should work again
