### PR TITLE
Sunrise: Redirect to 2024 sites until flagship events are over (Asia, Europe, US)

### DIFF
--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -510,20 +510,20 @@ function get_canonical_year_url( $domain, $path ) {
 	// See also `WordCamp\Sunrise\Latest_Site_Hints\get_latest_home_url()`.
 	switch ( $domain ) {
 		case "europe.wordcamp.$tld":
-			if ( time() <= strtotime( '2023-06-20' ) ) {
-				return "https://europe.wordcamp.$tld/2023/";
+			if ( time() <= strtotime( '2024-06-20' ) ) {
+				return "https://europe.wordcamp.$tld/2024/";
 			}
 			break;
 
 		case "us.wordcamp.$tld":
-			if ( time() <= strtotime( '2023-10-01' ) ) {
-				return "https://us.wordcamp.$tld/2023/";
+			if ( time() <= strtotime( '2024-09-25' ) ) {
+				return "https://us.wordcamp.$tld/2024/";
 			}
 			break;
 
 		case "asia.wordcamp.$tld":
-			if ( time() <= strtotime( '2023-02-20' ) ) {
-				return "https://asia.wordcamp.$tld/2023/";
+			if ( time() <= strtotime( '2024-03-15' ) ) {
+				return "https://asia.wordcamp.$tld/2024/";
 			}
 			break;
 	}


### PR DESCRIPTION
This updates the root URL (ex `us.wordcamp.org`) redirection logic to use the 2024 URLs and event dates for all 3 flagships. This should prevent unexpected redirects if the 2025 sites are created early.

See [slack thread](https://wordpress.slack.com/archives/C08M59V3P/p1704473628744309)

Props juliarosia, kau-boy for talking it through in slack.
