### PR TITLE
Remove the layout type default.

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-organize-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-organize-events.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
 
-<!-- wp:group {"tagName":"main","className":"entry-content","layout":{"type":"default"}} -->
+<!-- wp:group {"tagName":"main","className":"entry-content"} -->
     <main class="wp-block-group entry-content">
         <!-- wp:pattern {"slug":"wporg-events-2023/page-organize-events"} /-->   
     </main>


### PR DESCRIPTION
This fixes the fact that the sub nav is not sticking on the organize page.

Fixes #1139 
