### PR TITLE
SSL: Don't attempt to send headers if already sent

### DIFF
--- a/public_html/wp-content/mu-plugins/ssl.php
+++ b/public_html/wp-content/mu-plugins/ssl.php
@@ -24,8 +24,9 @@ add_action( 'init', function() {
  * but this is intentionally kept in place just to be safe.
  */
 function wcorg_force_ssl() {
-	if ( php_sapi_name() == 'cli' || is_ssl() )
+	if ( 'cli' === php_sapi_name() || is_ssl() || headers_sent() ) {
 		return;
+	}
 
 	// Our SSL certificate covers only *.wordcamp.org but year.city.wordcamp.org rediercts should still work.
 	// if ( ! preg_match( '#^(?:[^.]+\.)?wordcamp\.org$#i', $_SERVER['HTTP_HOST'] ) )

--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -210,6 +210,8 @@ function add_filters_to_page_title( array $parts ): array {
 	$extra_terms = array();
 
 	foreach ( $facets as $facet => $values ) {
+		$values = (array) $values;
+
 		switch ( $facet ) {
 			case 'type':
 			case 'format':
@@ -221,7 +223,7 @@ function add_filters_to_page_title( array $parts ): array {
 							return ucwords( $name );
 						}
 					},
-					(array) $values
+					$values
 				);
 
 				break;


### PR DESCRIPTION
This fixes a few PHP notices in the production logs