### PR TITLE
Fix missing logo on visa letters

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs-pdf-generator.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs-pdf-generator.php
@@ -72,7 +72,7 @@ class WordCamp_Docs_PDF_Generator {
 		$file = $this->get_tmp_folder( $filename );
 
 		$command = sprintf(
-			'wkhtmltopdf -d %d -T %s -R %s -B %s -L %s %s %s',
+			'wkhtmltopdf --enable-local-file-access -d %d -T %s -R %s -B %s -L %s %s %s',
 			$dpi,
 			escapeshellarg( $margins[0] ),
 			escapeshellarg( $margins[1] ),

--- a/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs-pdf-generator.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs-pdf-generator.php
@@ -72,6 +72,7 @@ class WordCamp_Docs_PDF_Generator {
 		$file = $this->get_tmp_folder( $filename );
 
 		$command = sprintf(
+			// Allowing local file access is safe because the inputs to `$source_file` should have been escaped.
 			'wkhtmltopdf --enable-local-file-access -d %d -T %s -R %s -B %s -L %s %s %s',
 			$dpi,
 			escapeshellarg( $margins[0] ),


### PR DESCRIPTION
Generated attendee and speaker visa letters didn't have the WPCS logo on them as intended. Fixed this by allowing wkhtmltopdf to access local files.

From [wkhtmltopdf docs](https://wkhtmltopdf.org/usage/wkhtmltopdf.txt)

```
      --enable-local-file-access      Allowed conversion of a local file to read
                                      in other local files.
```

Fixes #786

Props kdrewien, kcristiano, @yoga1103

### Screenshots

<img width="944" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/c609ccc6-95fd-4fc3-b840-51e25bf2a067">

### How to test the changes in this Pull Request:

 1. Go to Docs
 2. Select one of the Visa letter options
 3. Generate the PDF
 4. View the PDF, there should be WPCS logo
