### PR TITLE
Stripe: Attach metadata to the transaction, rather than the Checkout Session

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -873,7 +873,7 @@ class CampTix_Stripe_API_Client {
 		}
 
 		if ( is_array( $metadata ) && ! empty( $metadata ) ) {
-			$args['metadata'] = $this->clean_metadata( $metadata );
+			$args['payment_intent_data']['metadata'] = $this->clean_metadata( $metadata );
 		}
 
 		return $this->send_request( 'create_session', $args );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-payment-stripe.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-payment-stripe.php
@@ -274,15 +274,15 @@ function _handle_post_data( &$data ) {
 							),
 						),
 					),
-					'metadata' => array(
-						'invoice_id'       => $data['payment']['invoice_id'],
-						'wordcamp_id'      => $data['payment']['wordcamp_id'],
-						'wordcamp_site_id' => $data['payment']['wordcamp_id'],
-						'wordcamp_url'     => set_url_scheme( esc_url_raw( get_blog_option( $data['payment']['wordcamp_id'], 'home', '' ) ), 'https' ),
-					),
 					'payment_intent_data' => array(
 						'description'          => 'Event Sponsorship Payment:' . $data['payment']['description'], // Displayed in Stripe Dashboard.
 						'statement_descriptor' => mb_strcut( 'Event Sponsorship Payment', 0, 22 ), // Displayed on purchasers statement.
+						'metadata'             => array(
+							'invoice_id'       => $data['payment']['invoice_id'],
+							'wordcamp_id'      => $data['payment']['wordcamp_id'],
+							'wordcamp_site_id' => $data['payment']['wordcamp_id'],
+							'wordcamp_url'     => set_url_scheme( esc_url_raw( get_blog_option( $data['payment']['wordcamp_id'], 'home', '' ) ), 'https' ),
+						),
 					),
 				) );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Stripes API's allow metadata to be attached to multiple objects, during the migration in #1228 I attached metadata to the Checkout Session object, rather than to the payment that then occurs.

This fixes it, by attaching the metadata to the payment intent, which then gets applied against the payment.
We don't need the metadata on the Checkout Session.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #1227 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
