### PR TITLE
Remove subrole restriction to show cross link menu item

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-subroles.php
+++ b/public_html/wp-content/mu-plugins/wcorg-subroles.php
@@ -55,31 +55,27 @@ function add_subrole_caps( $allcaps, $caps, $args, $user ) {
 			 *
 			 * - Access and use the WordCamp Mentors Dashboard screen on Central.
 			 * - Edit `wordcamp` posts on Central.
+			 * - Use "WordCamp Post" link in Admin Bar on all sites (sse `add_wcpt_cross_link()`)
 			 */
 			case 'mentor_manager':
-				// These capabilities only apply on central.wordcamp.org.
-				if ( BLOG_ID_CURRENT_SITE === get_current_blog_id() ) {
-					$newcaps = array(
-						'read'                       => true, // Access to wp-admin.
-						'wordcamp_manage_mentors'    => true,
-						'wordcamp_wrangle_wordcamps' => true,
-					);
-				}
+				$newcaps = array(
+					'read'                       => true, // Access to wp-admin.
+					'wordcamp_manage_mentors'    => true,
+					'wordcamp_wrangle_wordcamps' => true,
+				);
 				break;
 
 			/**
 			 * WordCamp Wrangler
 			 *
 			 * - Edit `wordcamp` posts on Central.
+			 * - Use "WordCamp Post" link in Admin Bar on all sites (sse `add_wcpt_cross_link()`)
 			 */
 			case 'wordcamp_wrangler':
-				// These capabilities only apply on central.wordcamp.org.
-				if ( BLOG_ID_CURRENT_SITE === get_current_blog_id() ) {
-					$newcaps = array(
-						'read'                       => true, // Access to wp-admin.
-						'wordcamp_wrangle_wordcamps' => true,
-					);
-				}
+				$newcaps = array(
+					'read'                       => true, // Access to wp-admin.
+					'wordcamp_wrangle_wordcamps' => true,
+				);
 				break;
 
 			/**
@@ -89,7 +85,7 @@ function add_subrole_caps( $allcaps, $caps, $args, $user ) {
 			 */
 			case 'report_viewer':
 				// These capabilities only apply on central.wordcamp.org.
-				if ( BLOG_ID_CURRENT_SITE === get_current_blog_id() ) {
+				if ( WORDCAMP_ROOT_BLOG_ID === get_current_blog_id() ) {
 					$newcaps = array(
 						'read'                  => true, // Access to wp-admin.
 						'view_wordcamp_reports' => true,

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,7 @@ The platform also includes tools for program volunteers and administrators to ma
 
 ## Setup
 
-There are two primary ways to setup this repo for local development.
-
-1. [Using VVV for installing as WordCamp.org as a part of WordPress.org meta network.](https://github.com/WordPress/meta-environment/blob/master/docs/install.md)
-
-1. [Using Docker for a standalone WordCamp.org installation.](.docker/readme.md)
+Follow the instructions for [setting up a Docker environment](.docker/readme.md).
 
 
 ## Support


### PR DESCRIPTION
Fixes #961 

The capability is needed on all sites for `add_wcpt_cross_link()` to work. 

Note: Being a deputy is required in order to pass the `is_user_member_of_blog()` check in `wp_admin_bar_site_menu()`.