### PR TITLE
Events: Show upcoming events on home page

### DIFF
--- a/.docker/data/wordcamp_dev.sql
+++ b/.docker/data/wordcamp_dev.sql
@@ -2335,8 +2335,39 @@ LOCK TABLES `wc_wordcamp_payments_index` WRITE;
 /*!40000 ALTER TABLE `wc_wordcamp_payments_index` DISABLE KEYS */;
 /*!40000 ALTER TABLE `wc_wordcamp_payments_index` ENABLE KEYS */;
 UNLOCK TABLES;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
+--
+-- Dumping data for table `wporg_events`
+--
+
+CREATE TABLE `wporg_events` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(32) NOT NULL DEFAULT '',
+  `source_id` varchar(32) NOT NULL DEFAULT '',
+  `status` varchar(16) NOT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
+  `url` text NOT NULL,
+  `description` longtext,
+  `attendees` int unsigned DEFAULT NULL,
+  `meetup` varchar(255) DEFAULT NULL,
+  `meetup_url` text,
+  `date_utc` datetime NOT NULL,
+  `date_utc_offset` varchar(32) DEFAULT NULL,
+  `end_date` datetime NOT NULL,
+  `location` text,
+  `country` varchar(64) DEFAULT NULL,
+  `latitude` double NOT NULL,
+  `longitude` double NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `event_source_id` (`type`,`source_id`),
+  UNIQUE KEY `event_type_url` (`type`,`url`(255)),
+  KEY `date` (`date_utc`),
+  KEY `country` (`country`),
+  KEY `lat_lon` (`latitude`,`longitude`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -176,6 +176,7 @@ define( 'WORDCAMP_PAYMENT_STRIPE_SECRET',           '' );
 define( 'WORDCAMP_PAYMENT_STRIPE_PUBLISHABLE_LIVE', '' );
 define( 'WORDCAMP_PAYMENT_STRIPE_SECRET_LIVE',      '' );
 
+define( 'WORDCAMP_PROD_GOOGLE_MAPS_API_KEY', '' );
 define( 'WORDCAMP_DEV_GOOGLE_MAPS_API_KEY', '' );
 
 define( 'MEETUP_API_BASE_URL', 'https://api.meetup.com/' );

--- a/composer.lock
+++ b/composer.lock
@@ -69,12 +69,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1"
+                "reference": "270e7f7f2b53e4b9ce068d7537e3687531e39ad0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
-                "reference": "d5311dafbe40fdc6d16ca2119b17a39ac19800a1",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/270e7f7f2b53e4b9ce068d7537e3687531e39ad0",
+                "reference": "270e7f7f2b53e4b9ce068d7537e3687531e39ad0",
                 "shasum": ""
             },
             "type": "wordpress-theme",
@@ -82,7 +82,7 @@
                 "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
                 "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
             },
-            "time": "2023-08-22T15:22:31+00:00"
+            "time": "2023-09-04T15:30:39+00:00"
         }
     ],
     "packages-dev": [

--- a/public_html/wp-content/themes/wporg-events-2023/functions.php
+++ b/public_html/wp-content/themes/wporg-events-2023/functions.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Events_2023;
 
 defined( 'WPINC' ) || die();
 
+require_once __DIR__ . '/inc/event-getters.php';
 
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 

--- a/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WordPressdotorg\Events_2023;
+
+defined( 'WPINC' ) || die();
+
+
+/**
+ * Get a list of all upcoming events across all sites.
+ */
+function get_all_upcoming_events(): array {
+	global $wpdb;
+
+	$events = $wpdb->get_results( '
+		SELECT
+			id, `type`, title, url, meetup, location, latitude, longitude, date_utc,
+			date_utc_offset AS tz_offset
+		FROM `wporg_events`
+		WHERE
+			status = "scheduled" AND
+			(
+				( "wordcamp" = type AND date_utc BETWEEN NOW() AND ADDDATE( NOW(), 180 ) ) OR
+				( "meetup" = type AND date_utc BETWEEN NOW() AND ADDDATE( NOW(), 60 ) )
+			)
+		ORDER BY date_utc ASC
+		LIMIT 400'
+	);
+
+	foreach ( $events as $event ) {
+		// `capital_P_dangit()` won't work here because the current filter isn't `the_title` and there isn't a safelisted prefix before `$text`.
+		$event->title = str_replace( 'Wordpress', 'WordPress', $event->title );
+
+		// `date_utc` is a misnomer, the value is actually in the local timezone of the event. So, convert to a true Unix timestamp (UTC).
+		// Can't do this reliably in the query because MySQL converts it to the server timezone.
+		$event->timestamp = strtotime( $event->date_utc ) - $event->tz_offset;
+
+		unset( $event->date_utc );
+	}
+
+	return $events;
+}

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/front-page-map.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/front-page-map.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Title: Event Map
+ * Slug: wporg-events-2023/event-map
+ * Inserter: no
+ */
+
+namespace WordPressdotorg\Events_2023;
+
+defined( 'WPINC' ) || die();
+
+$map_options = array(
+	'id'      => 'all-upcoming-events',
+	'markers' => get_all_upcoming_events(),
+);
+
+?>
+
+<!-- wp:wporg/google-map <?php echo wp_json_encode( $map_options ); ?> /-->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/local-navigation.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/local-navigation.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Title: Local Navigation
+ * Slug: wporg-events-2023/local-navigation
+ * Inserter: no
+ *
+ * This nav bar also has the site title, so it should be used on interior pages.
+ */
+
+namespace WordPressdotorg\Events_2023;
+
+defined( 'WPINC' ) || die();
+
+?>
+
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}},"border":{"top":{"color":"var:preset|color|charcoal-3","style":"solid","width":"1px"},"right":{},"bottom":{},"left":{}}},"textColor":"white","fontSize":"small"} -->
+	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
+
+	<!-- wp:navigation {"ref":7206,"textColor":"white","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->

--- a/public_html/wp-content/themes/wporg-events-2023/templates/front-page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/front-page.html
@@ -1,0 +1,11 @@
+<!-- wp:wporg/global-header /-->
+
+<!-- wp:pattern {"slug":"wporg-events-2023/local-navigation"} /-->
+
+<!-- wp:group {"tagName":"main","className":"entry-content"} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-events-2023/event-map"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer /-->


### PR DESCRIPTION
This adds the Map block to the events.w.org homepage, and populates it with upcoming events. This only focuses on the functionality, we can iterate on design/copy in future PRs.

See #1007
Fixes #1014

### Screenshots


<img width="1749" alt="Screenshot 2023-09-05 at 3 36 54 PM" src="https://github.com/WordPress/wordcamp.org/assets/484068/4a7ea4e5-b3c9-4f01-bfb5-47fb460b1a93">
