### PR TITLE
Hide network admin tools on Events network

### DIFF
--- a/public_html/wp-content/plugins/camptix-network-tools/network-dashboard.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/network-dashboard.php
@@ -7,7 +7,11 @@ class CampTix_Network_Dashboard {
 	function __construct() {
 		self::$attendee_search_limit = apply_filters( 'camptix_nt_attendee_list_blog_limit', 700 ); // PHP times out around 900 sites.
 
-		add_action( 'network_admin_menu', array( $this, 'admin_menu' ) );
+		// The WordCamp network is the canonical place for network admin tools, but the rest of this file still
+		// needs to run to collect data.
+		if ( get_current_network_id() === WORDCAMP_NETWORK_ID ) {
+			add_action( 'network_admin_menu', array( $this, 'admin_menu' ) );
+		}
 		add_action( 'init', array( $this, 'init' ) );
 
 		$this->schedule_events();
@@ -134,8 +138,10 @@ class CampTix_Network_Dashboard {
 			switch_to_blog( $bid );
 
 			$post = $meta = false;
-			if ( in_array( 'camptix/camptix.php', (array) apply_filters( 'active_plugins', get_option( 'active_plugins', array() ) ) ) ) {
 
+			// Fetching database plugins because `switch_to_blog()` doesn't (de-)activate plugins.
+			// @todo: check if network-activated too, otherwise missing sites.
+			if ( in_array( 'camptix/camptix.php', (array) apply_filters( 'active_plugins', get_option( 'active_plugins', array() ) ) ) ) {
 				$options = get_option( 'camptix_options' );
 
 				$post = array(

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -10,6 +10,15 @@ use WordCamp\Budgets_Dashboard\Reimbursement_Requests as Reimbursements_Dashboar
 use DateTimeInterface;
 use WP_CLI;
 
+/*
+ * This _plugin_ needs to be network-activated on the NextGen network so that things like
+ * `WordCamp\Budgets_Dashboard\Sponsor_Invoices\update_index_row` run. This _file_ shouldn't be loaded, though,
+ * because invoices/payments/etc are manages centrally in the WordCamp network admin.
+ */
+if ( get_current_network_id() !== WORDCAMP_NETWORK_ID ) {
+	return;
+}
+
 defined( 'WPINC' ) or die();
 
 define( 'REDACTED_VALUE',               '[deleted for privacy]'    );


### PR DESCRIPTION
See #886

It seems like the WordCamp network will still be the canonical place to manage all sites, consistent with #952 