### PR TITLE
Limit Vendor `aggregate` cron to Central to preserve data

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -105,10 +105,8 @@ class Payment_Requests_Dashboard {
 		$blogs = $wpdb->get_col( $wpdb->prepare( "
 			SELECT blog_id
 			FROM `{$wpdb->blogs}`
-			WHERE site_id = %d
 			ORDER BY last_updated DESC
 			LIMIT %d;",
-			$wpdb->siteid,
 			3000
 		) );
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -10,12 +10,15 @@ class Payment_Requests_Dashboard {
 	public static function plugins_loaded() {
 		$current_site = get_current_site();
 
-		// Schedule the aggregate event only on the main blog in the network.
-		if ( get_current_blog_id() == $current_site->blog_id && ! wp_next_scheduled( 'wordcamp_payments_aggregate' ) ) {
-			wp_schedule_event( time(), 'daily', 'wordcamp_payments_aggregate' );
+		if ( WORDCAMP_ROOT_BLOG_ID === get_current_blog_id() ) {
+			// Schedule the aggregate event only on the main blog in the network.
+			if ( get_current_blog_id() == $current_site->blog_id && ! wp_next_scheduled( 'wordcamp_payments_aggregate' ) ) {
+				wp_schedule_event( time(), 'daily', 'wordcamp_payments_aggregate' );
+			}
+
+			add_action( 'wordcamp_payments_aggregate', array( __CLASS__, 'aggregate' ) );
 		}
 
-		add_action( 'wordcamp_payments_aggregate', array( __CLASS__, 'aggregate' ) );
 		add_action( 'network_admin_menu', array( __CLASS__, 'network_admin_menu' ) );
 		add_action( 'init', array( __CLASS__, 'upgrade' ) );
 


### PR DESCRIPTION
Fixes #1002 
See #886 

#1004 attempted to fix this previously, but that didn't work. The actual cause was that the code needed to be updated to be aware of the new Events network.
