### PR TITLE
Move password reset hooks to more logical place

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-login-message.php
+++ b/public_html/wp-content/mu-plugins/wcorg-login-message.php
@@ -125,3 +125,18 @@ function wcorg_get_wporg_login_url( $locale, $path = 'root' ) {
 
 	return $url;
 }
+
+// Prevent password resets, since they need to be done on w.org.
+add_filter( 'allow_password_reset', '__return_false' );
+add_filter( 'show_password_fields', '__return_false' );
+
+/**
+ * Redirect users to WordPress.org to reset their passwords.
+ *
+ * Otherwise, there's nothing to indicate where they can reset it.
+ */
+function wcorg_reset_passwords_at_wporg() {
+	wp_redirect( 'https://login.wordpress.org/lostpassword/' );
+	die();
+}
+add_action( 'login_form_lostpassword', 'wcorg_reset_passwords_at_wporg' );

--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -370,21 +370,6 @@ function wcorg_disable_admin_pointers() {
 }
 add_action( 'admin_init', 'wcorg_disable_admin_pointers' );
 
-// Prevent password resets, since they need to be done on w.org.
-add_filter( 'allow_password_reset', '__return_false' );
-add_filter( 'show_password_fields', '__return_false' );
-
-/**
- * Redirect users to WordPress.org to reset their passwords.
- *
- * Otherwise, there's nothing to indicate where they can reset it.
- */
-function wcorg_reset_passwords_at_wporg() {
-	wp_redirect( 'https://login.wordpress.org/lostpassword/' );
-	die();
-}
-add_action( 'login_form_lostpassword', 'wcorg_reset_passwords_at_wporg' );
-
 /**
  * Register scripts and styles.
  */


### PR DESCRIPTION
While looking at `mu-plugins/wcorg-misc.php`, I noticed a few hooks that alter the password reset functionality to guide users into using wordpress.org reset logic. Since there's also `mu-plugins/wcorg-login-message.php` which does the most part of changing login messages to indicate use their wordpress.org credentials, moving the reset changes to that file seemed appropriate.
