### PR TITLE
Events: Better date for the table.

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -66,11 +66,6 @@
 		}
 	}
 
-	.wporg-google-map__date-time-separator {
-		@media (--medium) {
-			display: none;
-		}
-	}
 
 	@media (--wide) {
 		.wporg-marker-list-item__date-time {
@@ -80,8 +75,21 @@
 			justify-content: flex-end;
 		}
 
-		.wporg-google-map__date-time-separator {
+		.wporg-google-map__date {
+			position: relative;
+		}
+
+		.wporg-google-map__date:after {
+		    content: '';
+			margin-top: -1px; /* vertical-middle doesn't subtract the size of the element */
+			margin-left: 8px;
+			margin-right: 8px;
+			height: 3px;
+			width: 3px;
+			border-radius: 3px;
+			background: var(--wp--preset--color--charcoal-5);
 			display: inline-block;
+			vertical-align: middle;
 		}
 	}
 }

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -66,6 +66,28 @@
 		}
 	}
 
+	.wporg-google-map__date {
+		position: relative;
+	}
+
+	.wporg-google-map__date:after {
+		content: '';
+		margin-top: -1px; /* vertical-middle doesn't subtract the size of the element */
+		margin-left: 8px;
+		margin-right: 8px;
+		height: 3px;
+		width: 3px;
+		border-radius: 3px;
+		background: var(--wp--preset--color--charcoal-5);
+		display: inline-block;
+		vertical-align: middle;
+	}
+
+	@media (--medium) {
+		.wporg-google-map__date:after {
+			display: none;
+		}
+	}
 
 	@media (--wide) {
 		.wporg-marker-list-item__date-time {
@@ -75,21 +97,8 @@
 			justify-content: flex-end;
 		}
 
-		.wporg-google-map__date {
-			position: relative;
-		}
-
 		.wporg-google-map__date:after {
-		    content: '';
-			margin-top: -1px; /* vertical-middle doesn't subtract the size of the element */
-			margin-left: 8px;
-			margin-right: 8px;
-			height: 3px;
-			width: 3px;
-			border-radius: 3px;
-			background: var(--wp--preset--color--charcoal-5);
 			display: inline-block;
-			vertical-align: middle;
 		}
 	}
 }

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -73,8 +73,8 @@
 	.wporg-google-map__date:after {
 		content: '';
 		margin-top: -1px; /* vertical-middle doesn't subtract the size of the element */
-		margin-left: 8px;
-		margin-right: 8px;
+		margin-left: 10px;
+		margin-right: 10px;
 		height: 3px;
 		width: 3px;
 		border-radius: 3px;

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -90,17 +90,17 @@ function render( $attributes, $content, $block ) {
  * This converts them to the keys that the Google Map block uses.
  */
 function get_clean_query_facets(): array {
-	$search = (array) get_query_var( 's' ) ?? array();
-	$search = sanitize_text_field( $search[0] ?? '' );
+	$search  = (array) get_query_var( 's' ) ?? array();
+	$search  = sanitize_text_field( $search[0] ?? '' );
 
-	$type = (array) get_query_var( 'event_type' ) ?? array();
-	$type = sanitize_text_field( $type[0] ?? '' );
+	$type    = (array) get_query_var( 'event_type' ) ?? array();
+	$type    = sanitize_text_field( $type[0] ?? '' );
 
-	$format = (array) get_query_var( 'format_type' ) ?? array();
-	$format = sanitize_text_field( $format[0] ?? '' );
+	$format  = (array) get_query_var( 'format_type' ) ?? array();
+	$format  = sanitize_text_field( $format[0] ?? '' );
 
-	$month = (array) get_query_var( 'month' ) ?? array();
-	$month = absint( $month[0] ?? 0 );
+	$month   = (array) get_query_var( 'month' ) ?? array();
+	$month   = absint( $month[0] ?? 0 );
 
 	$country = (array) get_query_var( 'country' ) ?? array();
 	$country = sanitize_text_field( $country[0] ?? '' );

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -61,7 +61,7 @@ function render( $attributes, $content, $block ) {
 			$content .= '<h3 class="wporg-marker-list-item__title"><a class="external-link" href="' . esc_url($event->url) . '">' . esc_html($event->title) . '</a></h3>';
 			$content .= '<div class="wporg-marker-list-item__location">' . esc_html($event->location) . '</div>';
 			$content .= sprintf(
-				'<time class="wporg-marker-list-item__date-time" date-time="%1$s" title="%1$s"><span class="wporg-google-map__date">%2$s</span><span class="wporg-google-map__time">%3$s</span></p>',
+				'<time class="wporg-marker-list-item__date-time" date-time="%1$s" title="%1$s"><span class="wporg-google-map__date">%2$s</span><span class="wporg-google-map__time">%3$s</span></time>',
 				gmdate( 'c', esc_html( $event->timestamp ) ),
 				gmdate( 'l, M j', esc_html( $event->timestamp ) ),
 				esc_html( gmdate('H:i', $event->timestamp) . ' (UTC-0)' ),

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -64,7 +64,7 @@ function render( $attributes, $content, $block ) {
 				'<time class="wporg-marker-list-item__date-time" date-time="%1$s" title="%1$s"><span class="wporg-google-map__date">%2$s</span><span class="wporg-google-map__time">%3$s</span></time>',
 				gmdate( 'c', esc_html( $event->timestamp ) ),
 				gmdate( 'l, M j', esc_html( $event->timestamp ) ),
-				esc_html( gmdate('H:i', $event->timestamp) . ' (UTC-0)' ),
+				esc_html( gmdate('H:i', $event->timestamp) . ' UTC' ),
 			);
 			$content .= '</li>';
 		}

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -60,7 +60,12 @@ function render( $attributes, $content, $block ) {
 			$content .= '<li class="wporg-marker-list-item">';
 			$content .= '<h3 class="wporg-marker-list-item__title"><a class="external-link" href="' . esc_url($event->url) . '">' . esc_html($event->title) . '</a></h3>';
 			$content .= '<div class="wporg-marker-list-item__location">' . esc_html($event->location) . '</div>';
-			$content .= '<div class="wporg-marker-list-item__date-time">' . gmdate( 'F j, Y', esc_html( $event->timestamp ) ) . '</div>';
+			$content .= sprintf(
+				'<time class="wporg-marker-list-item__date-time" date-time="%1$s" title="%1$s"><span class="wporg-google-map__date">%2$s</span><span class="wporg-google-map__time">%3$s</span></p>',
+				gmdate( 'c', esc_html( $event->timestamp ) ),
+				gmdate( 'l, M j', esc_html( $event->timestamp ) ),
+				esc_html( gmdate('H:i', $event->timestamp) . ' (UTC-0)' ),
+			);
 			$content .= '</li>';
 		}
 
@@ -85,17 +90,17 @@ function render( $attributes, $content, $block ) {
  * This converts them to the keys that the Google Map block uses.
  */
 function get_clean_query_facets(): array {
-	$search  = (array) get_query_var( 's' ) ?? array();
-	$search  = sanitize_text_field( $search[0] ?? '' );
+	$search = (array) get_query_var( 's' ) ?? array();
+	$search = sanitize_text_field( $search[0] ?? '' );
 
-	$type    = (array) get_query_var( 'event_type' ) ?? array();
-	$type    = sanitize_text_field( $type[0] ?? '' );
+	$type = (array) get_query_var( 'event_type' ) ?? array();
+	$type = sanitize_text_field( $type[0] ?? '' );
 
-	$format  = (array) get_query_var( 'format_type' ) ?? array();
-	$format  = sanitize_text_field( $format[0] ?? '' );
+	$format = (array) get_query_var( 'format_type' ) ?? array();
+	$format = sanitize_text_field( $format[0] ?? '' );
 
-	$month   = (array) get_query_var( 'month' ) ?? array();
-	$month   = absint( $month[0] ?? 0 );
+	$month = (array) get_query_var( 'month' ) ?? array();
+	$month = absint( $month[0] ?? 0 );
 
 	$country = (array) get_query_var( 'country' ) ?? array();
 	$country = sanitize_text_field( $country[0] ?? '' );


### PR DESCRIPTION
This PR improves the default date (which we hope to switch out with the user locale date) to match the designs.

Design: https://www.figma.com/file/jdMk5ssz2Av7KFfEaeK7de/Events?node-id=1617%3A14095&mode=dev

I did make a couple of choices here:
- Remove the year
  - Seems redundant. I went to check on other sites like meetup.com they also removed the year.
- The middot doesn't show up on tablet viewport sizes.
  - It already works like this. 

### Screenshots

| Mobile | Tablet | Desktop |
|--------|--------|--------|
| ![events wordpress test_upcoming-events_](https://github.com/WordPress/wordcamp.org/assets/1657336/e328cc8e-7ffb-4164-8f2a-8933308cf9f9) | ![events wordpress test_upcoming-events_ (1)](https://github.com/WordPress/wordcamp.org/assets/1657336/f0b514e2-adb5-413c-a852-4dadd7b74772) | ![events wordpress test_upcoming-events_ (2)](https://github.com/WordPress/wordcamp.org/assets/1657336/cdbdf48c-df8d-479b-8339-91ca8a13d919) | 

### How to test the changes in this Pull Request:

1. Pull this branch
2. Navigate to your upcoming events list.

