### PR TITLE
Plugins: Return early instead of deactivating programmatically

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -99,42 +99,6 @@ function wcorg_shortcode_menu( $attributes ) {
 add_shortcode( 'menu', 'wcorg_shortcode_menu' );
 
 /**
- * Disable certain network-activate plugins on specific sites.
- *
- * @param array $plugins
- *
- * @return array
- */
-function wcorg_disable_network_activated_plugins_on_sites( $plugins ) {
-	/*
-	 * central.wordcamp.org, plan.wordcamp.org
-	 *
-	 * These are plugins for individual WordCamp sites, so they aren't relevant for Central and Plan.
-	 * They clutter the admin menu and slow down page loads.
-	 */
-	if ( in_array( get_current_blog_id(), array( BLOG_ID_CURRENT_SITE, 63 ), true ) ) {
-		unset( $plugins['camptix-extras/camptix-extras.php'] );
-		unset( $plugins['camptix-network-tools/camptix-network-tools.php'] );
-		unset( $plugins['tagregator/bootstrap.php'] );
-		unset( $plugins['wordcamp-organizer-nags/wordcamp-organizer-nags.php'] );
-		unset( $plugins['wc-post-types/wc-post-types.php'] );
-	}
-
-	/*
-	 * plan.wordcamp.org
-	 */
-	if ( 63 === get_current_blog_id() ) {
-		unset( $plugins['camptix/camptix.php'] );
-		unset( $plugins['wordcamp-payments/bootstrap.php'] );
-		unset( $plugins['wordcamp-payments-network/bootstrap.php'] );
-	}
-
-	return $plugins;
-}
-add_filter( 'site_option_active_sitewide_plugins', 'wcorg_disable_network_activated_plugins_on_sites' );
-
-
-/**
  * Remove menu items on certain sites.
  *
  * This works together with `wcorg_disable_network_activated_plugins_on_sites()`. There are some plugins that we

--- a/public_html/wp-content/mu-plugins/wcorg-network-plugin-control.php
+++ b/public_html/wp-content/mu-plugins/wcorg-network-plugin-control.php
@@ -11,6 +11,11 @@
 namespace WordCamp\Plugins\Network;
 defined( 'WPINC' ) || die();
 
+add_filter( 'network_admin_plugin_action_links', __NAMESPACE__ . '\network_plugin_actions', 10, 2 );
+add_action( 'network_admin_notices', __NAMESPACE__ . '\network_plugin_notifier' );
+add_action( 'admin_notices', __NAMESPACE__ . '\network_plugin_notifier' );
+
+
 /**
  * The two arrays here depict the intended network activation state of each
  * plugin on WordCamp.org. When plugins are added, removed, or their state is
@@ -111,8 +116,6 @@ function network_plugin_actions( $actions, $plugin_file ) {
 	return $actions;
 }
 
-add_filter( 'network_admin_plugin_action_links', __NAMESPACE__ . '\network_plugin_actions', 10, 2 );
-
 /**
  * Display a network admin notice if there are plugins that don't have their intended
  * activation state.
@@ -127,7 +130,6 @@ function network_plugin_notifier() {
 
 	$all_plugins             = array_keys( get_plugins() );
 	$missing_plugins         = array_diff( array_merge( $state_activated, $state_deactivated ), $all_plugins );
-
 	$active_plugins          = array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) );
 	$wrong_state_deactivated = array_diff( $state_activated, $active_plugins, $missing_plugins );
 	$wrong_state_activated   = array_intersect( $state_deactivated, $active_plugins );
@@ -159,5 +161,3 @@ function network_plugin_notifier() {
 		<?php
 	}
 }
-
-add_action( 'network_admin_notices', __NAMESPACE__ . '\network_plugin_notifier' );

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -4,6 +4,17 @@
  * Plugin Description: Custom post types for Sessions, Speakers, Sponsors, Organizers, Volunteers.
  */
 
+// Bitwise mask for the sessions CPT, to add endpoints to the session pages. This should be a unique power of 2
+// greater than the core-defined ep_masks, but could potentially conflict with another plugin.
+// See https://developer.wordpress.org/reference/functions/add_rewrite_endpoint/.
+define( 'EP_SESSIONS', 16384 );
+
+// This should be network-activated, but isn't used on the root sites. On those it just clutters the admin menu
+// and slows down page loads. The constant above is needed for Speaker Feedback though.
+if ( get_current_blog_id() === BLOG_ID_CURRENT_SITE ) {
+	return;
+}
+
 require_once 'inc/utilities.php';
 require_once 'inc/back-compat.php';
 require_once 'inc/favorite-schedule-shortcode.php';
@@ -13,11 +24,6 @@ require_once 'inc/deprecated.php';
 use function WordCamp\Post_Types\Utilities\get_avatar_or_image;
 use function WordCamp\Theme_Templates\site_supports_block_templates;
 use function WordCamp\Blocks\has_block_with_attrs;
-
-// Bitwise mask for the sessions CPT, to add endpoints to the session pages. This should be a unique power of 2
-// greater than the core-defined ep_masks, but could potentially conflict with another plugin.
-// See https://developer.wordpress.org/reference/functions/add_rewrite_endpoint/.
-define( 'EP_SESSIONS', 16384 );
 
 class WordCamp_Post_Types_Plugin {
 	protected $wcpt_permalinks;

--- a/public_html/wp-content/plugins/wordcamp-dashboard-widgets/wordcamp-dashboard-widgets.php
+++ b/public_html/wp-content/plugins/wordcamp-dashboard-widgets/wordcamp-dashboard-widgets.php
@@ -1,11 +1,15 @@
 <?php
 
-/*
+/**
  * Plugin Name: WordCamp Dashboard Widgets
  * Description: Communicate non-urgent messages from Central to organizers through Dashboard widgets.
- * Version:     0.1
- * Author:      Ian Dunn
  */
+
+// This should be network-activated, but isn't used on the root sites. On those it just clutters the dashboard
+// and slows down page loads.
+if ( get_current_blog_id() === BLOG_ID_CURRENT_SITE ) {
+	return;
+}
 
 class WordCamp_Dashboard_Widgets {
 	protected $need_central_about_info;


### PR DESCRIPTION
See #905 
See #906  

The removed code needed to be updated to be compatible with the new network, but it turned out do better to just remove it and achieve the original goal in a simpler way.

It also avoids bugs where a plugin would be deactivated unintentionally, because it wasn't in the list of activated plugins when another plugin was deactivated. The goal disabling these plugins on root sites is still accomplished through early returns.

The "nags" plugin was renamed to Dashboard Widgets. CampTix Network Tools is ok to load on the root sites. It isn't worth it to modify Tagregator because it's published in the w.org plugin repo, so it's require extra logic.