### PR TITLE
Pre-fill sponsor agreement details from sponsor CPT

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs.php
@@ -86,36 +86,20 @@ class WordCamp_Docs {
 
 		// Check selected template on any step.
 		$templates = self::get_templates();
-		$template_selected = sanitize_text_field( $_POST['wcdocs_template'] );
-		if ( ! array_key_exists( $template_selected, $templates ) )
+		$template = sanitize_text_field( $_POST['wcdocs_template'] );
+		if ( ! array_key_exists( $template, $templates ) )
 			return self::error( __( 'Selected template does not exist', 'wordcamporg' ) );
 
-		$template = $templates[ $template_selected ];
+		$template = $templates[ $template ];
 
 		switch ( $step ) {
 			case 1: // submitted step 1
 
-				if ( 'sponsorship-agreement' == $template_selected ) {
-					self::$step = 10;
-				} else {
-					// Nothing else to check on this step.
-					self::$step = 20;
-				}
-
+				// Nothing else to check on this step.
+				self::$step = 2;
 				break;
 
-			case 10; // submitted step 10
-				// Sanitize input
-				$data = $template->sanitize( $_POST );
-
-				if ( 'sponsorship-agreement' == $template_selected ) {
-					if ( 'wcb_sponsor' === get_post_type( $data['sponsor_id'] ) ) {
-						self::$step = 20;
-					}
-				}
-				break;
-
-			case 20: // submitted step 20
+			case 2: // submitted step 2
 
 				require_once( WORDCAMP_DOCS__PLUGIN_DIR . 'classes/class-wordcamp-docs-pdf-generator.php' );
 				$generator = new WordCamp_Docs_PDF_Generator;
@@ -182,29 +166,12 @@ class WordCamp_Docs {
 					</p>
 				</form>
 
-				<?php elseif ( self::$step == 10 ) : ?>
+			<?php elseif ( self::$step == 2 ) : ?>
 
 				<form method="POST">
-					<input type="hidden" name="wcdocs_submit" value="10" />
+					<input type="hidden" name="wcdocs_submit" value="2" />
 					<input type="hidden" name="wcdocs_template" value="<?php echo esc_attr( $_POST['wcdocs_template'] ); ?>">
-					<?php wp_nonce_field( 'wcdocs_step_10' ); ?>
-
-					<?php
-						$template = self::get_template( $_POST['wcdocs_template'] );
-						$template->form_prefill_select( $_POST );
-					?>
-
-					<p class="submit">
-						<input type="submit" class="button-primary" value="Next &rarr;">
-					</p>
-				</form>
-
-			<?php elseif ( self::$step == 20 ) : ?>
-
-				<form method="POST">
-					<input type="hidden" name="wcdocs_submit" value="20" />
-					<input type="hidden" name="wcdocs_template" value="<?php echo esc_attr( $_POST['wcdocs_template'] ); ?>">
-					<?php wp_nonce_field( 'wcdocs_step_20' ); ?>
+					<?php wp_nonce_field( 'wcdocs_step_2' ); ?>
 
 					<?php
 						$template = self::get_template( $_POST['wcdocs_template'] );

--- a/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs.php
@@ -86,20 +86,36 @@ class WordCamp_Docs {
 
 		// Check selected template on any step.
 		$templates = self::get_templates();
-		$template = sanitize_text_field( $_POST['wcdocs_template'] );
-		if ( ! array_key_exists( $template, $templates ) )
+		$template_selected = sanitize_text_field( $_POST['wcdocs_template'] );
+		if ( ! array_key_exists( $template_selected, $templates ) )
 			return self::error( __( 'Selected template does not exist', 'wordcamporg' ) );
 
-		$template = $templates[ $template ];
+		$template = $templates[ $template_selected ];
 
 		switch ( $step ) {
 			case 1: // submitted step 1
 
-				// Nothing else to check on this step.
-				self::$step = 2;
+				if ( 'sponsorship-agreement' == $template_selected ) {
+					self::$step = 10;
+				} else {
+					// Nothing else to check on this step.
+					self::$step = 20;
+				}
+
 				break;
 
-			case 2: // submitted step 2
+			case 10; // submitted step 10
+				// Sanitize input
+				$data = $template->sanitize( $_POST );
+
+				if ( 'sponsorship-agreement' == $template_selected ) {
+					if ( 'wcb_sponsor' === get_post_type( $data['sponsor_id'] ) ) {
+						self::$step = 20;
+					}
+				}
+				break;
+
+			case 20: // submitted step 20
 
 				require_once( WORDCAMP_DOCS__PLUGIN_DIR . 'classes/class-wordcamp-docs-pdf-generator.php' );
 				$generator = new WordCamp_Docs_PDF_Generator;
@@ -166,12 +182,29 @@ class WordCamp_Docs {
 					</p>
 				</form>
 
-			<?php elseif ( self::$step == 2 ) : ?>
+				<?php elseif ( self::$step == 10 ) : ?>
 
 				<form method="POST">
-					<input type="hidden" name="wcdocs_submit" value="2" />
+					<input type="hidden" name="wcdocs_submit" value="10" />
 					<input type="hidden" name="wcdocs_template" value="<?php echo esc_attr( $_POST['wcdocs_template'] ); ?>">
-					<?php wp_nonce_field( 'wcdocs_step_2' ); ?>
+					<?php wp_nonce_field( 'wcdocs_step_10' ); ?>
+
+					<?php
+						$template = self::get_template( $_POST['wcdocs_template'] );
+						$template->form_prefill_select( $_POST );
+					?>
+
+					<p class="submit">
+						<input type="submit" class="button-primary" value="Next &rarr;">
+					</p>
+				</form>
+
+			<?php elseif ( self::$step == 20 ) : ?>
+
+				<form method="POST">
+					<input type="hidden" name="wcdocs_submit" value="20" />
+					<input type="hidden" name="wcdocs_template" value="<?php echo esc_attr( $_POST['wcdocs_template'] ); ?>">
+					<?php wp_nonce_field( 'wcdocs_step_20' ); ?>
 
 					<?php
 						$template = self::get_template( $_POST['wcdocs_template'] );

--- a/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs.php
@@ -87,14 +87,14 @@ class WordCamp_Docs {
 		// Check selected template on any step.
 		$templates = self::get_templates();
 		$template_selected = sanitize_text_field( $_POST['wcdocs_template'] );
-		if ( ! array_key_exists( $template_selected, $templates ) )
+		if ( ! array_key_exists( $template_selected, $templates ) ) {
 			return self::error( __( 'Selected template does not exist', 'wordcamporg' ) );
+		}
 
 		$template = $templates[ $template_selected ];
 
 		switch ( $step ) {
-			case 1: // submitted step 1
-
+			case 1: // submitted step 1.
 				if ( 'sponsorship-agreement' == $template_selected ) {
 					self::$step = 10;
 				} else {
@@ -104,8 +104,7 @@ class WordCamp_Docs {
 
 				break;
 
-			case 10; // submitted step 10
-				// Sanitize input
+			case 10: // submitted step 10.
 				$data = $template->sanitize( $_POST );
 
 				if ( 'sponsorship-agreement' == $template_selected ) {
@@ -113,10 +112,10 @@ class WordCamp_Docs {
 						self::$step = 20;
 					}
 				}
+
 				break;
 
-			case 20: // submitted step 20
-
+			case 20: // submitted step 20.
 				require_once( WORDCAMP_DOCS__PLUGIN_DIR . 'classes/class-wordcamp-docs-pdf-generator.php' );
 				$generator = new WordCamp_Docs_PDF_Generator;
 
@@ -149,6 +148,9 @@ class WordCamp_Docs {
 
 	/**
 	 * Render the contents of our admin section.
+	 *
+	 * phpcs:disable WordPress.Security.NonceVerification.Missing
+	 * nonce is checked on form_handler function
 	 */
 	public static function render_menu_page() {
 		?>
@@ -182,7 +184,7 @@ class WordCamp_Docs {
 					</p>
 				</form>
 
-				<?php elseif ( self::$step == 10 ) : ?>
+				<?php elseif ( 10 == self::$step ) : ?>
 
 				<form method="POST">
 					<input type="hidden" name="wcdocs_submit" value="10" />
@@ -199,7 +201,7 @@ class WordCamp_Docs {
 					</p>
 				</form>
 
-			<?php elseif ( self::$step == 20 ) : ?>
+			<?php elseif ( 20 == self::$step ) : ?>
 
 				<form method="POST">
 					<input type="hidden" name="wcdocs_submit" value="20" />
@@ -220,6 +222,7 @@ class WordCamp_Docs {
 		</div>
 		<?php
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 	private function __construct() {} // Not this time.
 }

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -4,7 +4,7 @@
  */
 class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Template {
 	/**
-	 * Step 10. Select the sposnor post from which the form will be pre-filled.
+	 * Step 10. Select the sponsor post from which the form will be pre-filled.
 	 */
 	public function form_prefill_select( $data ) {
 		$sponsors = get_posts( array(
@@ -12,28 +12,30 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 			'post_status'    => 'publish',
 			'posts_per_page' => 500,
 		) );
+
 		?>
+
 		<style>
-		.wcorg-sponsorship-agreement-form label {
-			display: block;
-			clear: both;
-			margin-top: 12px;
-		}
+			.wcorg-sponsorship-agreement-form label {
+				display: block;
+				clear: both;
+				margin-top: 12px;
+			}
 
-		.wcorg-sponsorship-agreement-form input,
-		.wcorg-sponsorship-agreement-form textarea,
-		.wcorg-sponsorship-agreement-form select {
-			width: 360px;
-		}
+			.wcorg-sponsorship-agreement-form input,
+			.wcorg-sponsorship-agreement-form textarea,
+			.wcorg-sponsorship-agreement-form select {
+				width: 360px;
+			}
 
-		.wcorg-sponsorship-agreement-form textarea {
-			height: 120px;
-		}
+			.wcorg-sponsorship-agreement-form textarea {
+				height: 120px;
+			}
 
-		.wcorg-sponsorship-agreement-form .description {
-			display: block;
-			clear: both;
-		}
+			.wcorg-sponsorship-agreement-form .description {
+				display: block;
+				clear: both;
+			}
 		</style>
 
 		<div class="wcorg-sponsorship-agreement-form">

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -3,80 +3,19 @@
  * Sponsorship Agreement Template
  */
 class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Template {
-	public function form_prefill_select( $data ) {
-		$sponsors = get_posts( array(
-			'post_type' 			=> 'wcb_sponsor',
-			'post_status'			=> 'publish',
-			'posts_per_page'	=> 500,
-		) );
-		?>
-		<style>
-		.wcorg-sponsorship-agreement-form label {
-			display: block;
-			clear: both;
-			margin-top: 12px;
-		}
-
-		.wcorg-sponsorship-agreement-form input,
-		.wcorg-sponsorship-agreement-form textarea,
-		.wcorg-sponsorship-agreement-form select {
-			width: 360px;
-		}
-
-		.wcorg-sponsorship-agreement-form textarea {
-			height: 120px;
-		}
-
-		.wcorg-sponsorship-agreement-form .description {
-			display: block;
-			clear: both;
-		}
-		</style>
-
-		<div class="wcorg-sponsorship-agreement-form">
-			<label><?php _e( 'Sponsor:', 'wordcamporg' ); ?></label>
-			<select name="sponsor_id">
-				<?php foreach ( $sponsors as $sponsor ) : ?>
-					<option value="<?php echo esc_attr( $sponsor->ID ) ?>"><?php echo esc_html( get_the_title( $sponsor ) ) ?></option>
-				<?php endforeach; ?>
-			</select>
-			<span class="description"><?php _e( 'Sponsorship details will be pre-filled with the data on sponsor post.', 'wordcamporg' ); ?></span>
-
-			<label><?php _e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
-			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ); ?></textarea>
-			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
-		</div>
-
-		<?php
-	}
-
 	public function form( $data ) {
-		$date_format = get_option( 'date_format' );
-
-		$sponsor_id  			= absint( $data['sponsor_id'] );
-		$sponsor_amount 	= get_post_meta( $sponsor_id, '_wcb_sponsor_amount', true );
-		$sponsor_currency	= get_post_meta( $sponsor_id, '_wcb_sponsor_currency', true );
-
-		$wordcamp    = get_wordcamp_post();
-		$start_date  = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? date( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
-		$end_date    = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? date( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
-
-		$number_formatter 	= new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
-		$sponsorship_amount = $number_formatter->format( $sponsor_amount ) . " {$sponsor_currency}";
-
-		$number_formatter 			= new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
-		$sponsorship_amount_num = $number_formatter->formatCurrency( $sponsor_amount, $sponsor_currency );
-
 		$data = wp_parse_args( $data, array(
-			'sponsor_name'						=> get_the_title( $sponsor_id ),
-			'sponsor_rep_name'				=> get_post_meta( $sponsor_id, '_wcpt_sponsor_first_name', true ) . ' ' . get_post_meta( $sponsor_id, '_wcpt_sponsor_last_name', true ),
-			'sponsor_rep_title' 			=> '',
-			'agreement_date' 					=> wp_date( $date_format ),
-			'wordcamp_location' 			=> $wordcamp->meta['Location'][0],
-			'wordcamp_date' 					=> ( $start_date !== $end_date ) ? "{$start_date} - {$end_date}" : $start_date,
-			'sponsorship_amount'			=> $sponsorship_amount,
-			'sponsorship_amount_num'	=> $sponsorship_amount_num,
-			'sponsorship_benefits'		=> '',
+			'sponsor_name' => '',
+			'sponsor_rep_name' => '',
+			'sponsor_rep_title' => '',
+
+			'agreement_date' => '',
+			'wordcamp_location' => '',
+			'wordcamp_date' => '',
+
+			'sponsorship_amount' => '',
+			'sponsorship_amount_num' => '',
+			'sponsorship_benefits' => '',
 		) );
 		?>
 		<style>
@@ -89,7 +28,7 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		.wcorg-sponsorship-agreement-form input,
 		.wcorg-sponsorship-agreement-form textarea,
 		.wcorg-sponsorship-agreement-form select {
-			width: 360px;
+			width: 240px;
 		}
 
 		.wcorg-sponsorship-agreement-form textarea {
@@ -323,7 +262,6 @@ h2 {
 	public function sanitize( $input ) {
 		$output = array();
 		foreach ( array(
-			'sponsor_id',
 			'sponsor_name',
 			'sponsor_rep_name',
 			'sponsor_rep_title',

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -46,7 +46,7 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 			<span class="description"><?php esc_html_e( 'Sponsorship details will be pre-filled with the data on sponsor post.', 'wordcamporg' ); ?></span>
 
 			<label><?php esc_html_e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
-			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ); ?></textarea>
+			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ?? '' ); ?></textarea>
 			<span class="description"><?php esc_html_e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
 		</div>
 
@@ -336,7 +336,7 @@ h2 {
 			'sponsorship_amount',
 			'sponsorship_amount_num',
 		) as $field )
-			$output[ $field ] = sanitize_text_field( wp_strip_all_tags( $input[ $field ] ) );
+			$output[ $field ] = sanitize_text_field( wp_strip_all_tags( $input[ $field ] ?? '' ) );
 
 		$output['sponsorship_benefits'] = wp_strip_all_tags( $input['sponsorship_benefits'] );
 		return $output;

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -40,7 +40,7 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 			<label><?php esc_html_e( 'Sponsor:', 'wordcamporg' ); ?></label>
 			<select name="sponsor_id">
 				<?php foreach ( $sponsors as $sponsor ) : ?>
-					<option value="<?php echo esc_attr( $sponsor->ID ) ?>"><?php echo esc_html( get_the_title( $sponsor ) ) ?></option>
+					<option value="<?php echo esc_attr( $sponsor->ID ); ?>"><?php echo esc_html( get_the_title( $sponsor ) ); ?></option>
 				<?php endforeach; ?>
 			</select>
 			<span class="description"><?php esc_html_e( 'Sponsorship details will be pre-filled with the data on sponsor post.', 'wordcamporg' ); ?></span>

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -53,30 +53,30 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 	public function form( $data ) {
 		$date_format = get_option( 'date_format' );
 
-		$sponsor_id  			= absint( $data['sponsor_id'] );
-		$sponsor_amount 	= get_post_meta( $sponsor_id, '_wcb_sponsor_amount', true );
-		$sponsor_currency	= get_post_meta( $sponsor_id, '_wcb_sponsor_currency', true );
+		$sponsor_id       = absint( $data['sponsor_id'] );
+		$sponsor_amount   = get_post_meta( $sponsor_id, '_wcb_sponsor_amount', true );
+		$sponsor_currency = get_post_meta( $sponsor_id, '_wcb_sponsor_currency', true );
 
-		$wordcamp    = get_wordcamp_post();
-		$start_date  = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? date( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
-		$end_date    = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? date( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
+		$wordcamp   = get_wordcamp_post();
+		$start_date = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? date( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
+		$end_date   = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? date( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
 
-		$number_formatter 	= new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
+		$number_formatter   = new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
 		$sponsorship_amount = $number_formatter->format( $sponsor_amount ) . " {$sponsor_currency}";
 
-		$number_formatter 			= new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
+		$number_formatter       = new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
 		$sponsorship_amount_num = $number_formatter->formatCurrency( $sponsor_amount, $sponsor_currency );
 
 		$data = wp_parse_args( $data, array(
-			'sponsor_name'						=> get_the_title( $sponsor_id ),
-			'sponsor_rep_name'				=> get_post_meta( $sponsor_id, '_wcpt_sponsor_first_name', true ) . ' ' . get_post_meta( $sponsor_id, '_wcpt_sponsor_last_name', true ),
-			'sponsor_rep_title' 			=> '',
-			'agreement_date' 					=> wp_date( $date_format ),
-			'wordcamp_location' 			=> $wordcamp->meta['Location'][0],
-			'wordcamp_date' 					=> ( $start_date !== $end_date ) ? "{$start_date} - {$end_date}" : $start_date,
-			'sponsorship_amount'			=> $sponsorship_amount,
-			'sponsorship_amount_num'	=> $sponsorship_amount_num,
-			'sponsorship_benefits'		=> '',
+			'sponsor_name'            => get_the_title( $sponsor_id ),
+			'sponsor_rep_name'        => get_post_meta( $sponsor_id, '_wcpt_sponsor_first_name', true ) . ' ' . get_post_meta( $sponsor_id, '_wcpt_sponsor_last_name', true ),
+			'sponsor_rep_title'       => '',
+			'agreement_date'          => wp_date( $date_format ),
+			'wordcamp_location'       => $wordcamp->meta['Location'][0],
+			'wordcamp_date'           => ( $start_date !== $end_date ) ? "{$start_date} - {$end_date}" : $start_date,
+			'sponsorship_amount'      => $sponsorship_amount,
+			'sponsorship_amount_num'  => $sponsorship_amount_num,
+			'sponsorship_benefits'    => '',
 		) );
 		?>
 		<style>

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -3,11 +3,14 @@
  * Sponsorship Agreement Template
  */
 class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Template {
+	/**
+	 * Step 10. Select the sposnor post from which the form will be pre-filled.
+	 */
 	public function form_prefill_select( $data ) {
 		$sponsors = get_posts( array(
-			'post_type' 			=> 'wcb_sponsor',
-			'post_status'			=> 'publish',
-			'posts_per_page'	=> 500,
+			'post_type'      => 'wcb_sponsor',
+			'post_status'    => 'publish',
+			'posts_per_page' => 500,
 		) );
 		?>
 		<style>
@@ -34,17 +37,17 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		</style>
 
 		<div class="wcorg-sponsorship-agreement-form">
-			<label><?php _e( 'Sponsor:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsor:', 'wordcamporg' ); ?></label>
 			<select name="sponsor_id">
 				<?php foreach ( $sponsors as $sponsor ) : ?>
 					<option value="<?php echo esc_attr( $sponsor->ID ) ?>"><?php echo esc_html( get_the_title( $sponsor ) ) ?></option>
 				<?php endforeach; ?>
 			</select>
-			<span class="description"><?php _e( 'Sponsorship details will be pre-filled with the data on sponsor post.', 'wordcamporg' ); ?></span>
+			<span class="description"><?php esc_html_e( 'Sponsorship details will be pre-filled with the data on sponsor post.', 'wordcamporg' ); ?></span>
 
-			<label><?php _e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
 			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ); ?></textarea>
-			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
+			<span class="description"><?php esc_html_e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
 		</div>
 
 		<?php
@@ -58,8 +61,8 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		$sponsor_currency = get_post_meta( $sponsor_id, '_wcb_sponsor_currency', true );
 
 		$wordcamp   = get_wordcamp_post();
-		$start_date = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? date( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
-		$end_date   = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? date( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
+		$start_date = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? gmdate( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
+		$end_date   = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? gmdate( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
 
 		$number_formatter   = new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
 		$sponsorship_amount = $number_formatter->format( $sponsor_amount ) . " {$sponsor_currency}";
@@ -67,7 +70,7 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		$number_formatter       = new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
 		$sponsorship_amount_num = $number_formatter->formatCurrency( $sponsor_amount, $sponsor_currency );
 
-		$data = wp_parse_args( $data, array(
+		$data = wp_parse_args( $data, array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'sponsor_name'            => get_the_title( $sponsor_id ),
 			'sponsor_rep_name'        => get_post_meta( $sponsor_id, '_wcpt_sponsor_first_name', true ) . ' ' . get_post_meta( $sponsor_id, '_wcpt_sponsor_last_name', true ),
 			'sponsor_rep_title'       => '',

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -3,19 +3,11 @@
  * Sponsorship Agreement Template
  */
 class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Template {
-	public function form( $data ) {
-		$data = wp_parse_args( $data, array(
-			'sponsor_name' => '',
-			'sponsor_rep_name' => '',
-			'sponsor_rep_title' => '',
-
-			'agreement_date' => '',
-			'wordcamp_location' => '',
-			'wordcamp_date' => '',
-
-			'sponsorship_amount' => '',
-			'sponsorship_amount_num' => '',
-			'sponsorship_benefits' => '',
+	public function form_prefill_select( $data ) {
+		$sponsors = get_posts( array(
+			'post_type' 			=> 'wcb_sponsor',
+			'post_status'			=> 'publish',
+			'posts_per_page'	=> 500,
 		) );
 		?>
 		<style>
@@ -28,7 +20,76 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		.wcorg-sponsorship-agreement-form input,
 		.wcorg-sponsorship-agreement-form textarea,
 		.wcorg-sponsorship-agreement-form select {
-			width: 240px;
+			width: 360px;
+		}
+
+		.wcorg-sponsorship-agreement-form textarea {
+			height: 120px;
+		}
+
+		.wcorg-sponsorship-agreement-form .description {
+			display: block;
+			clear: both;
+		}
+		</style>
+
+		<div class="wcorg-sponsorship-agreement-form">
+			<label><?php _e( 'Sponsor:', 'wordcamporg' ); ?></label>
+			<select name="sponsor_id">
+				<?php foreach ( $sponsors as $sponsor ) : ?>
+					<option value="<?php echo esc_attr( $sponsor->ID ) ?>"><?php echo esc_html( get_the_title( $sponsor ) ) ?></option>
+				<?php endforeach; ?>
+			</select>
+			<span class="description"><?php _e( 'Sponsorship details will be pre-filled with the data on sponsor post.', 'wordcamporg' ); ?></span>
+
+			<label><?php _e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
+			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ); ?></textarea>
+			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
+		</div>
+
+		<?php
+	}
+
+	public function form( $data ) {
+		$date_format = get_option( 'date_format' );
+
+		$sponsor_id  			= absint( $data['sponsor_id'] );
+		$sponsor_amount 	= get_post_meta( $sponsor_id, '_wcb_sponsor_amount', true );
+		$sponsor_currency	= get_post_meta( $sponsor_id, '_wcb_sponsor_currency', true );
+
+		$wordcamp    = get_wordcamp_post();
+		$start_date  = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? date( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
+		$end_date    = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? date( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
+
+		$number_formatter 	= new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
+		$sponsorship_amount = $number_formatter->format( $sponsor_amount ) . " {$sponsor_currency}";
+
+		$number_formatter 			= new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
+		$sponsorship_amount_num = $number_formatter->formatCurrency( $sponsor_amount, $sponsor_currency );
+
+		$data = wp_parse_args( $data, array(
+			'sponsor_name'						=> get_the_title( $sponsor_id ),
+			'sponsor_rep_name'				=> get_post_meta( $sponsor_id, '_wcpt_sponsor_first_name', true ) . ' ' . get_post_meta( $sponsor_id, '_wcpt_sponsor_last_name', true ),
+			'sponsor_rep_title' 			=> '',
+			'agreement_date' 					=> wp_date( $date_format ),
+			'wordcamp_location' 			=> $wordcamp->meta['Location'][0],
+			'wordcamp_date' 					=> ( $start_date !== $end_date ) ? "{$start_date} - {$end_date}" : $start_date,
+			'sponsorship_amount'			=> $sponsorship_amount,
+			'sponsorship_amount_num'	=> $sponsorship_amount_num,
+			'sponsorship_benefits'		=> '',
+		) );
+		?>
+		<style>
+		.wcorg-sponsorship-agreement-form label {
+			display: block;
+			clear: both;
+			margin-top: 12px;
+		}
+
+		.wcorg-sponsorship-agreement-form input,
+		.wcorg-sponsorship-agreement-form textarea,
+		.wcorg-sponsorship-agreement-form select {
+			width: 360px;
 		}
 
 		.wcorg-sponsorship-agreement-form textarea {
@@ -262,6 +323,7 @@ h2 {
 	public function sanitize( $input ) {
 		$output = array();
 		foreach ( array(
+			'sponsor_id',
 			'sponsor_name',
 			'sponsor_rep_name',
 			'sponsor_rep_title',


### PR DESCRIPTION
We already usually have needed details about sponsor in the sponsor post, because those are used for invoicing. Let's use that data for pre-filling sponsor agreements as well.

To achieve this, a new step was added when creating a sponsorship agreement. New step numbering allows plugging other new steps as well in future if needed.

Fixes #669 

### Screenshots

<img width="440" alt="CleanShot 2023-09-21 at 01 04 10@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/39fab9f5-6bcb-439e-8660-de9d78cb1878">

<img width="444" alt="CleanShot 2023-09-21 at 01 04 25@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/a568ad4f-1d26-4876-9bdc-4b5fdfc83fe7">

### How to test the changes in this Pull Request:

1. Open a WordCamp site
2. Check that you have a sponsor post with all details, create new if needed
3. Navigate to `/wp-admin/admin.php?page=wcdocs`
4. Follow steps and generate pdf
