### PR TITLE
Events: Update templates to use Map block directly

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\Events_2023;
 use WP, WP_Post, DateTimeZone, DateTime;
-use WordPressdotorg\MU_Plugins\Google_Map_Event_Filters;
+use WordPressdotorg\MU_Plugins\Google_Map;
 
 defined( 'WPINC' ) || die();
 
@@ -95,7 +95,7 @@ function prime_query_cache(): void {
 			'landing_page'    => $request_uri
 		);
 
-		$cache_key = Google_Map_Event_Filters\get_cache_key( $parts );
+		$cache_key = Google_Map\get_cache_key( $parts );
 		$events    = get_city_landing_page_events( $request_uri, true );
 
 		set_transient( $cache_key, $events, DAY_IN_SECONDS );

--- a/public_html/wp-content/themes/wporg-events-2023/parts/front-page/cover.html
+++ b/public_html/wp-content/themes/wporg-events-2023/parts/front-page/cover.html
@@ -25,6 +25,6 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:wporg/google-map-event-filters {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}},"filterSlug":"all-upcoming","googleMapBlockAttributes":{"id":"all-upcoming-map","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY","showList":false,"showSearch":false}} /-->
+	<!-- wp:wporg/google-map {"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}},"filterSlug":"all-upcoming","id":"all-upcoming-map","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY","showList":false,"showSearch":false} /-->
 </div>
 <!-- /wp:group -->

--- a/public_html/wp-content/themes/wporg-events-2023/parts/front-page/events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/parts/front-page/events.html
@@ -5,7 +5,7 @@
 	<h2 class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:700">Upcoming Events</h2>
 	<!-- /wp:heading -->
 
-	<!-- wp:wporg/google-map-event-filters {"filterSlug":"all-upcoming","googleMapBlockAttributes":{"id":"all-upcoming-list","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY","showMap":false}} /-->
+	<!-- wp:wporg/google-map {"filterSlug":"all-upcoming","id":"all-upcoming-list","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY","showMap":false} /-->
 
 	<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
 	<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-city-landing-page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-city-landing-page.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","className":"entry-content"} -->
 <main class="wp-block-group entry-content">
-	<!-- wp:wporg/google-map-event-filters {"filterSlug":"city-landing-pages","googleMapBlockAttributes":{"id":"city-landing-page","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY"}} /-->
+	<!-- wp:wporg/google-map {"filterSlug":"city-landing-pages","id":"city-landing-page","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
The Event Filters block was merged into the main block in https://github.com/WordPress/wporg-mu-plugins/pull/517
