### PR TITLE
Add in the query-total to the search results.

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters-with-count.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters-with-count.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Events List Filters With Event Count
+ * Slug: wporg-events-2023/event-list-filters-with-count
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"align":"wide","className":"wporg-events__filters","style":{"spacing":{"margin":{"top":"40px","bottom":"40px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide wporg-events__filters" style="margin-top:40px;margin-bottom:40px">
+	<!-- wp:group {"className":"wporg-events__filters__search","layout":{"type":"flex","flexWrap":"wrap"}} -->
+	<div class="wp-block-group wporg-events__filters__search">
+		<!-- wp:search {"showLabel":false,"placeholder":"Search events...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->
+
+		<!-- wp:query {"queryId":0,"query":{"perPage":500,"pages":0,"offset":0,"postType":"wporg_events","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
+			<!-- wp:wporg/query-total /-->
+		<!-- /wp:query -->
+	</div> <!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"wporg-query-filters","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group wporg-query-filters">
+		<!-- wp:wporg/query-filter {"key":"format_type","multiple":false} /-->
+		<!-- wp:wporg/query-filter {"key":"event_type","multiple":false} /-->
+		<!-- wp:wporg/query-filter {"key":"month","multiple":false} /-->
+		<!-- wp:wporg/query-filter {"key":"country","multiple":false} /-->
+	</div> <!-- /wp:group -->
+
+</div> <!-- /wp:group -->

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-upcoming-events.html
@@ -11,7 +11,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
+		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters-with-count"} /-->
 		<!-- wp:wporg/event-list {"groupByMonth":"true","limit":"500"} /-->
 	</div>
 	<!-- /wp:group -->

--- a/public_html/wp-content/themes/wporg-events-2023/templates/search.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/search.html
@@ -10,7 +10,7 @@
 	<div class="wp-block-group alignwide wporg-events__search"
 		style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
+		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters-with-count"} /-->
 		<!-- wp:wporg/event-list {"groupByMonth":"true","limit":"500"} /-->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
This PR builds on changes added in #1156, to add the `<!-- wp:query-total /-->` component to the filters template. 

Ultimately #1163 will replace this code but since it isn't clear when that will land, we don't need to delay this feature as it already works and is helpful for users.

## Templates

I duplicated the filters template which isn't very DRY but I don't see a better option.

Ideally we could add the `query-filters` into a template part but that had to be reversed in https://github.com/WordPress/wordcamp.org/commit/72b6a8e6ea6d3bc6dfb4c070ef2a093c5f744110 since it breaks the `overflow: scroll` behaviour on mobile for the filters.

Alternatively, we could move the search container to a new template, but that will add another dev and not really simplify things.


### Screenshots

| Page | Screenshot |
|--------|--------|
| `/upcoming-events` | ![events wordpress test_upcoming-events__month=05](https://github.com/WordPress/wordcamp.org/assets/1657336/ac83bbb2-7918-4d87-a0be-1756e4a7d4b4) |
| `?s={keyword} | ![events wordpress test__format_type=in-person s=help](https://github.com/WordPress/wordcamp.org/assets/1657336/4e1c45e7-58ed-43ec-b7de-7a661a965b3c) |
|`/` (no count) | ![events wordpress test__preview](https://github.com/WordPress/wordcamp.org/assets/1657336/a26749b5-fbd6-40cd-8640-01d1b6be408c) | 

### How to test the changes in this Pull Request:

1. Visit the homepage, ensure there are no results
2. Navigate to `/upcoming-events` and use filters, verify that the count matches the result list
3. Search for something, verify that the results match the count.

