### PR TITLE
Events: Return if required function not loaded

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/patterns/city-landing-page-map.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/city-landing-page-map.php
@@ -10,6 +10,10 @@ namespace WordPressdotorg\Events_2023;
 
 defined( 'WPINC' ) || die();
 
+if ( ! function_exists( 'get_city_landing_page_events' ) ) {
+	return;
+}
+
 $map_options = array(
 	'id' => 'city-landing-page',
 


### PR DESCRIPTION
It seems like the pattern sometimes gets loaded outside of the theme, e.g. `https://events.wordpress.org/wp-admin/upgrade.php?step=1`. When that happens, a fatal error occurs.
