### PR TITLE
CampTix: Only enqueue CSS when used, for performance

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -486,7 +486,7 @@ class CampTix_Plugin {
 	}
 
 	/**
-	 * Get a CSS file, @todo make it removable through an option.
+	 * Register front-end assets.
 	 */
 	function enqueue_scripts() {
 		wp_register_style(
@@ -508,9 +508,6 @@ class CampTix_Plugin {
 			'enterEmail' => __( 'Please enter the e-mail addresses in the forms above.', 'wordcamporg' ),
 			'ajaxURL'    => admin_url( 'admin-ajax.php' ),
 		) );
-
-		// Let's play by the rules and print this in the <head> section.
-		wp_enqueue_style( 'camptix' );
 	}
 
 	function admin_enqueue_scripts() {
@@ -5422,6 +5419,7 @@ class CampTix_Plugin {
 			return __( 'An error has occurred.', 'wordcamporg' );
 		}
 
+		wp_enqueue_style( 'camptix' );
 		wp_enqueue_script( 'camptix' ); // js in footer
 		return $this->shortcode_contents;
 	}


### PR DESCRIPTION
See #1128 

This speeds up most pages a little bit by not enqueuing an unnecessary file. It's also moved to the footer so it doesn't block the initial page render. That wasn't valid HTML when this plugin was originally written, but it is now.