### PR TITLE
Show empty tickets with "sold out" message

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -12,7 +12,6 @@ add_action( 'camptix_admin_notices',                         __NAMESPACE__ . '\s
 add_filter( 'camptix_dashboard_paypal_credentials',          __NAMESPACE__ . '\paypal_credentials'                  );
 add_filter( 'camptix_paypal_predefined_accounts',            __NAMESPACE__ . '\paypal_credentials'                  );
 add_filter( 'camptix_stripe_predefined_accounts',            __NAMESPACE__ . '\stripe_credentials'                  );
-add_action( 'init',                                          __NAMESPACE__ . '\hide_empty_tickets'                  );
 add_action( 'wp_print_styles',                               __NAMESPACE__ . '\print_login_message_styles'          );
 add_filter( 'camptix_require_login_please_login_message',    __NAMESPACE__ . '\override_please_login_message'       );
 add_action( 'camptix_checkout_start',                        __NAMESPACE__ . '\check_ip_throttling'                 );
@@ -22,6 +21,18 @@ add_action( 'transition_post_status',                        __NAMESPACE__ . '\t
 add_action( 'camptix_payment_result',                        __NAMESPACE__ . '\track_payment_results',        10, 3 );
 add_filter( 'camptix_shortcode_contents',                    __NAMESPACE__ . '\modify_shortcode_contents',    10, 2 );
 add_filter( 'camptix_max_tickets_per_order',                 __NAMESPACE__ . '\limit_one_ticket_per_order'          );
+
+/**
+ * Show empty tickets
+ *
+ * This provides a way for individual WordCamps to decide if they want to show sold-out tickets in the [tickets]
+ * shortcode output. This can help avoid confusion if the camp has several types of tickets (e.g., General
+ * Admission, Micro-sponsorship, etc) and the General Admission ticket sells out. If the General Admission ticket
+ * was hidden, some users may mistakenly think that the Micro-sponsorship ticket is the "normal" ticket, even
+ * though it costs several hundred dollars. Since we value keeping regular tickets accessible by as many people
+ * as possible, we don't want anyone getting the impression that WordCamps are expensive to attend.
+ */
+add_filter( 'camptix_hide_empty_tickets',                    '__return_false' );
 
 // Attendees
 add_filter( 'camptix_name_order',                            __NAMESPACE__ . '\set_name_order'                      );
@@ -204,29 +215,6 @@ function stripe_credentials( $credentials ) {
 	}
 
 	return $credentials;
-}
-
-/**
- * Show empty tickets
- *
- * This provides a way for individual WordCamps to decide if they want to show sold-out tickets in the [tickets]
- * shortcode output. This can help avoid confusion if the camp has several types of tickets (e.g., General
- * Admission, Micro-sponsorship, etc) and the General Admission ticket sells out. If the General Admission ticket
- * was hidden, some users may mistakenly think that the Micro-sponsorship ticket is the "normal" ticket, even
- * though it costs several hundred dollars. Since we value keeping regular tickets accessible by as many people
- * as possible, we don't want anyone getting the impression that WordCamps are expensive to attend.
- *
- * @todo change this to use feature-flags similar to the skip-feature flags
- */
-function hide_empty_tickets() {
-	$targeted_wordcamps_ids = array(
-		299, // San Francisco 2013
-		364, // San Francisco 2014
-	);
-
-	if ( in_array( get_current_blog_id(), $targeted_wordcamps_ids ) ) {
-		add_filter( 'camptix_hide_empty_tickets', '__return_false' );
-	}
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -25,12 +25,11 @@ add_filter( 'camptix_max_tickets_per_order',                 __NAMESPACE__ . '\l
 /**
  * Show empty tickets
  *
- * This provides a way for individual WordCamps to decide if they want to show sold-out tickets in the [tickets]
- * shortcode output. This can help avoid confusion if the camp has several types of tickets (e.g., General
- * Admission, Micro-sponsorship, etc) and the General Admission ticket sells out. If the General Admission ticket
- * was hidden, some users may mistakenly think that the Micro-sponsorship ticket is the "normal" ticket, even
- * though it costs several hundred dollars. Since we value keeping regular tickets accessible by as many people
- * as possible, we don't want anyone getting the impression that WordCamps are expensive to attend.
+ * This helps to avoid confusion if the camp has several types of tickets (e.g., General Admission, Micro-sponsorship,
+ * etc) and the General Admission ticket sells out. If the General Admission ticket was hidden, some users may
+ * mistakenly think that the Micro-sponsorship ticket is the "normal" ticket, even though it costs several hundred
+ * dollars. Since we value keeping regular tickets accessible by as many people as possible, we don't want anyone getting
+ * the impression that WordCamps are expensive to attend.
  */
 add_filter( 'camptix_hide_empty_tickets',                    '__return_false' );
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5532,6 +5532,11 @@ class CampTix_Plugin {
 							$price = $ticket->tix_price;
 							$discounted = '';
 
+							$row_class = '';
+							if( ! $ticket->tix_remaining ) {
+								$row_class = 'tix-sold-out';
+							}
+
 							$max = min( $ticket->tix_remaining, $max_tickets_per_order );
 							$selected = ( 1 == count( $this->tickets ) ) ? 1 : 0;
 							if ( isset( $this->tickets_selected[$ticket->ID] ) )
@@ -5546,7 +5551,7 @@ class CampTix_Plugin {
 								$price = $ticket->tix_discounted_price;
 							}
 							?>
-							<tr class="tix-ticket-<?php echo absint( $ticket->ID ); ?>">
+							<tr class="tix-ticket-<?php echo absint( $ticket->ID ); ?> <?php echo esc_attr( $row_class ); ?>">
 								<th class="tix-column-description" scope="row">
 									<label for="tix-qty-<?php echo absint( $ticket->ID ); ?>" class="tix-ticket-title">
 										<?php echo wp_kses_post( $ticket->post_title ); ?>
@@ -5571,11 +5576,15 @@ class CampTix_Plugin {
 									</td>
 								<?php endif; ?>
 								<td class="<?php echo esc_attr( implode( ' ', apply_filters( 'camptix_quantity_row_classes', array( 'tix-column-quantity' ) ) ) ); ?>">
-									<select id="tix-qty-<?php echo absint( $ticket->ID ); ?>" name="tix_tickets_selected[<?php echo esc_attr( $ticket->ID ); ?>]">
-										<?php foreach ( range( 0, $max ) as $value ) : ?>
-											<option <?php selected( $selected, $value ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $value ); ?></option>
-										<?php endforeach; ?>
-									</select>
+									<?php if( $ticket->tix_remaining ) : ?>
+										<select id="tix-qty-<?php echo absint( $ticket->ID ); ?>" name="tix_tickets_selected[<?php echo esc_attr( $ticket->ID ); ?>]">
+											<?php foreach ( range( 0, $max ) as $value ) : ?>
+												<option <?php selected( $selected, $value ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $value ); ?></option>
+											<?php endforeach; ?>
+										</select>
+									<?php else :
+										esc_html_e( 'Sold out', 'camptix' );
+									endif; ?>
 								</td>
 							</tr>
 						<?php endforeach; ?>


### PR DESCRIPTION
Currently sold-out tickets are hidden from the tickets page.

Showing the empty, sold-out, tickets helps to avoid confusion if the camp has several types of tickets (e.g., General Admission, Micro-sponsorship, etc) and the General Admission ticket sells out. If the General Admission ticket was hidden, some users may mistakenly think that the Micro-sponsorship ticket is the "normal" ticket, even though it costs several hundred dollars. Since we value keeping regular tickets accessible by as many people as possible, we don't want anyone getting the impression that WordCamps are expensive to attend.

Fixes #573 

Props @hlashbrooke

### Screenshots

<img width="609" alt="CleanShot 2023-09-22 at 00 39 10@2x" src="https://github.com/WordPress/wordcamp.org/assets/415544/ef0b5dde-fc98-4f71-b230-6d03819f7ed3">

### How to test the changes in this Pull Request:

1. Go to a WordCamp site
2. Modify a ticket type to have 0 remaining
3. Ensure you have another ticket type that has tickets left
4. Visit the tickets page
