### PR TITLE
Allow switch to wcpt-rejected status from wcpt-needs-vetting

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -303,7 +303,7 @@ class WordCamp_Loader extends Event_Loader {
 	 */
 	public static function get_valid_status_transitions( $status ) {
 		$transitions = array(
-			'wcpt-needs-vetting'   => array( 'wcpt-needs-orientati', 'wcpt-more-info-reque' ),
+			'wcpt-needs-vetting'   => array( 'wcpt-needs-orientati', 'wcpt-more-info-reque', 'wcpt-rejected' ),
 			'wcpt-needs-orientati' => array( 'wcpt-needs-vetting', 'wcpt-interview-sched' ),
 			'wcpt-more-info-reque' => array(),  // Allowed from any status, see below
 			'wcpt-interview-sched' => array( 'wcpt-needs-orientati', 'wcpt-approved-pre-pl' ),


### PR DESCRIPTION
As per the request, a WordCamp application status can be set directly to "Declined" after "Needs vetting" status. This simplifies the process for deputies.

Fixes #865 

Props @devinmaeztri 

### Screenshots

Before screenshot on the issue. After below.

<img width="387" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/7f45ea20-c673-4633-93db-adc8c4e772b8">

### How to test the changes in this Pull Request:

1. Navigate to WordCamp tracker and select WordCamp that needs vetting
2. Open the status selection
