### PR TITLE
QBO: Only access ID for successful responses to avoid fatal error

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -750,12 +750,12 @@ class WordCamp_QBO {
 	 * @return int|WP_Error The customer ID if success; a WP_Error if failure
 	 */
 	protected static function probably_get_customer_id( $sponsor, $currency_code ) {
-		$customer    = self::get_customer( $sponsor['company-name'], $currency_code );
-		$customer_id = $customer['Id'];
+		$customer = self::get_customer( $sponsor['company-name'], $currency_code );
 
 		if ( is_wp_error( $customer ) || ! $customer ) {
 			$customer_id = self::create_customer( $sponsor, $currency_code );
 		} else {
+			$customer_id = $customer['Id'];
 			self::update_customer( $customer, $sponsor );
 		}
 


### PR DESCRIPTION
ba7fa61eaabc82855f9ca9d555c2a5d7f7f1acd1 refactored this function, but accidentally started accessing the `Id` field before checking if the response was a `WP_Error`. That triggers a fatal error because it's treating an object like an array.

