### PR TITLE
Replace uses of deprecated `FILTER_SANITIZE_STRING`

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/ticket-types/ticket-types.php
@@ -165,7 +165,7 @@ function save_post( $post_id ) {
 	check_admin_referer( $nonce_action );
 
 	if ( isset( $_POST['tix_type'] ) ) {
-		$value = filter_input( INPUT_POST, 'tix_type', FILTER_SANITIZE_STRING );
+		$value = filter_input( INPUT_POST, 'tix_type', FILTER_UNSAFE_RAW );
 		update_post_meta( $post_id, META_KEY, $value );
 	}
 }

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -558,7 +558,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		$metadata = array(
-			'Refund reason' => filter_input( INPUT_POST, 'tix_refund_request_reason', FILTER_SANITIZE_STRING ),
+			'Refund reason' => filter_input( INPUT_POST, 'tix_refund_request_reason', FILTER_UNSAFE_RAW ),
 		);
 
 		// Create a new Idempotency token for the refund request.

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-details.php
@@ -235,7 +235,7 @@ class Meetup_Details extends Base_Details {
 	 */
 	public static function export_to_file() {
 
-		$fields = filter_input( INPUT_POST, 'fields', FILTER_SANITIZE_STRING, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
+		$fields = filter_input( INPUT_POST, 'fields', FILTER_UNSAFE_RAW, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
 		$action = filter_input( INPUT_POST, 'action' );
 		$nonce  = filter_input( INPUT_POST, self::$slug . '-nonce' );
 

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-status.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-status.php
@@ -324,7 +324,7 @@ class Meetup_Status extends Base_Status {
 		$refresh    = filter_input( INPUT_POST, 'refresh', FILTER_VALIDATE_BOOLEAN );
 		$action     = filter_input( INPUT_POST, 'action' );
 		$nonce      = filter_input( INPUT_POST, self::$slug . '-nonce' );
-		$fields     = filter_input( INPUT_POST, 'fields', FILTER_SANITIZE_STRING, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
+		$fields     = filter_input( INPUT_POST, 'fields', FILTER_UNSAFE_RAW, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
 		$statuses   = Meetup_Application::get_post_statuses();
 
 		$field_defaults = array(

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-status.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-status.php
@@ -216,7 +216,7 @@ class Meetup_Status extends Base_Status {
 	}
 
 	/**
-	 * Get all Meetup posts which have status changed between given time fram
+	 * Get all Meetup posts which have status changed between given time frame.
 	 *
 	 * @return array
 	 */
@@ -224,17 +224,14 @@ class Meetup_Status extends Base_Status {
 		global $wpdb;
 		$meetup_post_type = WCPT_MEETUP_SLUG;
 		$meetup_post_objs = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-			SELECT DISTINCT post_id
-			FROM {$wpdb->prefix}postmeta
-			WHERE 
-				meta_key LIKE '_status_change_log_$meetup_post_type%'
-			AND
-				meta_value >= %d
-			AND 
-				meta_value <= %d
-			",
+			$wpdb->prepare( "
+				SELECT DISTINCT post_id
+				FROM {$wpdb->prefix}postmeta
+				WHERE
+					meta_key LIKE %s AND
+					meta_value >= %d AND
+					meta_value <= %d",
+				sprintf( '_status_change_log_%s%%', $meetup_post_type ),
 				$this->range->start->getTimestamp(),
 				$this->range->end->getTimestamp()
 			)

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-details.php
@@ -408,7 +408,7 @@ class WordCamp_Details extends Base_Details {
 	public static function export_to_file() {
 		$start_date = filter_input( INPUT_POST, 'start-date' );
 		$end_date   = filter_input( INPUT_POST, 'end-date' );
-		$fields     = filter_input( INPUT_POST, 'fields', FILTER_SANITIZE_STRING, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
+		$fields     = filter_input( INPUT_POST, 'fields', FILTER_UNSAFE_RAW, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
 		$action     = filter_input( INPUT_POST, 'action' );
 		$nonce      = filter_input( INPUT_POST, self::$slug . '-nonce' );
 

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-status.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-status.php
@@ -493,7 +493,7 @@ class WordCamp_Status extends Base_Status {
 		$start_date = filter_input( INPUT_POST, 'start-date' );
 		$end_date   = filter_input( INPUT_POST, 'end-date' );
 		$status     = filter_input( INPUT_POST, 'status' );
-		$fields     = filter_input( INPUT_POST, 'fields', FILTER_SANITIZE_STRING, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
+		$fields     = filter_input( INPUT_POST, 'fields', FILTER_UNSAFE_RAW, array( 'flags' => FILTER_REQUIRE_ARRAY ) );
 		$refresh    = filter_input( INPUT_POST, 'refresh', FILTER_VALIDATE_BOOLEAN );
 		$action     = filter_input( INPUT_POST, 'action' );
 		$nonce      = filter_input( INPUT_POST, self::$slug . '-nonce' );

--- a/public_html/wp-content/plugins/wordcamp-reports/index.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/index.php
@@ -215,7 +215,7 @@ add_action( 'admin_menu', __NAMESPACE__ . '\add_reports_page' );
  * @return void
  */
 function render_page() {
-	$report       = filter_input( INPUT_GET, 'report', FILTER_SANITIZE_STRING );
+	$report       = filter_input( INPUT_GET, 'report', FILTER_UNSAFE_RAW );
 	$report_class = get_report_class_by_slug( $report );
 
 	$reports_with_admin = array_filter(
@@ -255,7 +255,7 @@ function enqueue_admin_assets( $hook_suffix ) {
 		filemtime( get_assets_dir_path() . 'css/admin-common.css' )
 	);
 
-	$report       = filter_input( INPUT_GET, 'report', FILTER_SANITIZE_STRING );
+	$report       = filter_input( INPUT_GET, 'report', FILTER_UNSAFE_RAW );
 	$report_class = get_report_class_by_slug( $report );
 
 	if ( ! is_null( $report_class ) && method_exists( $report_class, 'enqueue_admin_assets' ) ) {


### PR DESCRIPTION
`FILTER_SANITIZE_STRING` is deprecated in PHP 8.1 and throws notices when used.

These all appear to be simply trying to get the value, rather than doing any sanitization. That means that `FILTER_UNSAFE_RAW` is the appropriate replacement.

See https://stackoverflow.com/a/69207369/450127