### PR TITLE
Include sharable link in "favorite sessions" email

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -69,12 +69,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "216da2209e16c70fd137ea7123a9cd5d48b89c0c"
+                "reference": "d4e52af3e755c15787293e1fd1e25054af225eec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/216da2209e16c70fd137ea7123a9cd5d48b89c0c",
-                "reference": "216da2209e16c70fd137ea7123a9cd5d48b89c0c",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/d4e52af3e755c15787293e1fd1e25054af225eec",
+                "reference": "d4e52af3e755c15787293e1fd1e25054af225eec",
                 "shasum": ""
             },
             "type": "wordpress-theme",
@@ -82,7 +82,7 @@
                 "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
                 "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
             },
-            "time": "2024-04-29T03:23:57+00:00"
+            "time": "2024-04-30T17:07:09+00:00"
         }
     ],
     "packages-dev": [
@@ -4753,12 +4753,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "b5ac3f6a598c26f2d3866d6547f9d48689c0d468"
+                "reference": "1c01971a816aba069a1c9e5d9c200ac2e20c8dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/b5ac3f6a598c26f2d3866d6547f9d48689c0d468",
-                "reference": "b5ac3f6a598c26f2d3866d6547f9d48689c0d468",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/1c01971a816aba069a1c9e5d9c200ac2e20c8dc6",
+                "reference": "1c01971a816aba069a1c9e5d9c200ac2e20c8dc6",
                 "shasum": ""
             },
             "require": {
@@ -4799,7 +4799,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2024-04-26T16:22:14+00:00"
+            "time": "2024-04-30T16:50:57+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -542,7 +542,7 @@ function send_favourite_sessions_email( WP_REST_Request $request ) {
 	// Page by slug existance validated in REST API.
 	$pages = get_posts( array(
 		'name'        => $page_slug,
-		'post_type'	  => 'page',
+		'post_type'   => 'page',
 		'post_status' => 'publish',
 		'fields'      => 'ids',
 	) );

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -442,10 +442,11 @@ function flip_sessions_subarrays( $sessions ) {
  *
  * @param string $wordcamp_name       WordCamp name to be used in the email.
  * @param array  $fav_sessions_lookup Mapping session _id -> 1 for favourite sessions.
+ * @param string $url_base            The URL for schedule page, into which favourite sessions parameter will be added.
  *
  * @return string                     Plain text body of the email.
  */
-function generate_email_body( $wordcamp_name, $fav_sessions_lookup ) {
+function generate_email_body( $wordcamp_name, $fav_sessions_lookup, $url_base ) {
 	$date_format                 = get_option( 'date_format' );
 	$tracks                      = get_schedule_tracks( 'all' );
 	$tracks_explicitly_specified = false; // include all tracks in the email.
@@ -479,6 +480,9 @@ function generate_email_body( $wordcamp_name, $fav_sessions_lookup ) {
 		$email_message .= generate_plaintext_fav_sessions( $sessions_for_current_day, $fav_sessions_lookup );
 		$email_message .= "\n\n";
 	}
+
+	$email_message .= esc_html__( 'Link to your favorite sessions on schedule', 'wordcamporg' );
+	$email_message .= ' ' . add_query_arg( 'fav-sessions', implode( ',', array_keys( $fav_sessions_lookup ) ), $url_base );
 
 	return $email_message;
 }
@@ -522,6 +526,7 @@ function send_favourite_sessions_email( WP_REST_Request $request ) {
 	// Input sanitized by REST controller.
 	$email_address = $params['email-address'];
 	$fav_sessions  = $params['session-list'];
+	$page_slug     = $params['page-slug'];
 
 	// Don't send the email if no sessions were marked as favourite.
 	if ( count( explode( ',', $fav_sessions ) ) === 0 ) {
@@ -534,6 +539,16 @@ function send_favourite_sessions_email( WP_REST_Request $request ) {
 		);
 	}
 
+	// Page by slug existance validated in REST API.
+	$pages = get_posts( array(
+		'name'        => $page_slug,
+		'post_type'	  => 'page',
+		'post_status' => 'publish',
+		'fields'      => 'ids',
+	) );
+
+	$url_base = get_the_permalink( $pages[0] );
+
 	$fav_sessions_lookup = array_fill_keys( explode( ',', $fav_sessions ), 1 );
 
 	$wordcamp_name = get_wordcamp_name();
@@ -542,7 +557,7 @@ function send_favourite_sessions_email( WP_REST_Request $request ) {
 	$headers[] = 'Content-Type: text/plain; charset=' . get_bloginfo( 'charset' );
 
 	$subject = sprintf( __( 'My favorite sessions for %s', 'wordcamporg' ), $wordcamp_name );
-	$message = generate_email_body( $wordcamp_name, $fav_sessions_lookup );
+	$message = generate_email_body( $wordcamp_name, $fav_sessions_lookup, $url_base );
 
 	if ( wp_mail( $email_address, $subject, $message, $headers ) ) {
 		return new WP_REST_Response(

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -739,7 +739,7 @@ function register_fav_sessions_email() {
 					'validate_callback' => function( $value, $request, $param ) {
 						$pages = get_posts( array(
 							'name'        => $value,
-							'post_type'	  => 'page',
+							'post_type'   => 'page',
 							'post_status' => 'publish',
 							'fields'      => 'ids',
 						) );

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -733,6 +733,27 @@ function register_fav_sessions_email() {
 						return implode( ',', array_filter( $session_ids, 'is_numeric' ) );
 					},
 				),
+
+				'page-slug'     => array(
+					'required'          => true,
+					'validate_callback' => function( $value, $request, $param ) {
+						$pages = get_posts( array(
+							'name'        => $value,
+							'post_type'	  => 'page',
+							'post_status' => 'publish',
+							'fields'      => 'ids',
+						) );
+
+						if ( empty( $pages ) ) {
+							return false;
+						}
+
+						return true;
+					},
+					'sanitize_callback' => function( $value, $request, $param ) {
+						return sanitize_title( $value );
+					},
+				),
 			),
 		)
 	);

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -86,7 +86,7 @@ function register_speaker_post_meta() {
 			'type'              => 'string',
 			'single'            => true,
 			'show_in_rest' => array(
-				'prepare_callback' => function( $value, $request, $args ) {
+				'prepare_callback' => function ( $value, $request, $args ) {
 					$user_id = get_post_meta( get_the_ID(), '_wcpt_user_id', true );
 					if ( $user_id ) {
 						$wporg_user = get_userdata( $user_id );
@@ -97,7 +97,7 @@ function register_speaker_post_meta() {
 					return $value;
 				},
 			),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				$wporg_user = wcorg_get_user_by_canonical_names( $value );
 				if ( ! $wporg_user ) {
 					return '';
@@ -149,7 +149,7 @@ function register_session_post_meta() {
 		'_wcpt_session_time',
 		array(
 			'show_in_rest' => array(
-				'prepare_callback' => function( $value, $request, $args ) {
+				'prepare_callback' => function ( $value, $request, $args ) {
 					if ( $request->get_param( 'wc_session_utc' ) ) {
 						$datetime = date_create( wp_date( 'Y-m-d\TH:i:s\Z', $value ) );
 						return $datetime->getTimestamp();
@@ -180,7 +180,7 @@ function register_session_post_meta() {
 			'show_in_rest'      => true,
 			'single'            => true,
 			'auth_callback'     => __NAMESPACE__ . '\meta_auth_callback',
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( 'custom' === $value ) {
 					return $value;
 				}
@@ -204,7 +204,7 @@ function register_session_post_meta() {
 			'show_in_rest'      => true,
 			'single'            => true,
 			'auth_callback'     => __NAMESPACE__ . '\meta_auth_callback',
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				if ( $value ) {
 					$host = wp_parse_url( $value, PHP_URL_HOST );
 
@@ -254,7 +254,7 @@ function register_organizer_post_meta() {
 			'type'              => 'string',
 			'single'            => true,
 			'show_in_rest' => array(
-				'prepare_callback' => function( $value, $request, $args ) {
+				'prepare_callback' => function ( $value, $request, $args ) {
 					$user_id = get_post_meta( get_the_ID(), '_wcpt_user_id', true );
 					if ( $user_id ) {
 						$wporg_user = get_userdata( $user_id );
@@ -265,7 +265,7 @@ function register_organizer_post_meta() {
 					return $value;
 				},
 			),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				$wporg_user = wcorg_get_user_by_canonical_names( $value );
 				if ( ! $wporg_user ) {
 					return '';
@@ -318,7 +318,7 @@ function register_volunteer_post_meta() {
 			'type'              => 'string',
 			'single'            => true,
 			'show_in_rest' => array(
-				'prepare_callback' => function( $value, $request, $args ) {
+				'prepare_callback' => function ( $value, $request, $args ) {
 					$user_id = get_post_meta( get_the_ID(), '_wcpt_user_id', true );
 					if ( $user_id ) {
 						$wporg_user = get_userdata( $user_id );
@@ -329,7 +329,7 @@ function register_volunteer_post_meta() {
 					return $value;
 				},
 			),
-			'sanitize_callback' => function( $value ) {
+			'sanitize_callback' => function ( $value ) {
 				$wporg_user = wcorg_get_user_by_canonical_names( $value );
 				if ( ! $wporg_user ) {
 					return '';
@@ -400,7 +400,7 @@ function register_user_validation_route() {
 			'permission_callback' => '__return_true',
 			'args'                => array(
 				'username' => array(
-					'validate_callback' => function( $value ) {
+					'validate_callback' => function ( $value ) {
 						$wporg_user = wcorg_get_user_by_canonical_names( $value );
 						return (bool) $wporg_user;
 					},
@@ -507,7 +507,7 @@ function register_additional_rest_fields() {
 		'wcb_session',
 		'session_speakers',
 		array(
-			'get_callback' => function( $post ) {
+			'get_callback' => function ( $post ) {
 				$speaker_ids = get_post_meta( $post['id'], '_wcpt_speaker_id', false );
 				$speakers = array();
 
@@ -555,7 +555,7 @@ function register_additional_rest_fields() {
 		'wcb_session',
 		'session_cats_rendered',
 		array(
-			'get_callback' => function( $post ) {
+			'get_callback' => function ( $post ) {
 				$terms = get_terms( 'wcb_session_category', array( 'object_ids' => $post['id'] ) );
 				if ( $terms ) {
 					return implode( ', ', wp_list_pluck( $terms, 'name' ) );
@@ -708,17 +708,17 @@ function register_fav_sessions_email() {
 			'args'                => array(
 				'email-address' => array(
 					'required'          => true,
-					'validate_callback' => function( $value, $request, $param ) {
+					'validate_callback' => function ( $value, $request, $param ) {
 						return is_email( $value );
 					},
-					'sanitize_callback' => function( $value, $request, $param ) {
+					'sanitize_callback' => function ( $value, $request, $param ) {
 						return sanitize_email( $value );
 					},
 				),
 
 				'session-list'  => array(
 					'required'          => true,
-					'validate_callback' => function( $value, $request, $param ) {
+					'validate_callback' => function ( $value, $request, $param ) {
 						$session_ids = explode( ',', $value );
 						$session_count = count( $session_ids );
 						for ( $i = 0; $i < $session_count; $i++ ) {
@@ -728,7 +728,7 @@ function register_fav_sessions_email() {
 						}
 						return true;
 					},
-					'sanitize_callback' => function( $value, $request, $param ) {
+					'sanitize_callback' => function ( $value, $request, $param ) {
 						$session_ids = explode( ',', $value );
 						return implode( ',', array_filter( $session_ids, 'is_numeric' ) );
 					},
@@ -736,7 +736,7 @@ function register_fav_sessions_email() {
 
 				'page-slug'     => array(
 					'required'          => true,
-					'validate_callback' => function( $value, $request, $param ) {
+					'validate_callback' => function ( $value, $request, $param ) {
 						$pages = get_posts( array(
 							'name'        => $value,
 							'post_type'   => 'page',
@@ -750,7 +750,7 @@ function register_fav_sessions_email() {
 
 						return true;
 					},
-					'sanitize_callback' => function( $value, $request, $param ) {
+					'sanitize_callback' => function ( $value, $request, $param ) {
 						return sanitize_title( $value );
 					},
 				),

--- a/public_html/wp-content/plugins/wc-post-types/js/favourite-sessions.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/favourite-sessions.js
@@ -303,6 +303,7 @@ jQuery( document ).ready( function ( $ ) {
 		var data = {
 			'email-address': emailAddress,
 			'session-list': favSessions,
+			'page-slug': window.location.pathname.split('/').filter(n => n).pop(), // get last path = page slug
 		};
 
 		$.ajax( {


### PR DESCRIPTION
The "favorite sessions" email includes the sessions the user chose, it'd be helpful to include the link, so that they can easily apply those sessions to their phone or other device, and so that they can easily get a much better view of their personalized schedule on the website.

This PR adds that link to that email.

For ease, let's get the schedule page by slug. This way we do not need to pass the page ID just for this, but we neither blindly trust the input sent to REST API as a URL that belongs to the WordCamp site.

Fixes #186 

Props @iandunn 

### Screenshots

<img width="805" alt="CleanShot 2023-09-21 at 17 09 11@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/aece3b98-980f-4789-b7f1-5c5f4444d04b">

### How to test the changes in this Pull Request:

1. Go to WordCamp website schedule page
2. Favorite some sessions
3. Send the email
4. Open the link in email, favorite sessions should be indicated
