### PR TITLE
Do not require address for invoice and prevent sending email without attachment

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/admin/js/camptix-invoices.js
+++ b/public_html/wp-content/plugins/camptix-invoices/admin/js/camptix-invoices.js
@@ -3,7 +3,7 @@
 jQuery( document ).ready( function( $ ) {
 	function toggleInvoiceDetailsForm( showForm ) {
 		const $camptixInvoiceDetailsForm = $( '.camptix-invoice-details' );
-		const $camptixInvoiceDetailsFormFields = $camptixInvoiceDetailsForm.find( 'input,textarea,select' );
+		const $camptixInvoiceDetailsFormFields = $camptixInvoiceDetailsForm.find( 'input,textarea' );
 
 		if ( showForm ) {
 			$camptixInvoiceDetailsForm.show();

--- a/public_html/wp-content/plugins/camptix-invoices/admin/js/camptix-invoices.js
+++ b/public_html/wp-content/plugins/camptix-invoices/admin/js/camptix-invoices.js
@@ -3,7 +3,7 @@
 jQuery( document ).ready( function( $ ) {
 	function toggleInvoiceDetailsForm( showForm ) {
 		const $camptixInvoiceDetailsForm = $( '.camptix-invoice-details' );
-		const $camptixInvoiceDetailsFormFields = $camptixInvoiceDetailsForm.find( 'input,textarea' );
+		const $camptixInvoiceDetailsFormFields = $camptixInvoiceDetailsForm.find( 'input,select' );
 
 		if ( showForm ) {
 			$camptixInvoiceDetailsForm.show();

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -334,6 +334,7 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		if ( empty( $invoice_metas['email'] ) && is_email( $invoice_metas['email'] ) ) {
 			return false;
 		}//end if
+
 		$invoice_pdf = ctx_get_invoice( $invoice_id );
 		$attachments = array( $invoice_pdf );
 		$opt         = get_option( 'camptix_options' );
@@ -348,6 +349,7 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 				'Content-type: text/html; charset=UTF-8',
 			)
 		);
+
 		$message = array(
 			__( 'Hello,', 'wordcamporg' ),
 			// translators: event name.
@@ -359,6 +361,7 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 			// translators: event name.
 			sprintf( __( 'The %s team', 'wordcamporg' ), sanitize_text_field( $opt['event_name'] ) ),
 		);
+
 		$message = implode( PHP_EOL, $message );
 		$message = '<p>' . nl2br( $message ) . '</p>';
 		wp_mail( $invoice_metas['email'], $subject, $message, $headers, $attachments );

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -426,10 +426,6 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 			return true;
 		}
 
-		if ( empty( $invoice_metas['address'] ) ) {
-			return true;
-		}
-
 		if ( empty( $invoice_order['items'] ) ) {
 			return true;
 		}
@@ -535,7 +531,6 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 
 		if ( empty( $_POST['invoice-email'] )
 			|| empty( $_POST['invoice-name'] )
-			|| empty( $_POST['invoice-address'] )
 			|| ! is_email( wp_unslash( $_POST['invoice-email'] ) ) ) {
 
 			$camptix->error_flag( 'nope' );

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -336,6 +336,10 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		}//end if
 
 		$invoice_pdf = ctx_get_invoice( $invoice_id );
+		if ( empty( $invoice_pdf ) ) {
+			return false;
+		}
+
 		$attachments = array( $invoice_pdf );
 		$opt         = get_option( 'camptix_options' );
 

--- a/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-form.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-form.php
@@ -41,7 +41,7 @@ defined( 'WPINC' ) || die();
 			<tr>
 				<td class="tix-left">
 					<label for="invoice-address">
-						<?php echo esc_html__( 'Recipient street address', 'wordcamporg' ); ?><span class="tix-required-star">*</span>
+						<?php echo esc_html__( 'Recipient street address', 'wordcamporg' ); ?>
 					</label>
 				</td>
 				<td class="tix-right">


### PR DESCRIPTION
It was reported that an invoice email was sent without the invoice attached if the address field was left empty by bypassing the required attribute with a space character.

In this PR, we prevent the email if there's no attachment and make the address field optional.

Fixes #255 

<!-- List out anyone who helped with this task. -->
Props dd32

### Screenshots

<img width="563" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/e516fd09-e49f-4323-b2f9-6ad2e3e47bd7">

### How to test the changes in this Pull Request:

1. Activate Camptix Invoices plugin and enable it on Camptix settings
2. Go to tickets page, buy a ticket with invoice
3. Address field shouldn't be required
4. Invoice should be in email
5. Go buy another ticket with invoice, but before that modify `ctx_get_invoice` to bail early with false value
6. No invoice email received
