### PR TITLE
Events: Only show `30` days of upcoming meetups

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/blocks/events-landing-page/event-getters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/blocks/events-landing-page/event-getters.php
@@ -121,7 +121,7 @@ function get_all_upcoming_events( bool $force_refresh = false ): array {
 			status = "scheduled" AND
 			(
 				( "wordcamp" = type AND date_utc BETWEEN NOW() AND ADDDATE( NOW(), 180 ) ) OR
-				( "meetup" = type AND date_utc BETWEEN NOW() AND ADDDATE( NOW(), 60 ) )
+				( "meetup" = type AND date_utc BETWEEN NOW() AND ADDDATE( NOW(), 30 ) )
 			)
 		ORDER BY date_utc ASC
 		LIMIT 400'


### PR DESCRIPTION
This seems more relevant since many meetups have a monthly cadence. It'll cut down on the number of "duplicate" events in the list, where two instances recurring event show up in the same location.