### PR TITLE
Events: Update homepage copy

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/patterns/front-contributors.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/front-contributors.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group alignwide" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"}}},"className":"wporg-events__contributors"} -->
 	<div class="wp-block-columns alignwide wporg-events__contributors"><!-- wp:column {"verticalAlignment":"top","width":"50%","layout":{"type":"default"}} -->
 	<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:50%"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0"}}},"className":"is-style-default wporg-events_contributors__heading","fontFamily":"eb-garamond"} -->
-	<h2 class="wp-block-heading is-style-default wporg-events_contributors__heading has-eb-garamond-font-family" style="margin-top:0">Where all WordPress <em>contributors meet</em></h2>
+	<h2 class="wp-block-heading is-style-default wporg-events_contributors__heading has-eb-garamond-font-family" style="margin-top:0">Where WordPress contributors meet</h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:list {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|30"}}},"className":"is-style-links-list wporg-events_contributors__link-list"} -->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/front-cover.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/front-cover.php
@@ -15,7 +15,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-0"}}}},"textColor":"charcoal-0"} -->
-<p class="has-charcoal-0-color has-text-color has-link-color">All over the world contributors meet to share, learn, and collaborate for the WordPress project.</p>
+<p class="has-charcoal-0-color has-text-color has-link-color">All over the world contributors meet to share, learn, and collaborate on the WordPress project.</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
@@ -1,13 +1,4 @@
 .wporg-events__contributors {
-	.wp-block-heading em {
-		display: block;
-	}
-
-	.wporg-events_contributors__heading,
-	.wporg-events_contributors__link-list {
-		text-wrap: nowrap;
-	}
-
 	.is-style-links-list li:first-child {
 		border-top: none;
 	}


### PR DESCRIPTION
Fixes #1141

This PR updates copy as ticket requests.
Also updates the styles of "Where WordPress contributors meet".

## Screencast
https://github.com/WordPress/wordcamp.org/assets/18050944/671e3bce-ede9-4437-9a83-737b1c13d06b

 ## Question
Currently, there's such case (on mobile and desktop):
![Screenshot 2023-12-08 at 04 06 49](https://github.com/WordPress/wordcamp.org/assets/18050944/a8fb42f6-ef62-4148-bdd7-f2fd3c66f687)
![Screenshot 2023-12-08 at 04 06 42](https://github.com/WordPress/wordcamp.org/assets/18050944/ab063cb9-ef26-4ecc-9c81-91c4c494bf52)

Do we want to avoid that? That is, make it only:
```Where WordPress contributors meet```
or
```
Where WordPress 
contributors meet
```

cc @WordPress/meta-design 