### PR TITLE
Add help text blurb to front end feedback view for speakers

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/view-feedback.php
@@ -44,6 +44,12 @@ $show_order = isset( $_GET['forder'] ) ? $_GET['forder'] : 'oldest';
 <div class="speaker-feedback">
 	<h2><?php esc_html_e( 'Session Feedback', 'wordcamporg' ); ?></h2>
 
+	<?php if ( $is_session_speaker ) : ?>
+		<p><?php esc_html_e( 'This feedback is visible only to you and the event organizers. It was submitted by attendees who watched your talk and has been reviewed and approved by the event organizers.', 'wordcamporg' ); ?></p>
+
+		<p><?php esc_html_e( 'While marking feedback as "helpful" is optional, you can use this to filter messages that you would like to come back to later, and it helps the WordCamp program track the overall helpfulness of the feedback tool. Please note that commenters will not be able to see if you mark their comment as helpful.', 'wordcamporg' ); ?></p>
+	<?php endif; ?>
+
 	<p class="speaker-feedback__notice">
 		<?php if ( $is_session_speaker ) : ?>
 			<?php


### PR DESCRIPTION
Fixes #480 

Props @varlese

### Screenshots

<img width="601" alt="CleanShot 2023-08-08 at 20 53 22@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/671d74fd-afdf-4593-a84d-3a978c955f33">

### How to test the changes in this Pull Request:

1. Add new speaker (use the login you've logged in)
3. Add new session for that speaker
4. Go to public session page, leave feedback
5. Approve the feedback on dashboard
6. Go back to public session feedback page, you should see the message and feedback
