### PR TITLE
Payments: Add instructions for selecting a QBO community

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/views/sponsor-invoice/metabox-general.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/sponsor-invoice/metabox-general.php
@@ -73,6 +73,14 @@ defined( 'WPINC' ) or die();
 			</select>
 
 			<?php \WordCamp_Budgets::render_form_field_required_indicator(); ?>
+
+			<p class="description">
+				<?php echo wp_kses_data( sprintf(
+					// translators: email address.
+					__( 'Choose the location that corresponds to the city that the event is hosted in. If your city doesn\'t appear, email %s so that we can add it.', 'wordcamporg' ),
+					sprintf( '<a href="mailto:%1$s">%2$s</a>', EMAIL_CENTRAL_SUPPORT, EMAIL_CENTRAL_SUPPORT )
+				) ); ?>
+			</p>
 		</div>
 	</li>
 


### PR DESCRIPTION
This clarifies that it's the _event_ location, not the _sponsor_ location.
