### PR TITLE
Events: Fix list titles are not underlined + Improve CSS clearness

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/event-list.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/event-list.pcss
@@ -1,7 +1,7 @@
 .wporg-marker-list__container {
 	padding-left: 0;
 
-	.wporg-marker-list-item {
+	& .wporg-marker-list-item {
 		border: 1px solid var(--wp--preset--color--light-grey-1);
 		border-bottom: none;
 		padding: var(--wp--preset--spacing--20);
@@ -32,14 +32,14 @@
 			grid-template-columns: 60% 1fr 1fr;
 		}
 
-		.wporg-marker-list-item__title {
+		& .wporg-marker-list-item__title {
 			margin: 0;
 			font-family: var(--wp--preset--font-family--inter);
 			font-size: var(--wp--preset--font-size--small);
 			line-height: var(--wp--custom--body--typography--line-height);
 			--wp--preset--spacing--30: 0;
 
-			a {
+			& a {
 				text-decoration: none;
 			}
 
@@ -48,7 +48,7 @@
 			}
 		}
 
-		.wporg-marker-list-item__location {
+		& .wporg-marker-list-item__location {
 
 			@media (--medium-small) {
 				margin-top: 2px;
@@ -60,7 +60,7 @@
 			}
 		}
 
-		.wporg-marker-list-item__date-time {
+		& .wporg-marker-list-item__date-time {
 
 			@media (--small) {
 				display: inline-flex;
@@ -74,8 +74,8 @@
 			}
 		}
 
-		.wporg-marker-list-item__location::after,
-		.wporg-google-map__date::after {
+		& .wporg-marker-list-item__location::after,
+		& .wporg-google-map__date::after {
 			content: "";
 			margin-top: -1px; /* vertical-middle doesn't subtract the size of the element */
 			margin-left: 10px;
@@ -88,7 +88,7 @@
 			vertical-align: middle;
 		}
 
-		.wporg-marker-list-item__location::after {
+		& .wporg-marker-list-item__location::after {
 
 			@media (--small-only), (--large) {
 				display: none;

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/event-list.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/event-list.pcss
@@ -39,7 +39,7 @@
 			line-height: var(--wp--custom--body--typography--line-height);
 			--wp--preset--spacing--30: 0;
 
-			&.a {
+			a {
 				text-decoration: none;
 			}
 

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/footer/community-callout.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/footer/community-callout.pcss
@@ -1,9 +1,7 @@
-.wporg-events__community-callout {
+.wporg-events__community-callout .wp-block-group {
 
 	@media (--medium-small) {
-		.wp-block-group {
-			flex-direction: column;
-			align-items: flex-start;
-		}
+		flex-direction: column;
+		align-items: flex-start;
 	}
 }

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/contributors.pcss
@@ -1,9 +1,9 @@
 .wporg-events__contributors {
-	.is-style-links-list {
-		li {
+	& .is-style-links-list {
+		& li {
 			border-color: var(--wp--preset--color--light-grey-1);
 
-			a {
+			& a {
 				color: var(--wp--preset--color--charcoal-0);
 			}
 
@@ -17,7 +17,7 @@
 		}
 	}
 
-	.wporg-events__contributors__image {
+	& .wporg-events__contributors__image {
 
 		@media screen and (min-width: 1170px) {
 			min-width: 565px;

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/cover.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/front-page/cover.pcss
@@ -5,7 +5,7 @@
 		padding-right: var(--wp--preset--spacing--edge-space);
 	}
 
-	.wp-block-columns {
+	& .wp-block-columns {
 
 		@media (--medium) {
 			flex-wrap: wrap !important;
@@ -15,7 +15,7 @@
 			flex-wrap: nowrap !important;
 		}
 
-		.wp-block-column {
+		& .wp-block-column {
 			&:first-child {
 				padding-left: var(--wp--preset--spacing--edge-space);
 				padding-right: var(--wp--preset--spacing--edge-space);
@@ -24,7 +24,7 @@
 					padding-left: 0;
 					padding-right: 0;
 
-					> p {
+					& > p {
 						max-width: 460px;
 					}
 				}
@@ -45,21 +45,21 @@
 				flex-grow: 1 !important;
 			}
 
-			.wp-block-heading em {
+			& .wp-block-heading em {
 				display: block;
 			}
 		}
 	}
 
 
-	.wp-block-wporg-google-map {
+	& .wp-block-wporg-google-map {
 		height: 430px;
 
 		@media (--small-only) {
 			height: 246px;
 		}
 
-		.wporg-google-map__container {
+		& .wporg-google-map__container {
 			height: 100%;
 		}
 	}

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/page/misc.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/page/misc.pcss
@@ -17,7 +17,7 @@ body .is-layout-flex.page-upcoming-title-past-wrapper {
 .wporg-events__filters__no-count .wporg-events__filters__search {
 	flex: 1;
 
-	form {
+	& form {
 		flex: 1;
 		min-width: 240px;
 


### PR DESCRIPTION
This PR fixes 
1. List titles are not underlined. ([Ref](https://github.com/WordPress/wordcamp.org/pull/1172/files#r1424806482))
2. Align the format of `/community-callout.pcss` with others.
3. Try explicitly adding back the '&', and see how it feels? Do y'all prefer this? Just take this chance to align the style. If there's no particular preference, ~I will revert the commit. Because actually, mostly, the '&' wasn't added in the first place.~ **Update**: I'll keep it as this is how wporg-mu-plugins does.