### PR TITLE
Hide duplicate separator on city landing page

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
@@ -96,7 +96,7 @@ function prime_query_cache(): void {
 		);
 
 		$cache_key = Google_Map\get_cache_key( $parts );
-		$events    = get_city_landing_page_events( $request_uri, true );
+		$events    = get_city_landing_page_events( $request_uri );
 
 		set_transient( $cache_key, $events, DAY_IN_SECONDS );
 	}
@@ -181,7 +181,7 @@ function get_city_landing_page_events( string $request_uri ): array {
 			'location'  => $wordcamp->{'Location'},
 			'latitude'  => $coordinates['latitude'],
 			'longitude' => $coordinates['longitude'],
-			'date_utc'  => gmdate( 'Y-m-d H:i:s', $wordcamp->{'Start Date (YYYY-mm-dd)'} ),
+			'date_utc'  => gmdate( 'Y-m-d H:i:s', (int) $wordcamp->{'Start Date (YYYY-mm-dd)'} ),
 			'tz_offset' => get_wordcamp_offset( $wordcamp ),
 		);
 	}

--- a/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
+++ b/public_html/wp-content/themes/wporg-events-2023/postcss/blocks/wporg-google-map.pcss
@@ -1,13 +1,23 @@
-.wporg-map-marker__title {
-	font-family: var(--wp--preset--font-family--inter);
-	font-size: var(--wp--preset--font-size--normal);
-	font-weight: 600;
-}
+.wp-block-wporg-google-map {
+	.wporg-map-marker__title {
+		font-family: var(--wp--preset--font-family--inter);
+		font-size: var(--wp--preset--font-size--normal);
+		font-weight: 600;
+	}
 
-.wporg-map-marker__location {
-	margin-bottom: 2px;
-}
+	.wporg-map-marker__location {
+		margin-bottom: 2px;
+	}
 
-.wporg-map-marker__date-time {
-	margin-top: 0;
+	.wporg-map-marker__date-time {
+		margin-top: 0;
+	}
+
+	.wporg-marker-list-item__date-time {
+		gap: 0;
+
+		.wporg-google-map__date-time-separator {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
The map block adds one, and so does the theme, but we only need one of them.

<img width="464" alt="Screenshot 2024-01-15 at 4 18 51 PM" src="https://github.com/WordPress/wordcamp.org/assets/484068/2d349594-f97c-4315-a32b-17fe94bd2787">
