### PR TITLE
Latest Site Hint: Don't hint when the year is the same.

### DIFF
--- a/phpunit-database-testcase.php
+++ b/phpunit-database-testcase.php
@@ -20,6 +20,7 @@ class Database_TestCase extends WP_UnitTestCase {
 	protected static $slash_year_2016_site_id;
 	protected static $slash_year_2018_dev_site_id;
 	protected static $slash_year_2020_site_id;
+	protected static $slash_year_2020_dev_site_id;
 	protected static $yearless_site_id;
 	protected static $slash_year_with_yearless_site_id;
 
@@ -65,6 +66,12 @@ class Database_TestCase extends WP_UnitTestCase {
 			'network_id' => WORDCAMP_NETWORK_ID,
 		) );
 
+		self::$slash_year_2020_dev_site_id = $factory->blog->create( array(
+			'domain'     => 'vancouver.wordcamp.test',
+			'path'       => '/2020-developers/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+
 		// Sites like this are old edge cases from before a consistent structure was enforced.
 		self::$yearless_site_id = $factory->blog->create( array(
 			'domain'     => 'japan.wordcamp.test',
@@ -98,6 +105,7 @@ class Database_TestCase extends WP_UnitTestCase {
 		wp_delete_site( self::$slash_year_2016_site_id );
 		wp_delete_site( self::$slash_year_2018_dev_site_id );
 		wp_delete_site( self::$slash_year_2020_site_id );
+		wp_delete_site( self::$slash_year_2020_dev_site_id );
 
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE site_id = %d", WORDCAMP_NETWORK_ID ) );
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->site}     WHERE id      = %d", WORDCAMP_NETWORK_ID ) );

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -55,7 +55,7 @@ function canonical_link_past_home_pages_to_current_year() {
 	$latest_domain = get_latest_home_url( $current_blog->domain, $current_blog->path );
 
 	// Nothing to do. `wporg-seo` will still print the standard canonical link.
-	if ( ! $latest_domain || trailingslashit( get_site_url() ) === $latest_domain ) {
+	if ( ! $latest_domain ) {
 		return;
 	}
 
@@ -122,9 +122,7 @@ function show_notification_about_latest_site() {
 	global $current_blog;
 
 	$latest_domain = get_latest_home_url( $current_blog->domain, $current_blog->path );
-
-	// Check if there is newer site for the WordCamp.
-	if ( ! $latest_domain || $latest_domain === $current_blog->domain ) {
+	if ( ! $latest_domain ) {
 		return;
 	}
 

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -22,6 +22,14 @@ function maybe_add_latest_site_hints() {
 		return;
 	}
 
+	// Check to see if they simply differ by an identifier.
+	if (
+		str_contains( $latest_domain . get_site_url(), '-' ) &&
+		preg_replace( '/(\d{4})-[^/]+/', '$1', trailingslashit( get_site_url() ) ) === preg_replace( '/(\d{4})-[^/]+/', '$1', $latest_domain )
+	) {
+		return;
+	}
+
 	// Hook in before `WordPressdotorg\SEO\Canonical::rel_canonical_link()`, so that callback can be removed.
 	add_action( 'wp_head', __NAMESPACE__ . '\canonical_link_past_home_pages_to_current_year', 9 );
 

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -25,7 +25,7 @@ function maybe_add_latest_site_hints() {
 	// Check to see if they simply differ by an identifier.
 	if (
 		str_contains( $latest_domain . get_site_url(), '-' ) &&
-		preg_replace( '/(\d{4})-[^/]+/', '$1', trailingslashit( get_site_url() ) ) === preg_replace( '/(\d{4})-[^/]+/', '$1', $latest_domain )
+		preg_replace( '/(\d{4})-[^\/]+/', '$1', trailingslashit( get_site_url() ) ) === preg_replace( '/(\d{4})-[^\/]+/', '$1', $latest_domain )
 	) {
 		return;
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -159,10 +159,15 @@ class Test_WordCamp_SEO extends Database_TestCase {
 
 			'city/year old year should return newest' => array(
 				'vancouver.wordcamp.test',
-				'/2018-developers/',
+				'/2018/',
 				true,
 			),
 
+			'city/year old year should return newest' => array(
+				'vancouver.wordcamp.test',
+				'/2018-developers/',
+				true,
+			),
 		);
 	}
 

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -116,10 +116,10 @@ class Test_WordCamp_SEO extends Database_TestCase {
 	 */
 	public function test_maybe_add_latest_site_hints( $domain, $path, $expected ) {
 
-		// Sanity Check
+		// Sanity Check.
 		$this->assertFalse( has_filter( 'wp_head', 'WordCamp\Latest_Site_Hints\add_notification_styles' ) );
 
-		// Switch to blog
+		// Switch to blog.
 		$site = get_site_by_path( $domain, $path );
 		$this->assertNotFalse( $site );
 		switch_to_blog( $site->ID );
@@ -157,12 +157,11 @@ class Test_WordCamp_SEO extends Database_TestCase {
 				true,
 			),
 
-			'city/year old year should return newest' => array(
+			'city/year old year should return newest2' => array(
 				'vancouver.wordcamp.test',
 				'/2018-developers/',
 				true,
 			),
 		);
 	}
-
 }

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -157,7 +157,7 @@ class Test_WordCamp_SEO extends Database_TestCase {
 				true,
 			),
 
-			'city/year old year should return newest' => array(
+			'city/year old year should return newest 2018 plain' => array(
 				'vancouver.wordcamp.test',
 				'/2018-developers/',
 				true,

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -139,12 +139,6 @@ class Test_WordCamp_SEO extends Database_TestCase {
 	 */
 	public function data_maybe_add_latest_site_hints() {
 		return array(
-			"there isn't a newer site for the root WordCamp site" => array(
-				'wordcamp.test',
-				'/',
-				false,
-			),
-
 			'city/year newest year should return itself' => array(
 				'vancouver.wordcamp.test',
 				'/2020/',

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -157,7 +157,7 @@ class Test_WordCamp_SEO extends Database_TestCase {
 				true,
 			),
 
-			'city/year old year should return newest2' => array(
+			'city/year old year should return newest' => array(
 				'vancouver.wordcamp.test',
 				'/2018-developers/',
 				true,

--- a/public_html/wp-content/mu-plugins/tests/test-lets-encrypt-helper.php
+++ b/public_html/wp-content/mu-plugins/tests/test-lets-encrypt-helper.php
@@ -135,6 +135,7 @@ class Test_Lets_Encrypt extends Database_TestCase {
 				'2016.vancouver.wordcamp.test',
 				'2020.vancouver.wordcamp.test',
 				'2018-developers.vancouver.wordcamp.test',
+				'2020-developers.vancouver.wordcamp.test',
 			),
 			$actual['vancouver.wordcamp.test']
 		);

--- a/public_html/wp-content/mu-plugins/tests/test-lets-encrypt-helper.php
+++ b/public_html/wp-content/mu-plugins/tests/test-lets-encrypt-helper.php
@@ -46,6 +46,7 @@ class Test_Lets_Encrypt extends Database_TestCase {
 			'2016.vancouver.wordcamp.test',
 			'2018-developers.vancouver.wordcamp.test',
 			'2020.vancouver.wordcamp.test',
+			'2020-developers.vancouver.wordcamp.test',
 			'2021.japan.wordcamp.test',
 
 			// It should contain old year-less domains.


### PR DESCRIPTION
I've created an additional site for Canada 2024, such that they can have an English and French site. See https://wordpress.slack.com/archives/C08M59V3P/p1706836174954409

However, this has caused the latest site hint to suggest this:
> WordCamp Canada 2024 (FR) is over. Check out the next edition!

This change updates the code to strip the `-identifier` part of `/2024-fr/` from the url for the comparison.

### How to test the changes in this Pull Request:

1. Visit https://canada.wordcamp.org/2024-fr/
2. Notice the banner directing to  https://canada.wordcamp.org/2024/
3. Apply PR
4. Repeat 1 & 2, but the banner is no longer visible.
5. Check an older site, for example, https://montreal.wordcamp.org/2019-fr/ still shows the banner.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
