### PR TITLE
Allow bypassing max ticket limit when using coupon code

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5205,7 +5205,12 @@ class CampTix_Plugin {
 				$coupon->tix_discount_price = (float) get_post_meta( $coupon->ID, 'tix_discount_price', true );
 				$coupon->tix_discount_percent = (int) get_post_meta( $coupon->ID, 'tix_discount_percent', true );
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
+				$coupon->tix_bypass_max_tickets_per_order = true;
 				$this->coupon = $coupon;
+
+				if ( $coupon->tix_bypass_max_tickets_per_order ) {
+					$max_tickets_per_order = $max_tickets_per_order * 3;
+				}
 			} else {
 				$this->error_flags['invalid_coupon'] = true;
 			}
@@ -5578,7 +5583,12 @@ class CampTix_Plugin {
 
 							// Recount selects, change price.
 							if ( $ticket->tix_coupon_applied ) {
+								if ( $this->coupon->tix_bypass_max_tickets_per_order ) {
+									$max_tickets_per_order = $max_tickets_per_order * 3;
+								}
+
 								$max = min( $this->coupon->tix_coupon_remaining, $ticket->tix_remaining, $max_tickets_per_order );
+
 								if ( $selected > $this->coupon->tix_coupon_remaining )
 									$selected = $this->coupon->tix_coupon_remaining;
 
@@ -5645,6 +5655,11 @@ class CampTix_Plugin {
 											esc_html( $this->coupon->post_title ),
 											esc_html( $discount_text )
 										);
+
+										if ( $this->coupon->tix_bypass_max_tickets_per_order ) {
+											echo '. ';
+											_e( 'Max quantity changed.', 'wordcamporg' );
+										}
 										?>
 									<?php else : ?>
 										<a href="#" id="tix-coupon-link" class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_coupon_link_classes', array() ) ) ); ?>">
@@ -7332,6 +7347,11 @@ class CampTix_Plugin {
 				$coupon->tix_discount_price = (float) get_post_meta( $coupon->ID, 'tix_discount_price', true );
 				$coupon->tix_discount_percent = (int) get_post_meta( $coupon->ID, 'tix_discount_percent', true );
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
+				$coupon->tix_bypass_max_tickets_per_order = true;
+
+				if ( $coupon->tix_bypass_max_tickets_per_order ) {
+					$max_tickets_per_order = $max_tickets_per_order * 3;
+				}
 			} else {
 				$order['coupon'] = null;
 				$coupon = null;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4592,6 +4592,10 @@ class CampTix_Plugin {
 		$quantity = intval( get_post_meta( $post->ID, 'tix_coupon_quantity', true ) );
 		$used = intval( $this->get_used_coupons_count( $post->ID ) );
 		$applies_to = (array) get_post_meta( $post->ID, 'tix_applies_to' );
+		$bypass_max_tickets_per_order = (boolean) get_post_meta( $post->ID, 'tix_bypass_max_tickets_per_order', true );
+
+		$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order', 10 );
+		$max_tickets_per_order_after_bypass = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
 		?>
 		<div class="misc-pub-section">
 			<span class="left"><?php _e( 'Discount:', 'wordcamporg' ); ?></span>
@@ -4632,6 +4636,14 @@ class CampTix_Plugin {
 				<?php endwhile; ?>
 				<input type="hidden" name="tix_applies_to_submit" value="1" />
 			</div>
+		</div>
+		<div class="misc-pub-section">
+			<span class="left"><?php _e( 'Bulk buy:', 'wordcamporg' ) ?></span>
+			<?php $this->field_yesno( array(
+				'name'        => 'tix_bypass_max_tickets_per_order',
+				'value'       => $bypass_max_tickets_per_order,
+				'description' => wp_sprintf( __( 'Allow buying maximum of %s tickets instead of %s when this coupon is applied.', 'wordcamporg' ), $max_tickets_per_order_after_bypass, $max_tickets_per_order ),
+			) ); ?>
 		</div>
 		<div class="clear"></div>
 		<?php
@@ -5123,6 +5135,10 @@ class CampTix_Plugin {
 						add_post_meta( $post_id, 'tix_applies_to', $ticket_id );
 		}
 
+		if ( isset( $_POST['tix_bypass_max_tickets_per_order'] ) ) {
+			update_post_meta( $post_id, 'tix_bypass_max_tickets_per_order', intval( $_POST['tix_bypass_max_tickets_per_order'] ) );
+		}
+
 		if ( isset( $_POST['tix_coupon_start'] ) ) {
 			$_POST['tix_coupon_start'] = preg_match( '/^\d{4}\-\d{2}\-\d{2}$/', $_POST['tix_coupon_start'] ) ? $_POST['tix_coupon_start'] : '';
 			update_post_meta( $post_id, 'tix_coupon_start', $_POST['tix_coupon_start'] );
@@ -5205,7 +5221,7 @@ class CampTix_Plugin {
 				$coupon->tix_discount_price = (float) get_post_meta( $coupon->ID, 'tix_discount_price', true );
 				$coupon->tix_discount_percent = (int) get_post_meta( $coupon->ID, 'tix_discount_percent', true );
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
-				$coupon->tix_bypass_max_tickets_per_order = true;
+				$coupon->tix_bypass_max_tickets_per_order = (int) get_post_meta( $coupon->ID, 'tix_bypass_max_tickets_per_order', true );
 				$this->coupon = $coupon;
 
 				if ( $coupon->tix_bypass_max_tickets_per_order ) {
@@ -7347,7 +7363,7 @@ class CampTix_Plugin {
 				$coupon->tix_discount_price = (float) get_post_meta( $coupon->ID, 'tix_discount_price', true );
 				$coupon->tix_discount_percent = (int) get_post_meta( $coupon->ID, 'tix_discount_percent', true );
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
-				$coupon->tix_bypass_max_tickets_per_order = true;
+				$coupon->tix_bypass_max_tickets_per_order = (int) get_post_meta( $coupon->ID, 'tix_bypass_max_tickets_per_order', true );
 
 				if ( $coupon->tix_bypass_max_tickets_per_order ) {
 					$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5209,7 +5209,7 @@ class CampTix_Plugin {
 				$this->coupon = $coupon;
 
 				if ( $coupon->tix_bypass_max_tickets_per_order ) {
-					$max_tickets_per_order = $max_tickets_per_order * 3;
+					$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
 				}
 			} else {
 				$this->error_flags['invalid_coupon'] = true;
@@ -5584,7 +5584,7 @@ class CampTix_Plugin {
 							// Recount selects, change price.
 							if ( $ticket->tix_coupon_applied ) {
 								if ( $this->coupon->tix_bypass_max_tickets_per_order ) {
-									$max_tickets_per_order = $max_tickets_per_order * 3;
+									$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
 								}
 
 								$max = min( $this->coupon->tix_coupon_remaining, $ticket->tix_remaining, $max_tickets_per_order );
@@ -7350,7 +7350,7 @@ class CampTix_Plugin {
 				$coupon->tix_bypass_max_tickets_per_order = true;
 
 				if ( $coupon->tix_bypass_max_tickets_per_order ) {
-					$max_tickets_per_order = $max_tickets_per_order * 3;
+					$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order_after_coupon_bypass', $max_tickets_per_order * 3, $max_tickets_per_order );
 				}
 			} else {
 				$order['coupon'] = null;


### PR DESCRIPTION
Sometimes, there is a need for a sponsor or a company to buy more than the maximum allowed tickets per purchase. Currently, the maximum number of tickets per purchase is 10.

These needs typically go hand in hand with coupon codes. So this PR adds a bulk buy yes/no field to coupon options, message about changed max quantity when coupon is applied and an filter to override max quantity also after coupon with bypass has been applied. When bulk buy is active, triple the normal max quantity.

Fixes #740

Props @jaz-on, @coreymckrill

### Screenshots

<img width="295" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/d05fe35b-f70f-40cb-b4b0-36e3ef984dea">

<img width="602" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/60ff06c0-7082-41e0-ab1b-7bf9f9b345a4">

### How to test the changes in this Pull Request:

1. Open WordCamp site dashboard
2. Create ticket
3. Create coupon code, you should see the new setting set value to yes
4. Open tickets page, max quantity should be 10
5. Apply coupon code, max quantity should be 30 and message shown
6. Add following lines to `mu-plugins/sandbox-functionality.php`
```php
add_filter( 'camptix_max_tickets_per_order', function() {
  return 1;
} );
```
7. Open tickets page without coupon, max quantity should be 1
8. Apply coupon, max quantity should be 3
9. Proceed and buy tickets
