### PR TITLE
Events: Update templates to use WP Query

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/functions.php
+++ b/public_html/wp-content/themes/wporg-events-2023/functions.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/inc/city-landing-pages.php';
 
 // Block files.
 require_once __DIR__ . '/src/event-list/index.php';
+require_once __DIR__ . '/src/post-meta/index.php';
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_support' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );

--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -83,6 +83,8 @@ function inject_events_into_query( $posts, WP_Query $query ) {
 			'filter' => 'raw',
 		);
 
+		// add time block as a dependency, to make sure always enqueued
+
 		$meta = array(
 			'location'  => array( ucfirst( $event->location ) ),
 			'timestamp' => array( $event->timestamp ),
@@ -92,6 +94,8 @@ function inject_events_into_query( $posts, WP_Query $query ) {
 			'type'      => array( $event->type ),
 			'tz_offset' => array( $event->tz_offset ),
 		);
+
+		// need a permalink filter that returns the guid? probably
 
 		$post_object = new WP_Post( $post );
 

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters.php
@@ -14,6 +14,8 @@
 		<!-- wp:search {"showLabel":false,"placeholder":"Search events...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->
 	</div> <!-- /wp:group -->
 
+	<!-- wp:wporg/query-total  /-->
+
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"wporg-query-filters","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"format_type","multiple":false} /-->
@@ -21,5 +23,4 @@
 		<!-- wp:wporg/query-filter {"key":"month","multiple":false} /-->
 		<!-- wp:wporg/query-filter {"key":"country","multiple":false} /-->
 	</div> <!-- /wp:group -->
-
 </div> <!-- /wp:group -->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-query-no-results.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-query-no-results.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Title: Events Query: No Results
+ * Slug: wporg-events-2023/events-query-no-results
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"heading-2"} -->
+	<h1 class="wp-block-heading has-text-align-center has-heading-2-font-size">
+		<?php esc_html_e( 'No events found', 'wporg' ); ?>
+	</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">
+		<?php
+		printf(
+			wp_kses_data(
+				/* translators: %s is url of the event archives. */
+				__( 'View <a href="%s">upcoming events</a> or try a different search.', 'wporg' )
+			),
+			esc_url( home_url( '/upcoming-events/' ) )
+		);
+		?>
+	</p>
+	<!-- /wp:paragraph -->
+</div> <!-- /wp:group -->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-query.php
@@ -9,42 +9,10 @@
 
 <!-- wp:query {"queryId":0,"query":{"perPage":500,"pages":0,"offset":0,"postType":"wporg_events","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"className":"wporg-events-query"} -->
 <div class="wp-block-query wporg-events-query">
-	<?php
-	// This has to be `require`d, because using `<!-- wp:pattern ...` won't pass the query ID context to the
-	// query-total block, and the number of events won't match.
-	require __DIR__ . '/events-list-filters.php';
-	?>
+	<!-- wp:pattern {"slug":"wporg-events-2023/events-list-filters"} /-->
 
 	<!-- wp:post-template {"className":"wporg-marker-list__container"} -->
-
-		<li class="wporg-marker-list-item">
-			<h3 class="wporg-marker-list-item__title">
-				<a class="external-link" href=" $event->url ">
-			        <!-- wp:post-title {"isLink":true,"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"inherit"}},"fontSize":"normal","fontFamily":"inter"} /-->
-			    </a>
-			</h3>
-
-			<div class="wporg-marker-list-item__location">
-				<!-- wp:wporg/post-meta {"key":"location"} /-->
-			</div>
-
-			<?php // todo have to create a block for this, and anything else that uses post context ?>
-			<time
-				class="wporg-marker-list-item__date-time"
-				date-time="gmdate( 'c', esc_html( $event->timestamp ) )"
-				title="gmdate( 'c', esc_html( $event->timestamp ) )"
-			>
-				<span class="wporg-google-map__date">
-					<!-- wp:wporg/post-meta {"key":"timestamp"} /-->
-					<?php // gmdate( 'l, M j', esc_html( $event->timestamp ) ) ?>
-				</span>
-
-				<span class="wporg-google-map__time">
-					<!-- wp:wporg/post-meta {"key":"timestamp"} /-->
-					<?php // esc_html( gmdate('H:i', $event->timestamp) . ' UTC' ) ?>
-				</span>
-			</time>
-		</li>
+		<!-- wp:wporg/event-list {"groupByMonth":true} /-->
 	<!-- /wp:post-template -->
 
 	<!-- wp:query-pagination -->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-query.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Title: Events Query
+ * Slug: wporg-events-2023/events-query
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:query {"queryId":0,"query":{"perPage":500,"pages":0,"offset":0,"postType":"wporg_events","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"className":"wporg-events-query"} -->
+<div class="wp-block-query wporg-events-query">
+	<?php
+	// This has to be `require`d, because using `<!-- wp:pattern ...` won't pass the query ID context to the
+	// query-total block, and the number of events won't match.
+	require __DIR__ . '/events-list-filters.php';
+	?>
+
+	<!-- wp:post-template {"className":"wporg-marker-list__container"} -->
+
+		<li class="wporg-marker-list-item">
+			<h3 class="wporg-marker-list-item__title">
+				<a class="external-link" href=" $event->url ">
+			        <!-- wp:post-title {"isLink":true,"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"inherit"}},"fontSize":"normal","fontFamily":"inter"} /-->
+			    </a>
+			</h3>
+
+			<div class="wporg-marker-list-item__location">
+				<!-- wp:wporg/post-meta {"key":"location"} /-->
+			</div>
+
+			<?php // todo have to create a block for this, and anything else that uses post context ?>
+			<time
+				class="wporg-marker-list-item__date-time"
+				date-time="gmdate( 'c', esc_html( $event->timestamp ) )"
+				title="gmdate( 'c', esc_html( $event->timestamp ) )"
+			>
+				<span class="wporg-google-map__date">
+					<!-- wp:wporg/post-meta {"key":"timestamp"} /-->
+					<?php // gmdate( 'l, M j', esc_html( $event->timestamp ) ) ?>
+				</span>
+
+				<span class="wporg-google-map__time">
+					<!-- wp:wporg/post-meta {"key":"timestamp"} /-->
+					<?php // esc_html( gmdate('H:i', $event->timestamp) . ' UTC' ) ?>
+				</span>
+			</time>
+		</li>
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:query-no-results -->
+		<!-- wp:pattern {"slug":"wporg-events-2023/events-query-no-results"} /-->
+	<!-- /wp:query-no-results -->
+</div> <!-- /wp:query -->

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
@@ -8,6 +8,7 @@
 	"icon": "list-view",
 	"description": "List of WordPress Events",
 	"textdomain": "wporg",
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"attributes": {
 		"events": {
 			"type": "string",

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
@@ -9,6 +9,11 @@
 	"description": "List of WordPress Events",
 	"textdomain": "wporg",
 	"usesContext": [ "postId", "postType", "queryId" ],
+	"providesContext": {
+		"queryId": "queryId",
+		"query": "query",
+		"postId": "postId"
+	},
 	"attributes": {
 		"events": {
 			"type": "string",

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -39,7 +39,7 @@ function init() {
  *
  * @return string Returns the block markup.
  */
-function render( $attributes, $content, $block ) {
+function render__remove_me_once_functionality_ported_to_new_render( $attributes, $content, $block ) {
 	$facets = Events_2023\get_clean_query_facets();
 	$events = Google_Map\get_events( $attributes['events'], 0, 0, $facets );
 
@@ -80,6 +80,50 @@ function render( $attributes, $content, $block ) {
 		$wrapper_attributes,
 		do_blocks( $content )
 	);
+}
+
+// add types
+function render( $attributes, $content, $block ) {
+	ob_start();
+
+	global $post;
+
+	$url = $post->guid;
+
+	?>
+
+	<li class="wporg-marker-list-item">
+		<h3 class="wporg-marker-list-item__title">
+			<a class="external-link" href="<?php echo esc_url( $url ); ?>">
+				<?php echo esc_html( $post->post_title ); ?>
+				<!-- wp:post-title {"isLink":true,"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"inherit"}},"fontSize":"normal","fontFamily":"inter"} /-->
+			</a>
+		</h3>
+
+		<div class="wporg-marker-list-item__location">
+				<!-- wp:wporg/post-meta {"key":"location"} /--></div>
+
+				<?php // todo have to create a block for this, and anything else that uses post context ?>
+				<time
+					class="wporg-marker-list-item__date-time"
+					date-time="gmdate( 'c', esc_html( $event->timestamp ) )"
+					title="gmdate( 'c', esc_html( $event->timestamp ) )"
+				>
+                       <span class="wporg-google-map__date">
+                               <!-- wp:wporg/post-meta {"key":"timestamp"} /-->
+                               <?php // gmdate( 'l, M j', esc_html( $event->timestamp ) ) ?>
+                       </span>
+
+					<span class="wporg-google-map__time">
+                               <!-- wp:wporg/post-meta {"key":"timestamp"} /-->
+                               <?php // esc_html( gmdate('H:i', $event->timestamp) . ' UTC' ) ?>
+                       </span>
+				</time>
+	</li>
+
+	<?php
+
+	return ob_get_clean();
 }
 
 /**

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -25,7 +25,7 @@ function init() {
 	register_block_type(
 		dirname( dirname( __DIR__ ) ) . '/build/event-list',
 		array(
-			'render_callback' => __NAMESPACE__ . '\render',
+			'render_callback' => __NAMESPACE__ . '\render'
 		)
 	);
 }

--- a/public_html/wp-content/themes/wporg-events-2023/src/post-meta/block.json
+++ b/public_html/wp-content/themes/wporg-events-2023/src/post-meta/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/post-meta",
+	"version": "0.1.0",
+	"title": "WordPress Post Meta",
+	"category": "design",
+	"icon": "list-view",
+	"description": "Displays Post Meta",
+	"textdomain": "wporg",
+	"attributes": {
+		"id": {
+			"type": "integer"
+		},
+		"key": {
+			"type": "string",
+			"default": "",
+			"required": true
+		},
+		"single": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"editorScript": "file:./index.js"
+}

--- a/public_html/wp-content/themes/wporg-events-2023/src/post-meta/edit.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/post-meta/edit.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { Disabled } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit( { attributes, name } ) {
+	return (
+		<div { ...useBlockProps() }>
+			<Disabled>
+				<ServerSideRender block={ name } attributes={ attributes } />
+			</Disabled>
+		</div>
+	);
+}

--- a/public_html/wp-content/themes/wporg-events-2023/src/post-meta/index.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/post-meta/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/public_html/wp-content/themes/wporg-events-2023/src/post-meta/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/post-meta/index.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Block Name: Post Meta
+ * Description: Display a post meta value.
+ */
+
+namespace WordPressdotorg\Events_2023\Post_Meta;
+use WP_Block;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+
+/**
+ * Register block.
+ */
+function init(): void {
+	register_block_type(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block.
+ */
+function render( array $attributes, string $content, WP_Block $block ): string {
+	if ( empty( $attributes['id'] ) ) {
+		$attributes['id'] = get_the_ID();
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes( array(
+		'class' => 'wporg-post-meta-key-' . $attributes['key']
+	) );
+
+	$value = get_post_meta( $attributes['id'], $attributes['key'], $attributes['single'] );
+
+	return sprintf(
+		'<span %1$s>%2$s</span>',
+		$wrapper_attributes,
+		$value
+	);
+}

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming-events.html
@@ -11,8 +11,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
-		<!-- wp:wporg/event-list {"groupByMonth":"true","limit":"500"} /-->
+		<!-- wp:pattern {"slug":"wporg-events-2023/events-query"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>


### PR DESCRIPTION
Follows #1156 
Fixes #1152 

Now that the events data is available via a query block, we can update the templates/patterns/etc to use that instead of the custom rendering in the event-list block. That block may still be needed to access some of the data, though, since patterns can't have any content that's specific to a post in the loop.