### PR TITLE
WCPT: Save venue street name and number

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -261,6 +261,8 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 							case 'locality':
 							case 'administrative_area_level_1':
 							case 'postal_code':
+							case 'street_number':
+							case 'route':
 								$$type = $component->long_name;
 								break;
 
@@ -275,12 +277,14 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			}
 
 			$values = array(
-				'coordinates'  => $coordinates  ?? null,
-				'city'         => $locality     ?? null,
-				'state'        => $administrative_area_level_1 ?? null,
-				'country_code' => $country_code ?? null,
-				'country_name' => $country_name ?? null,
-				'zip'          => $postal_code  ?? null,
+				'coordinates'   => $coordinates ?? null,
+				'street_name'   => $route ?? null,
+				'street_number' => $street_number ?? null,
+				'city'          => $locality ?? null,
+				'state'         => $administrative_area_level_1 ?? null,
+				'country_code'  => $country_code ?? null,
+				'country_name'  => $country_name ?? null,
+				'zip'           => $postal_code ?? null,
 			);
 
 			return $values;
@@ -512,6 +516,8 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		public static function get_venue_address_meta_keys() {
 			return array(
 				'_venue_coordinates',
+				'_venue_street_name',
+				'_venue_street_number',
 				'_venue_city',
 				'_venue_state',
 				'_venue_country_code',
@@ -519,6 +525,8 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'_venue_zip',
 
 				'_host_coordinates',
+				'_host_street_name',
+				'_host_street_number',
 				'_host_city',
 				'_host_state',
 				'_host_country_code',

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -148,18 +148,20 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		 *
 		 * @param int   $post_id              Post id.
 		 * @param array $original_meta_values Original meta values before save.
+		 * @param bool  $force_update         `true` to force an update even if the address hasn't changed.
 		 */
-		public function update_venue_address( $post_id, $original_meta_values ) {
-			if ( $this->get_event_type() !== get_post_type() ) {
+		public function update_venue_address( $post_id, $original_meta_values, $force_update = false ) {
+			if ( $this->get_event_type() !== get_post_type( $post_id ) ) {
 				return;
 			}
 
 			//phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in `metabox_save` in class-event-admin.php.
 			$address_key = self::get_address_key( $post_id );
 			$new_address = $_POST[ wcpt_key_to_str( $address_key, 'wcpt_' ) ];
+			$address_changed = empty( $original_meta_values[ $address_key ][0] ) || $new_address !== $original_meta_values[ $address_key ][0];
 
 			// No need to geocode if it hasn't changed.
-			if ( ! empty( $original_meta_values[ $address_key ][0] ) && $new_address === $original_meta_values[ $address_key ][0] ) {
+			if ( ! $address_changed && ! $force_update ) {
 				return;
 			}
 


### PR DESCRIPTION
We previously didn't save those, but they'll be needed for #1205. This PR updates them when a WordCamp post is saved, so that new posts will have the data. We'll also need to backfill the data for existing posts with a cli script.