### PR TITLE
Fix errors on Events network

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/privacy.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/privacy.php
@@ -42,7 +42,7 @@ function render_cookie_banner() {
 	global $wp_widget_factory;
 
 	/** @var Jetpack_EU_Cookie_Law_Widget $cookie_law_widget */
-	$cookie_law_widget = $wp_widget_factory->widgets['Jetpack_EU_Cookie_Law_Widget'];
+	$cookie_law_widget = $wp_widget_factory->widgets['Jetpack_EU_Cookie_Law_Widget'] ?? false;
 
 	if ( ! is_callable( array( $cookie_law_widget, 'enqueue_frontend_scripts' ) ) ) {
 		Logger\log( 'cookie_law_widget_missing' );

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -52,7 +52,7 @@ class WordCamp_New_Site {
 				$url        = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) );
 				$valid_url  = isset( $url['host'], $url['path'] );
 				$tld        = get_top_level_domain();
-				$network_id = "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
+				$network_id = $valid_url && "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
 				?>
 
 				<?php if ( $valid_url && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -10,6 +10,12 @@ use WordCamp\Budgets_Dashboard\Reimbursement_Requests as Reimbursements_Dashboar
 use DateTimeInterface;
 use WP_CLI;
 
+defined( 'WPINC' ) || die();
+
+define( 'REDACTED_VALUE',               '[deleted for privacy]'    );
+define( 'REDACT_PAID_REQUESTS_CRON_ID', 'wcb_redact_paid_requests' );
+
+
 /*
  * This _plugin_ needs to be network-activated on the NextGen network so that things like
  * `WordCamp\Budgets_Dashboard\Sponsor_Invoices\update_index_row` run. This _file_ shouldn't be loaded, though,
@@ -19,10 +25,6 @@ if ( get_current_network_id() !== WORDCAMP_NETWORK_ID ) {
 	return;
 }
 
-defined( 'WPINC' ) or die();
-
-define( 'REDACTED_VALUE',               '[deleted for privacy]'    );
-define( 'REDACT_PAID_REQUESTS_CRON_ID', 'wcb_redact_paid_requests' );
 
 /*
  * Core functionality and helper functions shared between modules

--- a/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
+++ b/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
@@ -217,6 +217,10 @@ function get_wordcamp_sites() {
 
 	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org.
 
+	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-event/class-event-loader.php';
+	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-wordcamp/wordcamp-loader.php';
+
+	// Cancelled camps are often restarted in future years, especially after COVID.
 	$cloneable_post_statuses = array_merge(
 		WordCamp_Loader::get_public_post_statuses(),
 		array( 'wcpt-cancelled' )


### PR DESCRIPTION
* Payments: Define constants before returning early to avoid fatal
* Site Cloner: Load required file to avoid fatal on Events network.
* WCPT: Check if URL valid to avoid notice
* Jetpack Tweaks: Fallback to `false` to avoid PHP notice