### PR TITLE
Composer: Update `composer.lock` fixing parent theme install issue

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5015aea9e9c14085f9efc84446b689b",
+    "content-hash": "29291fe29de76306f51d13fde11ef2cd",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -62,6 +62,27 @@
                 }
             ],
             "time": "2021-02-20T09:56:44+00:00"
+        },
+        {
+            "name": "wporg/wporg-parent-2021",
+            "version": "dev-build",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/wporg-parent-2021.git",
+                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
+                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
+                "shasum": ""
+            },
+            "type": "wordpress-theme",
+            "support": {
+                "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
+                "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
+            },
+            "time": "2023-08-22T15:22:31+00:00"
         }
     ],
     "packages-dev": [
@@ -4113,27 +4134,6 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2023-08-21T14:28:38+00:00"
-        },
-        {
-            "name": "wporg/wporg-parent-2021",
-            "version": "dev-build",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
-                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
-                "shasum": ""
-            },
-            "type": "wordpress-theme",
-            "support": {
-                "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
-                "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
-            },
-            "time": "2023-08-22T15:22:31+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",


### PR DESCRIPTION
I've updated the `composer.lock` by removing it and running `composer update`. It seems the issue was, that in 29c821b55b5f077267c59b7ed61c25b5dcc2801b the package was manually moved from `require-dev` to `require`, but in the `composer.lock` it was not moved from `packages-dev` to `packages` as well.

Fixes #1016