### PR TITLE
Do not send organiser reminders with "send X days after the camp ends" trigger if WordCamp didn't happen

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -168,6 +168,13 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			update_post_meta( self::$wordcamp_dayton_post_id, '_timestamp_added_to_planning_schedule', $compare_date );
 		}
 
+		if ( 'wcor_send_after' === $send_when ) {
+			wp_update_post( array(
+				'ID'          => self::$wordcamp_dayton_post_id,
+				'post_status' => 'wcpt-scheduled',
+			) );
+		}
+
 		$wordcamp = get_post( self::$wordcamp_dayton_post_id );
 
 		$this->assertSame( '', $wordcamp->wcor_sent_email_ids );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -548,9 +548,9 @@ class WCOR_Mailer {
 			}
 
 			foreach ( $reminder_emails as $email ) {
-				$recipient = $this->get_recipients( $wordcamp->ID, $email->ID );
-
 				if ( $this->timed_email_is_ready_to_send( $wordcamp, $email, $sent_email_ids ) ) {
+					$recipient = $this->get_recipients( $wordcamp->ID, $email->ID );
+
 					if ( $this->mail( $recipient, $email->post_title, $email->post_content, array(), $email, $wordcamp ) ) {
 						$sent_email_ids[] = $email->ID;
 						update_post_meta( $wordcamp->ID, 'wcor_sent_email_ids', $sent_email_ids );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -591,7 +591,7 @@ class WCOR_Mailer {
 			return $ready;
 		}
 
-		if ( ! in_array( $email->ID, $sent_email_ids ) ) {
+		if ( in_array( $email->ID, $sent_email_ids ) ) {
 			return $ready;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -639,16 +639,16 @@ class WCOR_Mailer {
 				if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
 					$ready = true;
 				}
-			} elseif ( 'wcor_send_after_and_no_report' == $send_when ) {
-				$days_after_and_no_report = absint( get_post_meta( $email->ID, 'wcor_send_days_after_and_no_report', true ) );
-				$report_received          = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
+			}
+		} elseif ( 'wcor_send_after_and_no_report' == $send_when ) {
+			$days_after_and_no_report = absint( get_post_meta( $email->ID, 'wcor_send_days_after_and_no_report', true ) );
+			$report_received          = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
 
-				if ( $end_date && $days_after_and_no_report && ! $report_received ) {
-					$execution_timestamp = $end_date + ( $days_after_and_no_report * DAY_IN_SECONDS );
+			if ( $end_date && $days_after_and_no_report && ! $report_received ) {
+				$execution_timestamp = $end_date + ( $days_after_and_no_report * DAY_IN_SECONDS );
 
-					if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
-						$ready = true;
-					}
+				if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
+					$ready = true;
 				}
 			}
 		}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -552,16 +552,6 @@ class WCOR_Mailer {
 					continue;
 				}
 
-				$send_when = get_post_meta( $email->ID, 'wcor_send_when', true );
-
-				/**
-				 * Do not send emails with "send X days after the camp ends" trigger if WordCamp didn't happen.
-				 * All WordCamps that happen, should have public status.
-				 */
-				if ( 'wcor_send_after' === $send_when && ! in_array( $post->post_status, WordCamp_Loader::get_public_post_statuses() ) ) {
-					continue;
-				}
-
 				$recipient = $this->get_recipients( $wordcamp->ID, $email->ID );
 
 				if ( ! $this->mail( $recipient, $email->post_title, $email->post_content, array(), $email, $wordcamp ) ) {
@@ -621,13 +611,19 @@ class WCOR_Mailer {
 					}
 				}
 			} elseif ( 'wcor_send_after' == $send_when ) {
-				$days_after = absint( get_post_meta( $email->ID, 'wcor_send_days_after', true ) );
+				/**
+				 * Do not send emails with "send X days after the camp ends" trigger if WordCamp didn't happen.
+				 * All WordCamps that happen, should have public status.
+				 */
+				if ( in_array( $wordcamp->post_status, WordCamp_Loader::get_public_post_statuses() ) ) {
+					$days_after = absint( get_post_meta( $email->ID, 'wcor_send_days_after', true ) );
 
-				if ( $end_date && $days_after ) {
-					$send_date = $end_date + ( $days_after * DAY_IN_SECONDS );
+					if ( $end_date && $days_after ) {
+						$send_date = $end_date + ( $days_after * DAY_IN_SECONDS );
 
-					if ( $send_date <= current_time( 'timestamp' ) ) {
-						$ready = true;
+						if ( $send_date <= current_time( 'timestamp' ) ) {
+							$ready = true;
+						}
 					}
 				}
 			} elseif ( 'wcor_send_after_pending' == $send_when ) {


### PR DESCRIPTION
We sent organisers reminders with "send X days after the camp ends" trigger even if the WordCamp didn't happen. Especially during the pandemic, many WordCamps were put back to pre-planning but had dates in the tracker. This can also happen from time to time for various reasons.

The `wcor_send_after` emails were sent out due to the `$pending_wordcamps` query grabbing those emails, and in `timed_email_is_ready_to_send` function only checking the end date even the function is called from `send_timed_emails` for various different WordCamp statuses.

This PR adds a check against the status of WordCamp in `timed_email_is_ready_to_send` function for `wcor_send_after` trigger. Only public WordCamp statuses (in schedule, closed) do get the email.

Also, some minor code refactoring was done to make conditions easier to read and tests were updated for this scenario.

Fixes #496 

Props @coreymckrill

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. Schedule some WordCamps with pre-planning statuses and past date(s)
2. Run `wcor_send_timed_emails` cron job
