### PR TITLE
Fix event list location position

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/event-list.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/event-list.pcss
@@ -29,14 +29,6 @@
 		}
 
 		@media (--wide) {
-			grid-template-columns: 45% 1fr 1.5fr;
-		}
-
-		@media (--huge) {
-			grid-template-columns: 55% 1fr 1fr;
-		}
-
-		@media (--xhuge) {
 			grid-template-columns: 60% 1fr 1fr;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordcamp.org/pull/1151#issuecomment-1849530963

In design, for a 1280px screen size, the width left part (event title section) of an event item is 470px. The total width of the event item is 1080px. 470/1080~=43%. So I set the ratio to 45% for screen sizes smaller than --wide (1280px).
For those larger than 1280px, I've configured it to be 60% (950/1560).

## Screencast


https://github.com/WordPress/wordcamp.org/assets/18050944/e4635086-1883-4513-bb4d-5db37f6ebfd1



