### PR TITLE
Fix select wordcamp overlap issue

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -2123,16 +2123,16 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 	font-weight: 400;
 }
 
+.report-form .field_wordcamp-id .select2-container {
+	width: 100% !important;
+}
+
 .report-results {
 	border-radius: 3px;
 	border: 1px #c6c6c6 solid;
 	font-family: monospace;
 	font-size: 13px;
 	padding: 0 1em 1em;
-}
-
-.report-form .field_wordcamp-id .select2-container {
-	width: 100% !important;
 }
 
 #content .report-results h3,

--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -2131,6 +2131,10 @@ li:after { content: "."; display: block; height: 0; clear: both; visibility: hid
 	padding: 0 1em 1em;
 }
 
+.report-form .field_wordcamp-id .select2-container {
+	width: 100% !important;
+}
+
 #content .report-results h3,
 #content .report-results h4 {
 	margin: 1em 0 0.5em;


### PR DESCRIPTION
### After Applying Patch Wordcamp Dropdown Overlap Issue will Resolved in Below Pages.

- https://central.wordcamp.org/reports/sponsorship-grants-report/
- https://central.wordcamp.org/reports/ticket-revenue-report/
- https://central.wordcamp.org/reports/payment-activity-report/

### **Screenshots:** 
Before Patch Desktop: https://prnt.sc/azOqP9aupomK 
After Patch Desktop : https://prnt.sc/gXrcnxI_2BSp

Before Patch Mobile : https://prnt.sc/OX6LplNSNv4Z
After Patch Mobile  : https://prnt.sc/3KzZVJ6Ie0F5
