### PR TITLE
Events: Show filter count on Past Events

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -23,7 +23,7 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  */
 function init() {
 	register_block_type(
-		dirname( dirname( __DIR__ ) ) . '/build/event-list',
+		dirname( __DIR__, 2 ) . '/build/event-list',
 		array(
 			'render_callback' => __NAMESPACE__ . '\render',
 		)

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
@@ -2,11 +2,11 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
-	<div class="wp-block-group alignfull"
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group alignwide"
 		style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
 		<!-- wp:post-title /-->
-		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
+		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters-with-count"} /-->
 		<!-- wp:wporg/event-list {"events":"all-past"} /-->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
This updates the Past Events template to use the same filter part and alignment as Upcoming Events.

Other changes are needed to the template before it can launch, but the `wporg-events-2023/event-list-filters` part is being renamed in #1183, and Past Events should use the new one that has filters anyway. I just broke this off into a separate PR to avoid adding diff noise to #1183.