### PR TITLE
Prevent users from creating new WordCamp and Meetup posts on central dashboard

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -5,6 +5,8 @@
  * @package WordCamp Post Type
  */
 
+use function WordCamp\Trusted_Deputy_Capabilities\is_deputy as is_deputy;
+
 /**
  * Class Event_Admin
  *
@@ -65,6 +67,7 @@ abstract class Event_Admin {
 
 		add_action( 'send_decline_notification_action',  'Event_Admin::send_decline_notification', 10, 3 );
 
+		add_action( 'wp_insert_post_empty_content', array( $this, 'maybe_prevent_creation_of_new_post' ), 999, 2 );
 	}
 
 	/**
@@ -692,6 +695,59 @@ abstract class Event_Admin {
 			}
 		}
 
+	}
+
+	/**
+	 * Prevent users from creating new WordCamp and Meetup posts on dashboard. In most of the cases, all posts should be created
+	 * thru the public application forms in order to get all needed information and to initiate the vetting process correctly.
+	 *
+	 * Expectatio is made for users with administartor and deputy roles, as they need to create events manually from time to time,
+	 *
+	 * Used wp_insert_post_empty_content hook is run fo creation and updates, which is why post ID needs to be checked. The hook
+	 * short circuits creation of new post when truthy value is retuned.
+	 *
+	 * @param  boolean $maybe_empty Whether the post should be considered "empty".
+	 * @param  array   $postarr      Array of post data.
+	 *
+	 * @return boolean              Whether the post should be considered "empty".
+	 */
+	public function maybe_prevent_creation_of_new_post( $maybe_empty, $postarr ) {
+		$post_type = $postarr['post_type'];
+
+		// Apply only for WordCamp and Meetup post types.
+		if ( $this->get_event_type() !== $post_type ) {
+			return $maybe_empty;
+		}
+
+		// The action hooked into is used also when updating posts, which all users should be able to do based on their caps.
+		if ( ! empty( $postarr['ID'] ) ) {
+			return $maybe_empty;
+		}
+
+		// Doing the checks only on dashboard ensures that other use cases like application forms do still work.
+		if ( ! is_admin() ) {
+			return $maybe_empty;
+		}
+
+		// Allow admins to create new posts in event CPT's.
+		if ( in_array('administrator',  wp_get_current_user()->roles) ) {
+			return $maybe_empty;
+		}
+
+		// Allow deputies to create new posts in event CPT's.
+		if ( is_deputy( get_current_user_id() ) ) {
+			return $maybe_empty;
+		}
+
+		$error = new WP_Error(
+			'not_allowed_to_create_new_wcpt',
+			esc_html( wp_sprintf( 'Only administrators and deputies can create new %s\'s. You should probably be using the public application forms on central.wordcamp.org.', $post_type ) )
+		);
+
+		// Display the error.
+		wp_die( $error );
+
+		return $error;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -701,10 +701,10 @@ abstract class Event_Admin {
 	 * Prevent users from creating new WordCamp and Meetup posts on dashboard. In most of the cases, all posts should be created
 	 * thru the public application forms in order to get all needed information and to initiate the vetting process correctly.
 	 *
-	 * Expectatio is made for users with administartor and deputy roles, as they need to create events manually from time to time,
+	 * Expectation is made for users with administrator and deputy roles, as they need to create events manually from time to time.
 	 *
 	 * Used wp_insert_post_empty_content hook is run fo creation and updates, which is why post ID needs to be checked. The hook
-	 * short circuits creation of new post when truthy value is retuned.
+	 * short circuits creation of new post when truthy value is returned.
 	 *
 	 * @param  boolean $maybe_empty Whether the post should be considered "empty".
 	 * @param  array   $postarr      Array of post data.
@@ -745,7 +745,7 @@ abstract class Event_Admin {
 		);
 
 		// Display the error.
-		wp_die( $error );
+		wp_die( $error ); // phpcs:ignore -- User input escaped in function.
 
 		return $error;
 	}

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -707,7 +707,7 @@ abstract class Event_Admin {
 	 * @param  boolean $maybe_empty Whether the post should be considered "empty".
 	 * @param  array   $postarr     Array of post data.
 	 *
-	 * @return mixed                Booleab whether the post should be considered "empty" or WP_Error in case user is not allowed to create post.
+	 * @return mixed                Boolean whether the post should be considered "empty" or WP_Error in case user is not allowed to create post.
 	 */
 	public function maybe_prevent_creation_of_new_post( $maybe_empty, $postarr ) {
 		$post_type = $postarr['post_type'];

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -5,8 +5,6 @@
  * @package WordCamp Post Type
  */
 
-use function WordCamp\Trusted_Deputy_Capabilities\is_deputy as is_deputy;
-
 /**
  * Class Event_Admin
  *
@@ -67,7 +65,7 @@ abstract class Event_Admin {
 
 		add_action( 'send_decline_notification_action',  'Event_Admin::send_decline_notification', 10, 3 );
 
-		add_action( 'wp_insert_post_empty_content', array( $this, 'maybe_prevent_creation_of_new_post' ), 999, 2 );
+		add_filter( 'wp_insert_post_empty_content', array( $this, 'maybe_prevent_creation_of_new_post' ), 999, 2 );
 	}
 
 	/**
@@ -707,9 +705,9 @@ abstract class Event_Admin {
 	 * short circuits creation of new post when truthy value is returned.
 	 *
 	 * @param  boolean $maybe_empty Whether the post should be considered "empty".
-	 * @param  array   $postarr      Array of post data.
+	 * @param  array   $postarr     Array of post data.
 	 *
-	 * @return boolean              Whether the post should be considered "empty".
+	 * @return mixed                Booleab whether the post should be considered "empty" or WP_Error in case user is not allowed to create post.
 	 */
 	public function maybe_prevent_creation_of_new_post( $maybe_empty, $postarr ) {
 		$post_type = $postarr['post_type'];
@@ -729,13 +727,8 @@ abstract class Event_Admin {
 			return $maybe_empty;
 		}
 
-		// Allow admins to create new posts in event CPT's.
-		if ( in_array('administrator',  wp_get_current_user()->roles) ) {
-			return $maybe_empty;
-		}
-
-		// Allow deputies to create new posts in event CPT's.
-		if ( is_deputy( get_current_user_id() ) ) {
+		// Allow WordCamp Wranglers (deputies, admins) to create new posts in event CPT's.
+		if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
 			return $maybe_empty;
 		}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -697,7 +697,7 @@ abstract class Event_Admin {
 
 	/**
 	 * Prevent users from creating new WordCamp and Meetup posts on dashboard. In most of the cases, all posts should be created
-	 * thru the public application forms in order to get all needed information and to initiate the vetting process correctly.
+	 * through the public application forms in order to get all needed information and to initiate the vetting process correctly.
 	 *
 	 * Expectation is made for users with administrator and deputy roles, as they need to create events manually from time to time.
 	 *


### PR DESCRIPTION
Prevent users from creating new WordCamp and Meetup posts on dashboard. In most of the cases, all posts should be created thru the public application forms in order to get all needed information and to initiate the vetting process correctly.

Expectation is made for users with administrator and deputy roles, as they need to create events manually from time to time.

Used wp_insert_post_empty_content hook is run fo creation and updates, which is why post ID needs to be checked. The hook short circuits creation of new post when truthy value is returned.

Fixes #728, See #734 

Props @NewYorkerLaura

### Screenshots

<img width="802" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/1881b5a9-71a6-4447-aecc-ca7a16e6361a">

Message shown when user without admin or deputy role tries to create new event.

### How to test the changes in this Pull Request:

1. Log in as user with contributor role
2. Send a WordCamp application via public form https://central.wordcamp.test/wordcamp-organizer-application/
3. Log out and log in as user with admin or deputy role
4. Navigate to https://central.wordcamp.test/wp-admin/edit.php?post_type=wordcamp and you should see the application just sent
5. Navigate to https://central.wordcamp.test/wp-admin/post-new.php?post_type=wordcamp and you should be able to create a new WordCamp
6. Add the user with contributor role to the site
7. Log out and log in as user with contributor role
8. Navigate to central dashboard and try to update the WordCamp you send application for
9. On the central dashboard try to create new WordCamp or Meetup, you should see the error
10. On the central dashboard try to create new post, that should be possible
