### PR TITLE
1029-Typo on the tickets page

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/health-advisory.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/health-advisory.php
@@ -37,7 +37,7 @@ class Health_Advisory_Field extends CampTix_Addon {
 		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
 			<td class="tix-required tix-left" colspan="2">
 				<p><?php esc_html_e( 'We invite you to help us make WordCamps a welcome and safe experience for everyone. When planning to attend WordCamp, we recommend that you stay at home if you are sick, or have recently come in contact with someone who is ill.', 'wordcamporg' ); ?></p>
-				<p><?php esc_html_e( 'If you see another attendee wearing a sticker requesting that people wear a mask near them, please do wear a mask while within 6 feet (2 meters) of them or keep your distance.', 'wordcamporg' ); ?></p>
+				<p><?php esc_html_e( 'If you see another attendee wearing a mask requesting that people wear a mask near them, please do wear a mask while within 6 feet (2 meters) of them or keep your distance.', 'wordcamporg' ); ?></p>
 			</td>
 		</tr>
 


### PR DESCRIPTION
The ticket page says

If you see another attendee wearing a sticker requesting that people wear a mask near them, please do wear a mask while within 6 feet (2 meters) of them or keep your distance.

"sticker" looks to be a wrong word there, needs to fix.

To reproduce

Steps to reproduce the behavior:

    Go to the tickets page on any WordCamp site
    Select quantity of tickets
    Scroll down to the end of the details
    See the content

Expected message

If you see another attendee wearing a mask requesting that people wear a mask near them, please do wear a mask while within 6 feet (2 meters) of them or keep your distance.