### PR TITLE
WCPT: Search for domain on correct network when updating site ID

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -143,7 +143,8 @@ class WordCamp_New_Site {
 		update_post_meta( $wordcamp_id, $key, esc_url( $url ) );
 
 		// If this site exists make sure we update the _site_id mapping.
-		$existing_site_id = domain_exists( $parsed_url['host'], $parsed_url['path'], 1 );
+		$network_id       = 'events.wordpress.test' === $parsed_url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
+		$existing_site_id = domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
 
 		if ( $existing_site_id ) {
 			update_post_meta( $wordcamp_id, '_site_id', absint( $existing_site_id ) );


### PR DESCRIPTION
Previously the `_site_id` meta field wasn't being updated for NextGen events when the URL changed.
