### PR TITLE
Fix undefined index notices in Events theme and Reports plugin

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -241,6 +241,13 @@ function add_filters_to_page_title( array $parts ): array {
 			case 'country':
 				$countries = wcorg_get_countries();
 
+				$values = array_filter(
+					$values,
+					function ( $country_code ) use ( $countries ) {
+						return isset( $countries[ $country_code ] );
+					}
+				);
+
 				$values = array_map(
 					function ( $country_code ) use ( $countries ) {
 						return $countries[ $country_code ]['name'];


### PR DESCRIPTION
* Events: Remove invalid countries to avoid notices from pentesters
* Reports: Fix undefined index notices