### PR TITLE
Docker: Convert hostname to lowercase to fix fatal error

### DIFF
--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -43,7 +43,7 @@ const WORDCAMP_ROOT_BLOG_ID = 5;
 const EVENTS_NETWORK_ID     = 2;
 const EVENTS_ROOT_BLOG_ID   = 47;
 
-switch ( $_SERVER['HTTP_HOST'] ) {
+switch ( strtolower( $_SERVER['HTTP_HOST'] ) ) {
 	case 'events.wordpress.test':
 		define( 'SITE_ID_CURRENT_SITE',  EVENTS_NETWORK_ID );
 		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID );


### PR DESCRIPTION
See #1019 

Otherwise pentesters using `curl` with a hostname like `Events.wordpress.org` (not the uppercase) will clutter the logs with fatal errors because the Global Fonts mu-plugin isn't loaded. Regular browsers automatically convert the domain to lowercase before sending the request.

The production config will need to be changed in SVN.
