### PR TITLE
Jetpack Tweaks: Enable jetpack forms package

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -2,7 +2,6 @@
 
 namespace WordCamp\Jetpack_Tweaks;
 use WP_Service_Worker_Caching_Routes, WP_Service_Worker_Scripts;
-use Grunion_Contact_Form;
 
 defined( 'WPINC' ) || die();
 
@@ -205,11 +204,8 @@ add_filter( 'jetpack_is_frontend', __NAMESPACE__ . '\workaround_is_frontend' );
  * @param int|null $post_id        Post ID.
  */
 function wrap_checkbox_radio_fieldset( $rendered_field, $field_label, $post_id ) {
-	// Get the current form style, if it's anything other than default, return early.
-	$class_name = Grunion_Contact_Form::$current_form->get_attribute( 'className' );
-	preg_match( '/is-style-([^\s]+)/i', $class_name, $matches );
-	$style = count( $matches ) >= 2 ? $matches[1] : 'default';
-	if ( 'default' !== $style ) {
+	// If the field uses "animated" or "notched" UI, return early.
+	if ( str_contains( $rendered_field, 'animated-label__label' ) || str_contains( $rendered_field, 'notched-label__label' ) ) {
 		return $rendered_field;
 	}
 
@@ -278,6 +274,3 @@ CSS;
 	wp_add_inline_style( 'grunion.css', $form_css );
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\inject_css_for_fieldset' );
-
-// Default forms in Jetpack got switched in 12.2, and the fix for accessibility (wrap_checkbox_radio_fieldset) breaks when upgrading: to 12.2+.
-add_filter( 'jetpack_contact_form_use_package', '__return_false' );


### PR DESCRIPTION
Somehow, the contact forms stopped working on WordCamp.org— the form wrapper is rendered, but the fields are not.

<img width="1162" alt="Screenshot 2023-10-02 at 2 01 34 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/267f8e17-2f3a-4ce3-9ffa-128a4e4772e2">

Removing the local override to use the classic "grunion" forms fixes the issue, so forms are now using the "form package". This was originally in place to keep an accessibility fix, so that has also been updated to work with the form package version.

Follow up to #874
See https://wordpress.slack.com/archives/C08M59V3P/p1696266125242069

### How to test the changes in this Pull Request:

1. View a contact form
2. It should work ✅ 
3. View a field with either checkboxes or radio buttons, using default form style
4. It should be wrapped in a fieldset

Will merge when tests pass to fix the forms on production ASAP.