### PR TITLE
Subroles: Restore Mentor Manager ability to edit Meetup posts.

### DIFF
--- a/public_html/wp-content/mu-plugins/trusted-deputy-capabilities.php
+++ b/public_html/wp-content/mu-plugins/trusted-deputy-capabilities.php
@@ -3,7 +3,10 @@
 namespace WordCamp\Trusted_Deputy_Capabilities;
 
 /*
- * Allow trusted WordCamp Deputies to perform limited Super Admin functions
+ * Allow trusted WordCamp Deputies to perform limited Super Admin functions.
+ *
+ * "Super Deputy" and "Trusted Deputy" are legacy terms from pre-2023. The current term is "Program Manager".
+ * See https://make.wordpress.org/community/2023/06/06/updates-to-the-community-team-mentor-program/
  *
  * They should be able to:
  *  - Perform administrator-level functions on all sites

--- a/public_html/wp-content/mu-plugins/wcorg-subroles.php
+++ b/public_html/wp-content/mu-plugins/wcorg-subroles.php
@@ -62,6 +62,7 @@ function add_subrole_caps( $allcaps, $caps, $args, $user ) {
 					'read'                       => true, // Access to wp-admin.
 					'wordcamp_manage_mentors'    => true,
 					'wordcamp_wrangle_wordcamps' => true,
+					'wordcamp_wrangle_meetups'   => true,
 				);
 				break;
 


### PR DESCRIPTION
#1041 accidentally removed the ability for folks with the "Mentor Manager" role to edit Meetup posts. Reported at https://wordpress.slack.com/archives/C08M59V3P/p169463014664263.

Before the change in #1041, that role granted access to edit both WordCamps and Meetups, because those two post types shared the same capability. When the roles were separated, the new role should have been added to the "Mentor Manager" capabilities, but wasn't. This PR adds it in order to restore access.
