### PR TITLE
Add Sponsor Tickets

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/css/wordcamp-budgets.css
+++ b/public_html/wp-content/plugins/wordcamp-payments/css/wordcamp-budgets.css
@@ -187,14 +187,8 @@ tr#row-payment-method label {
 	}
 
 /* Budget Tool */
-.wcb-budget-tool .left {
-	width: 50%;
-	float: left;
-}
-
-.wcb-budget-tool .right {
-	width: 50%;
-	float: left;
+.wcb-budget-tool .first-section {
+	display: flex;
 }
 
 .wcb-budget-tool .nav-tab-wrapper svg {
@@ -418,4 +412,10 @@ tr#row-payment-method label {
 .wcb-budget-summary .inspire {
 	color: #aaa;
 	font-weight: normal;
+}
+
+.wcb-budget-attendees,
+.wcb-budget-attendees td,
+.wcb-budget-attendees th {
+	border-left: none;
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -290,7 +290,6 @@ class WordCamp_Budget_Tool {
 
 			array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Venue', 'amount' => 0 ),
 			array( 'type' => 'expense', 'category' => 'venue', 'note' => 'Wifi Costs', 'amount' => 0, 'link' => 'per-day' ),
-			array( 'type' => 'expense', 'category' => 'other', 'note' => 'Comped Tickets', 'amount' => 0 ),
 			array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Video recording', 'amount' => 0 ),
 			array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Projector rental', 'amount' => 0 ),
 			array( 'type' => 'expense', 'category' => 'audio-visual', 'note' => 'Livestream', 'amount' => 0 ),
@@ -301,6 +300,7 @@ class WordCamp_Budget_Tool {
 			array( 'type' => 'expense', 'category' => 'food-beverage', 'note' => 'Coffee', 'amount' => 0 ),
 			array( 'type' => 'expense', 'category' => 'swag', 'note' => 'T-shirts', 'amount' => 0 ),
 			array( 'type' => 'expense', 'category' => 'speaker-event', 'note' => 'Speakers Dinner', 'amount' => 0, 'link' => 'per-speaker' ),
+			array( 'type' => 'expense', 'category' => 'comped-tickets', 'note' => 'For speakers, special guests, members of the press, volunteers, etc.', 'amount' => 0 ),
 		);
 
 		$extra_budget_for_next_gen = array(

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -274,6 +274,7 @@ class WordCamp_Budget_Tool {
 			array( 'type' => 'meta', 'name' => 'speakers', 'value' => 0 ),
 			array( 'type' => 'meta', 'name' => 'volunteers', 'value' => 0 ),
 			array( 'type' => 'meta', 'name' => 'organizers', 'value' => 0 ),
+			array( 'type' => 'meta', 'name' => 'sponsor-tickets', 'value' => 0 ),
 			array( 'type' => 'meta', 'name' => 'currency', 'value' => 'USD' ),
 			array( 'type' => 'meta', 'name' => 'ticket-price', 'value' => 0 ),
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -218,6 +218,7 @@ class WordCamp_Budget_Tool {
 		$count_speakers   = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'speakers' ) ), 'value' ) );
 		$count_volunteers = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'volunteers' ) ), 'value' ) );
 		$count_organizers = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'organizers' ) ), 'value' ) );
+		$count_sponsors   = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'sponsor-tickets' ) ), 'value' ) );
 		$count_attendees  = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'attendees' ) ), 'value' ) );
 		$count_days       = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'days' ) ), 'value' ) );
 		$count_tracks     = (int) current( wp_list_pluck( wp_list_filter( $meta, array( 'name' => 'tracks' ) ), 'value' ) );
