### PR TITLE
Add docker override file name to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .docker/database
 .docker/wordcamp*.pem
 .docker/test_suite
+docker-compose.override.yaml
 
 
 #
@@ -47,7 +48,7 @@ public_html/wp-content/plugins/wc-post-types/package-lock.json
 #
 public_html/wp-content/plugins/query-monitor/
 public_html/wp-content/plugins/user-switching/
-docker-compose.override.yaml
+
 
 #
 # Plugins

--- a/.gitignore
+++ b/.gitignore
@@ -109,9 +109,3 @@ public_html/wp-content/themes/twentytwentyone
 public_html/wp-content/themes/twentytwentytwo
 public_html/wp-content/themes/twentytwentythree
 public_html/wp-content/themes/wporg-parent-2021
-
-
-#
-# File System
-#
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ public_html/wp-content/plugins/wc-post-types/package-lock.json
 #
 public_html/wp-content/plugins/query-monitor/
 public_html/wp-content/plugins/user-switching/
-
+docker-compose.override.yaml
 
 #
 # Plugins
@@ -109,3 +109,9 @@ public_html/wp-content/themes/twentytwentyone
 public_html/wp-content/themes/twentytwentytwo
 public_html/wp-content/themes/twentytwentythree
 public_html/wp-content/themes/wporg-parent-2021
+
+
+#
+# File System
+#
+.DS_Store


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
We need to override the docker file to build a local environment with docker on m1 Mac, so I add that filename to gitignore.
And I also add .DS_Store files are created by the Mac OS X operating system.

<!-- List out anyone who helped with this task. -->
Props @ryelle 

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. Checkout new branch.
2. Add a docker-compose.override.yaml and a .DS_Store file.
3. Git add, git status, you can check to ignore these files.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
