### PR TITLE
WC Central Theme: Fixing some CSS responsive issues

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -1813,7 +1813,7 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 	font-size: 14px;
 	text-align: center;
 
-	width: 220px;
+	width: 219px;
 	margin: 22px 60px 0 0;
 }
 
@@ -1833,7 +1833,6 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 .single-wordcamp .wc-single-website img {
 	display: block;
 	margin: 0 auto 5px;
-	width: inherit;
 	border: 7px #fff solid;
 	box-sizing: border-box;
 	box-shadow: 0px 2px 5px #75888a;
@@ -3033,12 +3032,21 @@ h3#comments-title {
 		width: 100%;
 	}
 
+	#masthead {
+		width: 94%;
+	}
+
 	#footer {
 		margin-top: 30px;
 	}
 
 	#branding  {
 		overflow:hidden;
+	}
+
+	#site-title {
+		box-sizing: border-box;
+		width: 100%;
 	}
 
 	#content img {
@@ -3115,23 +3123,24 @@ h3#comments-title {
 		box-sizing: border-box;
 		margin-left: 0;
 		margin-bottom: 20px;
-		margin-right: 0;
 		width: 25%;
+	}
+
+
+	.single-wordcamp .wc-single-website {
+		margin-left: 20px;
+		margin-right: 20px;
+		max-width: 33%;
 	}
 
 	.single-wordcamp .wc-single-info {
 		padding-left: 25px;
 		padding-right: 25px;
-		width: 50%;
+		width: 100%;
 	}
 }
 
 @media screen and (max-width: 950px) {
-	#site-title {
-		box-sizing: border-box;
-		padding-left: 10px;
-	}
-
 	#access {
 		position: relative;
 		left: auto;
@@ -3217,8 +3226,8 @@ h3#comments-title {
 		overflow:hidden;
 	}
 
-	#site-title {
-		width: 100%;
+	#masthead {
+		width: 96%;
 	}
 
 	#container {
@@ -3363,11 +3372,8 @@ h3#comments-title {
 		width: 100%;
 	}
 
-	.single-wordcamp .wc-single-website {
-		width: 33%;
-	}
 	.single-wordcamp .wc-single-info {
-		width: 67%;
+		width: 100%;
 	}
 
 	.single-wordcamp .wc-single-past {
@@ -3495,6 +3501,16 @@ h3#comments-title {
 		width: 100%;
 	}
 
+	.single-wordcamp .wc-single-website {
+		margin-left: 0;
+		margin-right: 0;
+		max-width: 100%;
+	}
+
+	.single-wordcamp .wc-single-website img {
+		width: inherit;
+	}
+
 	.wc-single-past {
 		padding-left: 25px;
 		padding-right: 25px;
@@ -3528,6 +3544,10 @@ h3#comments-title {
 }
 
 @media screen and (max-width: 400px) {
+	#masthead {
+		width: 94%;
+	}
+
 	#site-title a {
 		background-size: contain;
 		width: 94%;


### PR DESCRIPTION
Fixes Trac: https://meta.trac.wordpress.org/ticket/6747

Props @baroliyamayur

This is a fix to the responsiveness issue reported on Meta Trac in issue 6747. It not only solved this spacing issue, but also two other issues:

1. The header logo is not positioned/aligned correctly in the different sizes.
1. The website image is blurry on all larger sizes, as the container is 1px too large
1. The website images are too small and not aligned with the "About" text

### Screenshots

I've made a couple of screenshots using devices that use the problematic screen sizes:

#### iPhone SE (portrait)

Before |  After
:---------:|:---------:
![central wordcamp test_wordcamps_new-site_(iPhone SE)-portrait-before](https://github.com/WordPress/wordcamp.org/assets/1793177/9651a781-f6a8-4f4a-9072-b1938189aedc)|![central wordcamp test_wordcamps_new-site_(iPhone SE)-portrait-after](https://github.com/WordPress/wordcamp.org/assets/1793177/217d8660-b954-41d5-8cde-99a3c892d5d9)

Issues:
- WordCamp Central logo misaligned

#### iPad mini (portrait)

Before |  After
:---------:|:---------:
![central wordcamp test_wordcamps_new-site_(iPad Mini)-portrait-before](https://github.com/WordPress/wordcamp.org/assets/1793177/ae7d39c6-f9d3-4dbc-b487-8aab3b0f75ee)|![central wordcamp test_wordcamps_new-site_(iPad Mini)-portrait-after](https://github.com/WordPress/wordcamp.org/assets/1793177/acea76d3-bc11-4477-9ebe-2bc60b13d913)

Issues:
- WordCamp Central logo misaligned
- Website image too small
- Column too small

#### iPad mini (landscape)

Before |  After
:---------:|:---------:
![central wordcamp test_wordcamps_new-site_(iPad Mini)-landscape-before](https://github.com/WordPress/wordcamp.org/assets/1793177/8c3a7f66-1be7-46d9-95ad-82b871db719f)|![central wordcamp test_wordcamps_new-site_(iPad Mini)-landscape-after](https://github.com/WordPress/wordcamp.org/assets/1793177/77d17c41-4a74-4387-a299-51131a2dbccc)


Issues:
- WordCamp Central logo misaligned
- Website image too small
- Column too small

#### Surface Pro 7 (landscape) / small laptop

Before |  After
:---------:|:---------:
![central wordcamp test_wordcamps_new-site_(Surface Pro 7)-landscape-before](https://github.com/WordPress/wordcamp.org/assets/1793177/3b801260-83b0-4b8f-9002-5a7e688cfe6e)|![central wordcamp test_wordcamps_new-site_(Surface Pro 7)-landscape-after](https://github.com/WordPress/wordcamp.org/assets/1793177/e2196aba-571d-4cb1-904e-e25476aac073)

With these changes applied, the website screenshots are no longer blurry. The "columns" also take up the same space, while the website images are larger. The "WordCamp Central" logo is also aligned with the WordCamp title ("New Site").

Issues:
- Website image too big and blurry
