### PR TITLE
Store custom fonts in the upload directory.

### DIFF
--- a/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
+++ b/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
@@ -7,6 +7,7 @@ defined( 'WPINC' ) || die();
 add_filter( 'classic_editor_network_default_settings', __NAMESPACE__ . '\classic_editor_default_settings' );
 add_filter( 'classic_editor_enabled_editors_for_post_type', __NAMESPACE__ . '\disable_editors_by_post_type', 10, 2 );
 add_action( 'after_setup_theme', __NAMESPACE__ . '\enable_block_templates' );
+add_filter( 'font_dir', __NAMESPACE__ . '\fonts_in_uploads' );
 
 /**
  * Configure the default settings for the Classic Editor
@@ -67,4 +68,27 @@ function disable_editors_by_post_type( $editors, $post_type ) {
  */
 function enable_block_templates() {
 	add_theme_support( 'block-templates' );
+}
+
+/**
+ * Store fonts in the Upload Directory.
+ *
+ * @see wp_get_font_dir()
+ *
+ * @param array
+ * @return array
+ */
+function fonts_in_uploads( $fonts_dir ) {
+
+	// This is fragile, but wp_get_font_dir doesn't pass it's raw wp_upload_dir() value through.
+	remove_filter( 'upload_dir', 'wp_get_font_dir' );
+	$upload_dir = wp_upload_dir();
+	add_filter( 'upload_dir', 'wp_get_font_dir' );
+
+	$fonts_dir['basedir'] = $upload_dir['basedir'] . '/fonts';
+	$fonts_dir['baseurl'] = $upload_dir['baseurl'] . '/fonts';
+	$fonts_dir['path']    = $fonts_dir['basedir'];
+	$fonts_dir['url']     = $fonts_dir['baseurl'];
+
+	return $fonts_dir;
 }

--- a/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
+++ b/public_html/wp-content/mu-plugins/gutenberg-tweaks.php
@@ -75,8 +75,8 @@ function enable_block_templates() {
  *
  * @see wp_get_font_dir()
  *
- * @param array
- * @return array
+ * @param array $fonts_dir The fonts directory, expected to reference wp-content/fonts/$site/.
+ * @return array The uploads fonts directory, expected to reference wp-content/uploads/$site/fonts.
  */
 function fonts_in_uploads( $fonts_dir ) {
 

--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -22,9 +22,6 @@ class WordCamp_Fonts_Plugin {
 		// Temporary workaround until we can use the core font library on WordCamp.org.
 		// See https://github.com/WordPress/gutenberg/pull/57697.
 		add_filter( 'wp_theme_json_data_theme', array( $this, 'inject_fonts_theme_json' ) );
-
-		// Store fonts in the WordCamp uploads.
-		add_filter( 'font_dir', array( $this, 'font_dir' ) );
 	}
 
 	/**
@@ -620,30 +617,6 @@ class WordCamp_Fonts_Plugin {
 
 		return $theme_json->update_with( $new_data );
 	}
-
-	/**
-	 * Store fonts in the Upload Directory.
-	 *
-	 * @see wp_get_font_dir()
-	 *
-	 * @param array
-	 * @return array
-	 */
-	public function font_dir( $fonts_dir ) {
-
-		// This is fragile, but wp_get_font_dir doesn't pass it's raw wp_upload_dir() value through.
-		remove_filter( 'upload_dir', 'wp_get_font_dir' );
-		$upload_dir = wp_upload_dir();
-		add_filter( 'upload_dir', 'wp_get_font_dir' );
-
-		$fonts_dir['basedir'] = $upload_dir['basedir'] . '/fonts';
-		$fonts_dir['baseurl'] = $upload_dir['baseurl'] . '/fonts';
-		$fonts_dir['path']    = $fonts_dir['basedir'];
-		$fonts_dir['url']     = $fonts_dir['baseurl'];
-
-		return $fonts_dir;
-	}
-
 }
 
 new WordCamp_Fonts_Plugin();

--- a/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
+++ b/public_html/wp-content/plugins/wc-fonts/wc-fonts.php
@@ -22,6 +22,9 @@ class WordCamp_Fonts_Plugin {
 		// Temporary workaround until we can use the core font library on WordCamp.org.
 		// See https://github.com/WordPress/gutenberg/pull/57697.
 		add_filter( 'wp_theme_json_data_theme', array( $this, 'inject_fonts_theme_json' ) );
+
+		// Store fonts in the WordCamp uploads.
+		add_filter( 'font_dir', array( $this, 'font_dir' ) );
 	}
 
 	/**
@@ -617,6 +620,30 @@ class WordCamp_Fonts_Plugin {
 
 		return $theme_json->update_with( $new_data );
 	}
+
+	/**
+	 * Store fonts in the Upload Directory.
+	 *
+	 * @see wp_get_font_dir()
+	 *
+	 * @param array
+	 * @return array
+	 */
+	public function font_dir( $fonts_dir ) {
+
+		// This is fragile, but wp_get_font_dir doesn't pass it's raw wp_upload_dir() value through.
+		remove_filter( 'upload_dir', 'wp_get_font_dir' );
+		$upload_dir = wp_upload_dir();
+		add_filter( 'upload_dir', 'wp_get_font_dir' );
+
+		$fonts_dir['basedir'] = $upload_dir['basedir'] . '/fonts';
+		$fonts_dir['baseurl'] = $upload_dir['baseurl'] . '/fonts';
+		$fonts_dir['path']    = $fonts_dir['basedir'];
+		$fonts_dir['url']     = $fonts_dir['baseurl'];
+
+		return $fonts_dir;
+	}
+
 }
 
 new WordCamp_Fonts_Plugin();


### PR DESCRIPTION
This is the first step forward for #1075, this change should allow WordCamps to install custom fonts themselves.

With this in place, the installed fonts end up with a URL like `https://example.wordcamp.test/2023/files/fonts/UMBCrPdDqW66y0Y2usFeQCH18mulUxBvI9p7TqbCHJ8BRq0b.woff2`

This doesn't support the `wc-fonts` `@import` functionality, and I can't immediately see a way to make those fonts available in the Editor; which is what #868 was doing.

See #1075