### PR TITLE
Prevent singular views for WordCamps that do not have public status

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-loader.php
@@ -17,7 +17,7 @@ abstract class Event_Loader {
 		add_action( 'plugins_loaded', array( $this, 'includes' ) );
 		add_action( 'init', array( $this, 'register_post_types' ) );
 		add_action( 'init', array( $this, 'register_post_statuses' ) );
-		add_filter( 'pre_get_posts', array( $this, 'query_public_statuses_on_archives' ) );
+		add_filter( 'pre_get_posts', array( $this, 'query_public_statuses' ) );
 		add_filter( 'cron_schedules', array( $this, 'add_weekly_cron_interval' ) );
 	}
 
@@ -80,12 +80,13 @@ abstract class Event_Loader {
 	 *
 	 * @param WP_Query $query
 	 */
-	public function query_public_statuses_on_archives( $query ) {
-		if ( ! $query->is_post_type_archive( WCPT_POST_TYPE_ID ) ) {
+	public function query_public_statuses( $query ) {
+		if ( is_admin() ) {
 			return;
 		}
 
-		if ( is_admin() ) {
+		// Bail if post type is something other than WordCamp.
+		if ( ! $query->is_post_type_archive( WCPT_POST_TYPE_ID ) && ! ( isset( $query->query_vars['post_type'] ) && WCPT_POST_TYPE_ID === $query->query_vars['post_type'] ) ) {
 			return;
 		}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-loader.php
@@ -85,7 +85,12 @@ abstract class Event_Loader {
 			return;
 		}
 
+		if ( ! $query->is_main_query() ) {
+			return;
+		}
+
 		// Bail if post type is something other than WordCamp.
+		// is_singular check breaks the frontpage so let's do it this way.
 		if ( ! $query->is_post_type_archive( WCPT_POST_TYPE_ID ) && ! ( isset( $query->query_vars['post_type'] ) && WCPT_POST_TYPE_ID === $query->query_vars['post_type'] ) ) {
 			return;
 		}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -146,7 +146,7 @@ class WordCamp_Loader extends Event_Loader {
 	 * Save the date that the camp was moved on to the official schedule
 	 *
 	 * It's stored in the `menu_order` field because the purpose of storing it is so we can sort the archives
-	 * by this timestamp. See WordCamp_Loader::query_public_statuses_on_archives().
+	 * by this timestamp. See WordCamp_Loader::query_public_statuses().
 	 *
 	 * Sorting by meta fields would be significantly slower, and the `menu_order` field is a good candidate for
 	 * re-purposing because it makes semantic sense and isn't being used.


### PR DESCRIPTION
WordCamps without public status are visible with direct URLs on Central. PR prevents that leakage.

Fixes #602

### How to test the changes in this Pull Request:

1. Change the status of WordCamp in tracker to be something else than public, for example, cancelled.
2. Try to view the WordCamp on Central
3. You should be redirected to frontpage
