### PR TITLE
Add Tracker URL field to WordCamp details report

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-base-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-base-details.php
@@ -171,10 +171,11 @@ abstract class Base_Details extends Base {
 		$meta_keys   = $this->get_meta_keys();
 
 		$row = [
-			'ID'      => $event->ID,
-			'Name'    => $event->post_title,
-			'Created' => get_the_date( 'Y-m-d', $event->ID ),
-			'Status'  => $event->post_status,
+			'ID'          => $event->ID,
+			'Tracker URL' => get_edit_post_link( $event->ID ),
+			'Name'        => $event->post_title,
+			'Created'     => get_the_date( 'Y-m-d', $event->ID ),
+			'Status'      => $event->post_status,
 		];
 
 		foreach ( $meta_keys as $key ) {

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-details.php
@@ -130,6 +130,7 @@ class WordCamp_Details extends Base_Details {
 				'Speakers',
 				'Sponsors',
 				'Organizers',
+				'Tracker URL',
 			),
 			array_diff( $this->get_meta_keys(), array_keys( $this->get_public_data_fields() ) )
 		);
@@ -171,6 +172,7 @@ class WordCamp_Details extends Base_Details {
 			array(
 				'ID',
 				'Name',
+				'Tracker URL',
 			),
 			array_keys( WordCamp_Admin::meta_keys( 'wordcamp' ) ),
 			array(
@@ -395,6 +397,7 @@ class WordCamp_Details extends Base_Details {
 			'End Date (YYYY-mm-dd)'   => 'checked',
 			'Location'                => 'checked',
 			'URL'                     => 'checked',
+			'Tracker URL'             => 'checked',
 		);
 
 		include get_views_dir_path() . 'report/wordcamp-details.php';


### PR DESCRIPTION
This is an attempt to add new "Tracker URL" field to WordCamp details report. Couldn't test, since csv export utility is in `mu-plugins-private` for some reason.

```
Warning: require_once(/usr/src/public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/utilities/class-export-csv.php): failed to open stream: No such file or directory in /usr/src/public_html/wp-content/mu-plugins/2-autoloader.php on line 27
```

Either that utility needs to be moved to a public repository, or this PR can act as a base for someone who has access to private plugins. I guess the latter one will be easier and faster.

Fixes #823 

Props @peiraisotta

### How to test the changes in this Pull Request:

1. Navigate to [WordCamp Details](https://central.wordcamp.test/wp-admin/index.php?page=wordcamp-reports&report=wordcamp-details) report
2. Do csv export, the field is selected by default
