### PR TITLE
Add city@wordcamp dot org as a recipient of invoice emails

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -353,6 +353,7 @@ function notify_organizer_status_changed( $invoice_id, $new_status ) {
 		return;
 	}
 
+	$wordcamp           = get_wordcamp_post();
 	$invoice            = get_post( $invoice_id );
 	$to                 = WordCamp_Budgets::get_requester_formatted_email( $invoice->post_author );
 	$subject            = "Invoice for {$invoice->post_title} $new_status";
@@ -362,6 +363,10 @@ function notify_organizer_status_changed( $invoice_id, $new_status ) {
 	$attachments        = array();
 	$attachment_message = '';
 	$invoice_filename   = false;
+
+	if ( $wordcamp->meta['E-mail Address'][0] !== $to ) {
+		$headers[] = "Cc: {$wordcamp->meta['E-mail Address'][0]}";
+	}
 
 	if ( 'approved' === $new_status ) {
 		$sponsor_id       = get_post_meta( $invoice_id, '_wcbsi_sponsor_id',           true );
@@ -526,9 +531,9 @@ function send_invoice_pending_reminder() {
 		$last_step_time      = $invoice_sent_at;
 		$wordcamp_post       = get_wordcamp_post();
 		$wordcamp_start_date = $wordcamp_post->meta['Start Date (YYYY-mm-dd)'][0] ?? false;
-		$wordcamp_lead_email = $wordcamp_post->meta['Email Address'][0]           ?? false;
+		$wordcamp_email      = $wordcamp_post->meta['E-mail Address'][0]          ?? false;
 
-		if ( empty( $wordcamp_post ) || ! $wordcamp_lead_email ) {
+		if ( empty( $wordcamp_post ) || ! $wordcamp_email ) {
 			// Maybe this is a central.wordcamp.org test sponsor invoice.
 			continue;
 		}
@@ -566,7 +571,7 @@ function send_invoice_pending_reminder() {
 			'step'    => $reminder_step,
 		);
 
-		send_invoice_pending_reminder_mail( $invoice_id, $wordcamp_lead_email );
+		send_invoice_pending_reminder_mail( $invoice_id, $wordcamp_email );
 
 		update_post_meta( $invoice_id, 'last_reminder_details', $current_reminder_details );
 	}


### PR DESCRIPTION
Add the main email address, which is typically city@wordcamp.org, to all sponsor invoice emails as CC. Emails include: when the invoice has been approved and sent, when it has been paid and when pending reminders.

On pending reminders, the CC was changed from lead organiser email to main email address for consistency.

Fixes #708
Fixes #641

Props @iandunn @CdrMarks @naokomc @kcristiano

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<img width="1233" alt="CleanShot 2023-09-21 at 21 07 44@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/d18c11d3-062c-472e-adfa-1f3bc0deed06">

### How to test the changes in this Pull Request:

1. On a WordCamp site, create a new sponsor invoice
2. On network admin payments, approve the invoice
3. Check your email (in dev, mailcatcher)