@@ -230,12 +231,16 @@ class WordCamp_Budget_Tool {
 				return $value * $count_volunteers;
 			case 'per-organizer':
 				return $value * $count_organizers;
+			case 'per-sponsor':
+				return $value * $count_sponsors;
 			case 'per-speaker-volunteer':
 				return $value * $count_speakers + $value * $count_volunteers;
 			case 'per-speaker-volunteer-organizer':
 				return $value * $count_speakers + $value * $count_volunteers + $value * $count_organizers;
 			case 'per-attendee':
 				return $value * $count_attendees;
+			case 'per-attendee-sponsor':
+				return $value * $count_attendees + $value * $count_sponsors;
 			case 'per-day':
 				return $value * $count_days;
 			case 'per-track':

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -580,10 +580,11 @@ class WordCamp_Budgets {
 	 */
 	public static function get_payment_categories() {
 		$categories = array(
-			// Changes here may need to be synchronized with `_get_default_budget_og_wordcamp()` or `_get_default_budget_next_gen_wordcamp`.
+			// Changes here may need to be synchronized with `_get_default_budget()`.
 			'after-party'     => esc_html__( 'After Party',                    'wordcamporg' ),
 			'audio-visual'    => esc_html__( 'Audio Visual',                   'wordcamporg' ),
 			'camera-shipping' => esc_html__( 'Camera Shipping',                'wordcamporg' ),
+			'comped-tickets'  => esc_html__( 'Complimentary Tickets',          'wordcamporg' ),
 			'food-beverages'  => esc_html__( 'Food & Beverage',                'wordcamporg' ),
 			'office-supplies' => esc_html__( 'Office Supplies',                'wordcamporg' ),
 			'signage-badges'  => esc_html__( 'Signage & Badges',               'wordcamporg' ),

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -9,6 +9,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 		$income    = $container.find( '.wcb-income-placeholder' ),
 		$expense   = $container.find( '.wcb-expense-placeholder' ),
 		$meta      = $container.find( '.wcb-meta-placeholder' ),
+		$attendees = $container.find( '.wcb-attendees-placeholder' ),
 		$summary   = $( '.wcb-summary-placeholder' ),
 		$form      = $( '.wcb-submit-form' );
 
@@ -368,7 +369,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 		},
 
 		addOne: function( item ) {
-			var view = new EntryView( { model: item } );
+			const view = new EntryView( { model: item } );
 
 			switch ( view.model.get( 'type' ) ) {
 				case 'expense':
@@ -378,6 +379,17 @@ window.wcb = window.wcb || { models: {}, input: [] };
 					var $c = $income;
 					break;
 				case 'meta':
+					switch ( view.model.get( 'name' ) ) {
+						case 'attendees':
+						case 'speakers':
+						case 'volunteers':
+						case 'organizers':
+							var $c = $attendees;
+							break;
+						default:
+							var $c = $meta;
+					}
+					break;
 				default:
 					var $c = $meta;
 			}

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -469,6 +469,17 @@ window.wcb = window.wcb || { models: {}, input: [] };
 			},
 		},
 
+		'per-sponsor' : {
+			'label'    : 'per sponsor',
+			'hasValue' : true,
+			'callback' : function( value ) {
+				return parseFloat( value ) * parseInt( wcb.table.collection.findWhere( {
+					type : 'meta',
+					name : 'sponsor-tickets',
+				} )?.get( 'value' ) );
+			},
+		},
+
 		'per-speaker-volunteer' : {
 			'label'    : ( networkStatus.isNextGenWordCamp ? 'per facilitator' : 'per speaker' ) + ' + volunteer',
 			'hasValue' : true,
@@ -514,6 +525,21 @@ window.wcb = window.wcb || { models: {}, input: [] };
 				return parseFloat( value ) * parseInt( wcb.table.collection.findWhere( {
 					type : 'meta',
 					name : 'attendees',
+				} ).get( 'value' ) );
+			},
+		},
+
+		'per-attendee-sponsor' : {
+			'label'    : 'per attendee + sponsor',
+			'hasValue' : true,
+			'callback' : function( value ) {
+				return parseFloat( value ) * parseInt( wcb.table.collection.findWhere( {
+					type : 'meta',
+					name : 'attendees',
+				} ).get( 'value' ) )
+				+ parseInt( wcb.table.collection.findWhere( {
+					type : 'meta',
+					name : 'sponsor-tickets',
 				} ).get( 'value' ) );
 			},
 		},

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -370,29 +370,27 @@ window.wcb = window.wcb || { models: {}, input: [] };
 
 		addOne: function( item ) {
 			const view = new EntryView( { model: item } );
+			const type = view.model.get('type');
+			const name = view.model.get('name');
 
-			switch ( view.model.get( 'type' ) ) {
-				case 'expense':
-					var $c = $expense;
-					break;
-				case 'income':
-					var $c = $income;
-					break;
-				case 'meta':
-					switch ( view.model.get( 'name' ) ) {
-						case 'attendees':
-						case 'speakers':
-						case 'volunteers':
-						case 'organizers':
-						case 'sponsor-tickets':
-							var $c = $attendees;
-							break;
-						default:
-							var $c = $meta;
-					}
-					break;
-				default:
-					var $c = $meta;
+			const typeMappings = {
+				'expense': $expense,
+				'income': $income,
+				'meta': $meta
+			};
+			
+			const metaNameMappings = {
+				'attendees': $attendees,
+				'speakers': $attendees,
+				'volunteers': $attendees,
+				'organizers': $attendees,
+				'sponsor-tickets': $attendees
+			};
+			
+			let $c = typeMappings[type] || $meta; // default to $meta if type is not found
+			
+			if (type === 'meta' && metaNameMappings[name]) {
+				$c = metaNameMappings[name];
 			}
 
 			$c.before( view.render().el );

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/budget-tool.js
@@ -278,7 +278,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 				if ( networkStatus.isNextGenWordCamp && ( name === 'days' || name === 'hours' ) ) {
 					this.model.set( 'name', this.$el.find( '.name' ).val() );
 				}
-				if ( _.contains( [ 'attendees', 'days', 'tracks', 'speakers', 'volunteers', 'organizers' ], name ) ) {
+				if ( _.contains( [ 'attendees', 'days', 'tracks', 'speakers', 'volunteers', 'organizers', 'sponsor-tickets' ], name ) ) {
 					value = parseInt( value.replace( /[^\d.-]/g, '' ) ) || 0;
 				} else if ( _.contains( [ 'ticket-price', 'hours' ], name ) ) {
 					value = parseFloat( value.replace( /[^\d.-]/g, '' ) ) || 0;
@@ -384,6 +384,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 						case 'speakers':
 						case 'volunteers':
 						case 'organizers':
+						case 'sponsor-tickets':
 							var $c = $attendees;
 							break;
 						default:
@@ -416,6 +417,7 @@ window.wcb = window.wcb || { models: {}, input: [] };
 		'speakers'              : networkStatus.isNextGenWordCamp ? 'Facilitators' : 'Speakers',
 		'volunteers'            : 'Volunteers',
 		'organizers'            : 'Organizers',
+		'sponsor-tickets'       : 'Sponsor Tickets',
 		'currency'              : 'Currency',
 		'ticket-price'          : 'Ticket Price',
 		// Only exists in the Central Network.

--- a/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
@@ -50,37 +50,43 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
 		<p style="max-width: 800px;"><?php esc_html_e( 'Welcome to your working budget. Feel free to play around with numbers here. They will not affect your approved budget.', 'wordcamporg' ); ?></p>
     <?php endif; ?>
 
-    <div class="left">
-        <h2><?php esc_html_e( 'Event Data', 'wordcamporg' ); ?></h2>
-        <table class="wcb-budget-container">
-            <tbody>
-                <tr class="wcb-group-header">
-                    <th style="width: 50%;"><?php esc_html_e( 'Name',  'wordcamporg' ); ?></th>
-                    <th style="width: 50%;"><?php esc_html_e( 'Value', 'wordcamporg' ); ?></th>
-                </tr>
-                <tr class="wcb-meta-placeholder" style="display: none;">
-                    <td colspan="2"></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <div class="left">
-        <h2><?php esc_html_e( 'Attendees', 'wordcamporg' ); ?></h2>
-        <table class="wcb-budget-container">
-            <tbody>
-                <tr class="wcb-group-header">
-                    <th style="width: 50%;"><?php esc_html_e( 'Name',  'wordcamporg' ); ?></th>
-                    <th style="width: 50%;"><?php esc_html_e( 'Value', 'wordcamporg' ); ?></th>
-                </tr>
-                <tr class="wcb-attendees-placeholder" style="display: none;">
-                    <td colspan="2"></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <div class="right">
-        <h2><?php esc_html_e( 'Summary', 'wordcamporg' ); ?></h2>
-        <div class="wcb-summary-placeholder"></div>
+    <div class="first-section">
+        <div>
+            <h2><?php esc_html_e( 'Event Data', 'wordcamporg' ); ?></h2>
+            <table class="wcb-budget-container">
+                <tbody>
+                    <tr class="wcb-group-header">
+                        <th style="width: 50%;"><?php esc_html_e( 'Name',  'wordcamporg' ); ?></th>
+                        <th style="width: 50%;"><?php esc_html_e( 'Value', 'wordcamporg' ); ?></th>
+                    </tr>
+                    <tr class="wcb-meta-placeholder" style="display: none;">
+                        <td colspan="2"></td>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div>
+            <h2><?php esc_html_e( 'Attendees', 'wordcamporg' ); ?></h2>
+            <table class="wcb-budget-container wcb-budget-attendees">
+                <tbody>
+                    <tr class="wcb-group-header">
+                        <th style="width: 50%;"><?php esc_html_e( 'Name',  'wordcamporg' ); ?></th>
+                        <th style="width: 50%;"><?php esc_html_e( 'Value', 'wordcamporg' ); ?></th>
+                    </tr>
+                    <tr class="wcb-attendees-placeholder" style="display: none;">
+                        <td colspan="2"></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div>
+            <h2><?php esc_html_e( 'Summary', 'wordcamporg' ); ?></h2>
+            <div class="wcb-summary-placeholder"></div>
+        </div>
     </div>
 
     <div class="clear"></div>
@@ -180,18 +186,6 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
                 ?>
             </td>
             <td class="amount">{{data.per_person}}</td>
-        </tr>
-        <tr>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td></td>
         </tr>
         <tr>
             <td></td>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/budget-tool/main.php
@@ -64,6 +64,20 @@ wcb.editable = <?php echo json_encode( $editable ); ?>;
             </tbody>
         </table>
     </div>
+    <div class="left">
+        <h2><?php esc_html_e( 'Attendees', 'wordcamporg' ); ?></h2>
+        <table class="wcb-budget-container">
+            <tbody>
+                <tr class="wcb-group-header">
+                    <th style="width: 50%;"><?php esc_html_e( 'Name',  'wordcamporg' ); ?></th>
+                    <th style="width: 50%;"><?php esc_html_e( 'Value', 'wordcamporg' ); ?></th>
+                </tr>
+                <tr class="wcb-attendees-placeholder" style="display: none;">
+                    <td colspan="2"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
     <div class="right">
         <h2><?php esc_html_e( 'Summary', 'wordcamporg' ); ?></h2>
         <div class="wcb-summary-placeholder"></div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #927

This PR adds `Sponsor Tickets` and `Complimentary Tickets` fields as requested.

<!-- List out anyone who helped with this task. -->
Props @timiwahalahti 

<!-- Don't forget to update the title with something descriptive. -->

### Screencasts

https://github.com/WordPress/wordcamp.org/assets/18050944/4de11e5e-9b9e-4fad-a266-328cadaf39a9

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. In Budget Tool, there should be a new section `Attendees` next to `Event Data`.
2. In the `Attendees` section, `Sponsor Tickets` should be there.
3. Clicking any of the `Expenses > Amount` entries, you should see `per sponsor` and `per attendee+sponsor`.
4. `Expenses` and `Cost Per Person` in the `Summary` section should reflect correctly on whatever number or amount you enter for `Sponsor Tickets` and amount in `Expenses > Amount` enries.
5. In `Expense > Category`, you should be able to add a new category `Complimentary Tickets`.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
