### PR TITLE
New reimbursement request and vendor payments status and notes functionality

### DIFF
--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -125,12 +125,12 @@ $trusted_deputies = array(
 
 $wcorg_subroles = array(
 	// contributorrole.
-	// 6 => array(
-	// 	'wordcamp_wrangler',
-	// 	'meetup_wrangler',
-	// 	'mentor_manager',
-	// 	'report_viewer',
-	// ),
+	6 => array(
+		'wordcamp_wrangler',
+		'meetup_wrangler',
+		'mentor_manager',
+		'report_viewer',
+	),
 );
 
 /*

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -125,12 +125,12 @@ $trusted_deputies = array(
 
 $wcorg_subroles = array(
 	// contributorrole.
-	6 => array(
-		'wordcamp_wrangler',
-		'meetup_wrangler',
-		'mentor_manager',
-		'report_viewer',
-	),
+	// 6 => array(
+	// 	'wordcamp_wrangler',
+	// 	'meetup_wrangler',
+	// 	'mentor_manager',
+	// 	'report_viewer',
+	// ),
 );
 
 /*

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -340,6 +340,7 @@ class Payment_Requests_Dashboard {
 			'paid',
 			'cancelled-failed',
 			'incomplete',
+			'needs-followup',
 		);
 
 		if ( isset( $_REQUEST['wcp-section'] ) && in_array( $_REQUEST['wcp-section'], $tabs ) ) {
@@ -363,6 +364,7 @@ class Payment_Requests_Dashboard {
 			'paid'             => __( 'Paid', 'wordcamporg' ),
 			'cancelled-failed' => __( 'Cancelled/Failed', 'wordcamporg' ),
 			'incomplete'       => __( 'Incomplete', 'wordcamporg' ),
+			'needs-followup'   => __( 'Needs follow-up', 'wordcamporg' ),
 		);
 
 		foreach ( $sections as $section_key => $section_caption ) {

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -364,7 +364,7 @@ class Payment_Requests_Dashboard {
 			'paid'             => __( 'Paid', 'wordcamporg' ),
 			'cancelled-failed' => __( 'Cancelled/Failed', 'wordcamporg' ),
 			'incomplete'       => __( 'Incomplete', 'wordcamporg' ),
-			'needs-followup'   => __( 'Needs follow-up', 'wordcamporg' ),
+			'needs-followup'   => __( 'Needs Follow-up', 'wordcamporg' ),
 		);
 
 		foreach ( $sections as $section_key => $section_caption ) {

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-list-table.php
@@ -54,7 +54,7 @@ class Payment_Requests_List_Table extends WP_List_Table {
 		$order    = 'asc';
 
 		if ( 'overdue' == $view ) {
-			$where .= $wpdb->prepare( " AND `status` = 'wcb-pending-approval' AND `due` > 0 AND `due` <= %d ", time() );
+			$where .= $wpdb->prepare( " AND `status` IN ( 'wcb-pending-approval', 'wcb-needs-followup' ) AND `due` > 0 AND `due` <= %d ", time() );
 		} elseif ( 'pending-approval' == $view ) {
 			$where .= " AND `status` = 'wcb-pending-approval' ";
 		} elseif ( 'approved' == $view ) {

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/reimbursement-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/reimbursement-requests-dashboard.php
@@ -51,6 +51,10 @@ function render_submenu_page() {
 			$section_explanation = 'These requests have been reviewed by a deputy, and sent back to the organizer because they lacked some required information.';
 			break;
 
+		case 'wcb-needs-followup':
+			$section_explanation = 'These requests have been reviewed by a deputy, and need more information or second opinion.';
+			break;
+
 		case 'wcb-cancelled':
 			$section_explanation = 'These requests have been reviewed by a deputy and cancelled/rejected.';
 			break;

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -277,6 +277,7 @@ class WCP_Payment_Request {
 			'draft',
 			'wcb-incomplete',
 			'wcb-pending-approval',
+			'wcb-needs-followup',
 			'wcb-approved',
 			'wcb-pending-payment',
 			'wcb-paid',

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -79,6 +79,7 @@ function get_post_statuses() {
 		'draft',
 		'wcb-incomplete',
 		'wcb-pending-approval',
+		'wcb-needs-followup',
 		'wcb-approved',
 		'wcb-pending-payment',
 		'wcb-paid',

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -19,8 +19,8 @@ class WordCamp_Budgets {
 		add_action( 'admin_enqueue_scripts',  array( $this, 'enqueue_common_assets' ),             11    );
 		add_filter( 'user_has_cap',           array( __CLASS__, 'user_can_view_payment_details' ), 10, 4 );
 		add_filter( 'default_title',          array( $this, 'set_default_payments_title' ),        10, 2 );
-		add_action( 'add_meta_boxes',         array( $this, 'init_meta_boxes' )       		                );
-		add_action( 'save_post',              array( $this, 'save_request' ),                     10, 2 );
+		add_action( 'add_meta_boxes',         array( $this, 'init_meta_boxes' )                          );
+		add_action( 'save_post',              array( $this, 'save_request' ),                      10, 2 );
 	}
 
 	/**
@@ -29,7 +29,7 @@ class WordCamp_Budgets {
 	public static function register_post_statuses() {
 		// Uses core's draft status too.
 
-		register_post_status( 'wcb-incomplete', array(
+		register_post_status( 'wcb-incomplete', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Incomplete', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -40,7 +40,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-pending-approval', array(
+		register_post_status( 'wcb-pending-approval', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Pending Approval', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -51,7 +51,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-needs-followup', array(
+		register_post_status( 'wcb-needs-followup', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Needs follow-up', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -62,7 +62,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-approved', array(
+		register_post_status( 'wcb-approved', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Approved', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -73,7 +73,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-pending-payment', array(
+		register_post_status( 'wcb-pending-payment', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Payment Sent', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -84,7 +84,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-paid', array(
+		register_post_status( 'wcb-paid', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Paid', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -95,7 +95,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-failed', array(
+		register_post_status( 'wcb-failed', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Failed', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -106,7 +106,7 @@ class WordCamp_Budgets {
 			),
 		) );
 
-		register_post_status( 'wcb-cancelled', array(
+		register_post_status( 'wcb-cancelled', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'label'       => esc_html_x( 'Cancelled', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
@@ -969,7 +969,7 @@ class WordCamp_Budgets {
 		update_post_meta( $post->ID, '_wcbrr_notes', $notes );
 		$this::notify_parties_of_new_note( $post, $new_note );
 
-		$this::log( $post->ID, get_current_user_id(), sprintf( 'Note: %s', $new_note_message ), array(
+		$this::log( $post->ID, get_current_user_id(), sprintf( 'Note: %s', $new_note_message ), array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'action' => 'note-added',
 		) );
 	}
@@ -1002,7 +1002,7 @@ class WordCamp_Budgets {
 
 		update_post_meta( $post->ID, '_wcbrr_notes_private', $notes );
 
-		$this::log( $post->ID, get_current_user_id(), __( 'Private note', 'wordcamporg' ), array(
+		$this::log( $post->ID, get_current_user_id(), __( 'Private note', 'wordcamporg' ), array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'action' => 'note-added',
 		) );
 	}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -49,6 +49,17 @@ class WordCamp_Budgets {
 			),
 		) );
 
+		register_post_status( 'wcb-needs-followup', array(
+			'label'       => esc_html_x( 'Needs follow-up', 'payment request', 'wordcamporg' ),
+			'public'      => false,
+			'protected'   => true,
+			'label_count' => _nx_noop(
+				'Needs follow-up <span class="count">(%s)</span>',
+				'Needs follow-up <span class="count">(%s)</span>',
+				'wordcamporg'
+			),
+		) );
+
 		register_post_status( 'wcb-approved', array(
 			'label'       => esc_html_x( 'Approved', 'payment request', 'wordcamporg' ),
 			'public'      => false,

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -52,12 +52,12 @@ class WordCamp_Budgets {
 		) );
 
 		register_post_status( 'wcb-needs-followup', array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
-			'label'       => esc_html_x( 'Needs follow-up', 'payment request', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Needs Follow-up', 'payment request', 'wordcamporg' ),
 			'public'      => false,
 			'protected'   => true,
 			'label_count' => _nx_noop(
-				'Needs follow-up <span class="count">(%s)</span>',
-				'Needs follow-up <span class="count">(%s)</span>',
+				'Needs Follow-up <span class="count">(%s)</span>',
+				'Needs Follow-up <span class="count">(%s)</span>',
 				'wordcamporg'
 			),
 		) );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -19,6 +19,8 @@ class WordCamp_Budgets {
 		add_action( 'admin_enqueue_scripts',  array( $this, 'enqueue_common_assets' ),             11    );
 		add_filter( 'user_has_cap',           array( __CLASS__, 'user_can_view_payment_details' ), 10, 4 );
 		add_filter( 'default_title',          array( $this, 'set_default_payments_title' ),        10, 2 );
+		add_action( 'add_meta_boxes',         array( $this, 'init_meta_boxes' )       		                );
+		add_action( 'save_post',              array( $this, 'save_request' ),                     10, 2 );
 	}
 
 	/**
@@ -865,5 +867,127 @@ class WordCamp_Budgets {
 		$log   = json_encode( $log );
 
 		update_post_meta( $post_id, '_wcp_log', wp_slash( $log ) );
+	}
+
+	/**
+	 * Register meta boxes
+	 */
+	public function init_meta_boxes() {
+		// global $wcp_payment_request, $post;
+
+		add_meta_box(
+			'wcbrr_notes',
+			esc_html__( 'Notes', 'wordcamporg' ),
+			array( $this, 'render_notes_metabox' ),
+			array( 'wcb_reimbursement', 'wcp_payment_request' ),
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the Notes metabox
+	 *
+	 * @param WP_Post $post
+	 */
+	public function render_notes_metabox( $post ) {
+		wp_nonce_field( 'notes', 'notes_nonce' );
+
+		$existing_notes = get_post_meta( $post->ID, '_wcbrr_notes', true );
+
+		require_once dirname( __DIR__ ) . '/views/wordcamp-budgets/metabox-notes.php';
+	}
+
+	/**
+	 * Save the post's data
+	 *
+	 * @param int     $post_id
+	 * @param WP_Post $post
+	 */
+	public function save_request( $post_id, $post ) {
+		if ( empty( $_POST ) || ! empty( $_POST['wcpn-request-import'] ) ) {
+			return;
+		}
+
+		check_admin_referer( str_replace( '_nonce', '', 'notes_nonce' ), 'notes_nonce' );
+		$this::validate_and_save_notes( $post, $_POST['wcbrr_new_note'] );
+	}
+
+	/**
+	 * Validate and save expense data
+	 *
+	 * @param WP_Post $post
+	 * @param string  $new_note_message
+	 */
+	public function validate_and_save_notes( $post, $new_note_message ) {
+		$new_note_message = sanitize_text_field( wp_unslash( $new_note_message ) );
+
+		if ( empty( $new_note_message ) ) {
+			return;
+		}
+
+		$notes = get_post_meta( $post->ID, '_wcbrr_notes', true );
+		if ( ! is_array( $notes ) ) {
+			$notes = array();
+		}
+
+		$new_note = array(
+			'timestamp' => time(),
+			'author_id' => get_current_user_id(),
+			'message'   => $new_note_message,
+		);
+
+		$notes[] = $new_note;
+
+		update_post_meta( $post->ID, '_wcbrr_notes', $notes );
+		$this::notify_parties_of_new_note( $post, $new_note );
+
+		$this::log( $post->ID, get_current_user_id(), sprintf( 'Note: %s', $new_note_message ), array(
+			'action' => 'note-added',
+		) );
+	}
+
+	/**
+	 * Notify WordCamp Central or the request author when new notes are added
+	 *
+	 * @param WP_Post $request
+	 * @param array   $note
+	 */
+	public function notify_parties_of_new_note( $request, $note ) {
+		$note_author = get_user_by( 'id', $note['author_id'] );
+
+		if ( $note_author->has_cap( 'manage_network' ) ) {
+			$to             = $this::get_requester_formatted_email( $request->post_author );
+			$subject_prefix = sprintf( '[%s] ', get_wordcamp_name() );
+		} else {
+			$to             = 'support@wordcamp.org';
+			$subject_prefix = '';
+		}
+
+		if ( ! $to ) {
+			return;
+		}
+
+		$subject          = sprintf( '%sNew note on `%s`', $subject_prefix, sanitize_text_field( $request->post_title ) );
+		$note_author_name = $this::get_requester_name( $note['author_id'] );
+		$request_url      = admin_url( sprintf( 'post.php?post=%s&action=edit', $request->ID ) );
+		$headers          = array( 'Reply-To: support@wordcamp.org' );
+
+		$message = sprintf( '
+			%s has added the following note on the reimbursement request for %s:
+
+			%s
+
+			You can view the request and respond to their note at:
+
+			%s',
+			sanitize_text_field( $note_author_name ),
+			sanitize_text_field( $request->post_title ),
+			sanitize_text_field( $note['message'] ),
+			esc_url_raw( $request_url )
+		);
+		$message = str_replace( "\t", '', $message );
+
+		wp_mail( $to, $subject, $message, $headers );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes-private.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes-private.php
@@ -1,0 +1,40 @@
+<?php
+
+defined( 'WPINC' ) or die();
+
+?>
+
+<?php if ( empty ( $existing_notes ) ) : ?>
+
+	<?php _e( 'There are no private notes yet.', 'wordcamporg' ); ?>
+
+<?php else : ?>
+
+	<?php foreach ( $existing_notes as $note ) : ?>
+		<div class="wcbrr-note">
+			<span class="wcbrr-note-meta">
+				<?php echo esc_html( date( 'Y-m-d', $note['timestamp'] ) ); ?>
+				<?php echo esc_html( WordCamp_Budgets::get_requester_name( $note['author_id'] ) ); ?>:
+			</span>
+
+			<?php echo esc_html( $note['message'] ); ?>
+		</div>
+	<?php endforeach; ?>
+
+<?php endif; ?>
+
+<div>
+	<h3>
+		<label for="wcbrr_new_note_private">
+			<?php _e( 'Add a private note', 'wordcamporg' ); ?>
+		</label>
+	</h3>
+
+	<textarea id="wcbrr_new_note_private" name="wcbrr_new_note_private" class="large-text"></textarea>
+
+	<?php submit_button(
+		esc_html__( 'Add private note', 'wordcamporg' ),
+		'secondary',
+		'wcbrr_add_note'
+	); ?>
+</div>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes-private.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes-private.php
@@ -1,32 +1,28 @@
 <?php
 
-defined( 'WPINC' ) or die();
+if ( ! defined( 'WPINC' ) ) {
+	die();
+}
 
-?>
-
-<?php if ( empty ( $existing_notes ) ) : ?>
-
-	<?php _e( 'There are no private notes yet.', 'wordcamporg' ); ?>
-
-<?php else : ?>
-
-	<?php foreach ( $existing_notes as $note ) : ?>
+if ( empty( $existing_notes ) ) :
+	esc_html_e( 'There are no private notes yet.', 'wordcamporg' );
+else :
+	foreach ( $existing_notes as $note ) : ?>
 		<div class="wcbrr-note">
 			<span class="wcbrr-note-meta">
-				<?php echo esc_html( date( 'Y-m-d', $note['timestamp'] ) ); ?>
+				<?php echo esc_html( gmdate( 'Y-m-d', $note['timestamp'] ) ); ?>
 				<?php echo esc_html( WordCamp_Budgets::get_requester_name( $note['author_id'] ) ); ?>:
 			</span>
 
 			<?php echo esc_html( $note['message'] ); ?>
 		</div>
-	<?php endforeach; ?>
-
-<?php endif; ?>
+	<?php endforeach;
+endif; ?>
 
 <div>
 	<h3>
 		<label for="wcbrr_new_note_private">
-			<?php _e( 'Add a private note', 'wordcamporg' ); ?>
+			<?php esc_html_e( 'Add a private note', 'wordcamporg' ); ?>
 		</label>
 	</h3>
 

--- a/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes.php
@@ -1,6 +1,5 @@
 <?php
 
-namespace WordCamp\Budgets\Reimbursement_Requests;
 defined( 'WPINC' ) or die();
 
 ?>
@@ -15,7 +14,7 @@ defined( 'WPINC' ) or die();
 		<div class="wcbrr-note">
 			<span class="wcbrr-note-meta">
 				<?php echo esc_html( date( 'Y-m-d', $note['timestamp'] ) ); ?>
-				<?php echo esc_html( \WordCamp_Budgets::get_requester_name( $note['author_id'] ) ); ?>:
+				<?php echo esc_html( WordCamp_Budgets::get_requester_name( $note['author_id'] ) ); ?>:
 			</span>
 
 			<?php echo esc_html( $note['message'] ); ?>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes.php
@@ -23,22 +23,24 @@ defined( 'WPINC' ) or die();
 
 <?php endif; ?>
 
-<div>
-	<h3>
-		<label for="wcbrr_new_note">
-			<?php _e( 'Add a Note', 'wordcamporg' ); ?>
-		</label>
+<?php if ( current_user_can( 'view_wordcamp_payment_details', $post->ID ) ) : ?>
+	<div>
+		<h3>
+			<label for="wcbrr_new_note">
+				<?php _e( 'Add a Note', 'wordcamporg' ); ?>
+			</label>
 
-		<?php if ( current_user_can( 'manage_network' ) ) : ?>
-			<p class="description">(visible to organizers)</p>
-		<?php endif; ?>
-	</h3>
+			<?php if ( current_user_can( 'manage_network' ) ) : ?>
+				<p class="description">(visible to organizers)</p>
+			<?php endif; ?>
+		</h3>
 
-	<textarea id="wcbrr_new_note" name="wcbrr_new_note" class="large-text"></textarea>
+		<textarea id="wcbrr_new_note" name="wcbrr_new_note" class="large-text"></textarea>
 
-	<?php submit_button(
-		esc_html__( 'Add Note', 'wordcamporg' ),
-		'secondary',
-		'wcbrr_add_note'
-	); ?>
-</div>
+		<?php submit_button(
+			esc_html__( 'Add Note', 'wordcamporg' ),
+			'secondary',
+			'wcbrr_add_note'
+		); ?>
+	</div>
+<?php endif; ?>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/wordcamp-budgets/metabox-notes.php
@@ -1,33 +1,29 @@
 <?php
 
-defined( 'WPINC' ) or die();
+if ( ! defined( 'WPINC' ) ) {
+	die();
+}
 
-?>
-
-<?php if ( empty ( $existing_notes ) ) : ?>
-
-	<?php _e( 'There are no notes yet.', 'wordcamporg' ); ?>
-
-<?php else : ?>
-
-	<?php foreach ( $existing_notes as $note ) : ?>
+if ( empty( $existing_notes ) ) :
+	esc_html_e( 'There are no private notes yet.', 'wordcamporg' );
+else :
+	foreach ( $existing_notes as $note ) : ?>
 		<div class="wcbrr-note">
 			<span class="wcbrr-note-meta">
-				<?php echo esc_html( date( 'Y-m-d', $note['timestamp'] ) ); ?>
+				<?php echo esc_html( gmdate( 'Y-m-d', $note['timestamp'] ) ); ?>
 				<?php echo esc_html( WordCamp_Budgets::get_requester_name( $note['author_id'] ) ); ?>:
 			</span>
 
 			<?php echo esc_html( $note['message'] ); ?>
 		</div>
-	<?php endforeach; ?>
+	<?php endforeach;
+endif;
 
-<?php endif; ?>
-
-<?php if ( current_user_can( 'view_wordcamp_payment_details', $post->ID ) ) : ?>
+if ( current_user_can( 'view_wordcamp_payment_details', $post->ID ) ) : ?>
 	<div>
 		<h3>
 			<label for="wcbrr_new_note">
-				<?php _e( 'Add a Note', 'wordcamporg' ); ?>
+				<?php esc_html_e( 'Add a Note', 'wordcamporg' ); ?>
 			</label>
 
 			<?php if ( current_user_can( 'manage_network' ) ) : ?>


### PR DESCRIPTION
### Add private notes to vendor payments and reimbursement requests
Only network managers (i.e. super deputies) can see these.

**How to test?**

1. Log in as a site admin (not a network or super deputy)
2. Crate reimbursement request
3. "Private notes" meta box should not be visible
4. Log out and log in as an network admin
5. Go to request
6. "Private notes" meta box should be visible
7. Leave a note, check that it is showing and you didn't receive any email notifications

### Add a new "Needs follow-up" status for payments
As requested by Community Team deputies who are working with payments. Added this status for vendor payments and reimbursement requests. Also, the network payments tool takes this status into consideration when combining payments for the overdue view.

**How to test?**

1. Log in as a network admin
3. Open one and edit it, the staus should be visible
4. Visit `wp-admin/network/admin.php?page=reimbursement-requests-dashboard` and tab "Needs follow-up" should be there
5. On a WordCamp site, create a vendor payment and set due date to past date, set the status to "Needs follow-up"
6. Visit `/wp-admin/network/admin.php?page=wcp-dashboard` and the payment should be listed on "Overdue" tab and separate "Needs follow-up" tab should be visible

### Extend notes to vendor payments
For ease and harmonisation, the regular notes meta box was extended for vendor payments. Only users with `view_wordcamp_payment_details` (network admins and original submitter) can add new notes, but everyone can see all notes. Because of this, the note functionality was moved to common `WordCamp_Budgets` class.

**How to test?**

1. Log in as a site admin
2. Go to vendor payments
3. "Notes" meta box should be visible
4. Log out and log in as an user who has not made the vendor payment
5. Go to payment and meta box should be visible but you are not able to add a note.

Fixes #864 

### Screenshots

<img width="301" alt="CleanShot 2023-09-20 at 23 12 14@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/96b0b6d8-adbc-42a2-990a-16009b0ae579">

<img width="308" alt="CleanShot 2023-09-20 at 23 13 37@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/33b13ee3-bf19-44f1-889b-92a0c8ee25a6">

<img width="1058" alt="CleanShot 2023-09-20 at 23 11 52@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/f406992d-d26e-4d70-9a8c-13f040de7df7">

