### PR TITLE
Gracefully handle unrefundable ticket refund attempts

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -1,9 +1,10 @@
 <?php
 
 class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
-	public $id          = 'stripe';
-	public $name        = 'Credit Card (Stripe)';
-	public $description = 'Credit card processing, powered by Stripe.';
+	public $id               = 'stripe';
+	public $name             = 'Credit Card (Stripe)';
+	public $description      = 'Credit card processing, powered by Stripe.';
+	protected $refund_expiry = 90; // days.
 
 	/**
 	 * See https://support.stripe.com/questions/which-currencies-does-stripe-support.
@@ -502,6 +503,30 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			// Unfortunately there's no way to remove the following failure message, but at least ours will display first:
 			// A payment error has occurred, looks like chosen payment method is not responding. Please try again later.
 		}
+	}
+
+	/**
+	 * Check if the transaction is refundable.
+	 *
+	 * @param  string $payment_token
+	 *
+	 * @return bool|obj WP_Error or boolean false if not refundable
+	 */
+	public function transaction_is_refundable( $payment_token ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		if ( empty( $this->refund_expiry ) ) {
+			return false;
+		}
+
+		$txn_details = $camptix->get_post_meta_from_payment_token( $payment_token, 'tix_transaction_details' );
+
+		if ( $txn_details['raw']['charge']['created'] + ( $this->refund_expiry * DAY_IN_SECONDS ) < time() ) {
+			return new WP_Error('refund-expired', sprintf( __( 'Stripe only allows refund within %d days of payment.', 'camptix' ), $this->refund_expiry ) );
+		}
+
+		return true;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6574,7 +6574,6 @@ class CampTix_Plugin {
 		$is_refundable = $payment_method_obj->transaction_is_refundable( $payment_token );
 
 		if ( is_wp_error( $is_refundable ) ) {
-			var_dump( $is_refundable );
 			return $is_refundable;
 		}
 

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -217,6 +217,17 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 	abstract function payment_checkout( $payment_token );
 
 	/**
+	 * Check if the transaction is refundable.
+	 *
+	 * @param  string $payment_token
+	 *
+	 * @return bool|obj WP_Error or boolean false if not refundable
+	 */
+	function transaction_is_refundable( $payment_token ) {
+		return true; // To maintain backwards compatibility, default to refundable.
+	}
+
+	/**
 	 * Handle the refund process
 	 *
 	 * @param string $payment_token

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -223,7 +223,7 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 	 *
 	 * @return bool|obj WP_Error or boolean false if not refundable
 	 */
-	function transaction_is_refundable( $payment_token ) {
+	public function transaction_is_refundable( $payment_token ) {
 		return true; // To maintain backwards compatibility, default to refundable.
 	}
 


### PR DESCRIPTION
CampTix allows users to refund their ticket purchases, but Stipe and PayPal only allow refunds within a certain number of days after the ticket purchase.

`transaction_is_refundable` method was added to `CampTix_Payment_Method` with it defaulting to true in order to maintain backwards compatibility. `CampTix_Payment_Method_Stripe` and `CampTix_Payment_Method_PayPal` override that method with their own, quite similar checks.

If the method class recognises that the transaction is not refundable, `WP_Error` is returned for passing a nice message to the tickets frontend if refunds are otherwise enabled.

Also if someone tries to go directly to the refund URL, they will be sent to the tickets page with an error and that will be logged. Some code styling was made on the same go.

Fixes #577

Props @iandunn @actual-saurabh @ePascalC

### Screenshots

<img width="640" alt="CleanShot 2023-09-22 at 00 04 30@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/c6af67f8-db4f-4a60-83d6-1291a191fc9c">

### How to test the changes in this Pull Request:

1. Go to WordCamp site and tickets -> setup -> enable refunds
2. Go to tickets -> attendees and open a ticket that has been bought over 4 months ago
3. Visit the access token link
4. Refund error message should be visible
5. Repeat steps 2-4 with both Stripe and PayPal paid tickets
6. Repeat steps 2-4 with ticket that has been bought less than a month ago -> refund should be possible
