### PR TITLE
Bump MYSQL version to 8.0

### DIFF
--- a/.docker/Dockerfile.mysql
+++ b/.docker/Dockerfile.mysql
@@ -1,4 +1,4 @@
-FROM mysql:5.7-debian
+FROM mysql:8.0-debian
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
Tracks with core updating version requirement: https://core.trac.wordpress.org/ticket/59701
