### PR TITLE
CampTix: Update global sponsor string to refer to WP events generically

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -705,7 +705,7 @@ function get_global_sponsors_string() {
 		$last_sponsor
 	);
 
-	$intro = __( 'WordPress Global Community Sponsors help fund WordCamps and meetups around the world.', 'wordcamporg' );
+	$intro = __( 'WordPress Global Community Sponsors help fund WordPress events around the world.', 'wordcamporg' );
 
 	$thank_you = sprintf(
 		/* translators: %1$s: list of sponsor names; %2$s: URL; */


### PR DESCRIPTION
NextGen events exist now too, but there isn't a clear way to describe them to folks who don't already know what they are. It's also simpler to just say "WordPress events" rather than listing each type.

See https://wordpress.slack.com/archives/C05JYJJRNKB/p1691745126053109
