### PR TITLE
Adapt `wordcamp` post type for NextGen events

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -12,6 +12,9 @@ defined( 'WPINC' ) || die();
 /**
  * Retrieve `wordcamp` posts and their metadata.
  *
+ * This assumes is it's being called on WORDCAMP_ROOT_BLOG_ID, so the caller will need to switch_to_blog()
+ * if needed.
+ *
  * @param array $args Optional. Extra arguments to pass to `get_posts()`.
  *
  * @return array
@@ -38,7 +41,7 @@ function get_wordcamps( $args = array() ) {
 }
 
 /**
- * Retrieves the `wordcamp` post and postmeta associated with the current site.
+ * Retrieves the `wordcamp` post and post meta associated with the current site.
  *
  * @return false|WP_Post
  */
@@ -48,7 +51,7 @@ function get_wordcamp_post( $site_id = null ) {
 	}
 
 	// Switch to central.wordcamp.org to get posts.
-	switch_to_blog( BLOG_ID_CURRENT_SITE );
+	switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
 
 	$wordcamp = get_posts( array(
 		'post_type'   => 'wordcamp',
@@ -78,7 +81,7 @@ function get_wordcamp_post( $site_id = null ) {
  */
 function get_wordcamp_site_id( $wordcamp_post ) {
 	// Switch to central.wordcamp.org to get post meta.
-	switch_to_blog( BLOG_ID_CURRENT_SITE );
+	switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
 
 	$site_id = get_post_meta( $wordcamp_post->ID, '_site_id', true );
 	if ( ! $site_id ) {
@@ -251,7 +254,7 @@ function wcorg_get_wordcamp_duration( WP_Post $wordcamp ) {
 function get_wordcamp_dropdown( $name = 'wordcamp_id', $query_options = array(), $selected = 0 ) {
 	global $wpdb;
 
-	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org
+	switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
 
 	if ( empty( $query_options ) ) {
 		$wordcamps = $wpdb->get_results( "

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-new-site.php
@@ -76,6 +76,13 @@ class Test_WordCamp_New_Site extends WP_UnitTestCase {
 				2342,
 				true,
 			),
+
+			'events.wordpress.org url are also valid' => array(
+				'events.wordpress.test',
+				'/rome/2023/training/',
+				2342,
+				true,
+			),
 		);
 	}
 }

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -47,10 +47,10 @@ class WordCamp_New_Site {
 			/>
 
 			<?php if ( current_user_can( 'manage_sites' ) ) : ?>
-				<?php $url = trailingslashit( get_post_meta( $post_id, $key, true ) ); ?>
-				<?php $url = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) ); ?>
-				<?php $valid_url = isset( $url['host'], $url['path'] ); ?>
 				<?php
+				$url        = trailingslashit( get_post_meta( $post_id, $key, true ) );
+				$url        = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) );
+				$valid_url  = isset( $url['host'], $url['path'] );
 				$tld        = get_top_level_domain();
 				$network_id = "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
 				?>
@@ -227,7 +227,7 @@ class WordCamp_New_Site {
 			return;
 		}
 
-		$url_components = parse_url( $url );
+		$url_components = wp_parse_url( $url );
 		if ( ! $url_components || empty( $url_components['scheme'] ) || empty( $url_components['host'] ) ) {
 			Logger\log( 'return_invalid_url', compact( 'wordcamp_id', 'url', 'url_components' ) );
 			return;

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -4,24 +4,7 @@ namespace WordCamp\Sunrise\Events;
 use WP_Network, WP_Site;
 
 defined( 'WPINC' ) || die();
-
-/*
- * Matches URLs of regular sites, but not the root site.
- *
- * For example, `events.wordpress.org/vancouver/2023/diversity-day/`.
- *
- */
-const PATTERN_EVENT_SITE = '
-	@ ^
-	/
-	( [\w-]+ )    # Capture the city.
-	/
-	( \d{4} )     # Capture the year.
-	/
-	( [\w-]+ )    # Capture the event type.
-	/?
-	@ix
-';
+use const WordCamp\Sunrise\PATTERN_CITY_YEAR_TYPE_PATH;
 
 set_network_and_site();
 
@@ -44,7 +27,7 @@ function set_network_and_site() {
 	$site_id      = $current_site->id;
 	$path         = stripslashes( $_SERVER['REQUEST_URI'] );
 
-	if ( 1 === preg_match( PATTERN_EVENT_SITE, $path ) ) {
+	if ( 1 === preg_match( PATTERN_CITY_YEAR_TYPE_PATH, $path ) ) {
 		if ( is_admin() ) {
 			$path = preg_replace( '#(.*)/wp-admin/.*#', '$1/', $path );
 		}

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -7,56 +7,6 @@ defined( 'WPINC' ) || die();
 
 
 /*
- * Matches `2020-foo.narnia.wordcamp.org/`, with or without additional `REQUEST_URI` params.
- */
-const PATTERN_YEAR_DOT_CITY_DOMAIN_PATH = '
-	@ ^
-	( \d{4} [\w-]* )           # Capture the year, plus any optional extra identifier.
-	\.
-	( [\w-]+ )                 # Capture the city.
-	\.
-	( wordcamp | buddycamp )   # Capture the second-level domain.
-	\.
-	( org | test )             # Capture the top level domain.
-	/
-	@ix
-';
-
-/*
- * Matches `narnia.wordcamp.org/2020-foo/`, with or without additional `REQUEST_URI` params.
- */
-const PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH = '
-	@ ^
-	( [\w-]+ )                 # Capture the city.
-	\.
-	( wordcamp | buddycamp )   # Capture the second-level domain.
-	\.
-	( org | test )             # Capture the top-level domain.
-	( / \d{4} [\w-]* / )       # Capture the site path (the year, plus any optional extra identifier).
-	@ix
-';
-
-/*
- * Matches a request URI like `/2020/2019/save-the-date-for-wordcamp-vancouver-2020/`.
- */
-const PATTERN_CITY_SLASH_YEAR_REQUEST_URI_WITH_DUPLICATE_DATE = '
-	@ ^
-	( / \d{4} [\w-]* / )   # Capture the site path (the year, plus any optional extra identifier).
-
-	(                      # Capture the `/%year%/%monthnum%/%day%/` permastruct tags.
-		[0-9]{4} /         # The year is required.
-
-		(?:                # The month and day are optional.
-			[0-9]{2} /
-		){0,2}
-	)
-
-	(.+)                   # Capture the slug.
-	$ @ix
-';
-
-
-/*
  * Allow legacy CLI scripts in local dev environments to override the server hostname.
  *
  * This makes it possible to run bin scripts in local environments that use different domain names (e.g., wordcamp.dev)

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -3,8 +3,70 @@
 namespace WordCamp\Sunrise;
 defined( 'WPINC' ) || die();
 
-load_network_sunrise();
 
+/*
+ * Matches `2020-foo.narnia.wordcamp.org/`, with or without additional `REQUEST_URI` params.
+ */
+const PATTERN_YEAR_DOT_CITY_DOMAIN_PATH = '
+	@ ^
+	( \d{4} [\w-]* )           # Capture the year, plus any optional extra identifier.
+	\.
+	( [\w-]+ )                 # Capture the city.
+	\.
+	( wordcamp | buddycamp )   # Capture the second-level domain.
+	\.
+	( org | test )             # Capture the top level domain.
+	/
+	@ix
+';
+
+/*
+ * Matches `narnia.wordcamp.org/2020-foo/`, with or without additional `REQUEST_URI` params.
+ */
+const PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH = '
+	@ ^
+	( [\w-]+ )                 # Capture the city.
+	\.
+	( wordcamp | buddycamp )   # Capture the second-level domain.
+	\.
+	( org | test )             # Capture the top-level domain.
+	( / \d{4} [\w-]* / )       # Capture the site path (the year, plus any optional extra identifier).
+	@ix
+';
+
+/*
+ * Matches a request URI like `/2020/2019/save-the-date-for-wordcamp-vancouver-2020/`.
+ */
+const PATTERN_CITY_SLASH_YEAR_REQUEST_URI_WITH_DUPLICATE_DATE = '
+	@ ^
+	( / \d{4} [\w-]* / )   # Capture the site path (the year, plus any optional extra identifier).
+
+	(                      # Capture the `/%year%/%monthnum%/%day%/` permastruct tags.
+		[0-9]{4} /         # The year is required.
+
+		(?:                # The month and day are optional.
+			[0-9]{2} /
+		){0,2}
+	)
+
+	(.+)                   # Capture the slug.
+	$ @ix
+';
+
+/*
+ * Matches a URL path like '/vancouver/2023/diversity-day/`.
+ */
+const PATTERN_CITY_YEAR_TYPE_PATH = '
+	@ ^
+	/
+	( [\w-]+ )    # Capture the city.
+	/
+	( \d{4} )     # Capture the year.
+	/
+	( [\w-]+ )    # Capture the event type.
+	/?
+	@ix
+';
 
 /**
  * Load the sunrise file for the current network.
@@ -30,3 +92,6 @@ function load_network_sunrise() {
 function get_top_level_domain() {
 	return 'local' === WORDCAMP_ENVIRONMENT ? 'test' : 'org';
 }
+
+
+load_network_sunrise();


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordcamp.org/issues/900
Closes https://github.com/WordPress/wordcamp.org/pull/911
Closes #943 

After more discussions with stakeholders, it seems like the underlying differences between the processes for managing WordCamps and NextGen events are smaller than initially thought. Adapting the existing `wordcamp` post type to work with both types of event seems like the quicker and more logical approach now.

- [x] Accept new format for URLs
- [x] Provision new NextGen sites on that network
- [x] Update things like `get_wordcamp_post()` to always pull from Central
- [ ] Identify the things that shouldn't be identical on the Events network, and add checklist items for them