### PR TITLE
Events: Prepare events to fix `invalid date` error

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
@@ -97,6 +97,7 @@ function prime_query_cache(): void {
 
 		$cache_key = Google_Map\get_cache_key( $parts );
 		$events    = get_city_landing_page_events( $request_uri );
+		$events    = Google_Map\prepare_events( $events );
 
 		set_transient( $cache_key, $events, DAY_IN_SECONDS );
 	}


### PR DESCRIPTION
https://github.com/WordPress/wporg-mu-plugins/pull/552 applied `prepare_events()` to all code paths callbacks for `google_map_event_filters_{$filter_slug}`. #1191 removed the `timestamp` property from events, because `prepare_events()` adds it dynamically.

That commit should have also updated `prime_query_cache()`, since it sets the same transient as `Google_Map\get_events()`. That was missed, and that caused the city landing pages to display `invalid date` after the `events_landing_prime_query_cache` cron job ran.
