### PR TITLE
Automatically disable Attendance UI

### DIFF
--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -356,9 +356,9 @@ class CampTix_Attendance extends CampTix_Addon {
 		<label for="camptix-attendance-generate"><?php esc_html_e( 'Generate a new secret link (old links will expire)', 'wordcamporg' ); ?></label>
 		<p class="description">
 			<?php if ( empty( $this->secret_generated ) ) {
-				echo esc_html( sprintf( _( 'Link will expire automatically after two weeks from generating it.', 'wordcamporg' ), $this->secret_expiry ) );
+				echo esc_html( sprintf( __( 'Link will expire automatically after two weeks from generating it.', 'wordcamporg' ), $this->secret_expiry ) );
 			} else {
-				echo esc_html( sprintf( _( 'Link will expire automatically on %s.', 'wordcamporg' ), wp_date( 'Y-m-d H:i:s', strtotime( "+{$this->secret_expiry}", strtotime( $this->secret_generated ) ) ) ) );
+				echo esc_html( sprintf( __( 'Link will expire automatically on %s.', 'wordcamporg' ), wp_date( 'Y-m-d H:i:s', strtotime( "+{$this->secret_expiry}", strtotime( $this->secret_generated ) ) ) ) );
 			} ?>
 		</p>
 		<?php

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -356,9 +356,9 @@ class CampTix_Attendance extends CampTix_Addon {
 		<label for="camptix-attendance-generate"><?php esc_html_e( 'Generate a new secret link (old links will expire)', 'wordcamporg' ); ?></label>
 		<p class="description">
 			<?php if ( empty( $this->secret_generated ) ) {
-				printf( esc_html__( 'Link will expire automatically after two weeks from generating it.', 'wordcamporg' ), $this->secret_expiry );
+				echo esc_html( sprintf( _( 'Link will expire automatically after two weeks from generating it.', 'wordcamporg' ), $this->secret_expiry ) );
 			} else {
-				printf( esc_html__( 'Link will expire automatically on %s.', 'wordcamporg' ), wp_date( 'Y-m-d H:i:s', strtotime( "+{$this->secret_expiry}", strtotime( $this->secret_generated ) ) ) );
+				echo esc_html( sprintf( _( 'Link will expire automatically on %s.', 'wordcamporg' ), wp_date( 'Y-m-d H:i:s', strtotime( "+{$this->secret_expiry}", strtotime( $this->secret_generated ) ) ) ) );
 			} ?>
 		</p>
 		<?php

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -3,9 +3,9 @@
  * Allows event organizers to track which attendees showed up to the event.
  */
 class CampTix_Attendance extends CampTix_Addon {
-	public $secret    = '';
-	public $questions = array();
-  public $secret_expiry = '2 weeks';
+	public $secret        = '';
+	public $questions     = array();
+	public $secret_expiry = '2 weeks';
 
 	/**
 	 * Runs during CampTix init.
@@ -356,9 +356,9 @@ class CampTix_Attendance extends CampTix_Addon {
 		<label for="camptix-attendance-generate"><?php esc_html_e( 'Generate a new secret link (old links will expire)', 'wordcamporg' ); ?></label>
 		<p class="description">
 			<?php if ( empty( $this->secret_generated ) ) {
-				echo sprintf( esc_html__( "Link will expire automatically after two weeks from generating it.", 'wordcamporg' ), $this->secret_expiry );
+				printf( esc_html__( 'Link will expire automatically after two weeks from generating it.', 'wordcamporg' ), $this->secret_expiry );
 			} else {
-				echo sprintf( esc_html__( "Link will expire automatically on %s.", 'wordcamporg' ), wp_date( 'Y-m-d H:i:s', strtotime( "+{$this->secret_expiry}", strtotime( $this->secret_generated ) ) ) );
+				printf( esc_html__( 'Link will expire automatically on %s.', 'wordcamporg' ), wp_date( 'Y-m-d H:i:s', strtotime( "+{$this->secret_expiry}", strtotime( $this->secret_generated ) ) ) );
 			} ?>
 		</p>
 		<?php

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -38,6 +38,7 @@ class CampTix_Attendance extends CampTix_Addon {
 		if ( strtotime( $this->secret_generated ) < strtotime( "-{$this->secret_expiry}" ) ) {
 			$camptix_options['attendance-enabled'] = 0;
 			$camptix_options['attendance-secret'] = '';
+			$camptix_options['attendance-secret-generated'] = '';
 			update_option( 'camptix_options', $camptix_options );
 			return;
 		}


### PR DESCRIPTION
Camptix Attendance UI must be turned on to reveal attendee info with a link without user authentication. Currently, we trust organisers to disable the UI when they no longer need it. That can lead to the UI being open and the potential of attendee info leakage.

To mitigate the potential issues, this PR automatically disabled the UI after two weeks from generating the code.

It is done simply by saving the time when the secret was generated and comparing that when the link or Camptix settings are visited. If the link is older than two weeks, the UI will be disabled and the secret removed.

This could have been done with a cron job or event, but that just felt too complicated.

Fixes #620 

### Screenshots

<img width="660" alt="CleanShot 2023-09-21 at 15 08 19@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/c3982c92-735d-41ed-bc6e-604801b4c8aa">

<img width="661" alt="CleanShot 2023-09-21 at 15 07 18@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/1dc33b1d-dd4c-4cc7-b71c-293965bc306e">

### How to test the changes in this Pull Request:

1. Open a WordCamp website dashboard
2. Navigate to tickets -> setup ->  attendance UI `wp-admin/edit.php?post_type=tix_ticket&page=camptix_options&tix_section=attendance-ui`
3. Enable and generate a new code
4. You should be able to see the UI with the link
5. Temporarily change the expiry by modifying `$secret_expiry` value (set to 1 second for example)
6. Try to revisit the link, UI should not be visible
7. Check that settings have reseted
