### PR TITLE
Sunrise: Redirect `/uganda/2024/wordpress-showcase/` to `masaka`

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -25,6 +25,7 @@ function manually_load_plugins() {
 	ms_upload_constants();
 
 	require_once dirname( dirname( __DIR__ ) ) . '/sunrise.php';
+	require_once dirname( dirname( __DIR__ ) ) . '/sunrise-events.php';
 
 	require_once dirname( __DIR__ ) . '/0-error-handling.php';
 	require_once dirname( __DIR__ ) . '/wordcamp/lets-encrypt-helper.php';

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This isn't technically an mu-plugin, but it's easier to just put this here than creating a whole new suite.
+ *
+ * @todo `sunrise-events.php` isn't watched by phpunit-watcher because it can only watch entire folders, and
+ * `wp-content` is too big to monitor without significant performance impacts. You'll have to modify this file
+ * to automatically re-run tests.
+ *
+ * See https://github.com/spatie/phpunit-watcher/issues/113
+ */
+
+
+namespace WordCamp\Sunrise\Events;
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group sunrise
+ * @group mu-plugins
+ */
+class Test_Sunrise_Events extends WP_UnitTestCase {
+	/**
+	 * @covers WordCamp\Sunrise\get_redirect_url
+	 *
+	 * @dataProvider data_get_redirect_url
+	 */
+	public function test_get_redirect_url( $request_uri, $expected_url ) {
+		$actual_url = get_redirect_url( $request_uri );
+
+		$this->assertSame( $expected_url, $actual_url );
+	}
+
+	/**
+	 * Test cases for test_get_redirect_url().
+	 *
+	 * @return array
+	 */
+	public function data_get_redirect_url() {
+		return array(
+			'no redirect' => array(
+				'request_uri'  => '/foo/2024/bar/',
+				'expected_url' => '',
+			),
+
+			'without subpath or query vars' => array(
+				'request_uri'  => '/uganda/2024/wordpress-showcase/',
+				'expected_url' => 'https://events.wordpress.test/masaka/2024/wordpress-showcase/',
+			),
+
+			'with subpath and query vars' => array(
+				'request_uri'  => '/uganda/2024/wordpress-showcase/schedule/?foo=bar',
+				'expected_url' => 'https://events.wordpress.test/masaka/2024/wordpress-showcase/schedule/?foo=bar',
+			),
+		);
+	}
+}

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -2,12 +2,55 @@
 
 namespace WordCamp\Sunrise\Events;
 use WP_Network, WP_Site;
+use function WordCamp\Sunrise\{ get_top_level_domain };
 
 defined( 'WPINC' ) || die();
 use const WordCamp\Sunrise\PATTERN_CITY_YEAR_TYPE_PATH;
 
-set_network_and_site();
+main();
 
+
+/**
+ * Controller for this file.
+ */
+function main() {
+	// Redirecting would interfere with bin scripts, unit tests, etc.
+	if ( php_sapi_name() !== 'cli' ) {
+		$redirect_url = get_redirect_url( $_SERVER['REQUEST_URI'] );
+
+		if ( $redirect_url ) {
+			header( 'Location: ' . $redirect_url, true, 301 );
+			die();
+		}
+	}
+
+	set_network_and_site();
+}
+
+/**
+ * Get the URL to redirect to, if any.
+ */
+function get_redirect_url( string $request_uri ): string {
+	$domain       = 'events.wordpress.' . get_top_level_domain();
+	$old_full_url = sprintf(
+		'https://%s/%s',
+		$domain,
+		ltrim( $request_uri, '/' )
+	);
+
+	$renamed_sites = array(
+		'/uganda/2024/wordpress-showcase/' => '/masaka/2024/wordpress-showcase/',
+	);
+
+	foreach ( $renamed_sites as $old_site_path => $new_site_path ) {
+		if ( str_starts_with( $request_uri, $old_site_path ) ) {
+			$new_full_url = str_replace( $old_site_path, $new_site_path, $old_full_url );
+			return $new_full_url;
+		}
+	}
+
+	return '';
+}
 
 /**
  * Determine the current network and site.

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -55,6 +55,8 @@ const PATTERN_CITY_SLASH_YEAR_REQUEST_URI_WITH_DUPLICATE_DATE = '
 
 /*
  * Matches a URL path like '/vancouver/2023/diversity-day/`.
+ *
+ * These are used by the `events.wordpress.org` network.
  */
 const PATTERN_CITY_YEAR_TYPE_PATH = '
 	@ ^


### PR DESCRIPTION
The site was renamed, so this is necessary to fix the Jetpack identity crisis. It helps w/ UX too in case anyone has already started using the old URL.

See https://wordpress.slack.com/archives/C05JYJJRNKB/p1695963625326129