### PR TITLE
Fix various PHP notices

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4978,7 +4978,8 @@ class CampTix_Plugin {
 			// Release a reservation.
 			if ( isset( $_POST['tix_reservation_release'] ) && is_array( $_POST['tix_reservation_release'] ) ) {
 				$release = $_POST['tix_reservation_release'];
-				$release_token = array_shift( array_keys( $release ) );
+				$release = array_keys( $release );
+				$release_token = array_shift( $release );
 
 				$reservations = $this->get_reservations( $post_id );
 				if ( isset( $reservations[$release_token] ) ) {
@@ -4990,7 +4991,8 @@ class CampTix_Plugin {
 			// Cancel a reservation: same as release, but decreases quantity.
 			if ( isset( $_POST['tix_reservation_cancel'] ) && is_array( $_POST['tix_reservation_cancel'] ) ) {
 				$cancel = $_POST['tix_reservation_cancel'];
-				$cancel_token = array_shift( array_keys( $cancel ) );
+				$cancel = array_keys( $cancel );
+				$cancel_token = array_shift( $cancel );
 
 				$reservations = $this->get_reservations( $post_id );
 				if ( isset( $reservations[$cancel_token] ) ) {
@@ -7035,9 +7037,9 @@ class CampTix_Plugin {
 		$receipt_email = false;
 		$payment_method = false;
 
-		if ( isset( $_POST['tix_payment_method'] ) && array_key_exists( $_POST['tix_payment_method'], $this->get_enabled_payment_methods() ) )
+		if ( isset( $_POST['tix_payment_method'] ) && array_key_exists( (string) $_POST['tix_payment_method'], $this->get_enabled_payment_methods() ) ) {
 			$payment_method = $_POST['tix_payment_method'];
-		elseif ( ! empty( $this->order['total'] ) && $this->order['total'] > 0 ) {
+		} elseif ( ! empty( $this->order['total'] ) && $this->order['total'] > 0 ) {
 			$this->error_flags['invalid_payment_method'] = true;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -819,10 +819,10 @@ Thanks for helping us with these details!",
 	 */
 	protected function sanitize_save_misc_fields( $post_id ) {
 		$post = get_post( $post_id );
-
 		// Status
 		if ( current_user_can( 'manage_network' ) ) {
-			$safe_value = strtotime( sanitize_text_field( $_POST['date_vendor_paid'] ) );
+			// phpcs:ignore WordPress.Security.NonceVerification -- Nonce is verified in `save_payment()`.
+			$safe_value = strtotime( sanitize_text_field( $_POST['date_vendor_paid'] ?? '' ) );
 			update_post_meta( $post_id, '_camppayments_date_vendor_paid', $safe_value );
 		}
 

--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -284,7 +284,9 @@ function sort_facets( array $facets ): array {
 	array_walk(
 		$facets,
 		function ( &$facet ) {
-			sort( $facet );
+			if ( is_array( $facet ) ) {
+				sort( $facet );
+			}
 		}
 	);
 


### PR DESCRIPTION
* Events: Check `sort()` argument type to avoid notice
* Payments: Provide default value to avoid undefined notice
* CampTix: Only variables should be passed by reference
* CampTix: `array_key_exists()` expects a string