### PR TITLE
Add `wporg-mu-plugins/.../utilities` to docker environment

### DIFF
--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -26,6 +26,10 @@
 			"url": "https://wpackagist.org/"
 		},
 		{
+			"type": "vcs",
+			"url": "https://github.com/WordPress/wporg-mu-plugins.git"
+		},
+		{
 			"type": "package",
 			"package": [
 				{
@@ -119,6 +123,7 @@
 		"wpackagist-plugin/wp-cldr": "*",
 		"wpackagist-plugin/wp-super-cache": "*",
 		"wordpress-meta/wporg-profiles-wp-activity-notifier": "1.1",
+		"wporg/wporg-mu-plugins": "dev-build",
 		"wpackagist-theme/p2": "*",
 		"wpackagist-theme/twentyten": "*",
 		"wpackagist-theme/twentyeleven": "*",
@@ -133,5 +138,12 @@
 		"wpackagist-theme/twentytwentyone": "*",
 		"wpackagist-theme/twentytwentytwo": "*",
 		"wpackagist-theme/twentytwentythree": "*"
+	},
+	"scripts": {
+    "post-update-cmd": [
+    	"mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+    	"mv wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/utilities public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+    	"rm -rf wp-content/mu-plugins/wporg-mu-plugins"
+    ]
 	}
 }

--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -17,6 +17,7 @@
 	"extra": {
 		"installer-paths": {
 			"public_html/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+			"public_html/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
 			"public_html/wp-content/themes/{$name}/": ["type:wordpress-theme"]
 		}
 	},
@@ -142,8 +143,8 @@
 	"scripts": {
     "post-update-cmd": [
     	"mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-    	"mv wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/utilities public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-    	"rm -rf wp-content/mu-plugins/wporg-mu-plugins"
+    	"mv public_html/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/utilities public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+    	"rm -rf public_html/wp-content/mu-plugins/wporg-mu-plugins"
     ]
 	}
 }

--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -141,10 +141,10 @@
 		"wpackagist-theme/twentytwentythree": "*"
 	},
 	"scripts": {
-    "post-update-cmd": [
-    	"mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-    	"mv public_html/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/utilities public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-    	"rm -rf public_html/wp-content/mu-plugins/wporg-mu-plugins"
-    ]
+		"post-update-cmd": [
+			"mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+			"mv public_html/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/utilities public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+			"rm -rf public_html/wp-content/mu-plugins/wporg-mu-plugins"
+		]
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -936,16 +936,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "9.2.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
                 "shasum": ""
             },
             "require": {
@@ -1001,7 +1001,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
             },
             "funding": [
                 {
@@ -1009,7 +1010,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-07-26T13:44:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",


### PR DESCRIPTION
Utilities were moved from the repo into `wporg-mu-plugins` repository, which broke for example CSV exports and meetup.com API calls. 

This PR adds that repository and uses Composer `post-update-cmd` [scripts](https://getcomposer.org/doc/articles/scripts.md) to move the utilities from `wporg-mu-plugins` into the path where `2-autoloader.php` expects it to be.

We cannot use `git@github.com` format as the repository URL, since that fails on Docker. We would need to add github.com into `~/.ssh/known_hosts` so it's just easier to use HTTPS instead of SSH. See https://github.com/docker-library/golang/issues/148 for more details.

I'm a bit puzzled about why the repository ends up in root `wp-content` (outside `public_html`) instead of `vendor`, but that seems to be the case, and we clean up a bit later so didn't bother to care too much 🤷‍♂️

In `post-update-cmd` let's first create the needed parent directories. The `-p` flag on the [`mkdir`](https://linux.die.net/man/1/mkdir) command does that. Then move only `utilities` directory, since we don't need anything else from the repo. Lastly do some cleanup and remove the `wp-content` directory where the repository was installed.

Fixes #769

Props @iandunn 

### How to test the changes in this Pull Request:

1. Open Docker command shell
2. `cd ../` because shell opens in `public_html` instead of our root directory
3. `rm -r composer.lock` for good measure
4. `php composer.phar install`
5. Check the logs in case of errors
6. Verify that the utilities directory is where it should be, `ls public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync`
7. Open [central.wordcamp.test](central.wordcamp.test) and navigate to [reports](https://central.wordcamp.test/wp-admin/index.php?page=wordcamp-reports)
8. Run an CSV export on some report, for example the [WordCamp Details](https://central.wordcamp.test/wp-admin/index.php?page=wordcamp-reports&report=wordcamp-details)
9. Check that CSV file is generated (should auto download) and looks good