### PR TITLE
Separate Meetup Wrangler subrole

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-subroles.php
+++ b/public_html/wp-content/mu-plugins/wcorg-subroles.php
@@ -79,6 +79,18 @@ function add_subrole_caps( $allcaps, $caps, $args, $user ) {
 				break;
 
 			/**
+			 * Meetup Wrangler
+			 *
+			 * - Edit `wp_meetup` posts on Central.
+			 */
+			case 'meetup_wrangler':
+				$newcaps = array(
+					'read'                     => true, // Access to wp-admin.
+					'wordcamp_wrangle_meetups' => true,
+				);
+				break;
+
+			/**
 			 * Report Viewer
 			 *
 			 * - View private `wordcamp` reports on Central.
@@ -119,6 +131,7 @@ function map_subrole_caps( $primitive_caps, $meta_cap, $user_id, $args ) {
 	switch ( $meta_cap ) {
 		case 'wordcamp_manage_mentors':
 		case 'wordcamp_wrangle_wordcamps':
+		case 'wordcamp_wrangle_meetups':
 			$required_caps[] = $meta_cap;
 			break;
 
@@ -127,12 +140,18 @@ function map_subrole_caps( $primitive_caps, $meta_cap, $user_id, $args ) {
 		case 'edit_published_wordcamps':
 		case 'edit_wordcamp':
 		case 'edit_others_wordcamps':
+			if ( $current_user && $current_user->has_cap( 'wordcamp_wrangle_wordcamps' ) ) {
+				$required_caps[] = 'wordcamp_wrangle_wordcamps';
+			}
+			break;
+
+		// Allow Meetup Wranglers to edit Meetup posts.
 		case 'edit_wp_meetups':
 		case 'edit_published_wp_meetups':
 		case 'edit_wp_meetup':
 		case 'edit_others_wp_meetups':
-			if ( $current_user && $current_user->has_cap( 'wordcamp_wrangle_wordcamps' ) ) {
-				$required_caps[] = 'wordcamp_wrangle_wordcamps';
+			if ( $current_user && $current_user->has_cap( 'wordcamp_wrangle_meetups' ) ) {
+				$required_caps[] = 'wordcamp_wrangle_meetups';
 			}
 			break;
 
@@ -151,10 +170,8 @@ function map_subrole_caps( $primitive_caps, $meta_cap, $user_id, $args ) {
 			}
 
 			if ( defined( 'WCPT_MEETUP_SLUG' ) && WCPT_MEETUP_SLUG === $post_type ) {
-				// Use same permission for meetups as well as wordcamps.
-				// TODO: In future consider changing this to wrangle_events.
-				if ( $current_user && $current_user->has_cap( 'wordcamp_wrangle_wordcamps' ) ) {
-					$required_caps[] = 'wordcamp_wrangle_wordcamps';
+				if ( $current_user && $current_user->has_cap( 'wordcamp_wrangle_meetups' ) ) {
+					$required_caps[] = 'wordcamp_wrangle_meetups';
 				}
 			}
 			break;

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -181,10 +181,6 @@ abstract class Event_Admin {
 			return;
 		}
 
-		if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
-			return;
-		}
-
 		add_meta_box(
 			'wcpt_log',
 			'Log',
@@ -201,10 +197,6 @@ abstract class Event_Admin {
 	 */
 	public function add_note_metabox() {
 		if ( ! current_user_can( $this->get_edit_capability() ) ) {
-			return;
-		}
-
-		if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
 			return;
 		}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 		 * @return string
 		 */
 		public static function get_edit_capability() {
-			return 'wordcamp_wrangle_wordcamps';
+			return 'wordcamp_wrangle_meetups';
 		}
 
 		/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/meetup.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/meetup.php
@@ -7,13 +7,6 @@ use WordPress_Community\Applications\Meetup_Application;
 
 defined( 'WPINC' ) || die();
 
-/*
- * todo
- * grant access to regular deputies to vet meetups
- * also do that for wordcamps, so prob use same system
-	maybe just create array for regular deupties like the ones we have for super deputies , but it doesn't requier proxy access?
- */
-
 $meetup_application = new Meetup_Application();
 
 add_shortcode( $meetup_application::SHORTCODE_SLUG, array( $meetup_application, 'render_application_shortcode' ) );


### PR DESCRIPTION
Fixes #995 

This adds a new `wordcamp_wrangle_meetups` subrole, which allows folks to edit the `wp_meetup` post. The `wordcamp_wrangle_wordcamps` subrole no longer has the ability to view/modify `wordcamp` posts.