### PR TITLE
Fix Attendee Survey, it's missing some next gen events.

### DIFF
--- a/public_html/wp-content/plugins/camptix-attendee-survey/includes/admin-page.php
+++ b/public_html/wp-content/plugins/camptix-attendee-survey/includes/admin-page.php
@@ -61,13 +61,18 @@ function get_feedback_details() {
 		'post_type' => WCPT_POST_TYPE_ID,
 		'post_status' => 'wcpt-closed',
 		'posts_per_page' => -1,
+		'date_query'     => array(
+			array(
+				'after'     => '2023-09-01', // The feature doesn't exist before this date.
+				'inclusive' => true,
+			),
+		),
 	) );
 
 	$feedback_details = array();
 
 	foreach ( $wordcamps as $camp ) {
-		// It's a bit counter intuitive, but the site ID is the blog ID.
-		$blog_id = get_post_meta( $camp->ID, '_site_id', true );
+		$blog_id = get_wordcamp_site_id( $camp );
 
 		switch_to_blog( $blog_id );
 


### PR DESCRIPTION
The attendee survey is not pulling all the Next Gen events because sometimes `$blog_id = get_post_meta( $camp->ID, '_site_id', true );` returns an empty string.

This PR updates that line to use `get_wordcamp_site_id` ([ref](https://github.com/WordPress/wordcamp.org/blob/05a520922cc35980d227e26cc415f09913125104/public_html/wp-content/mu-plugins/4-helpers-wcpt.php#L85)) since it handles that case.

Incidentally, this PR updates the WordCamp query to only start looking after this feature was launched in #929.


## Screenshots

| Before | After |
|--------|--------|
| <img width="1760" alt="Screenshot 2023-12-20 at 12 18 49 PM" src="https://github.com/WordPress/wordcamp.org/assets/1657336/c5eb04b3-3308-44a1-b62f-f60ce582a53e"> | <img width="1760" alt="Screenshot 2023-12-20 at 12 18 21 PM" src="https://github.com/WordPress/wordcamp.org/assets/1657336/c9a4996e-fa49-4c56-abff-53a18fbb26b4"> | 

