### PR TITLE
Camptix Network Tools: Better logging table schema

### DIFF
--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -27,7 +27,7 @@ class CampTix_Network_Tools {
 		), get_site_option( 'camptix_nt_options', array() ) );
 		$this->options = $this->validate_options( $this->options );
 
-		if ( $this->options['db_version'] != $this->db_version ) {
+		if ( $this->options['db_version'] < $this->db_version ) {
 			$this->upgrade();
 			update_site_option( 'camptix_nt_options', $this->options );
 		}

--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -12,7 +12,7 @@
 
 class CampTix_Network_Tools {
 	private $options;
-	private $db_version = 20131202;
+	private $db_version = 20240226;
 	const PLUGIN_URL    = 'http://wordpress.org/plugins/camptix-network-tools';
 
 	function __construct() {
@@ -59,7 +59,8 @@ class CampTix_Network_Tools {
 			message text NOT NULL,
 			section varchar(32) DEFAULT 'general',
 			data mediumtext NOT NULL,
-			UNIQUE KEY id (id)
+			PRIMARY KEY (`id`),
+  			KEY `blog_object` (`blog_id`,`object_id`)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';


### PR DESCRIPTION
The table schema for the `camptix_log` network wide table has no useful indexes, which causes slow query performance in wp-admin when retrieving logs for a site/attendee, and makes querying the log table inefficient.

This PR
 - Defines the unique ID as a primary key
 - Defines an index for (blog_id, object_id) such as to allow querying events for a blog, and/or object in a performant manner.

Example query explain before, query time for a various item was 2.8s
This was the query when loading `wp-admin/post.php?post=1234&action=edit`
```
EXPLAIN SELECT * FROM camptix_log WHERE blog_id = 123 AND object_id = 1234 ORDER BY id ASC;

id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
1	SIMPLE	wc_camptix_log	index	NULL	id	8	NULL	1689611	Using where
```

Example query explain after, query time was 0.0006s
```
EXPLAIN SELECT * FROM camptix_log WHERE blog_id = 123 AND object_id = 1234 ORDER BY id ASC;

id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
1	SIMPLE	wc_camptix_log	ref	blog_object	blog_object	16	const,const	8	Using where
```

PR'ing this, although I've already actually made this change to the production logs, after taking a backup.
```
ALTER TABLE camptix_log DROP INDEX `id`, ADD PRIMARY KEY `id`(`id`), ADD INDEX `blog_object` (`blog_id`, `object_id`);
```