### PR TITLE
Post Types: Move back-compat registration later to avoid Gutenberg fatal

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
@@ -10,7 +10,16 @@ class WordCamp_Post_Types_Plugin_Back_Compat {
 	protected $template   = '';
 
 	function __construct() {
+		// This must run before `WordCamp_Post_Types_Plugin::init()` so that `wcpt_back_compat_init` is registered
+		// before it's needed. This can't run before `init` because `gutenberg_get_theme_preview_path()` calls
+		// `wp_get_current_user()`, which isn't registered earlier.
+		add_action( 'init', array( $this, 'init' ), 5 );
+	}
 
+	/**
+	 * Substitute the old shortcodes on older sites.
+	 */
+	public function init() {
 		// Array of themes that should work with this class.
 		$compat_themes = array(
 			'wordcamp-base',


### PR DESCRIPTION
There's a fatal error on `wp-admin/site-editor.php?wp_theme_preview=twentytwentythree&return=themes.php` because `WordCamp_Post_Types_Plugin_Back_Compat::__construct()` calls `wp_get_theme()->get_stylesheet();` That used to work, but now `gutenberg_get_theme_preview_path()` hooks in and calls `wp_get_current_user()`, which isn't registered at this point.

Moving the registration later avoids the issue.