### PR TITLE
Only show pay by check/ACH when the US is selected

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -332,7 +332,8 @@ class WCP_Payment_Request {
 			$box['args']['show_vendor_requested_payment_method'] = true;
 		}
 
-		$selected_payment_method = get_post_meta( $post->ID, "_{$this->meta_key_prefix}_payment_method", true );
+		$selected_payment_method          = get_post_meta( $post->ID, "_{$this->meta_key_prefix}_payment_method", true );
+		$selected_payment_receipt_country = get_post_meta( $post->ID, "_{$this->meta_key_prefix}_payment_receipt_country_iso3166", true );
 
 		require_once dirname( __DIR__ ) . '/views/payment-request/metabox-payment.php';
 	}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -415,7 +415,7 @@ class WCP_Payment_Request {
 	 * @param string  $name
 	 * @param bool    $required
 	 */
-	protected function render_radio_input( $post, $label, $name, $required = true ) {
+	protected function render_radio_input( $post, $label, $name, $required = true, $is_visible = true ) {
 		$selected = get_post_meta( $post->ID, "_{$this->meta_key_prefix}_" . $name, true );
 		$options  = $this->get_field_value( $name, $post );
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -365,9 +365,10 @@ function get_meta_fields_mapping( $post_type ) {
 		$mapping_fields = array_merge(
 			$mapping_fields,
 			array(
-				$prefix . 'name_of_payer'               => __( 'Payer Name', 'wordcamporg' ),
-				$prefix . 'currency'                    => __( 'Currency', 'wordcamporg' ),
-				$prefix . 'payment_method'              => __( 'Payment Method', 'wordcamporg' ),
+				$prefix . 'name_of_payer'                   => __( 'Payer Name', 'wordcamporg' ),
+				$prefix . 'currency'                        => __( 'Currency', 'wordcamporg' ),
+				$prefix . 'payment_method'                  => __( 'Payment Method', 'wordcamporg' ),
+				$prefix . 'payment_receipt_country_iso3166' => __( 'Country for payment receipt', 'wordcamporg' ),
 
 				// Payment Method - Direct Deposit.
 				$prefix . 'ach_bank_name'               => __( 'Bank Name', 'wordcamporg' ),

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -312,6 +312,7 @@ class WordCamp_Budgets {
 				 */
 				case 'vendor_country_iso3166':
 				case 'bank_country_iso3166':
+				case 'payment_receipt_country_iso3166':
 				case 'interm_bank_country_iso3166':
 				case 'beneficiary_country_iso3166':
 				case 'check_country':
@@ -376,6 +377,7 @@ class WordCamp_Budgets {
 			'bank_state',
 			'bank_zip_code',
 			'bank_country_iso3166',
+			'payment_receipt_country_iso3166',
 			'bank_bic',
 			'interm_bank_name',
 			'interm_bank_street_address',

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -48,18 +48,16 @@ jQuery( document ).ready( function( $ ) {
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
 
-			var initialValue = $('#bank_country_iso3166').val();
-			if (initialValue !== 'US') {
-				$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
-			}
 			$('#bank_country_iso3166').on('select2:select', function(e) {
-				var selectedValue = $(this).val();
+				const selectedValue = $(this).val();
 			
 				if (selectedValue === 'US') {
 					$('#payment_method_direct_deposit_container, #payment_method_check_container').show();
 				} else {
 					$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
 				}
+
+				$('#row-payment-method').show();
 			});
 		},
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -46,7 +46,7 @@ jQuery( document ).ready( function( $ ) {
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
 
-			$('#payment_receipt_country_iso3166').on('select2:select', function(e) {
+			$('#payment_receipt_country_iso3166').on('change', function(e) {
 				const selectedValue = $(this).val();
 			
 				if (selectedValue === 'US') {
@@ -56,7 +56,7 @@ jQuery( document ).ready( function( $ ) {
 				}
 
 				$('#row-payment-method').show();
-			}).trigger('select2:select');
+			}).trigger('change');
 		},
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 jQuery( document ).ready( function( $ ) {
 	'use strict';
 
@@ -45,7 +46,7 @@ jQuery( document ).ready( function( $ ) {
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
 
-			$('#bank_country_iso3166').on('select2:select', function(e) {
+			$('#payment_receipt_country_iso3166').on('select2:select', function(e) {
 				const selectedValue = $(this).val();
 			
 				if (selectedValue === 'US') {
@@ -55,7 +56,7 @@ jQuery( document ).ready( function( $ ) {
 				}
 
 				$('#row-payment-method').show();
-			});
+			}).trigger('select2:select');
 		},
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -35,9 +35,6 @@ jQuery( document ).ready( function( $ ) {
 			paymentCategory.change( app.toggleOtherCategoryDescription );
 			paymentCategory.trigger( 'change' );   // Set the initial state
 
-			currency.change( wcb.setDefaultPaymentMethod );
-			currency.trigger( 'change' );   // Set the initial state
-
 			$( '#row-files' ).find( 'a.wcb-insert-media' ).click( wcb.showUploadModal );
 
 			$('[name="post_status"]').on('change', function() {

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -47,6 +47,20 @@ jQuery( document ).ready( function( $ ) {
 				$notes.toggle(state);
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
+
+			var initialValue = $('#bank_country_iso3166').val();
+			if (initialValue !== 'US') {
+				$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
+			}
+			$('#bank_country_iso3166').on('select2:select', function(e) {
+				var selectedValue = $(this).val();
+			
+				if (selectedValue === 'US') {
+					$('#payment_method_direct_deposit_container, #payment_method_check_container').show();
+				} else {
+					$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
+				}
+			});
 		},
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 jQuery( document ).ready( function( $ ) {
 	'use strict';
 
@@ -61,18 +60,16 @@ jQuery( document ).ready( function( $ ) {
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
 
-			var initialValue = $('#bank_country_iso3166').val();
-			if (initialValue !== 'US') {
-				$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
-			}
 			$('#bank_country_iso3166').on('select2:select', function(e) {
-				var selectedValue = $(this).val();
+				const selectedValue = $(this).val();
 			
 				if (selectedValue === 'US') {
 					$('#payment_method_direct_deposit_container, #payment_method_check_container').show();
 				} else {
 					$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
 				}
+
+				$('#row-payment-method').show();
 			});
 		},
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 jQuery( document ).ready( function( $ ) {
 	'use strict';
 
@@ -57,7 +58,7 @@ jQuery( document ).ready( function( $ ) {
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
 
-			$('#bank_country_iso3166').on('select2:select', function(e) {
+			$('#payment_receipt_country_iso3166').on('select2:select', function(e) {
 				const selectedValue = $(this).val();
 			
 				if (selectedValue === 'US') {
@@ -67,7 +68,7 @@ jQuery( document ).ready( function( $ ) {
 				}
 
 				$('#row-payment-method').show();
-			});
+			}).trigger('select2:select');
 		},
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 jQuery( document ).ready( function( $ ) {
 	'use strict';
 
@@ -59,6 +60,20 @@ jQuery( document ).ready( function( $ ) {
 				$notes.toggle(state);
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
+
+			var initialValue = $('#bank_country_iso3166').val();
+			if (initialValue !== 'US') {
+				$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
+			}
+			$('#bank_country_iso3166').on('select2:select', function(e) {
+				var selectedValue = $(this).val();
+			
+				if (selectedValue === 'US') {
+					$('#payment_method_direct_deposit_container, #payment_method_check_container').show();
+				} else {
+					$('#payment_method_direct_deposit_container, #payment_method_check_container').hide();
+				}
+			});
 		},
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -58,7 +58,7 @@ jQuery( document ).ready( function( $ ) {
 				$notes.find('textarea').attr('required', state);
 			}).trigger('change');
 
-			$('#payment_receipt_country_iso3166').on('select2:select', function(e) {
+			$('#payment_receipt_country_iso3166').on('change', function(e) {
 				const selectedValue = $(this).val();
 			
 				if (selectedValue === 'US') {
@@ -68,7 +68,7 @@ jQuery( document ).ready( function( $ ) {
 				}
 
 				$('#row-payment-method').show();
-			}).trigger('select2:select');
+			}).trigger('change');
 		},
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -39,9 +39,6 @@ jQuery( document ).ready( function( $ ) {
 			reason.change( app.toggleOtherReasonDescription );
 			reason.trigger( 'change' );   // Set the initial state
 
-			currency.change( wcb.setDefaultPaymentMethod );
-			currency.trigger( 'change' );   // Set the initial state
-
 			paymentMethod.find( 'input[name=payment_method]' ).change( wcb.togglePaymentMethodFields );
 			paymentMethod.find( 'input[name=payment_method]:checked' ).trigger( 'change' ); // Set the initial state
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 jQuery( document ).ready( function( $ ) {
 	'use strict';
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
@@ -150,32 +150,6 @@ jQuery( document ).ready( function( $ ) {
 		},
 
 		/**
-		 * Set the default payment method based on the currency
-		 *
-		 * Don't override any existing payment method choices.
-		 *
-		 * @param {object} event
-		 */
-		setDefaultPaymentMethod : function ( event ) {
-			var newCurrency           = $( this ).find( 'option:selected' ).val(),
-			    selectedPaymentMethod = $( 'input[name=payment_method]:checked' ).val(),
-				newPaymentMethod;
-
-			if ( 'null' === newCurrency.slice( 0, 4 ) || undefined !== selectedPaymentMethod ) {
-				return;
-			}
-
-			if ( 'USD' == newCurrency ) {
-				newPaymentMethod = $( '#payment_method_direct_deposit' );
-			} else {
-				newPaymentMethod = $( '#payment_method_wire' );
-			}
-
-			newPaymentMethod.prop( 'checked', true );
-			newPaymentMethod.trigger( 'change' );
-		},
-
-		/**
 		 * Initialize Core's Media Picker
 		 *
 		 * @param {object} event

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-radio.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-radio.php
@@ -7,18 +7,20 @@
 		<?php foreach ( $options as $option ) : ?>
 			<?php $option_name = $name . '_' . sanitize_title_with_dashes( str_replace( ' ', '_', $option ) ); ?>
 
-			<input
-				type="radio"
-				id="<?php echo esc_attr( $option_name ); ?>"
-				name="<?php echo esc_attr( $name ); ?>"
-				value="<?php echo esc_attr( $option ); ?>"
-				<?php checked( $option, $selected ); ?>
-				<?php __checked_selected_helper( $required, true, true, 'required' ); ?>
-				/>
+			<span id="<?php echo esc_attr( $option_name ) . '_container'; ?>">
+				<input
+					type="radio"
+					id="<?php echo esc_attr( $option_name ); ?>"
+					name="<?php echo esc_attr( $name ); ?>"
+					value="<?php echo esc_attr( $option ); ?>"
+					<?php checked( $option, $selected ); ?>
+					<?php __checked_selected_helper( $required, true, true, 'required' ); ?>
+					/>
 
-			<label for="<?php echo esc_attr( $option_name ); ?>">
-				<?php echo esc_html( $option ); ?>:
-			</label>
+				<label for="<?php echo esc_attr( $option_name ); ?>">
+					<?php echo esc_html( $option ); ?>:
+				</label>
+			</span>
 		<?php endforeach; ?>
 
 		<?php

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-radio.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-radio.php
@@ -1,4 +1,4 @@
-<tr id="row-<?php echo esc_attr( str_replace( '_', '-', $name ) ); ?>">
+<tr id="row-<?php echo esc_attr( str_replace( '_', '-', $name ) ); ?>" class="<?php echo true === $is_visible ? 'active' : 'hidden'; ?>">
 	<th>
 		<?php echo esc_html( $label ); ?>:
 	</th>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -25,6 +25,7 @@
 				); ?>
 			<?php endif; ?>
 
+			<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Bank Country', 'wordcamporg' ), 'bank_country_iso3166' ); ?>
 			<?php $this->render_radio_input( $post, esc_html__( 'Payment Method', 'wordcamporg' ), 'payment_method' ); ?>
 		</table>
 
@@ -62,7 +63,6 @@
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank City',              'wordcamporg' ), 'bank_city'                  ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank State / Province',  'wordcamporg' ), 'bank_state'                 ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank ZIP / Postal Code', 'wordcamporg' ), 'bank_zip_code'              ); ?>
-				<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Bank Country',           'wordcamporg' ), 'bank_country_iso3166'       ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank SWIFT BIC',         'wordcamporg' ), 'bank_bic'                   ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Account Number or IBAN', 'wordcamporg' ), 'beneficiary_account_number' ); ?>
 			</table>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -25,8 +25,8 @@
 				); ?>
 			<?php endif; ?>
 
-			<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Bank Country', 'wordcamporg' ), 'bank_country_iso3166' ); ?>
-			<?php $this->render_radio_input( $post, esc_html__( 'Payment Method', 'wordcamporg' ), 'payment_method' ); ?>
+			<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Country', 'wordcamporg' ), 'bank_country_iso3166' ); ?>
+			<?php $this->render_radio_input( $post, esc_html__( 'Payment Method', 'wordcamporg' ), 'payment_method', true, false ); ?>
 		</table>
 
 		<table id="payment_method_direct_deposit_fields" class="form-table payment_method_fields <?php echo 'Direct Deposit' == $selected_payment_method ? 'active' : 'hidden'; ?>">

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -25,8 +25,8 @@
 				); ?>
 			<?php endif; ?>
 
-			<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Country', 'wordcamporg' ), 'bank_country_iso3166' ); ?>
-			<?php $this->render_radio_input( $post, esc_html__( 'Payment Method', 'wordcamporg' ), 'payment_method', true, false ); ?>
+			<?php $this->render_country_input( $post, esc_html__( 'Country for payment receipt', 'wordcamporg' ), 'payment_receipt_country_iso3166' ); ?>
+			<?php $this->render_radio_input( $post, esc_html__( 'Payment Method', 'wordcamporg' ), 'payment_method', true, $selected_payment_receipt_country ? true : false ); ?>
 		</table>
 
 		<table id="payment_method_direct_deposit_fields" class="form-table payment_method_fields <?php echo 'Direct Deposit' == $selected_payment_method ? 'active' : 'hidden'; ?>">
@@ -63,6 +63,7 @@
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank City',              'wordcamporg' ), 'bank_city'                  ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank State / Province',  'wordcamporg' ), 'bank_state'                 ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank ZIP / Postal Code', 'wordcamporg' ), 'bank_zip_code'              ); ?>
+				<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Bank Country',           'wordcamporg' ), 'bank_country_iso3166' ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Bank SWIFT BIC',         'wordcamporg' ), 'bank_bic'                   ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s Account Number or IBAN', 'wordcamporg' ), 'beneficiary_account_number' ); ?>
 			</table>


### PR DESCRIPTION
Closes #977

This PR hides the `Direct Deposit` and `Check` payment methods when the selected country is NOT the US.

### Screencasts


https://github.com/WordPress/wordcamp.org/assets/18050944/a445c785-9efb-4c24-a266-abcc8cbcd53b



<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go to Budget Tool > Vendor Payment and Reimbursement Request > Add New.
2. Under `Payment Details / Payment Information`, select your `Country for payment receipt` as either `United States` or `non-US countries`.
3. You should see it behave as requested or as video above.
4. Save changes, and you should see the data is correctly saved.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
