### PR TITLE
Notify Community Team when new post is pending in Central 

### DIFF
--- a/public_html/wp-content/plugins/notify-central-on-pending-posts.php
+++ b/public_html/wp-content/plugins/notify-central-on-pending-posts.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Notify WordCamp Central on pending posts
+ * Plugin URI: http://wordcamp.org
+ * Description: Send email notification to WordCamp Central when post status becomes pending.
+ * Version: 1.0
+ *
+ * Heavily inspired from Pending Submission Notifications plugin by Razvan Horeanga.
+ */
+
+namespace Notify_Central_Pending_Posts;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Invalid request.' );
+}
+
+add_action( 'transition_post_status', __NAMESPACE__ . '\send_notification_email', 10, 3 );
+
+/**
+ * Send the notification email.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ */
+function send_notification_email( $new_status, $old_status, $post ) {
+	if ( 'pending' === $new_status && user_can( $post->post_author, 'edit_posts' ) ) {
+		// Prevent many emails from the same post.
+		$sent = get_post_meta( $post->ID, '_ncpp_sent', true );
+		if ( ! empty( $sent ) ) {
+			return;
+		}
+
+		$edit_link    = get_edit_post_link( $post->ID, '' );
+		$preview_link = get_permalink( $post->ID ) . '&preview=true';
+
+		$username           = get_userdata( $post->post_author );
+		$username_last_edit = get_the_modified_author();
+
+		$subject = __( 'New post on WordCamp Central pending review', 'wordcamporg' ) . ": {$post->post_title}";
+
+		$message  = __( 'Hello team! A new post on WordCamp Central is pending review.', 'wordcamporg' );
+		$message .= "\r\n\r\n";
+		$message .= __( 'Title' ) . ": {$post->post_title}\r\n";
+		$message .= __( 'Author' ) . ": {$username->user_login}\r\n";
+		$message .= "\r\n\r\n";
+		$message .= __( 'Edit' ) . ": {$edit_link}\r\n";
+		$message .= __( 'Preview' ) . ": {$preview_link}";
+
+		wp_mail( 'support@wordcamp.org', $subject, $message );
+
+		// Save a pointer that notification has been sent.
+		update_post_meta( $post->ID, '_ncpp_sent', wp_date( 'Y-m-d H:i:s' ) );
+	}
+}


### PR DESCRIPTION
Many WordCamp organisers do have a contributor role on the WordCamp Central website. That means they can write a post, but not publish it. When they are to publish that post, it goes to pending review status.

The team has witnessed a few times that the author doesn't know/understand that no one in Central is looking at pending posts automatically. That results in posts not being published (non at the moment) or delayed.

To avoid these situations, send notification to Community Team when the post status is changed to pending.

Fixes #718 

Props @pkevan 

### Screenshots

<img width="614" alt="CleanShot 2023-09-21 at 18 40 41@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/d21828d5-4e8b-40d4-bd17-c871def48123">

### How to test the changes in this Pull Request:

1. Go to Central and create a new post
2. Check "Pending review" on post sidebar
3. Click "Send as pending"
4. Check your mail (on local, mailcatcher)

### After merge & deploy

- [ ] Activate the plugin on Central
