### PR TITLE
Events: Add room so list dates fit on a single line.

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -19,6 +19,10 @@
 		grid-template-columns: 50% 1fr 1fr;
 	}
 
+	@media (--wide) {
+		grid-template-columns: 45% 1fr 1.5fr;
+	}
+
 	@media (--huge) {
 		grid-template-columns: 55% 1fr 1fr;
 	}


### PR DESCRIPTION
See https://github.com/WordPress/wordcamp.org/commit/aa8bc21b93f9a4a8727d1b373714950b66756e2e#r134023495

`1300px`:

<img width="1171" alt="Screenshot 2023-12-04 at 2 41 59 PM" src="https://github.com/WordPress/wordcamp.org/assets/484068/69a7fee5-3126-49b8-85e4-f77ded076d0e">

`1150px`:

<img width="1018" alt="Screenshot 2023-12-04 at 2 42 30 PM" src="https://github.com/WordPress/wordcamp.org/assets/484068/ca338912-3f10-4183-86e9-2b57933ddc27">
