### PR TITLE
Error Handler: Add temporary logging to troubleshoot fatal

### DIFF
--- a/public_html/wp-content/mu-plugins/0-error-handling.php
+++ b/public_html/wp-content/mu-plugins/0-error-handling.php
@@ -355,6 +355,26 @@ function send_error_to_slack( $err_no, $err_msg, $file, $line, $occurrences = 0 
 		),
 	);
 
+	// temporary to troubleshoot URL routing error.
+	// maybe the `$url` above has some clues about the request that are stripped out by redact/esc functions.
+	// see https://wordpress.slack.com/archives/GDDSW0WNS/p1697474288356909.
+	$fields = array(
+		array(
+			'title' => 'tmp raw HTTP_HOST / SERVER_NAME',
+			'value' => sprintf(
+				'host: %s, name: %s, redir: %s, qs: %s, uri: %s, sapi: %s, ip: %s',
+				$_SERVER['HTTP_HOST'],
+				$_SERVER['SERVER_NAME'],
+				$_SERVER['REDIRECT_URL'],
+				$_SERVER['QUERY_STRING'],
+				$_SERVER['REQUEST_URI'],
+				php_sapi_name(),
+				$_SERVER['REMOTE_ADDR']
+			),
+			'short' => false,
+		),
+	);
+
 	if ( ! str_contains( $err_msg, $file ) ) {
 		$fields[] = array(
 			'title' => 'File',


### PR DESCRIPTION
Still seeing this error, even after #1033:

`Uncaught Error: Call to undefined function WordPressdotorg\MU_Plugins\Global_Fonts\get_font_stylesheet_url() in wp-content/themes/wporg-parent-2021/functions.php:46`

It's probably a different reason this time, so this PR adds some extra logging to get more clues.