### PR TITLE
Add sponsor level to listing, add sponsorship amount and currency meta fields and to listing

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-sponsor-info.php
@@ -1,4 +1,9 @@
 <?php
+/** Metabox view */
+
+/** @var string $amount */
+/** @var string $available_currencies */
+/** @var string $currency */
 /** @var string $company_name */
 /** @var string $website */
 /** @var string $first_name */
@@ -16,6 +21,56 @@
 /** @var string $first_time */
 /** @var array $available_countries */
 ?>
+<ul class="wcpt-form">
+	<li class="wcpt-form-header">
+		<?php esc_html_e( 'Sponsorship', 'wordcamporg' ); ?>
+	</li>
+
+	<li>
+		<label for="_wcb_sponsor_amount">
+			<?php esc_html_e( 'Amount:', 'wordcamporg' ); ?>
+		</label>
+
+		<input
+			type="number"
+			class="regular-text"
+			id="_wcb_sponsor_amount"
+			name="_wcb_sponsor_amount"
+			value="<?php echo esc_attr( $amount ); ?>"
+			step="any"
+			min="0"
+			required
+		/>
+
+		<?php wcorg_required_indicator(); ?>
+
+		<span class="description"><?php esc_html_e( 'No commas, thousands separators or currency symbols. Ex. 1234.56', 'wordcamporg' ); ?></span>
+	</li>
+
+	<li>
+		<label for="_wcb_sponsor_currency">
+			<?php esc_html_e( 'Currency:', 'wordcamporg' ); ?>
+		</label>
+
+		<select
+			id="_wcb_sponsor_currency"
+			name="_wcb_sponsor_currency"
+			class="select-currency"
+		>
+			<?php foreach ( $available_currencies as $symbol => $name ) : ?>
+				<option
+					value="<?php echo esc_attr( $symbol ); ?>"
+					<?php selected( $symbol, $currency ); ?>
+				>
+					<?php echo ( $symbol ) ? esc_html( $name . ' (' . $symbol . ')' ) : ''; ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+
+		<?php wcorg_required_indicator(); ?>
+	</li>
+</ul>
+
 <ul class="wcpt-form">
 	<li class="wcpt-form-header">
 		<?php _e( 'Contact Information', 'wordcamporg' ); ?>

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1220,6 +1220,9 @@ class WordCamp_Post_Types_Plugin {
 	 * @param WP_Post $sponsor
 	 */
 	public function metabox_sponsor_info( $sponsor ) {
+		$amount   = get_post_meta( $sponsor->ID, '_wcb_sponsor_amount',   true );
+		$currency = get_post_meta( $sponsor->ID, '_wcb_sponsor_currency', true );
+
 		$company_name   = get_post_meta( $sponsor->ID, '_wcpt_sponsor_company_name',   true );
 		$website        = get_post_meta( $sponsor->ID, '_wcpt_sponsor_website',        true );
 		$first_name     = get_post_meta( $sponsor->ID, '_wcpt_sponsor_first_name',     true );
@@ -1246,6 +1249,8 @@ class WordCamp_Post_Types_Plugin {
 		} else {
 			$available_countries = wcorg_get_countries();
 		}
+
+		$available_currencies = WordCamp_Budgets::get_currencies();
 
 		wp_nonce_field( 'edit-sponsor-info', 'wcpt-meta-sponsor-info' );
 
@@ -1376,6 +1381,8 @@ class WordCamp_Post_Types_Plugin {
 			);
 
 			$text_values_wcb = array(
+				'amount',
+				'currency',
 				'first_time',
 			);
 
@@ -1727,14 +1734,15 @@ class WordCamp_Post_Types_Plugin {
 			'wcb_sponsor_level',
 			'wcb_sponsor',
 			array(
-				'labels'       => $labels,
-				'rewrite'      => array( 'slug' => 'sponsor_level' ),
-				'query_var'    => 'sponsor_level',
-				'hierarchical' => true,
-				'public'       => true,
-				'show_ui'      => true,
-				'show_in_rest' => true,
-				'rest_base'    => 'sponsor_level',
+				'labels'            => $labels,
+				'rewrite'           => array( 'slug' => 'sponsor_level' ),
+				'query_var'         => 'sponsor_level',
+				'hierarchical'      => true,
+				'public'            => true,
+				'show_ui'           => true,
+				'show_in_rest'      => true,
+				'show_admin_column' => true,
+				'rest_base'         => 'sponsor_level',
 			)
 		);
 
@@ -1868,6 +1876,15 @@ class WordCamp_Post_Types_Plugin {
 					ARRAY_FILTER_USE_KEY
 				);
 				break;
+
+			case 'manage_wcb_sponsor_posts_columns':
+				$original_columns = $columns;
+
+				$columns = array_slice( $original_columns, 0, 3, true );
+				$columns += array( 'wcb_sponsor_amount' => __( 'Amount', 'wordcamporg' ) );
+				$columns += array_slice( $original_columns, 1, null, true );
+
+				break;
 			default:
 		}
 
@@ -1950,6 +1967,14 @@ class WordCamp_Post_Types_Plugin {
 				break;
 			case 'wcb_session_track':
 				echo get_the_term_list( get_the_ID(), 'wcb_track', '', ', ' );
+				break;
+
+			case 'wcb_sponsor_amount':
+				echo sprintf(
+					'%1$s %2$s',
+					esc_html( get_post_meta( get_the_ID(), '_wcb_sponsor_amount', true ) ),
+					esc_html( get_post_meta( get_the_ID(), '_wcb_sponsor_currency', true ) )
+				);
 				break;
 			default:
 		}


### PR DESCRIPTION
As per the Community Team's request.

Add sponsorship level taxonomy column to sponsors list.
Add meta fields for sponsorship amount and currency.
Add above fields as a column to sponsors list.

Fixes #824 

### Screenshots
<img width="1151" alt="CleanShot 2023-08-08 at 20 34 12@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/3bcf997c-c785-496e-a132-92f82b9e687d">

<img width="912" alt="CleanShot 2023-08-08 at 20 34 24@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/0c6f809c-d96a-4acb-9ad6-8708253cf4f4">


### How to test the changes in this Pull Request:

1. Navigate to WordCamp website and sponsors list
2. Add amount, currency and level to some sponsor
3. Go back to the list and you should see data in said fields
