### PR TITLE
Budget Tool: Add Organizers to event data

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -260,6 +260,7 @@ class WordCamp_Budget_Tool {
 			array( 'type' => 'meta', 'name' => 'tracks', 'value' => 0 ),
 			array( 'type' => 'meta', 'name' => 'speakers', 'value' => 0 ),
 			array( 'type' => 'meta', 'name' => 'volunteers', 'value' => 0 ),
+			array( 'type' => 'meta', 'name' => 'organizers', 'value' => 0 ),
 			array( 'type' => 'meta', 'name' => 'currency', 'value' => 'USD' ),
 			array( 'type' => 'meta', 'name' => 'ticket-price', 'value' => 0 ),
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -209,6 +209,7 @@ class WordCamp_Budget_Tool {
 		// The metadata is an array of arrays, so we can filter out the relevant item, pluck just the value, then retrieve it.
 		$count_speakers   = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'speakers' ) ), 'value' ) );
 		$count_volunteers = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'volunteers' ) ), 'value' ) );
+		$count_organizers = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'organizers' ) ), 'value' ) );
 		$count_attendees  = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'attendees' ) ), 'value' ) );
 		$count_days       = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'days' ) ), 'value' ) );
 		$count_tracks     = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'tracks' ) ), 'value' ) );
@@ -219,6 +220,8 @@ class WordCamp_Budget_Tool {
 				return $value * $count_speakers;
 			case 'per-volunteer':
 				return $value * $count_volunteers;
+			case 'per-organizer':
+				return $value * $count_organizers;
 			case 'per-speaker-volunteer':
 				return $value * $count_speakers + $value * $count_volunteers;
 			case 'per-attendee':

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -224,6 +224,8 @@ class WordCamp_Budget_Tool {
 				return $value * $count_organizers;
 			case 'per-speaker-volunteer':
 				return $value * $count_speakers + $value * $count_volunteers;
+			case 'per-speaker-volunteer-organizer':
+				return $value * $count_speakers + $value * $count_volunteers + $value * $count_organizers;
 			case 'per-attendee':
 				return $value * $count_attendees;
 			case 'per-day':

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -269,7 +269,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 				var value = this.$el.find( '.value' ).val(),
 					name  = this.model.get( 'name' );
 
-				if ( _.contains( [ 'attendees', 'days', 'tracks', 'speakers', 'volunteers' ], name ) ) {
+				if ( _.contains( [ 'attendees', 'days', 'tracks', 'speakers', 'volunteers', 'organizers' ], name ) ) {
 					value = parseInt( value.replace( /[^\d.-]/g, '' ) ) || 0;
 				} else if ( _.contains( [ 'ticket-price' ], name ) ) {
 					value = parseFloat( value.replace( /[^\d.-]/g, '' ) ) || 0;
@@ -396,6 +396,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 		'tracks'       : 'Tracks',
 		'speakers'     : 'Speakers',
 		'volunteers'   : 'Volunteers',
+		'organizers'   : 'Organizers',
 		'currency'     : 'Currency',
 		'ticket-price' : 'Ticket Price',
 	};

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -424,6 +424,17 @@ window.wcb = window.wcb || { models: {}, input: [] };
 			},
 		},
 
+		'per-organizer' : {
+			'label'    : 'per organizer',
+			'hasValue' : true,
+			'callback' : function( value ) {
+				return parseFloat( value ) * parseInt( wcb.table.collection.findWhere( {
+					type : 'meta',
+					name : 'organizers',
+				} ).get( 'value' ) );
+			},
+		},
+
 		'per-speaker-volunteer' : {
 			'label'    : 'per speakers + volunteers',
 			'hasValue' : true,

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -452,6 +452,27 @@ window.wcb = window.wcb || { models: {}, input: [] };
 			},
 		},
 
+		'per-speaker-volunteer-organizer' : {
+			'label'    : 'per speakers + volunteers + organizers',
+			'hasValue' : true,
+			'callback' : function( value ) {
+				return parseFloat( value ) * (
+					parseInt( wcb.table.collection.findWhere( {
+						type : 'meta',
+						name : 'volunteers',
+					} ).get( 'value' ) )
+					+ parseInt( wcb.table.collection.findWhere( {
+						type : 'meta',
+						name : 'speakers',
+					} ).get( 'value' ) )
+					+ parseInt( wcb.table.collection.findWhere( {
+						type : 'meta',
+						name : 'organizers',
+					} ).get( 'value' ) )
+				);
+			},
+		},
+
 		'per-attendee' : {
 			'label'    : 'per attendee',
 			'hasValue' : true,

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -391,7 +391,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 	} );
 
 	wcb.metaLabels = {
-		'attendees'    : 'Attendees',
+		'attendees'    : 'Total attendees',
 		'days'         : 'Days',
 		'tracks'       : 'Tracks',
 		'speakers'     : 'Speakers',

--- a/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
@@ -171,6 +171,10 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
         </tr>
         <tr>
             <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
             <td class="amount">
                 <# if (data.variance_raw < 0) { #>
                 <a href="#" target="_blank" class="inspire"><?php esc_html_e( 'inspire me', 'wordcamporg' ); ?></a>


### PR DESCRIPTION
To make the budget tool clearer on how and easier to count organizers to the cost, the Community Team asked to add new field and formulas.

- Rename the field Attendees to Total Attendees
- Add a field between Volunteers and Currency called Organizers
- Add formulas for: "per organizer" and "per speakers + volunteers + organizers"

Fixes #784 

### Screenshots

<img width="1739" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/bfe672a4-341a-4085-a9ec-231284a958f9">


### How to test the changes in this Pull Request:

1. Navigate to budget tool
2. Fill in total attendees, volunteers, speakers and organisers
3. Add few expense rows with "per organiser" and "per volunteer + speaker + organiser" formulas
4. Check that calculations are correct
