### PR TITLE
Events: Breakpoint change for a cleaner cover

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/postcss/base/breakpoints.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/base/breakpoints.pcss
@@ -22,7 +22,7 @@
  * wporg-parent-2021
  * @link https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/sass/base/_breakpoints.scss
  */
-@custom-media --small-only (max-width: 559px);
+@custom-media --small-only (max-width: 599px);
 @custom-media --giant (min-width: 2000px);
 
 /*

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -17,7 +17,6 @@
 	}
 
 	@media (--xlarge) {
-		grid-template-columns: 50% 1fr 2fr;
 		font-size: var(--wp--preset--font-size--normal);
 	}
 

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -13,11 +13,11 @@
 		display: grid;
 		align-items: start;
 		gap: var(--wp--preset--spacing--20);
-		grid-template-columns: 45% 1fr 1fr;
+		grid-template-columns: 45% 1fr 1.5fr;
 	}
 
 	@media (--xlarge) {
-		grid-template-columns: 50% 1fr 1fr;
+		grid-template-columns: 50% 1fr 1.5fr;
 		font-size: var(--wp--preset--font-size--normal);
 	}
 
@@ -71,17 +71,13 @@
 
 		@media (--small) {
 			display: inline-flex;
+			justify-content: right;
 		}
 
 		@media (--medium) {
 			.wporg-google-map__date {
 				display: block;
 			}
-		}
-
-		@media (--large) {
-			display: block;
-			text-align: right;
 		}
 
 		@media (--huge) {
@@ -111,15 +107,13 @@
 		vertical-align: middle;
 	}
 
-	@media (--large) {
-		.wporg-marker-list-item__location::after,
-		.wporg-google-map__date::after {
+	.wporg-marker-list-item__location::after {
+
+		@media (--small-only) {
 			display: none;
 		}
-	}
 
-	@media (--small-only) {
-		.wporg-marker-list-item__location::after {
+		@media (--large) {
 			display: none;
 		}
 	}

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -9,7 +9,7 @@
 	list-style: none;
 	font-size: var(--wp--preset--font-size--small);
 
-	@media (--medium) {
+	@media (--large) {
 		display: grid;
 		align-items: start;
 		gap: var(--wp--preset--spacing--20);
@@ -54,21 +54,34 @@
 		text-decoration: none;
 	}
 
-	@media (--medium-small) {
-		.wporg-marker-list-item__location {
+
+	.wporg-marker-list-item__location {
+
+		@media (--medium-small) {
 			margin-top: 2px;
 			margin-bottom: -2px;
+		}
+
+		@media (--small) {
+			display: inline;
 		}
 	}
 
 	.wporg-marker-list-item__date-time {
-		@media (--medium) {
-			display: block;
-			text-align: right;
 
+		@media (--small) {
+			display: inline-flex;
+		}
+
+		@media (--medium) {
 			.wporg-google-map__date {
 				display: block;
 			}
+		}
+
+		@media (--large) {
+			display: block;
+			text-align: right;
 		}
 
 		@media (--huge) {
@@ -84,7 +97,8 @@
 		position: relative;
 	}
 
-	.wporg-google-map__date:after {
+	.wporg-marker-list-item__location::after,
+	.wporg-google-map__date::after {
 		content: '';
 		margin-top: -1px; /* vertical-middle doesn't subtract the size of the element */
 		margin-left: 10px;
@@ -97,8 +111,15 @@
 		vertical-align: middle;
 	}
 
-	@media (--medium) {
-		.wporg-google-map__date:after {
+	@media (--large) {
+		.wporg-marker-list-item__location::after,
+		.wporg-google-map__date::after {
+			display: none;
+		}
+	}
+
+	@media (--small-only) {
+		.wporg-marker-list-item__location::after {
 			display: none;
 		}
 	}

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -13,11 +13,11 @@
 		display: grid;
 		align-items: start;
 		gap: var(--wp--preset--spacing--20);
-		grid-template-columns: 45% 1fr 1.5fr;
+		grid-template-columns: 45% 1fr 2fr;
 	}
 
 	@media (--xlarge) {
-		grid-template-columns: 50% 1fr 1.5fr;
+		grid-template-columns: 50% 1fr 2fr;
 		font-size: var(--wp--preset--font-size--normal);
 	}
 

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/cover.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/cover.pcss
@@ -6,7 +6,22 @@
 	}
 
 	@media (--medium) {
+		.wp-block-columns {
+			flex-wrap: wrap !important;
+
+			.wp-block-column {
+				flex-grow: 1 !important;
+			}
+		}
+	}
+
+	@media (--large) {
 		padding-left: var(--wp--preset--spacing--edge-space);
+		padding-right: var(--wp--preset--spacing--edge-space);
+
+		.wp-block-columns {
+			flex-wrap: nowrap !important;
+		}
 
 		.wp-block-columns .wp-block-column:first-child {
 			padding-left: 0;
@@ -23,9 +38,6 @@
 	}
 
 	@media (--huge) {
-
-		padding-right: var(--wp--preset--spacing--edge-space);
-
 		.wp-block-columns .wp-block-column:first-child {
 			flex-basis: 33% !important;
 		}


### PR DESCRIPTION
Fixes #1138

## Screencast
**Keep the mobile's vertical distribution of cover area (Heading, sub text, and map) until it reaches 960px**

https://github.com/WordPress/wordcamp.org/assets/18050944/70959692-8829-4982-a5c6-a9a75e19da92

**Between 600-900, place location, date, and time labels horizontally in a single line.**

https://github.com/WordPress/wordcamp.org/assets/18050944/08cc89d2-0a81-45e1-83f4-6553f288374d



