### PR TITLE
Show events on city landing pages

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -20,6 +20,9 @@ defined( 'WPINC' ) || die();
  * @return array
  */
 function get_wordcamps( $args = array() ) {
+	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-event/class-event-loader.php';
+	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-wordcamp/wordcamp-loader.php';
+
 	$args = wp_parse_args(
 		$args,
 		array(

--- a/public_html/wp-content/themes/wporg-events-2023/functions.php
+++ b/public_html/wp-content/themes/wporg-events-2023/functions.php
@@ -1,13 +1,58 @@
 <?php
 
 namespace WordPressdotorg\Events_2023;
+use WP;
 
 defined( 'WPINC' ) || die();
 
 require_once __DIR__ . '/inc/event-getters.php';
 
+add_filter( 'parse_request', __NAMESPACE__ . '\add_city_landing_page_query_vars' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
+/**
+ * Override the current query vars so that the city landing page loads instead.
+ */
+function add_city_landing_page_query_vars( WP $wp ): void {
+	if ( ! wp_using_themes() || ! is_main_query() || ! is_city_landing_page() ) {
+		return;
+	}
+
+	// This assumes there's a placeholder page in the database with this slug.
+	$wp->set_query_var( 'page', '' );
+	$wp->set_query_var( 'pagename', 'city-landing-page' );
+}
+
+/**
+ * Determine if the current request is for a city landing page.
+ *
+ * See `get_city_landing_sites()` for examples of request URIs.
+ */
+function is_city_landing_page() {
+	global $wp, $wpdb;
+
+	// The landing page formats will always match the rewrite rule for pages, which sets `page` and `pagename`.
+	if ( empty( $wp->query_vars['page'] ) && empty( $wp->query_vars['pagename'] ) ) {
+		return false;
+	}
+
+	$city = explode( '/', $wp->request );
+	$city = $city[0] ?? false;
+
+	// Using this instead of `get_sites()` so that the search doesn't match false positives.
+	$sites = $wpdb->get_results( $wpdb->prepare( "
+		SELECT blog_id
+		FROM {$wpdb->blogs}
+		WHERE
+			site_id = %d AND
+			path REGEXP %s
+		LIMIT 1",
+		EVENTS_NETWORK_ID,
+		"^/$city/\d{4}/[a-z-]+/$"
+	) );
+
+	return ! empty( $sites );
+}
 
 /**
  * Enqueue scripts and styles.

--- a/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WordPressdotorg\Events_2023;
+use WP_Post, DateTimeZone, DateTime;
 
 defined( 'WPINC' ) || die();
 
@@ -38,4 +39,120 @@ function get_all_upcoming_events(): array {
 	}
 
 	return $events;
+}
+
+/**
+ * Get events based on the given request URI.
+ *
+ * See `get_city_landing_sites()` for how request URIs map to events.
+ */
+function get_city_landing_page_events( string $request_uri ): array {
+	$limit = 300;
+	$sites = get_city_landing_sites( $request_uri, $limit );
+
+	switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+
+	$wordcamps = get_wordcamps( array(
+		'post_status'  => 'wcpt-scheduled',
+		'numberposts'  => $limit,
+		'meta_key'     => '_site_id',
+		'meta_value'   => wp_list_pluck( $sites, 'blog_id' ),
+		'meta_compare' => 'IN',
+	) );
+
+	$events = array();
+
+	foreach ( $wordcamps as $wordcamp ) {
+		$coordinates = $wordcamp->_venue_coordinates ?? $wordcamp->_host_coordinates;
+
+		$events[] = array(
+			'id'        => $wordcamp->_site_id,
+			'title'     => get_wordcamp_name( $wordcamp->_site_id ),
+			'url'       => $wordcamp->{'URL'},
+			'type'      => 'wordcamp',
+			'meetup'    => '',
+			'location'  => $wordcamp->{'Location'},
+			'latitude'  => $coordinates['latitude'] ?? '',
+			'longitude' => $coordinates['longitude'] ?? '',
+			'timestamp' => $wordcamp->{'Start Date (YYYY-mm-dd)'},
+			'tz_offset' => get_wordcamp_offset( $wordcamp ),
+		);
+	}
+
+	restore_current_blog();
+
+	return $events;
+}
+
+/**
+ * Get sites that match the given request URI.
+ *
+ * /rome/          -> All sites in Rome
+ * /rome/training/ -> All training sites in Rome
+ * /rome/2023/     -> All sites in Rome in 2023
+ */
+function get_city_landing_sites( string $request_uri, int $limit ): array {
+	global $wpdb;
+
+	$request   = trim( $request_uri, '/' );
+	$request   = explode( '/', $request );
+	$num_parts = count( $request );
+
+	if ( 1 !== $num_parts && 2 !== $num_parts ) {
+		return array();
+	}
+
+	$city = $request[0];
+
+	if ( is_numeric( $request[1] ?? '' ) && 4 === strlen( $request[1] ) ) {
+		$year  = absint( $request[1] );
+		$title = false;
+	} else {
+		$title = $request[1] ?? '';
+		$year  = false;
+	}
+
+	if ( $year ) {
+		$regex = "^/$city/$year/";
+	} elseif ( $title ) {
+		$regex = "^/$city/\d{4}/$title/";
+	} else {
+		$regex = "^/$city/";
+	}
+
+	// Using this instead of `get_sites()` so that the search doesn't match false positives.
+	$sites = $wpdb->get_results( $wpdb->prepare( "
+		SELECT blog_id
+		FROM {$wpdb->blogs}
+		WHERE
+			site_id = %d AND
+			path REGEXP %s
+			ORDER BY blog_id DESC
+			LIMIT %d",
+		EVENTS_NETWORK_ID,
+		$regex,
+		$limit
+	) );
+
+	return $sites;
+}
+
+/**
+ * Get a WordCamp's UTC offset in seconds.
+ *
+ * Forked from `official-wordpress-events`.
+ */
+function get_wordcamp_offset( WP_Post $wordcamp ): int {
+	if ( ! $wordcamp->{'Event Timezone'} || ! $wordcamp->{'Start Date (YYYY-mm-dd)'} ) {
+		return 0;
+	}
+
+	$wordcamp_timezone = new DateTimeZone( $wordcamp->{'Event Timezone'} );
+
+	$wordcamp_datetime = new DateTime(
+		'@' . $wordcamp->{'Start Date (YYYY-mm-dd)'},
+		$wordcamp_timezone
+	);
+
+	return $wordcamp_timezone->getOffset( $wordcamp_datetime );
 }

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/city-landing-page-map.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/city-landing-page-map.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Title: City Landing Page Map
+ * Slug: wporg-events-2023/city-landing-page-map
+ * Inserter: no
+ */
+
+namespace WordPressdotorg\Events_2023;
+
+defined( 'WPINC' ) || die();
+
+$map_options = array(
+	'id' => 'city-landing-page',
+
+	// Can't use $wp->request because Gutenberg calls this on `init`, before `parse_request`.
+	'markers' => get_city_landing_page_events( $_SERVER['REQUEST_URI'] ),
+);
+
+?>
+
+<!-- wp:wporg/google-map <?php echo wp_json_encode( $map_options ); ?> /-->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/front-page-map.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/front-page-map.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * Title: Event Map
- * Slug: wporg-events-2023/event-map
+ * Title: Front Page Map
+ * Slug: wporg-events-2023/front-page-map
  * Inserter: no
  */
 

--- a/public_html/wp-content/themes/wporg-events-2023/templates/front-page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/front-page.html
@@ -4,7 +4,7 @@
 
 <!-- wp:group {"tagName":"main","className":"entry-content"} -->
 <main class="wp-block-group entry-content">
-	<!-- wp:pattern {"slug":"wporg-events-2023/event-map"} /-->
+	<!-- wp:pattern {"slug":"wporg-events-2023/front-page-map"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-city-landing-page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-city-landing-page.html
@@ -1,0 +1,11 @@
+<!-- wp:wporg/global-header /-->
+
+<!-- wp:pattern {"slug":"wporg-events-2023/local-navigation"} /-->
+
+<!-- wp:group {"tagName":"main","className":"entry-content"} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:pattern {"slug":"wporg-events-2023/city-landing-page-map"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:wporg/global-footer /-->


### PR DESCRIPTION
See #1007 

This sets up landing pages like the following:

| URL | Events |
|--------|--------|
| `events.wordpress.org/rome/` | All events in Rome |
| `events.wordpress.org/rome/training/` | All training events in Rome |
| `events.wordpress.org/rome/2023/` | All events in Rome in 2023 | 
