### PR TITLE
Network Plugins: Disable Tagregator on Events network

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-network-plugin-control.php
+++ b/public_html/wp-content/mu-plugins/wcorg-network-plugin-control.php
@@ -45,7 +45,6 @@ function _get_network_plugin_state_list( $state ) {
 			'gutenberg/gutenberg.php',
 			'jetpack/jetpack.php',
 			'jquery-ui-css/jquery-ui-css.php',
-			'tagregator/bootstrap.php',
 			'wordcamp-payments/bootstrap.php',
 			'wordcamp-payments-network/bootstrap.php',
 			'wordcamp-coming-soon-page/bootstrap.php',
@@ -84,6 +83,14 @@ function _get_network_plugin_state_list( $state ) {
 			'wp-cldr/wp-cldr.php',
 		),
 	);
+
+	$network_id = get_current_network_id();
+
+	if ( WORDCAMP_NETWORK_ID === $network_id ) {
+		$network_plugin_state['activated'][] = 'tagregator/bootstrap.php';
+	} elseif ( EVENTS_NETWORK_ID === $network_id ) {
+		$network_plugin_state['deactivated'][] = 'tagregator/bootstrap.php';
+	}
 
 	return $network_plugin_state[ $state ];
 }


### PR DESCRIPTION
See #905
See #847

It's being retired because it's no longer used as much, hasn't been kept up to date, and social media APIs are more hostile than they used to be.
