### PR TITLE
Events: Specify API key for map

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/blocks/events-landing-page/events-landing-page.php
+++ b/public_html/wp-content/themes/wporg-events-2023/blocks/events-landing-page/events-landing-page.php
@@ -48,5 +48,7 @@ function render_events_landing_page( array $block_attributes, string $content ):
 			return 'No events available';
 	}
 
+	$map_options['apiKey'] = 'production' === wp_get_environment_type() ? 'WORDCAMP_PROD_GOOGLE_MAPS_API_KEY' : 'WORDCAMP_DEV_GOOGLE_MAPS_API_KEY';
+
 	return do_blocks( '<!-- wp:wporg/google-map '. wp_json_encode( $map_options ) .' /-->' );
 }


### PR DESCRIPTION
This is required after https://github.com/WordPress/wporg-mu-plugins/pull/482