### PR TITLE
Make sure survey is sent AFTER event has completed.

### DIFF
--- a/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
+++ b/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
@@ -131,7 +131,7 @@ function is_time_to_send_email( $email_id ) {
 
 	$send_date = $end_date + ( DAYS_AFTER_TO_SEND * DAY_IN_SECONDS );
 
-	return date( 'Y-m-d', $send_date ) === current_time( 'Y-m-d' );
+	return gmdate( 'Y-m-d', $send_date ) === current_time( 'Y-m-d', true );
 }
 
 /**

--- a/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
+++ b/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
@@ -118,6 +118,10 @@ function is_time_to_send_email( $email_id ) {
 		return false;
 	}
 
+	if ( ! 'wcpt-closed' === $wordcamp_post->post_status ) {
+		return false;
+	}
+
 	$end_date = $wordcamp_post->meta['End Date (YYYY-mm-dd)'][0];
 
 	if ( empty( $end_date ) ) {

--- a/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
+++ b/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
@@ -118,7 +118,7 @@ function is_time_to_send_email( $email_id ) {
 		return false;
 	}
 
-	if ( ! 'wcpt-closed' === $wordcamp_post->post_status ) {
+	if ( 'wcpt-closed' !== $wordcamp_post->post_status ) {
 		return false;
 	}
 

--- a/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
+++ b/public_html/wp-content/plugins/camptix-attendee-survey/includes/cron.php
@@ -120,17 +120,14 @@ function is_time_to_send_email( $email_id ) {
 
 	$end_date = $wordcamp_post->meta['End Date (YYYY-mm-dd)'][0];
 
-	if ( ! isset( $end_date ) ) {
+	if ( empty( $end_date ) ) {
 		log( 'WordCamp missing end date', $email_id, $wordcamp_post );
 		return false;
 	}
 
-	$date            = new \DateTime("@$end_date ");
-	$current_date    = new \DateTime();
-	$interval        = $current_date->diff($date);
-	$days_difference = $interval->days;
+	$send_date = $end_date + ( DAYS_AFTER_TO_SEND * DAY_IN_SECONDS );
 
-	return DAYS_AFTER_TO_SEND === $days_difference;
+	return date( 'Y-m-d', $send_date ) === current_time( 'Y-m-d' );
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-organizer-survey/includes/debrief-survey/cron.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-survey/includes/debrief-survey/cron.php
@@ -124,6 +124,10 @@ function is_time_to_send_email( $email_id ) {
 		return false;
 	}
 
+	if ( 'wcpt-closed' !== $wordcamp_post->post_status ) {
+		return false;
+	}
+
 	$end_date = $wordcamp_post->meta['End Date (YYYY-mm-dd)'][0];
 
 	if ( empty( $end_date ) ) {
@@ -131,12 +135,9 @@ function is_time_to_send_email( $email_id ) {
 		$end_date = $wordcamp_post->meta['Start Date (YYYY-mm-dd)'][0];
 	}
 
-	$date            = new \DateTime("@$end_date ");
-	$current_date    = new \DateTime();
-	$interval        = $current_date->diff($date);
-	$days_difference = $interval->days;
+	$send_date = $end_date + ( DAYS_AFTER_TO_SEND * DAY_IN_SECONDS );
 
-	return DAYS_AFTER_TO_SEND === $days_difference;
+	return gmdate( 'Y-m-d', $send_date ) === current_time( 'Y-m-d', true );
 }
 
 /**


### PR DESCRIPTION
The attendee survey has sent out 2 days before the end date for rome because it was only looking for a date difference and not making sure that happened after the event. This PR fixes that logic.

I've decided to send on the exact day. I did so because this feature is still not well tested and I don't want it to go back in time and send any previous events. I would prefer to restrict it to the exact day for now. I could be persuaded otherwise.

I also added a check to make sure the WordCamp is closed as well.

