### PR TITLE
Docker: Install full `wporg-mu-plugins`

### DIFF
--- a/.docker/config/composer.json
+++ b/.docker/config/composer.json
@@ -16,6 +16,7 @@
 	},
 	"extra": {
 		"installer-paths": {
+			"public_html/wp-content/mu-plugins-private/{$name}/pub-sync/tmp": ["wporg/wporg-mu-plugins"],
 			"public_html/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
 			"public_html/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
 			"public_html/wp-content/themes/{$name}/": ["type:wordpress-theme"]
@@ -142,9 +143,8 @@
 	},
 	"scripts": {
 		"post-update-cmd": [
-			"mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-			"mv public_html/wp-content/mu-plugins/wporg-mu-plugins/mu-plugins/utilities public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-			"rm -rf public_html/wp-content/mu-plugins/wporg-mu-plugins"
+			"mv public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/tmp/mu-plugins/* public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+			"rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/tmp/"
 		]
 	}
 }

--- a/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
+++ b/public_html/wp-content/mu-plugins/load-other-mu-plugins.php
@@ -10,6 +10,8 @@ wcorg_include_network_only_plugins();
  * Load mu-plugins that should run on all networks.
  */
 function wcorg_include_common_plugins() {
+	// Include the private `wporg-mu-plugins` from `dotorg.svn`. These are different than the
+	// ones included in `wcorg_include_network_only_plugins()`.
 	if ( file_exists( dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php' ) ) {
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins.php';
 	}
@@ -25,8 +27,9 @@ function wcorg_include_network_only_plugins() {
 	if ( EVENTS_NETWORK_ID === SITE_ID_CURRENT_SITE ) {
 		$network_folder = 'events';
 
+		// Include the public `wporg-mu-plugins` that are synced from Git to SVN. These are different than the
+		// ones included in `wcorg_include_common_plugins()`.
 		require_once dirname( __DIR__ ) . '/mu-plugins-private/wporg-mu-plugins/pub-sync/loader.php';
-
 	} else {
 		$network_folder = 'wordcamp';
 	}


### PR DESCRIPTION
This installs the full `wporg-mu-plugins` repo, so that the Events network will work in the Docker env. 

See https://github.com/WordPress/wordcamp.org/pull/1013 for where the full `wporg-mu-plugins` was required.

https://github.com/WordPress/wordcamp.org/pull/987 for original Composer setup for `wporg-mu-plugins`, and discussion of alternate approach that was implemented here.

The Git repo contains a bunch of files in the root directory that aren't synced to SVN, so it's just the `mu-plugins` subdirectory that we want installed in `pub-sync`. In order to do that I cloned the repo into a `tmp` subdirectory, then moved `mu-plugins` into place, then deleted the `tmp` folder that contains all stuff we don't sync.