### PR TITLE
Events: Append facets to the page title

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/city-landing-pages.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace WordPressdotorg\Events_2023;
-use WP, WP_Post, DateTimeZone, DateTime;
+use WP;
 use WordCamp\Sunrise;
 use WordPressdotorg\MU_Plugins\Google_Map;
 


### PR DESCRIPTION
Fixes #1174 

This is modeled after [how the Showcase does sets the title](https://github.com/WordPress/wporg-showcase-2022/blob/625b65aa1876da9c68c5c08e00b6fbdabb8acde2/source/wp-content/themes/wporg-showcase-2022/functions.php#L418).

A few examples:

* https://events.wordpress.test/upcoming-events/ - `Upcoming Events - WordPress Events`
* https://events.wordpress.test/upcoming-events/?country%5B%5D=DE - `Upcoming Events filtered by: Germany - WordPress Events`
* https://events.wordpress.test/upcoming-events/?month%5B%5D=02&month%5B%5D=03&format_type%5B%5D=online - `Upcoming Events filtered by: Online, February, March - WordPress Events`

This doesn't affect search results, since Core already handles those and they already include the search query.