### PR TITLE
Events: Set `date_utc` for city landing pages

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
@@ -172,7 +172,7 @@ function get_city_landing_page_events( string $request_uri ): array {
 			continue;
 		}
 
-		$events[] = array(
+		$events[] = (object) array(
 			'id'        => $wordcamp->_site_id,
 			'title'     => get_wordcamp_name( $wordcamp->_site_id ),
 			'url'       => $wordcamp->{'URL'},
@@ -181,7 +181,7 @@ function get_city_landing_page_events( string $request_uri ): array {
 			'location'  => $wordcamp->{'Location'},
 			'latitude'  => $coordinates['latitude'],
 			'longitude' => $coordinates['longitude'],
-			'timestamp' => $wordcamp->{'Start Date (YYYY-mm-dd)'},
+			'date_utc'  => gmdate( 'Y-m-d H:i:s', $wordcamp->{'Start Date (YYYY-mm-dd)'} ),
 			'tz_offset' => get_wordcamp_offset( $wordcamp ),
 		);
 	}


### PR DESCRIPTION
The return value of `get_city_landing_page_events()` started being passed through `Google_Map\prepare_events()` with https://github.com/WordPress/wporg-mu-plugins/pull/552. Because of that, the event needs to be an object, and it needs to set `date_utc` rather than `timestamp`. Otherwise PHP warnings are thrown.