### PR TITLE
Make sure plugins pull multi-event sponsor info from central.wordcamp.org

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -798,7 +798,7 @@ function get_sponsorship_level_name_from_id( $level_id ) {
 	$level_name = '';
 
 	if ( $level_id ) {
-		switch_to_blog( BLOG_ID_CURRENT_SITE );
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
 
 		$level_name = get_the_title( $level_id );
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -675,7 +675,7 @@ function switch_email_template( $template_slug ) {
  * @return string
  */
 function get_global_sponsors_string() {
-	switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordpress.org
+	switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // central.wordcamp.org.
 
 	$posts = get_posts( array(
 		'post_type'      => 'mes',

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -771,7 +771,7 @@ function get_sponsorship_region_description_from_id( $region_id ) {
 		}
 
 		if ( ! $region_description ) {
-			switch_to_blog( BLOG_ID_CURRENT_SITE );
+			switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
 
 			$region = get_term( $region_id, 'mes-regions' );
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1273,7 +1273,7 @@ class WordCamp_Post_Types_Plugin {
 		$mes_id = get_post_meta( $sponsor->ID, '_mes_id', true );
 
 		if ( $mes_id ) {
-			switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org .
+			switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // central.wordcamp.org.
 
 			$mes_agreement_id = get_post_meta( $mes_id, 'mes_sponsor_agreement', true );
 			if ( $mes_agreement_id ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -842,7 +842,7 @@ class WordCamp_New_Site {
 			'twitter_handle', 'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country',
 		);
 
-		switch_to_blog( BLOG_ID_CURRENT_SITE ); // Switch to central.wordcamp.org.
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // Switch to central.wordcamp.org.
 
 		foreach ( $meta_field_keys as $key ) {
 			$sponsor_meta[ "_wcpt_sponsor_$key" ] = get_post_meta( $assigned_sponsor->ID, "mes_$key", true );
@@ -868,7 +868,7 @@ class WordCamp_New_Site {
 		global $multi_event_sponsors;
 		$data = array();
 
-		switch_to_blog( BLOG_ID_CURRENT_SITE ); // Switch to central.wordcamp.org.
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // Switch to central.wordcamp.org.
 
 		$data['featured_images']   = array();
 		$data['assigned_sponsors'] = $multi_event_sponsors->get_wordcamp_me_sponsors( $wordcamp_id, 'sponsor_level' );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #951 

- [x] **public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php**

```
function get_global_sponsors_string() {
	switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // central.wordcamp.org.
```
There would be no data if using `BLOG_ID_CURRENT_SITE`.
| Before | After |
| -------| ----- |
| <img width="155" alt="Screen Shot 2023-08-03 at 1 15 09 AM" src="https://github.com/WordPress/wordcamp.org/assets/18050944/690547b8-2117-4c7f-877d-8295d649906e"> | <img width="310" alt="Screen Shot 2023-08-03 at 1 15 30 AM" src="https://github.com/WordPress/wordcamp.org/assets/18050944/1e260887-21b3-4704-a061-9420c4b43442"> |

- [x] **public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php**
```
if ( ! $region_description ) {
	switch_to_blog( WORDCAMP_ROOT_BLOG_ID );

        $region = get_term( $region_id, 'mes-regions' );
```
I'm not 100% sure about how to test this, not familiar with the flow and I don't see `get_sponsorship_region_description_from_id` gets called anywhere. But I believe `WORDCAMP_ROOT_BLOG_ID` should be used here as the term `region` only exists in central.wordcamp.org. ([ref](https://central.wordcamp.org/wp-admin/edit-tags.php?taxonomy=mes-regions&post_type=mes)), not on local or flagship WordCamp sites.

- [x] **public_html/wp-content/plugins/wc-post-types/wc-post-types.php**

```
if ( $mes_id ) {
	switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // central.wordcamp.org.

	$mes_agreement_id = get_post_meta( $mes_id, 'mes_sponsor_agreement', true );
	if ( $mes_agreement_id ) {
		$agreement_url = wp_get_attachment_url( $mes_agreement_id );
	} else {
		$agreement_url = '';
	}
	restore_current_blog();
}
```
I'm not certain about how to test this locally either. And I don't see any agreements attached to any of the MES. I do see some sponsors on local/flagship WC sites with attached agreements, though. Perhaps these were added by organizers after new WC sites were set up. Regardless, I believe it needs changing to `WORDCAMP_ROOT_BLOG_ID`. Because it used to use `BLOG_ID_CURRENT_SITE`, and `events.wordpress.org` didn't even have MES plugin activated.

- [x] **public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php**

```
public static function get_stub_me_sponsors_meta( $assigned_sponsor ) {
		$sponsor_meta    = array( '_mes_id' => $assigned_sponsor->ID );
		$meta_field_keys = array(
			'company_name', 'website', 'first_name', 'last_name', 'email_address', 'phone_number',
			'twitter_handle', 'street_address1', 'street_address2', 'city', 'state', 'zip_code', 'country',
		);

		switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // Switch to central.wordcamp.org.
```
MES metadata would not be copied to the sponsor posts in a new site if not using `WORDCAMP_ROOT_BLOG_ID`.
| Before | After |
| ------ | ------|
| <img width="1226" alt="Screen Shot 2023-08-03 at 1 13 37 AM" src="https://github.com/WordPress/wordcamp.org/assets/18050944/1ff61ebe-7082-4d0d-bd0a-31e5bd274d87"> | <img width="1225" alt="Screen Shot 2023-08-03 at 1 13 27 AM" src="https://github.com/WordPress/wordcamp.org/assets/18050944/2e6a99b9-f7fa-4ac1-b31b-95a70f6eea43"> |

```
protected function get_assigned_sponsor_data( $wordcamp_id ) {
		/** @var $multi_event_sponsors Multi_Event_Sponsors */
		global $multi_event_sponsors;
		$data = array();

		switch_to_blog( WORDCAMP_ROOT_BLOG_ID ); // Switch to central.wordcamp.org.

		$data['featured_images']   = array();
		$data['assigned_sponsors'] = $multi_event_sponsors->get_wordcamp_me_sponsors( $wordcamp_id, 'sponsor_level' );
```
Don't know how to test this feature as well, but this should also be changed to `WORDCAMP_ROOT_BLOG_ID` as a function of the MES plugin is used later, and only central has it activated.

- [x] **public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php**

```
function get_sponsorship_level_name_from_id( $level_id ) {
	$level_id   = absint( $level_id );
	$level_name = '';

	if ( $level_id ) {
		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );

		$level_name = get_the_title( $level_id );
```
Also believe this one should be changed to use `WORDCAMP_ROOT_BLOG_ID`. Otherwise, it would retrieve the sponsor level name from `events.wordpress.org` where there's no MES data existing, and get nothing. This function is also found not to be called anywhere.

- [x] **Other `switch_to_blog( BLOG_ID_CURRENT_SITE );` that I skipped**.

Since I don't see any of these have connections with the MES.

1. **public_html/wp-content/mu-plugins/4-helpers-wcpt.php**
```
330 switch_to_blog( BLOG_ID_CURRENT_SITE );
364 switch_to_blog( BLOG_ID_CURRENT_SITE );
385 switch_to_blog( BLOG_ID_CURRENT_SITE );
```
2. **public_html/wp-content/plugins/wordcamp-dashboard-widgets/wordcamp-dashboard-widgets.php**

```
75 switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org.
```
3. **public_html/wp-content/plugins/wordcamp-reports/includes/validation.php**
```
137 $switched = switch_to_blog( BLOG_ID_CURRENT_SITE );
```
4. **public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php**
```
218 switch_to_blog( BLOG_ID_CURRENT_SITE ); // central.wordcamp.org.
```

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

<!-- If you can, add the appropriate [Component] and [Status] labels. -->

@ryelle @timiwahalahti
I'm not sure how familiar you are with the goals and changes in this PR, but if you are, your review on this PR would be highly appreciated, especially as @iandunn is currently not available.