### PR TITLE
Site Cloner: Warn before cloning into closed camp.

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-site-cloner/templates/site-control.php
+++ b/public_html/wp-content/plugins/wordcamp-site-cloner/templates/site-control.php
@@ -7,6 +7,8 @@
 namespace WordCamp\Site_Cloner;
 defined( 'WPINC' ) or die();
 
+$wordcamp = get_wordcamp_post();
+
 ?>
 
 <div id="wcsc-cloner">
@@ -14,6 +16,18 @@ defined( 'WPINC' ) or die();
 		<?php esc_html_e( 'WordCamp Sites', 'wordcamporg' ); ?>
 		<span id="wcsc-sites-count" class="title-count wcsc-sites-count"></span>
 	</h3>
+
+	<?php if ( 'wcpt-closed' === $wordcamp->post_status ) : ?>
+		<div class="notice notice-warning">
+			<p>
+				<?php echo esc_html( sprintf(
+					// translators: %s is the name of the WordCamp.
+					__( '%s has already completed, are you sure you want to overwrite it with styles and settings from another site?', 'wordcamporg' ),
+					get_wordcamp_name()
+				) ); ?>
+			</p>
+		</div>
+	<?php endif; ?>
 
 	<div class="filters"></div>
 


### PR DESCRIPTION
This helps to avoid unintentionally overwriting an old site with a new one when the organizer actually intends to clone _from_ the old site _to_ a new one.

<img width="458" alt="Screenshot 2023-09-20 at 8 54 56 AM" src="https://github.com/WordPress/wordcamp.org/assets/484068/39cc7353-256a-4a55-bd58-158b91efb0d9">


See https://wordpress.slack.com/archives/C08M59V3P/p1694606665478859