### PR TITLE
Events: Empty the action for the filters if we are on the search page…

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/functions.php
+++ b/public_html/wp-content/themes/wporg-events-2023/functions.php
@@ -85,7 +85,7 @@ function get_country_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Country', 'wporg' ),
 		'key' => 'country',
-		'action' => home_url( '/upcoming-events/' ),
+		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
 		'options' => $countries,
 		'selected' => $selected,
 	);
@@ -114,7 +114,7 @@ function get_event_type_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Type', 'wporg' ),
 		'key' => 'event_type',
-		'action' => home_url( '/upcoming-events/' ),
+		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
 		'options' => array(
 			'meetup'   => 'Meetup',
 			'wordcamp' => 'WordCamp',
@@ -146,7 +146,7 @@ function get_format_type_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Format', 'wporg' ),
 		'key' => 'format_type',
-		'action' => home_url( '/upcoming-events/' ),
+		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
 		'options' => array(
 			'online'    => 'Online',
 			'in-person' => 'In Person',
@@ -185,7 +185,7 @@ function get_month_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Month', 'wporg' ),
 		'key' => 'month',
-		'action' => home_url( '/upcoming-events/' ),
+		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
 		'options' => $months,
 		'selected' => $selected,
 	);

--- a/public_html/wp-content/themes/wporg-events-2023/functions.php
+++ b/public_html/wp-content/themes/wporg-events-2023/functions.php
@@ -85,7 +85,7 @@ function get_country_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Country', 'wporg' ),
 		'key' => 'country',
-		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
+		'action' => is_search() ? '' : home_url( '/upcoming-events/' ),
 		'options' => $countries,
 		'selected' => $selected,
 	);
@@ -114,7 +114,7 @@ function get_event_type_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Type', 'wporg' ),
 		'key' => 'event_type',
-		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
+		'action' => is_search() ? '' : home_url( '/upcoming-events/' ),
 		'options' => array(
 			'meetup'   => 'Meetup',
 			'wordcamp' => 'WordCamp',
@@ -146,7 +146,7 @@ function get_format_type_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Format', 'wporg' ),
 		'key' => 'format_type',
-		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
+		'action' => is_search() ? '' : home_url( '/upcoming-events/' ),
 		'options' => array(
 			'online'    => 'Online',
 			'in-person' => 'In Person',
@@ -185,7 +185,7 @@ function get_month_options( array $options ): array {
 		'label' => $label,
 		'title' => __( 'Month', 'wporg' ),
 		'key' => 'month',
-		'action' => is_search() ? "" : home_url( '/upcoming-events/' ),
+		'action' => is_search() ? '' : home_url( '/upcoming-events/' ),
 		'options' => $months,
 		'selected' => $selected,
 	);


### PR DESCRIPTION
This PR updates the action to the filters to `""` if we are on the search page so they repost to the same page.

That means the following is true:
- If a users only adds filters on `upcoming-events` they will stay on that page
- If a users search for a keyword they will end up on the search archive
  - Users can add filters there and they will apply.
  