### PR TITLE
Events 2023: Update local nav

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/patterns/header-local-navigation.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/header-local-navigation.php
@@ -14,8 +14,10 @@ defined( 'WPINC' ) || die();
 
 ?>
 
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"white","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"className":"has-display-contents","backgroundColor":"white","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"},":hover":{"color":{"text":"var:preset|color|charcoal-1"}}}}},"textColor":"charcoal-1","fontSize":"small"} -->
+
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"local-navigation"} /-->
+	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"white","overlayTextColor":"charcoal-1","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"local-navigation"} /-->
+
 <!-- /wp:wporg/local-navigation-bar -->

--- a/public_html/wp-content/themes/wporg-events-2023/templates/front-page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/front-page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","className":"entry-content","layout":{"type":"default"}} -->
 <main class="wp-block-group entry-content">

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-city-landing-page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-city-landing-page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","className":"entry-content"} -->
 <main class="wp-block-group entry-content">

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-organize-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-organize-events.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","className":"entry-content","layout":{"type":"default"}} -->
     <main class="wp-block-group entry-content">

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|edge-space"}}},"className":"entry-content","layout":{"type":"default"}} -->
 <main class="wp-block-group entry-content"


### PR DESCRIPTION
Currently the local nav is not sticky like on other sites (Showcase, Main, Developer). This PR fixes that and also updates the background of the mobile navigation to be black text on white background to match the rest of the UI.

**Note: This is pending an [answer](https://www.figma.com/file/jdMk5ssz2Av7KFfEaeK7de?node-id=1617:14140&mode=dev#638450593) from design.**

### Screenshots

| Desktop | Desktop scrolled | Mobile | Mobile nav open |
|-|-|-|-|
| ![localhost_8888_(Desktop) (13)](https://github.com/WordPress/wordcamp.org/assets/1017872/451b4e66-3e70-4481-b46c-f2fc3ef2d343) | ![localhost_8888_(Desktop) (14)](https://github.com/WordPress/wordcamp.org/assets/1017872/110c5d04-0f51-4e17-8fcc-37b4afff9d65) | ![localhost_8888_(iPhone 12 Pro) (1)](https://github.com/WordPress/wordcamp.org/assets/1017872/b69c326e-247c-4ee0-ab93-186096c7e385) | ![Screenshot 2023-12-07 at 12 01 33 PM](https://github.com/WordPress/wordcamp.org/assets/1017872/b38523db-e229-4b4f-a088-94f710d8af92) |

