### PR TITLE
Mu-plugins: Add margin to fixed navigation on sites with the latest event banner

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -71,7 +71,8 @@ function canonical_link_past_home_pages_to_current_year() {
  */
 function add_notification_styles() { ?>
   <style type="text/css">
-		html:not(#specificity-hack) {
+		html:not(#specificity-hack),
+		.wordcamp-latest-site-notify-fixed-position-fix {
 			/* 44 = 10px x2 for padding, 24px for line height. */
 			margin-top: calc(44px + var(--wp-admin--admin-bar--height, 0px)) !important;
 		}
@@ -110,6 +111,23 @@ function add_notification_styles() { ?>
 			color: #72aee6;
 		}
   </style>
+  <script>
+      document.addEventListener("DOMContentLoaded", (event) => {
+          const fixedElements = document.querySelectorAll('nav, nav *'); // Select all elements
+          const fixedElementsArray = Array.from(fixedElements);
+
+          const fixedElementsWithPositionFixed = fixedElementsArray.filter(element => {
+              const computedStyle = getComputedStyle(element);
+              return computedStyle.position === 'fixed';
+          });
+
+          console.log(fixedElementsWithPositionFixed);
+
+          fixedElementsWithPositionFixed.forEach(element => {
+              element.classList.add('wordcamp-latest-site-notify-fixed-position-fix')
+          });
+      });
+  </script>
 <?php }
 
 /**


### PR DESCRIPTION
The solution to the linked issue is not really easy, since different WordCamp themes use very different markup and CSS to make the navigation fixed. There is also no way to change the reference point for a fixed positioned element.

This PR will introduce some JavaScript that searches for any `<nav>` item with `position: fixed` and adds a CSS class, that is than used in the existing CSS selector pushing down the navigation as well.

Fixes #1098

### Screenshots

This is how the pages look like with this PR applied (compared to #1098):

![image](https://github.com/WordPress/wordcamp.org/assets/1793177/62c645fc-0f7f-4ae3-94b7-068d86cee92f)

![image](https://github.com/WordPress/wordcamp.org/assets/1793177/cfb3909d-a51a-4612-ac3b-5b4733f37161)