### PR TITLE
Fix default application user

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-events/class-events-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-events/class-events-application.php
@@ -149,14 +149,14 @@ class Events_Application extends WordCamp_Application {
 	 */
 	public function create_post( $data ) {
 		// Create the post.
-		$wordcamp_user_id = get_user_by( 'email', 'support@wordcamp.org' )->ID;
+		$user     = wcorg_get_user_by_canonical_names( $data['q_wporg_username'] );
 		$statuses = \WordCamp_Loader::get_post_statuses();
 
 		$post = array(
 			'post_type'   => self::get_event_type(),
 			'post_title'  => esc_html( $data['q_event_location'] ),
 			'post_status' => self::get_default_status(),
-			'post_author' => $wordcamp_user_id,
+			'post_author' => is_a( $user, 'WP_User' ) ? $user->ID : 7694169, // Set `wordcamp` as author if supplied username is not valid.
 		);
 
 		$post_id = wp_insert_post( $post, true );


### PR DESCRIPTION
Make sure the application user is saved, instead of defaulting to the WordCamp user, which should be the fallback.

Fixes #1252.