### PR TITLE
Update nginx.conf to server .woff2 fonts

### DIFF
--- a/.docker/config/nginx.conf
+++ b/.docker/config/nginx.conf
@@ -70,7 +70,7 @@ server {
 		rewrite "/[\w-]+/\d{4}/[\w-]+/files/(.+)$" /wp-includes/ms-files.php?file=$1 last;
 	}
 
-	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|ttf)$ {
+	location ~* /wp-content/.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf)$ {
 		root /usr/src/public_html;
 		expires max;
 		log_not_found off;


### PR DESCRIPTION
We use .woff2 fonts on wordpress.org. This project will inherit some of those styles and fonts because of the events.wordpress.org crossover.
 
https://github.com/WordPress/wporg-mu-plugins/blob/b0fff4be072f71ed7d478d8b96638805aa0ca041/mu-plugins/global-fonts/index.php#L214