### PR TITLE
Events: Add event limit to event-list block.

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
@@ -12,6 +12,10 @@
 		"events": {
 			"type": "string",
 			"default": "all-upcoming"
+		},
+		"limit": {
+			"type": "number",
+			"default": 100
 		}
 	},
 	"supports": {

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -43,7 +43,7 @@ function render( $attributes, $content, $block ) {
 	schedule_filter_cron( $attributes['events'], 0, 0, $facets );
 
 	// Get all the filters that are currently applied.
-	$filtered_events = array_slice( filter_events( $events ), 0, 10);
+	$filtered_events = array_slice( filter_events( $events ), 0, (int) $attributes['limit'] );
 
 	// Group events by month year.
 	$grouped_events = array();

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming.html
@@ -13,7 +13,7 @@
 		<!-- /wp:group -->
 
 		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
-		<!-- wp:wporg/event-list /-->
+		<!-- wp:wporg/event-list {"limit": "500"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>

--- a/public_html/wp-content/themes/wporg-events-2023/templates/search.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/search.html
@@ -11,7 +11,7 @@
 		style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
-		<!-- wp:wporg/event-list /-->
+		<!-- wp:wporg/event-list {"limit": "500"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>


### PR DESCRIPTION
This PR adds an attribute to the event-list to control the number of events that are displayed. 

We currently don't have paging, but will get it when we convert to using WP_QUERY. For now we should show all the events on the upcoming and search results (although filtered) pages.

This also coincides with this commit https://github.com/WordPress/wporg-mu-plugins/commit/17510b989037c9ee7323757346f66289ea7dcb0f which ups the limit on the API side.

