### PR TITLE
Site Cloner: Only run cron on WordCamp network

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
+++ b/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
@@ -193,7 +193,7 @@ function sites_endpoint() {
  */
 function prime_wordcamp_sites() {
 	// This only needs to run on a single site, then the whole network can use the cached result.
-	if ( ! is_main_site() ) {
+	if ( WORDCAMP_NETWORK_ID !== get_current_network_id() || ! is_main_site() ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #1102 

When it's ran on the Events network, it ends up not finding any sites because the `wordcamp` posts live on Central.
