### PR TITLE
Send copy of call for speakers email to the speaker itself

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
 Plugin Name: WordCamp Forms to Drafts
 Description: Convert form submissions into drafts for our custom post types.
@@ -22,16 +21,16 @@ class WordCamp_Forms_To_Drafts {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_action( 'wp_print_styles',                    array( $this, 'print_front_end_styles'      )        );
-		add_action( 'wp_enqueue_scripts',                 array( $this, 'enqueue_inert_script'        )        );
-		add_filter( 'the_content',                        array( $this, 'force_login_to_use_form'     ),  8    );
-		add_action( 'template_redirect',                  array( $this, 'populate_form_based_on_user' ),  9    );
-		add_action( 'grunion_pre_message_sent',           array( $this, 'call_for_sponsors'           ), 10, 3 );
-		add_action( 'grunion_pre_message_sent',           array( $this, 'call_for_speakers'           ), 10, 3 );
-		add_action( 'grunion_pre_message_sent',           array( $this, 'call_for_volunteers'         ), 10, 3 );
-		add_filter( 'jetpack_contact_form_email_headers', array( $this, 'maybe_modify_email_headers'  ), 10, 4 );
-		add_filter( 'contact_form_subject',               array( $this, 'maybe_modify_email_subject'  ), 10, 2 );
-		add_filter( 'contact_form_message',               array( $this, 'maybe_modify_email_message'  ), 10, 2 );
+		add_action( 'wp_print_styles',                    array( $this, 'print_front_end_styles' ) );
+		add_action( 'wp_enqueue_scripts',                 array( $this, 'enqueue_inert_script' ) );
+		add_filter( 'the_content',                        array( $this, 'force_login_to_use_form' ), 8 );
+		add_action( 'template_redirect',                  array( $this, 'populate_form_based_on_user' ), 9 );
+		add_action( 'grunion_pre_message_sent',           array( $this, 'call_for_sponsors' ), 10, 3 );
+		add_action( 'grunion_pre_message_sent',           array( $this, 'call_for_speakers' ), 10, 3 );
+		add_action( 'grunion_pre_message_sent',           array( $this, 'call_for_volunteers' ), 10, 3 );
+		add_filter( 'jetpack_contact_form_email_headers', array( $this, 'maybe_modify_email_headers' ), 10, 4 );
+		add_filter( 'contact_form_subject',               array( $this, 'maybe_modify_email_subject' ), 10, 2 );
+		add_filter( 'contact_form_message',               array( $this, 'maybe_modify_email_message' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
When the speaker submits a talk to WordCamp, send a "receipt" of that to the speaker. It will help people keep track of what talks they’ve submitted to WordCamps, and when.

Instead of sending out separate emails and handling logic for that, I decided to just modify the email that goes out in any case. This helps to keep the code a tad cleaner, but has also the added benefit of organisers being able to reply to that email and continue the discussion with the speaker on a thread that has all of the submitted information. In addition, the same code can be extended for sponsor and volunteer applications easily.

Fixes #376

Props @melchoyce

### Screenshots

<img width="1062" alt="CleanShot 2023-09-21 at 11 36 13@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/698a39da-8f64-4635-8fa7-3f1fec0af13b">

### How to test the changes in this Pull Request:

1. Head to WordCamp site and open a Call for Speakers post
2. Fill the form
3. Check the email (on Docker, use Mailcatcher for that)
