### PR TITLE
Events: Stop large cumulative layout shift caused my map height

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/cover.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/cover.pcss
@@ -31,15 +31,19 @@
 		}
 
 		.wp-block-columns .wp-block-column:last-child {
-			flex-basis: 66.665%  !important;
+			flex-basis: 66.665% !important;
 		}
 	}
 
-	& .wp-block-wporg-google-map .wporg-google-map__container {
+	& .wp-block-wporg-google-map {
 		height: 430px;
 
 		@media (--small-only) {
 			height: 246px;
+		}
+
+		& .wporg-google-map__container {
+			height: 100%;
 		}
 	}
 }


### PR DESCRIPTION
See #1128 

There is a large shift in the page content when the map loads, as the container has no height set beforehand. This has a significant impact on the Lighthouse score. This PR sets the height on the initial container, and the map to fill it, which we can do because there is no search field or other associated UI surrounding the map which needs to also fit in the container.

There should be no visual change, other than the layout shift not happening. The layout should stay set from initial load.