### PR TITLE
Stripe: Check if transaction actually completed before setting as timeout.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -337,18 +337,6 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			if ( 'payment_return' == $_GET['tix_action'] ) {
 				$this->payment_return();
 			}
-
-			/*
-			 * TODO: We might need to add this, like with paypal, incase the transaction completes
-			 *       but the user never returns to WordCamp to finalise it.. or something...
-			 *
-			 * This would be extra helpful to auto-cancel disputed tickets, or where
-			 * delayed-settlement transfer payments are used (if they get enabled in the future).
-			 *
-			 * if ( 'payment_notify' == $_GET['tix_action'] ) {
-			 *   $this->payment_notify();
-			 * }
-			 */
 		}
 	}
 

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -55,6 +55,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		);
 
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
+		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
 	}
 
 	/**
@@ -523,6 +524,8 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 				)
 			);
 
+			update_user_meta( $order['attendee_id'], '_stripe_checkout_session_id', wp_slash( $session['id'] ) );
+
 			wp_redirect( esc_url_raw( $session['url'] ) );
 			die();
 		}
@@ -627,6 +630,47 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		);
 
 		return $result;
+	}
+
+	/**
+	 * Check if a stripe session timed out.
+	 */
+	public function pre_attendee_timeout( $attendee_id ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		// precheck the attendee is in draft.
+		if ( 'draft' !== get_post_field( 'post_status', $attendee_id ) ) {
+			return;
+		}
+
+		$stripe_session_id = get_post_meta( $attendee_id, '_stripe_checkout_session_id', true );
+		$payment_token     = get_post_meta( $attendee_id, 'tix_payment_token', true );
+		if ( ! $session_id || ! $payment_token ) {
+			return;
+		}
+
+		$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
+		$session = $stripe->get_session( $stripe_session_id );
+
+		if ( empty( $session['status'] ) ) {
+			return;
+		}
+
+		// Uh oh, we've hit timeout on a ticket, but the linked checkout session succeeded.
+		if ( 'succeeded' === $session['status'] && 'paid' === $session['payment_status'] ) {
+			$camptix->log( 'Stripe checkout timed out, but order succeeded.', $attendee_id, $session );
+
+			$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
+			$payment_data   = array(
+				'transaction_id'      => $transaction_id,
+				'transaction_details' => array(
+					'raw' => $session,
+				),
+			);
+
+			$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data, false /* non-interactive */ );
+		}
 	}
 }
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6989,6 +6989,7 @@ class CampTix_Plugin {
 		$max_loops = 500;
 
 		while ( $attendees = get_posts( array(
+			'fields' => 'ids',
 			'post_type' => 'tix_attendee',
 			'post_status' => 'draft',
 			'posts_per_page' => 100,
@@ -7009,9 +7010,19 @@ class CampTix_Plugin {
 			),
 		) ) ) {
 
-			foreach ( $attendees as $attendee ) {
-				$attendee->post_status = 'timeout';
-				wp_update_post( $attendee );
+			foreach ( $attendees as $attendee_id ) {
+				do_action( 'camptix_pre_attendee_timeout', $attendee_id );
+
+				// Check the post_status again, incase a filter has caused the post to change.
+				if ( 'draft' !== get_post_field( 'post_status', $attendee_id ) ) {
+					continue;
+				}
+
+				wp_update_post( [
+					'ID'          => $attendee_id,
+					'post_status' => 'timeout',
+				] );
+
 				$processed++;
 			}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7023,6 +7023,8 @@ class CampTix_Plugin {
 					'post_status' => 'timeout',
 				] );
 
+				$this->log( 'Attendee timeout', $attendee_id );
+
 				$processed++;
 			}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7493,7 +7493,7 @@ class CampTix_Plugin {
 	 * @param string $payment_token The payment token.
 	 * @param int    $result        The payment status.
 	 * @param array  $data          The payment data.
-	 * @param bool   $interactie    Whether this is the browser (default) or a cron task.
+	 * @param bool   $interactive   Whether this is the browser (default) or a cron task.
 	 */
 	function payment_result( $payment_token, $result, $data = array(), $interactive = true ) {
 		if ( empty( $payment_token ) )


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR attempts to check if a stripe transaction was actually processed, before an attendee is moved from `draft` to `timeout`.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #1255 & #1227

### How to test the changes in this Pull Request:

_(This is untested so far)_

1. Make a transaction
2. Either trigger #1255 OR change the status of the attendee to `draft`
3. Either wait for the timeout, or trigger `do_action( 'camptix_pre_attendee_timeout', $id )`
4. Check the attendee is now in a paid state, and got the emails.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
