### PR TITLE
Enhance next gen event budget tool - Days and Hours

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/css/wordcamp-budgets.css
+++ b/public_html/wp-content/plugins/wordcamp-payments/css/wordcamp-budgets.css
@@ -292,6 +292,11 @@ tr#row-payment-method label {
 	cursor: pointer;
 }
 
+.wcb-budget-container .wcb-entry select.name {
+	padding: 0;
+}
+
+
 .wcb-budget-container .wcb-entry .select2-container {
 	vertical-align: bottom;
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -220,7 +220,7 @@ class WordCamp_Budget_Tool {
 		$count_organizers = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'organizers' ) ), 'value' ) );
 		$count_attendees  = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'attendees' ) ), 'value' ) );
 		$count_days       = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'days' ) ), 'value' ) );
-		$count_tracks     = is_wordcamp_type('next-gen') ? 0 : (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'tracks' ) ), 'value' ) );
+		$count_tracks     = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'tracks' ) ), 'value' ) );
 		$ticket_price     = (float) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'ticket-price' ) ), 'value' ) );
 
 		switch ( $link ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -167,6 +167,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 			'click .move'              : 'move',
 			'change input'             : 'editSave',
 			'change select.category'   : 'editSave',
+			'change select.name'       : 'editSave',
 			'change select.link-value' : 'linkChange',
 			'change select.value'      : 'editSave',
 
@@ -268,10 +269,13 @@ window.wcb = window.wcb || { models: {}, input: [] };
 			if ( this.model.get( 'type' ) == 'meta' ) {
 				var value = this.$el.find( '.value' ).val(),
 					name  = this.model.get( 'name' );
-
+				
+				if ( networkStatus.isNextGenWordCamp && ( name === 'days' || name === 'hours' ) ) {
+					this.model.set( 'name', this.$el.find( '.name' ).val() );
+				}
 				if ( _.contains( [ 'attendees', 'days', 'tracks', 'speakers', 'volunteers', 'organizers' ], name ) ) {
 					value = parseInt( value.replace( /[^\d.-]/g, '' ) ) || 0;
-				} else if ( _.contains( [ 'ticket-price' ], name ) ) {
+				} else if ( _.contains( [ 'ticket-price', 'hours' ], name ) ) {
 					value = parseFloat( value.replace( /[^\d.-]/g, '' ) ) || 0;
 				}
 
@@ -403,6 +407,15 @@ window.wcb = window.wcb || { models: {}, input: [] };
 		// Only exists in the Event Network.
 		'format'				: 'Format of Event',
 	};
+
+	if (networkStatus.isNextGenWordCamp) {
+		wcb.metaDropdown = {
+			'days': 'Days',
+			'hours': 'Hours',
+		};
+
+		delete wcb.metaLabels['days'];
+	}
 
 	wcb.linkData = {
 		'per-speaker' : {

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -126,7 +126,11 @@ window.wcb = window.wcb || { models: {}, input: [] };
 
 			data[ 'variance' ]     = data[ 'income' ] - data[ 'expenses' ];
 			data[ 'variance_raw' ] = data[ 'variance' ];
-			data[ 'per_person' ]   = ( attendees && days ) ? data[ 'expenses' ] / attendees.get( 'value' ) / days.get( 'value' ) : 0;
+			if ( networkStatus.isNextGenWordCamp ) {
+				data[ 'per_person' ]   = ( attendees ) ? data[ 'expenses' ] / attendees.get( 'value' ) : 0;	
+			} else {
+				data[ 'per_person' ]   = ( attendees && days ) ? data[ 'expenses' ] / attendees.get( 'value' ) / days.get( 'value' ) : 0;
+			}
 
 			data = _.mapObject( data, function( v, k ) {
 				if ( k == 'variance_raw' ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -507,7 +507,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 				return parseFloat( value ) * parseInt( wcb.table.collection.findWhere( {
 					type : 'meta',
 					name : 'days',
-				} ).get( 'value' ) );
+				} )?.get( 'value' ) );
 			},
 		},
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -546,6 +546,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 
 	if (networkStatus.isNextGenWordCamp) {
 		delete wcb.linkData[ 'per-track' ];
+		delete wcb.linkData[ 'per-day' ];
 	}
 
 	var table = new EntriesView( { collection: new Entries() } );

--- a/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
@@ -158,7 +158,13 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
             <td class="amount <# if (data.variance_raw < 0) { #>wcb-negative<# } #>">{{data.variance}}</td>
         </tr>
         <tr>
-            <td><?php esc_html_e( 'Cost Per Person Per Day', 'wordcamporg' ); ?></td>
+            <td>
+                <?php 
+                    is_wordcamp_type('next-gen') ? 
+                        esc_html_e( 'Cost Per Person', 'wordcamporg' ) :
+                        esc_html_e( 'Cost Per Person Per Day', 'wordcamporg' )
+                ?>
+            </td>
             <td class="amount">{{data.per_person}}</td>
         </tr>
         <tr>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
@@ -185,7 +185,19 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
 </script>
 <script type="text/template" id="wcb-tmpl-entry">
     <# if (data.type == 'meta') { #>
-        <td>{{wcb.metaLabels[data.name]}}</td>
+        <td>
+            <# if (wcb.metaDropdown?.[data.name]) { #>
+                <select class="name">
+					<# _.each( wcb.metaDropdown, function( value, key ) { #>
+						<option value="{{key}}" <# if( key === data.name ) { #> selected <# } #> >
+							{{value}}
+						</option>
+					<# }); #>
+                </select>
+            <# } else { #>
+                {{wcb.metaLabels[data.name]}}
+            <# } #>
+        </td>
 
         <# if (wcb.editable) { #>
             <td class="editable">


### PR DESCRIPTION
Close #976

This PR updated the Days and Hours fields as requested in the ticket.

### Screencast


https://github.com/WordPress/wordcamp.org/assets/18050944/913a41ec-b76b-4b33-864e-13a511b7e622



### How to test the changes in this Pull Request:

1. Create a new next-gen event site through WordCamps >> Add new
2. Go to Budgets.
3. Play around with the Days and Hours dropdown and see if it behaves the same as the screencast above demonstrates.
4. Save what you've changed, and see if everything's saved.
5. Og wordcamp should remain everything the same. ie, `Days` remain pure text label.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
