### PR TITLE
Helpers: Restore switched blog when returning early

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -252,6 +252,7 @@ function get_wordcamp_offset( WP_Post $wordcamp ): int {
 	switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
 
 	if ( ! $wordcamp->{'Event Timezone'} || ! $wordcamp->{'Start Date (YYYY-mm-dd)'} ) {
+		restore_current_blog();
 		return 0;
 	}
 


### PR DESCRIPTION
Otherwise it stays switched, and that leads to subtle bugs elsewhere in the codebase.

Fixes the bug introduced in #1215
