### PR TITLE
Allow organisers to refund tickets more freely

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -3983,6 +3983,19 @@ class CampTix_Plugin {
 					</div>
 
 					<div class="misc-pub-section">
+						<?php
+							$access_token = get_post_meta( $post->ID, 'tix_access_token', true );
+							$refund_link = $this->get_refund_tickets_link( $access_token );
+
+							$refunds_available_text = __( 'only for organizers', 'wordcamporg' );
+							if ( $this->options['refunds_enabled'] ) {
+								$refunds_available_text = __( 'for attendee', 'wordcamporg' );
+							}
+						?>
+						<span><a href="<?php echo esc_url( $refund_link ); ?>"><?php _e( 'Refund Request', 'wordcamporg' ); ?></a> (<?php echo $refunds_available_text ?>)</span>
+					</div>
+
+					<div class="misc-pub-section">
 						<div class="tix-pub-section-item">
 							<input id="tix_privacy_<?php esc_attr( $post->ID ); ?>" name="tix_privacy" type="checkbox" <?php checked( get_post_meta( $post->ID, 'tix_privacy', true ), 'private' ); ?> />
 							<label for="tix_privacy_<?php esc_attr( $post->ID ); ?>"><?php _e( 'Hide from public attendees list', 'wordcamporg' ); ?></label>
@@ -4661,6 +4674,12 @@ class CampTix_Plugin {
 
 		$rows[] = array( __( 'Edit Token', 'wordcamporg' ), sprintf( '<a href="%s">%s</a>', $this->get_edit_attendee_link( $post->ID, $edit_token ), $edit_token ) );
 		$rows[] = array( __( 'Access Token', 'wordcamporg' ), sprintf( '<a href="%s">%s</a>', $this->get_access_tickets_link( $access_token ), $access_token ) );
+
+		$refunds_available_text = __( 'only for organizers', 'wordcamporg' );
+		if ( $this->options['refunds_enabled'] ) {
+			$refunds_available_text = __( 'for attendee', 'wordcamporg' );
+		}
+		$rows[] = array( __( 'Refund Request', 'wordcamporg' ), sprintf( '<a href="%s">Link</a> %s', $this->get_refund_tickets_link( $access_token ), $refunds_available_text ) );
 
 		// Transaction
 		$rows[] = array( __( 'Transaction', 'wordcamporg' ), '' );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6469,6 +6469,7 @@ class CampTix_Plugin {
 						wp_update_post( $attendee );
 					}
 
+					// Dumb result in order for checks below to pass, with this we avoid adding new check.
 					$result = CampTix_Plugin::PAYMENT_STATUS_REFUNDED;
 				} else {
 					$payment_method_obj = $this->get_payment_method_by_id( $transaction['payment_method'] );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6409,6 +6409,7 @@ class CampTix_Plugin {
 		$tickets = array();
 
 		foreach ( $attendees as $attendee ) {
+			$attendee_email  ??= get_post_meta( $attendee->ID, 'tix_email', true );
 			$tix_payment_token = get_post_meta( $attendee->ID, 'tix_payment_token', true );
 			$txn_id            = get_post_meta( $attendee->ID, 'tix_transaction_id', true );
 			if ( $txn_id ) {
@@ -6465,7 +6466,13 @@ class CampTix_Plugin {
 				if ( current_user_can( $this->caps['manage_attendees'] ) && empty( $transactions ) ) {
 					$result = $this->payment_result(
 						$tix_payment_token,
-						CampTix_Plugin::PAYMENT_STATUS_REFUNDED
+						CampTix_Plugin::PAYMENT_STATUS_REFUNDED,
+						array(
+							'refund_transaction_id'      => 'no-transaction',
+							'refund_transaction_details' => array(
+								'No payment transaction to refund.',
+							)
+						)
 					);
 				} else {
 					$payment_method_obj = $this->get_payment_method_by_id( $transaction['payment_method'] );
@@ -6517,7 +6524,7 @@ class CampTix_Plugin {
 						</tr>
 						<tr>
 							<td class="tix-left"><?php _e( 'E-mail', 'wordcamporg' ); ?></td>
-							<td class="tix-right"><?php echo esc_html( $transaction['receipt_email'] ?? '' ); ?></td>
+							<td class="tix-right"><?php echo esc_html( $transaction['receipt_email'] ?? $attendee_email ); ?></td>
 						</tr>
 						<tr>
 							<td class="tix-left"><?php _e( 'Original Payment', 'wordcamporg' ); ?></td>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6403,6 +6403,7 @@ class CampTix_Plugin {
 		}
 
 		$transactions = array();
+		$transaction  = false;
 		$is_refundable = false;
 		$order_total = 0;
 		$tickets = array();
@@ -6410,29 +6411,29 @@ class CampTix_Plugin {
 		foreach ( $attendees as $attendee ) {
 			$txn_id = get_post_meta( $attendee->ID, 'tix_transaction_id', true );
 			if ( $txn_id ) {
-				$transactions[ $txn_id ]                   = get_post_meta( $attendee->ID, 'tix_transaction_details', true );
-				$transactions[ $txn_id ]['transaction_id'] = $txn_id;
-				$transactions[ $txn_id ]['payment_amount'] = get_post_meta( $attendee->ID, 'tix_order_total', true );
-				$transactions[ $txn_id ]['receipt_email']  = get_post_meta( $attendee->ID, 'tix_receipt_email', true );
-				$transactions[ $txn_id ]['payment_method'] = get_post_meta( $attendee->ID, 'tix_payment_method', true );
-				$transactions[ $txn_id ]['payment_token']  = get_post_meta( $attendee->ID, 'tix_payment_token', true );
+				$transaction                   = get_post_meta( $attendee->ID, 'tix_transaction_details', true );
+				$transaction['transaction_id'] = $txn_id;
+				$transaction['payment_amount'] = get_post_meta( $attendee->ID, 'tix_order_total', true );
+				$transaction['receipt_email']  = get_post_meta( $attendee->ID, 'tix_receipt_email', true );
+				$transaction['payment_method'] = get_post_meta( $attendee->ID, 'tix_payment_method', true );
+				$transaction['payment_token']  = get_post_meta( $attendee->ID, 'tix_payment_token', true );
+
+				$transactions[ $txn_id ] = $transaction;
 			}
+
 			$ticket_id = get_post_meta( $attendee->ID, 'tix_ticket_id', true );
 
-			if ( isset( $tickets[$ticket_id] ) )
-				$tickets[$ticket_id]++;
-			else
-				$tickets[$ticket_id] = 1;
+			$tickets[ $ticket_id ] ??= 0;
+			$tickets[ $ticket_id ]++;
 		}
 
 		if ( ! current_user_can( $this->caps['manage_attendees'] ) ) {
-			if ( count( $transactions ) != 1 || $transactions[ $txn_id ]['payment_amount'] <= 0 ) {
+			if ( count( $transactions ) != 1 || $transaction['payment_amount'] <= 0 ) {
 				$this->error_flags['cannot_refund'] = true;
 				$this->redirect_with_error_flags();
 				die();
 			}
 
-			$transaction = array_shift( $transactions );
 			if ( ! $transaction['receipt_email'] || ! $transaction['transaction_id'] || ! $transaction['payment_amount'] ) {
 				$this->error_flags['cannot_refund'] = true;
 				$this->redirect_with_error_flags();
@@ -6519,11 +6520,11 @@ class CampTix_Plugin {
 						</tr>
 						<tr>
 							<td class="tix-left"><?php _e( 'E-mail', 'wordcamporg' ); ?></td>
-							<td class="tix-right"><?php echo esc_html( $transaction['receipt_email'] ); ?></td>
+							<td class="tix-right"><?php echo esc_html( $transaction['receipt_email'] ?? '' ); ?></td>
 						</tr>
 						<tr>
 							<td class="tix-left"><?php _e( 'Original Payment', 'wordcamporg' ); ?></td>
-							<td class="tix-right"><?php printf( "%s %s", esc_html( $this->options['currency'] ), esc_html( $transaction['payment_amount'] ) ); ?></td>
+							<td class="tix-right"><?php printf( "%s %s", esc_html( $this->options['currency'] ), esc_html( $transaction['payment_amount'] ?? 0 ) ); ?></td>
 						</tr>
 						<tr>
 							<td class="tix-left"><?php _e( 'Purchased Tickets', 'wordcamporg' ); ?></td>
@@ -6534,12 +6535,20 @@ class CampTix_Plugin {
 							</td>
 						</tr>
 						<tr>
+							<td class="tix-left"><?php _e( 'Attendee', 'wordcamporg' ); ?></td>
+							<td class="tix-right">
+								<?php foreach ( $attendees as $attendee ) : ?>
+									<?php echo esc_html( sprintf( "%s %s (%s)", $attendee->tix_first_name, $attendee->tix_last_name, $this->get_ticket_title( $ticket_id ) ) ); ?><br />
+								<?php endforeach; ?>
+							</td>
+						</tr>
+						<tr>
 							<td class="tix-left"><?php _e( 'Refund Amount', 'wordcamporg' ); ?></td>
-							<td class="tix-right"><?php printf( "%s %s", esc_html( $this->options['currency'] ), esc_html( $transaction['payment_amount'] ) ); ?></td>
+							<td class="tix-right"><?php printf( "%s %s", esc_html( $this->options['currency'] ), esc_html( $transaction['payment_amount'] ?? 0 ) ); ?></td>
 						</tr>
 						<tr>
 							<td class="tix-left"><?php _e( 'Refund Reason', 'wordcamporg' ); ?></td>
-							<td class="tix-right"><textarea name="tix_refund_request_reason"><?php echo esc_textarea( $reason ); ?></textarea></td>
+							<td class="tix-right"><textarea name="tix_refund_request_reason" style="width:100%"><?php echo esc_textarea( $reason ); ?></textarea></td>
 						</tr>
 
 					</tbody>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6542,7 +6542,7 @@ class CampTix_Plugin {
 							<td class="tix-left"><?php _e( 'Attendee', 'wordcamporg' ); ?></td>
 							<td class="tix-right">
 								<?php foreach ( $attendees as $attendee ) : ?>
-									<?php echo esc_html( sprintf( "%s %s (%s)", $attendee->tix_first_name, $attendee->tix_last_name, $this->get_ticket_title( $ticket_id ) ) ); ?><br />
+									<?php echo esc_html( sprintf( "%s %s", $attendee->tix_first_name, $attendee->tix_last_name ) ); ?><br />
 								<?php endforeach; ?>
 							</td>
 						</tr>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -3982,18 +3982,15 @@ class CampTix_Plugin {
 						<span><a href="<?php echo esc_url( $edit_link ); ?>"><?php _e( 'Edit Attendee Info', 'wordcamporg' ); ?></a></span>
 					</div>
 
+					<?php if ( 'publish' === $post->post_status ) : ?>
 					<div class="misc-pub-section">
 						<?php
 							$access_token = get_post_meta( $post->ID, 'tix_access_token', true );
-							$refund_link = $this->get_refund_tickets_link( $access_token );
-
-							$refunds_available_text = __( 'only for organizers', 'wordcamporg' );
-							if ( $this->options['refunds_enabled'] ) {
-								$refunds_available_text = __( 'for attendee', 'wordcamporg' );
-							}
+							$refund_link  = $this->get_refund_tickets_link( $access_token );
 						?>
-						<span><a href="<?php echo esc_url( $refund_link ); ?>"><?php _e( 'Refund Request', 'wordcamporg' ); ?></a> (<?php echo $refunds_available_text ?>)</span>
+						<span><a href="<?php echo esc_url( $refund_link ); ?>"><?php _e( 'Ticket Refund / Cancellation', 'wordcamporg' ); ?></a></span>
 					</div>
+					<?php endif; ?>
 
 					<div class="misc-pub-section">
 						<div class="tix-pub-section-item">
@@ -4674,12 +4671,7 @@ class CampTix_Plugin {
 
 		$rows[] = array( __( 'Edit Token', 'wordcamporg' ), sprintf( '<a href="%s">%s</a>', $this->get_edit_attendee_link( $post->ID, $edit_token ), $edit_token ) );
 		$rows[] = array( __( 'Access Token', 'wordcamporg' ), sprintf( '<a href="%s">%s</a>', $this->get_access_tickets_link( $access_token ), $access_token ) );
-
-		$refunds_available_text = __( 'only for organizers', 'wordcamporg' );
-		if ( $this->options['refunds_enabled'] ) {
-			$refunds_available_text = __( 'for attendee', 'wordcamporg' );
-		}
-		$rows[] = array( __( 'Refund Request', 'wordcamporg' ), sprintf( '<a href="%s">Link</a> %s', $this->get_refund_tickets_link( $access_token ), $refunds_available_text ) );
+		$rows[] = array( __( 'Refund Request', 'wordcamporg' ), sprintf( '<a href="%s">%s</a>', $this->get_refund_tickets_link( $access_token ), $access_token ) );
 
 		// Transaction
 		$rows[] = array( __( 'Transaction', 'wordcamporg' ), '' );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6469,7 +6469,7 @@ class CampTix_Plugin {
 						wp_update_post( $attendee );
 					}
 
-					// Dumb result in order for checks below to pass, with this we avoid adding new check.
+					// Mock successful result to allow standard validation flow for free ticket refunds.
 					$result = CampTix_Plugin::PAYMENT_STATUS_REFUNDED;
 				} else {
 					$payment_method_obj = $this->get_payment_method_by_id( $transaction['payment_method'] );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6451,7 +6451,7 @@ class CampTix_Plugin {
 		// Has a refund request been submitted?
 		$reason = '';
 		if ( current_user_can( $this->caps['manage_attendees'] ) ) {
-			$reason = wp_sprintf( __( 'In behalf of attendee by %s (%s)', 'wordcamporg' ), wp_get_current_user()->display_name, wp_get_current_user()->user_login );
+			$reason = wp_sprintf( __( 'On behalf of attendee by %s (%s)', 'wordcamporg' ), wp_get_current_user()->display_name, wp_get_current_user()->user_login );
 		}
 
 		if ( isset( $_POST['tix_refund_request_submit'] ) ) {

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6451,7 +6451,13 @@ class CampTix_Plugin {
 		// Has a refund request been submitted?
 		$reason = '';
 		if ( current_user_can( $this->caps['manage_attendees'] ) ) {
-			$reason = wp_sprintf( __( 'On behalf of attendee by %s (%s)', 'wordcamporg' ), wp_get_current_user()->display_name, wp_get_current_user()->user_login );
+			// Default refund message, overwritten by user-supplied reason if set.
+			$reason = sprintf(
+				/* translators: 1: User Display Name, 2: User Login */
+				__( 'On behalf of attendee by %1$s (%2$s)', 'wordcamporg' ),
+				wp_get_current_user()->display_name,
+				wp_get_current_user()->user_login
+			);
 		}
 
 		if ( isset( $_POST['tix_refund_request_submit'] ) ) {

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1560,8 +1560,8 @@ class CampTix_Plugin {
 				$this->add_settings_field_helper( 'event_name', __( 'Event Name', 'wordcamporg' ), 'field_text' );
 				$this->add_settings_field_helper( 'currency', __( 'Currency', 'wordcamporg' ), 'field_currency' );
 
-				$this->add_settings_field_helper( 'refunds_enabled', __( 'Enable Refunds', 'wordcamporg' ), 'field_enable_refunds', false,
-					__( "This will allows your customers to refund their tickets purchase by filling out a simple refund form.", 'wordcamporg' )
+				$this->add_settings_field_helper( 'refunds_enabled', __( 'Enable Refund Requests by Attendees', 'wordcamporg' ), 'field_enable_refunds', false,
+					__( "This will allows your customers to refund their tickets purchase by filling out a simple refund form. Organizers are able to refund regardless of this setting.", 'wordcamporg' )
 				);
 
 				break;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6409,7 +6409,8 @@ class CampTix_Plugin {
 		$tickets = array();
 
 		foreach ( $attendees as $attendee ) {
-			$txn_id = get_post_meta( $attendee->ID, 'tix_transaction_id', true );
+			$tix_payment_token = get_post_meta( $attendee->ID, 'tix_payment_token', true );
+			$txn_id            = get_post_meta( $attendee->ID, 'tix_transaction_id', true );
 			if ( $txn_id ) {
 				$transaction                   = get_post_meta( $attendee->ID, 'tix_transaction_details', true );
 				$transaction['transaction_id'] = $txn_id;
@@ -6462,19 +6463,15 @@ class CampTix_Plugin {
 			} else {
 				// Allow organizers to refund tickets without transactions (i.e. free tickets)
 				if ( current_user_can( $this->caps['manage_attendees'] ) && empty( $transactions ) ) {
-					// Change status for all attendees within the same purchase.
-					foreach ( $attendees as $attendee ) {
-						$attendee->post_status = 'refund';
-						wp_update_post( $attendee );
-					}
-
-					// Mock successful result to allow standard validation flow for free ticket refunds.
-					$result = CampTix_Plugin::PAYMENT_STATUS_REFUNDED;
+					$result = $this->payment_result(
+						$tix_payment_token,
+						CampTix_Plugin::PAYMENT_STATUS_REFUNDED
+					);
 				} else {
 					$payment_method_obj = $this->get_payment_method_by_id( $transaction['payment_method'] );
 
-					// Bail if a payment method does not exist.
-					if ( ! $payment_method_obj ) {
+					// Bail if a payment method does not exist, or doesn't support refunds.
+					if ( ! $payment_method_obj || empty( $payment_method_obj->supported_features['refund-single'] ) ) {
 						$this->error_flags['cannot_refund'] = true;
 						$this->redirect_with_error_flags();
 						die();

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6461,7 +6461,7 @@ class CampTix_Plugin {
 			if ( ! $check ) {
 				$this->error( __( 'You have to agree to the terms to request a refund.', 'wordcamporg' ) );
 			} else {
-				// Allow organisers to refund tickets without transactions (i.e. free tickets)
+				// Allow organizers to refund tickets without transactions (i.e. free tickets)
 				if ( current_user_can( $this->caps['manage_attendees'] ) && empty( $transactions ) ) {
 					// Change status for all attendees within the same purchase.
 					foreach ( $attendees as $attendee ) {


### PR DESCRIPTION
Sometimes, organisers need to refund tickets on behalf of the attendee when the refunds are turned off. Sometimes, they also need to refund free tickets, for example, when a volunteer cancels their attendance.

In this PR:
* Refund link is added to singular attendee edit view, with an indication if that will work for attendee or only for organisers
* Users with `manage_attendees` capability can do refunds even if refunds are turned off
* Users with `manage_attendees` capability can refund free tickets

Fixes #761
Fixes #770 

Props @iandunn 

### Screenshots

Refund link on attendee edit, when refunds are turned off.
<img width="298" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/6ebc5784-5319-437c-9eb0-3ab2d470b678">

Refund link on attendee edit information table, when refunds are turned on.
<img width="562" alt="image" src="https://github.com/WordPress/wordcamp.org/assets/415544/a7d9cfaf-ba22-4cfd-9e1b-df9926adfb02">

### How to test the changes in this Pull Request:

1. Open WordCamp site, create ticket and 100% discount code
2. Purchase tickets by paying and with discount code
3. Check that refunds are off
4. Open one of the attendees and their refund request links, you should be able to see the refund form
5. Do the same but open links on incognito, refund form should not be visible
6. Try to refund attendee which was purchased with discount code
