### PR TITLE
WCPT: Get user info regardless of role on site

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
@@ -137,6 +137,7 @@ function get_user_nicenames_from_ids( $user_ids ) {
 
 	$user_query = new WP_User_Query(
 		array(
+			'blog_id' => 0, // All sites, see https://core.trac.wordpress.org/ticket/38851.
 			'include' => $user_ids,
 			'fields'  => array( 'user_nicename' ),
 		)


### PR DESCRIPTION
Previously the query only looked at users with a role on the current site, which didn't always include everyone.

See https://core.trac.wordpress.org/ticket/38851
See https://wordpress.slack.com/archives/C08M59V3P/p1700830335858499
