### PR TITLE
Events: Add `other` type for NextGen events

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/functions.php
+++ b/public_html/wp-content/themes/wporg-events-2023/functions.php
@@ -118,6 +118,7 @@ function get_event_type_options( array $options ): array {
 		'options' => array(
 			'meetup'   => 'Meetup',
 			'wordcamp' => 'WordCamp',
+			'other'    => 'Other',
 		),
 		'selected' => $selected,
 	);


### PR DESCRIPTION
This splits WordCamps into two options: `WordCamp` for traditional WordCamps, and `Other` for NextGen WordCamps.

Fixes #1146

The SQL is updated in https://github.com/WordPress/wporg-mu-plugins/pull/540