### PR TITLE
Fix reasons that events don't show up on city landing page

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -143,7 +143,8 @@ class WordCamp_New_Site {
 		update_post_meta( $wordcamp_id, $key, esc_url( $url ) );
 
 		// If this site exists make sure we update the _site_id mapping.
-		$network_id       = 'events.wordpress.test' === $parsed_url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
+		$tld              = get_top_level_domain();
+		$network_id       = "events.wordpress.$tld" === $parsed_url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
 		$existing_site_id = domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
 
 		if ( $existing_site_id ) {

--- a/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
@@ -126,9 +126,12 @@ function get_city_landing_sites( string $request_uri, int $limit ): array {
 		FROM {$wpdb->blogs}
 		WHERE
 			site_id = %d AND
-			path REGEXP %s
-			ORDER BY blog_id DESC
-			LIMIT %d",
+			path REGEXP %s AND
+			public = 1 AND
+			archived = 0 AND
+			deleted = 0
+		ORDER BY blog_id DESC
+		LIMIT %d",
 		EVENTS_NETWORK_ID,
 		$regex,
 		$limit

--- a/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/event-getters.php
@@ -65,6 +65,10 @@ function get_city_landing_page_events( string $request_uri ): array {
 	foreach ( $wordcamps as $wordcamp ) {
 		$coordinates = $wordcamp->_venue_coordinates ?? $wordcamp->_host_coordinates;
 
+		if ( empty( $coordinates['latitude'] ) || empty( $coordinates['longitude'] ) ) {
+			continue;
+		}
+
 		$events[] = array(
 			'id'        => $wordcamp->_site_id,
 			'title'     => get_wordcamp_name( $wordcamp->_site_id ),
@@ -72,8 +76,8 @@ function get_city_landing_page_events( string $request_uri ): array {
 			'type'      => 'wordcamp',
 			'meetup'    => '',
 			'location'  => $wordcamp->{'Location'},
-			'latitude'  => $coordinates['latitude'] ?? '',
-			'longitude' => $coordinates['longitude'] ?? '',
+			'latitude'  => $coordinates['latitude'],
+			'longitude' => $coordinates['longitude'],
 			'timestamp' => $wordcamp->{'Start Date (YYYY-mm-dd)'},
 			'tz_offset' => get_wordcamp_offset( $wordcamp ),
 		);


### PR DESCRIPTION
These reasons contributed to some events not showing up on their landing page:

* The site creation routine has `events.wordpress.test` hardcoded, so sites created on production were missing the `_site_id` meta field. Affected production has been updated manually.
* Events that don't have coordinates caused a JS fatal on the map, so they've been skipped.

Additionally, deleted sites were excluded from the site query just to be safe.