### PR TITLE
Events: Remove query string from request URI to only match city

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/patterns/city-landing-page-map.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/city-landing-page-map.php
@@ -14,11 +14,12 @@ if ( ! function_exists( __NAMESPACE__ . '\get_city_landing_page_events' ) ) {
 	return;
 }
 
-$map_options = array(
-	'id' => 'city-landing-page',
+// Can't use $wp->request because Gutenberg calls this on `init`, before `parse_request`.
+$request_uri = str_replace( '?' . $_SERVER['QUERY_STRING'], '', $_SERVER['REQUEST_URI'] );
 
-	// Can't use $wp->request because Gutenberg calls this on `init`, before `parse_request`.
-	'markers' => get_city_landing_page_events( $_SERVER['REQUEST_URI'] ),
+$map_options = array(
+	'id'      => 'city-landing-page',
+	'markers' => get_city_landing_page_events( $request_uri ),
 );
 
 ?>


### PR DESCRIPTION
Otherwise adding URL parameters would cause no results to be returned.

See https://wordpress.slack.com/archives/C05JYJJRNKB/p1694560283990669?thread_ts=1694555515.164809&cid=C05JYJJRNKB
See #1007 