### PR TITLE
Jetpack Tweaks: Add extra spam checks for contact form submissions

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -192,7 +192,7 @@ add_filter( 'jetpack_is_frontend', __NAMESPACE__ . '\workaround_is_frontend' );
 /**
  * Extra processing to check if contact form submissions are spam.
  *
- * @param bool $is_spam The spam flag.
+ * @param bool  $is_spam The spam flag.
  * @param array $form Form values formatted for Akismet.
  *
  * @return bool

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/miscellaneous.php
@@ -188,3 +188,24 @@ function workaround_is_frontend( $is_frontend ) {
 	return $is_frontend;
 }
 add_filter( 'jetpack_is_frontend', __NAMESPACE__ . '\workaround_is_frontend' );
+
+/**
+ * Extra processing to check if contact form submissions are spam.
+ *
+ * @param bool $is_spam The spam flag.
+ * @param array $form Form values formatted for Akismet.
+ *
+ * @return bool
+ */
+function extra_spam_checks( $is_spam, $form ) {
+	// Already found to be spam, short circuit.
+	if ( $is_spam ) {
+		return $is_spam;
+	}
+
+	// Check if the comment is only an email.
+	$email = isset( $form['comment_author_email'] ) ? $form['comment_author_email'] : '';
+	$msg = isset( $form['comment_content'] ) ? $form['comment_content'] : '';
+	return trim( $email ) === trim( $msg );
+}
+add_filter( 'jetpack_contact_form_is_spam', __NAMESPACE__ . '\extra_spam_checks', 10, 2 );


### PR DESCRIPTION
In [WCUS slack](https://wcus.slack.com/archives/C9KMESY0H/p1705951308570189), I got a report that the contact form was getting a lot of spam, but Akismet was not catching it. The spam came in as just a name & email, with the message text as just the email.

<img width="838" alt="Screenshot 2024-02-21 at 5 36 50 PM" src="https://github.com/WordPress/wordcamp.org/assets/541093/788b3d59-cd28-40c3-a7e3-615d05351b36">

This change checks contact form submissions to make sure that the email & message text are different. If they are the same, the message is marked as spam.

Props @hellojuliarose, @aaroncampbell.

### How to test the changes in this Pull Request:

1. Go to a contact form, enter a name, email, and in the Message field, repeat the email
2. Submit the form - it should submit successfully
3. View the responses in wp-admin, the submission should be in the "spam" table
4. Go back to the contact form, enter a valid message this time (anything but just the same email)
5. Submit the form - it should submit successfully
6. View the responses in wp-admin, the submission should be in the "all" responses table

Try other forms like speaker submission, they should work as expected.