### PR TITLE
Events: Make the contributor images transition smooth for different screen sizes

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/patterns/front-contributors-gallery.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/front-contributors-gallery.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<!-- wp:jetpack/tiled-gallery {"columnWidths":[["65.48121","34.51879"]],"ids":[79,85,82],"style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} -->
+<!-- wp:jetpack/tiled-gallery {"columnWidths":[["65.48121","34.51879"]],"ids":[79,85,82]} -->
 <div class="wp-block-jetpack-tiled-gallery aligncenter is-style-rectangular">
 	<div class="tiled-gallery__gallery">
 		<div class="tiled-gallery__row">

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/front-contributors.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/front-contributors.php
@@ -10,12 +10,12 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"}}},"className":"wporg-events__contributors"} -->
 	<div class="wp-block-columns alignwide wporg-events__contributors"><!-- wp:column {"verticalAlignment":"top","width":"50%","layout":{"type":"default"}} -->
-	<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:50%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-default","fontFamily":"eb-garamond"} -->
-	<h2 class="wp-block-heading is-style-default has-eb-garamond-font-family" style="margin-top:0">Where all WordPress <em>contributors meet</em></h2>
+	<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:50%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-default wporg-events_contributors__heading","fontFamily":"eb-garamond"} -->
+	<h2 class="wp-block-heading is-style-default wporg-events_contributors__heading has-eb-garamond-font-family" style="margin-top:0">Where all WordPress <em>contributors meet</em></h2>
 	<!-- /wp:heading -->
 
-	<!-- wp:list {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30"}}},"className":"is-style-links-list"} -->
-	<ul style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--30)" class="is-style-links-list"><!-- wp:list-item {"fontSize":"medium"} -->
+	<!-- wp:list {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30"}}},"className":"is-style-links-list wporg-events_contributors__link-list"} -->
+	<ul style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--30)" class="is-style-links-list wporg-events_contributors__link-list"><!-- wp:list-item {"fontSize":"medium"} -->
 	<li class="has-medium-font-size"><a href="https://central.wordcamp.org">WordCamp Central</a> ↗</li>
 	<!-- /wp:list-item -->
 
@@ -42,8 +42,8 @@
 	<!-- /wp:list --></div>
 	<!-- /wp:column -->
 
-		<!-- wp:column {"verticalAlignment":"top","width":"50%"} -->
-		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:50%">
+		<!-- wp:column {"verticalAlignment":"bottom","width":"50%","className":"wporg-events__contributors__image"} -->
+		<div class="wp-block-column is-vertically-aligned-bottom wporg-events__contributors__image" style="flex-basis:50%">
 			<!-- wp:pattern {"slug":"wporg-events-2023/front-contributors-gallery"} /-->
 		</div>	<!-- /wp:column -->
 	</div>	<!-- /wp:columns -->

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
@@ -3,6 +3,11 @@
 		display: block;
 	}
 
+	.wporg-events_contributors__heading,
+	.wporg-events_contributors__link-list {
+		text-wrap: nowrap;
+	}
+
 	.is-style-links-list li:first-child {
 		border-top: none;
 	}
@@ -19,7 +24,10 @@
 		}
 	}
 
-	.wp-block-jetpack-tiled-gallery {
-		min-width: 565px;
+	@media screen and (min-width: 1170px) {
+		.wporg-events__contributors__image {
+			min-width: 565px;
+			align-self: flex-start;
+		}
 	}
 }

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
@@ -1,5 +1,4 @@
 .wporg-events__contributors {
-
 	.wp-block-heading em {
 		display: block;
 	}
@@ -13,10 +12,14 @@
 	}
 
 	.is-style-links-list li {
-		border-color:  var(--wp--preset--color--light-grey-1);
+		border-color: var(--wp--preset--color--light-grey-1);
 
 		a {
-			color:  var(--wp--preset--color--charcoal-0);	
+			color: var(--wp--preset--color--charcoal-0);
 		}
+	}
+
+	.wp-block-jetpack-tiled-gallery {
+		min-width: 565px;
 	}
 }


### PR DESCRIPTION
This PR makes the contributor images transition smooth for different screen sizes.

Between 782px and 1170px, the layout isn't perfect, but I've made the images scale proportionally while sticking to the footer. 
In this range, to maintain the aspect ratio, the images can't align with the top of the 'Where All WordPress' text on the left while also sticking to the top of the footer, and also not overlapping with the components on the left. Moreover, transitioning to a mobile layout too soon just to avoid overlap doesn't make sense, as there's still enough space in the rest of the page to render everything completely. IMO, this modification looks good enough.

I'm going to merge it first. If anyone feels the images shrinking to the top is better than to the bottom, we can change it later.

cc @StevenDufresne 

I've also [removed](https://github.com/WordPress/wordcamp.org/commit/6fa2425c56c6462cbbe0fb641d65e4243297c00f) a couple of styles that seem unused.

## Screencast

https://github.com/WordPress/wordcamp.org/assets/18050944/c02dc5d2-9b6e-48a1-906c-4dc6df5bda9c

