### PR TITLE
Run WordCamp Participation Notifier when post is published

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -29,7 +29,7 @@ class WordCamp_Participation_Notifier {
 		require_once WP_CONTENT_DIR . '/mu-plugins-private/wporg-mu-plugins/pub/profile-helpers.php';
 
 		// Sync with the wp.org username changes.
-		add_filter( 'update_post_meta', array( $this, 'username_meta_update' ), 10, 4 );
+		add_filter( 'update_post_meta',     array( $this, 'username_meta_update' ), 10, 4 );
 		add_filter( 'delete_post_meta',     array( $this, 'username_meta_delete' ), 10, 3 );
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_notify_on_post_save' ) );
 

--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -31,7 +31,7 @@ class WordCamp_Participation_Notifier {
 		// Sync with the wp.org username changes.
 		add_filter( 'update_post_meta',     array( $this, 'username_meta_update' ), 10, 4 );
 		add_filter( 'delete_post_meta',     array( $this, 'username_meta_delete' ), 10, 3 );
-		add_action( 'wp_after_insert_post', array( $this, 'maybe_notify_on_post_save' ) );
+		add_action( 'wp_after_insert_post', array( $this, 'maybe_notify_on_post_save' ), 10, 2 );
 
 		add_action( 'camptix_rl_buyer_completed_registration', array( $this, 'primary_attendee_registered' ), 10, 2 );
 		add_action( 'camptix_rl_registration_confirmed',       array( $this, 'additional_attendee_confirmed_registration' ), 10, 2 );
@@ -132,10 +132,8 @@ class WordCamp_Participation_Notifier {
 
 	/**
 	 * Add the organizer or speaker badge when notifiable post types are saved and User ID meta exists.
-	 *
-	 * @param  WP_Post $post The post object.
 	 */
-	public function maybe_notify_on_post_save( $post ) {
+	public function maybe_notify_on_post_save( int $post_id, WP_Post $post ): void {
 		if ( wp_is_post_revision( $post ) ) {
 			return;
 		}


### PR DESCRIPTION
WordCamp Participation Notifier sends profile activity log messages and hands out the badges for organisers and speakers, in the future possibly for volunteers and attendees as well.

The notifier relied on `add_post_meta` and `update_post_meta` hooks to detect when the notifications for profiles.wordpress.org should be sent. This has proven to cause problems, as many WordCamps do fill out the WordPress.org username for the post when they draft it. That has caused the filters to run, but bail because the post isn't public yet. In the end, people haven't received their badges or organisers have had to empty the username field, save and fill in the username again to send notifications.

This PR tries to fix that by hooking into `wp_after_insert_post` action that is run after the post itself and related meta have been saved. If all conditions are met (not revision, published, notifiable post type) then notifications are sent. 

The `username_meta_update` function was left because it is used to notify about a mentor assigned to a WordCamp, which has a bit different logic.

Someone with sandbox needs to test this and see that activity log and badges do in fact get assigned.

Fixes #809

Props @vertizio, @CdrMarks 

### How to test the changes in this Pull Request:

1. Navigate to WordCamp site
2. Create new organiser post, fill in the WordPress.org username field and save as a draft
3. Check that activity log didn't get message and badge was not assigned
4. Publish the organiser post
5. Check that activity log did get message and badge was assigned
