### PR TITLE
WC Post Types, Blocks: Add support for private speakers & sessions

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -46,6 +46,7 @@ function render( $attributes, $content, $block ) {
 		'meta_value'     => $post_ID,
 		'orderby'        => 'title',
 		'order'          => 'asc',
+		'post_status'    => array( 'publish', 'private' ),
 	);
 
 	$sessions = get_posts( $session_args );

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -613,6 +613,8 @@ function prepare_session_query_args( $args, $request ) {
 		$args['orderby']  = 'meta_value_num';
 	}
 
+	$args['post_status'] = array( 'publish', 'private' );
+
 	return $args;
 }
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1928,7 +1928,7 @@ class WordCamp_Post_Types_Plugin {
 				if ( ! empty( $speakers_ids ) ) {
 					$speakers = get_posts( array(
 						'post_type'      => 'wcb_speaker',
-						'post_status'    => array( 'publish', 'draft' ),
+						'post_status'    => 'any',
 						'posts_per_page' => -1,
 						'post__in'       => $speakers_ids,
 					) );
@@ -1937,12 +1937,12 @@ class WordCamp_Post_Types_Plugin {
 				$output = array();
 
 				foreach ( $speakers as $speaker ) {
-					$is_draft = ( 'draft' === $speaker->post_status ) ? __( ' (draft)', 'wordcamporg' ) : '';
+					$status_label = ( 'publish' !== $speaker->post_status ) ? get_post_status_object( $speaker->post_status )->label . ': ' : '';
 					$output[] = sprintf(
 						'<a href="%1$s">%2$s%3$s</a>',
 						esc_url( get_edit_post_link( $speaker->ID ) ),
-						esc_html( apply_filters( 'the_title', $speaker->post_title ) ),
-						$is_draft
+						$status_label,
+						esc_html( apply_filters( 'the_title', $speaker->post_title ) )
 					);
 				}
 


### PR DESCRIPTION
Fixes #717 — This is a simpler approach to the issue described, where it's difficult to style the speakers & sessions without making them public. By enabling private sessions & speakers to be used in blocks, this lets organizers (who have permissions to see private content) view and edit the content, without showing sessions & speakers to site visitors, and without notifying the wporg profiles code.

The intention to only show private sessions and not _all_ sessions is that all sessions are submitted as drafts, so this lets the organizer team update and privately publish the accepted talks, while leaving the rest alone.

### Screenshots

Private speakers now show up in the sessions list table, with updated label.

<img width="676" alt="Screenshot 2023-07-31 at 1 11 23 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/41dd9dd0-df7b-4111-b116-f37471fc34a7">

Private sessions appear in the Speaker Sessions block, which can be used on speaker posts.

<img width="696" alt="Screenshot 2023-07-31 at 1 13 53 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/73833de0-3bd9-41c7-a996-a3d2be5815dc">

And the main use for this, private sessions will show up in the schedule. In the following screenshot, the "Friday keynote" is a privately published regular session (the rest are public custom sessions).

<img width="1220" alt="Screenshot 2023-07-31 at 1 07 18 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/53b6dc1c-4604-4dce-8a14-8ebd8993dd8e">

### How to test the changes in this Pull Request:

1. Add some sessions and speakers
2. Publish them privately
3. The should be visible on the frontend when logged in, but not when logged out
