### PR TITLE
Events: Allow `multiple` values for `type`, `month`, `country` filters

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -42,7 +42,7 @@ function register_post_types() {
  * Inject rows from the `wporg_events` database table into `WP_Query` SELECT results.
  *
  * This allow us to use blocks like `wp:query`, `wp:post-title`, `wporg/query-filters` etc in templates.
- * Otherwise we'd have to write a custom block to display the data, and wouldn't be ablet to reuse existing
+ * Otherwise we'd have to write a custom block to display the data, and wouldn't be able to reuse existing
  * blocks.
  */
 function inject_events_into_query( $posts, WP_Query $query ) {
@@ -131,19 +131,26 @@ function get_clean_query_facets(): array {
 	$search  = (array) get_query_var( 's' ) ?? array();
 	$search  = sanitize_text_field( $search[0] ?? '' );
 
-	$type    = (array) get_query_var( 'event_type' ) ?? array();
-	$type    = sanitize_text_field( $type[0] ?? '' );
+	$type = (array) get_query_var( 'event_type' ) ?? array();
+	$type = array_map( 'sanitize_text_field', $type );
 
 	$format  = (array) get_query_var( 'format_type' ) ?? array();
 	$format  = sanitize_text_field( $format[0] ?? '' );
 
-	$month   = (array) get_query_var( 'month' ) ?? array();
-	$month   = absint( $month[0] ?? 0 );
+	$month = (array) get_query_var( 'month' ) ?? array();
+	$month = array_map( 'absint', $month );
 
 	$country = (array) get_query_var( 'country' ) ?? array();
-	$country = sanitize_text_field( $country[0] ?? '' );
+	$country = array_map( 'sanitize_text_field', $country );
 
 	$facets = compact( 'search', 'type', 'format', 'month', 'country' );
+
+	foreach ( $facets as & $facet ) {
+		if ( is_array( $facet ) ) {
+			$facet = array_filter( $facet ); // Remove empty.
+		}
+	}
+
 	$facets = array_filter( $facets ); // Remove empty.
 
 	return $facets;

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters-with-count.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters-with-count.php
@@ -21,9 +21,9 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"wporg-query-filters","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"format_type","multiple":false} /-->
-		<!-- wp:wporg/query-filter {"key":"event_type","multiple":false} /-->
-		<!-- wp:wporg/query-filter {"key":"month","multiple":false} /-->
-		<!-- wp:wporg/query-filter {"key":"country","multiple":false} /-->
+		<!-- wp:wporg/query-filter {"key":"event_type","multiple":true} /-->
+		<!-- wp:wporg/query-filter {"key":"month","multiple":true} /-->
+		<!-- wp:wporg/query-filter {"key":"country","multiple":true} /-->
 	</div> <!-- /wp:group -->
 
 </div> <!-- /wp:group -->

--- a/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters.php
+++ b/public_html/wp-content/themes/wporg-events-2023/patterns/events-list-filters.php
@@ -17,9 +17,9 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"className":"wporg-query-filters","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group wporg-query-filters">
 		<!-- wp:wporg/query-filter {"key":"format_type","multiple":false} /-->
-		<!-- wp:wporg/query-filter {"key":"event_type","multiple":false} /-->
-		<!-- wp:wporg/query-filter {"key":"month","multiple":false} /-->
-		<!-- wp:wporg/query-filter {"key":"country","multiple":false} /-->
+		<!-- wp:wporg/query-filter {"key":"event_type","multiple":true} /-->
+		<!-- wp:wporg/query-filter {"key":"month","multiple":true} /-->
+		<!-- wp:wporg/query-filter {"key":"country","multiple":true} /-->
 	</div> <!-- /wp:group -->
 
 </div> <!-- /wp:group -->


### PR DESCRIPTION
Fixes #1157 
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/544

This updates the theme to support multiple values for a facet. e.g., `country[]=DE&country[]=ES`. Combining different facets should continue to work, e.g., `month[]=10&month[]=11&country[]=DE`

These URLs should show combined results:

* https://events.wordpress.test/upcoming-events/?country%5B%5D=DE&country%5B%5D=ES - both spain and germany
* https://events.wordpress.test/upcoming-events/?month%5B%5D=10&month%5B%5D=11&country%5B%5D=DE - germany in october and november
* https://events.wordpress.test/upcoming-events/?event_type%5B%5D=meetup&event_type%5B%5D=wordcamp - meetups and wordcamp, but not nextgen events
* https://events.wordpress.test/upcoming-events/?country%5B%5D=AL&country%5B%5D=AS&country%5B%5D=SS - no results (b/c none in any of the individual countries)


These URLs should continue to work as they did before:

* https://events.wordpress.test/ - no filters applied
* https://events.wordpress.test/upcoming-events/?country[]=DE - only germany
* https://events.wordpress.test/past-events/ - no filters applied
* https://events.wordpress.test/upcoming-events/?event_type%5B%5D=other - only nextgen events