### PR TITLE
Camptix: Harden against junk input

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7065,6 +7065,9 @@ class CampTix_Plugin {
 		foreach( (array) $_POST['tix_attendee_info'] as $i => $attendee_info ) {
 			$attendee = new stdClass;
 
+			$attendee_info = array_filter( $attendee_info, 'is_scalar' );
+			$attendee_info = array_map( 'trim', $attendee_info );
+
 			if ( ! isset( $attendee_info['ticket_id'] ) || ! array_key_exists( $attendee_info['ticket_id'], $this->tickets_selected ) ) {
 				$this->error_flags['no_ticket_id'] = true;
 				continue;
@@ -7075,8 +7078,6 @@ class CampTix_Plugin {
 				$this->error_flags['tickets_excess'] = true;
 				continue;
 			}
-
-			$attendee_info = array_map( 'trim', $attendee_info );
 
 			$attendee_info['first_name'] = sanitize_text_field( $attendee_info['first_name'] );
 			$attendee_info['last_name'] = sanitize_text_field( $attendee_info['last_name'] );
@@ -7096,7 +7097,14 @@ class CampTix_Plugin {
 				foreach ( $questions as $question ) {
 					if ( isset( $_POST['tix_attendee_questions'][ $i ][ $question->ID ] ) ) {
 						$answer = $_POST['tix_attendee_questions'][ $i ][ $question->ID ];
-						$answer = ( is_array( $answer ) ) ? array_map( 'strip_tags', $answer ) : strip_tags( $answer );
+						if ( is_array( $answer ) ) {
+							$answer = array_filter( $answer, 'is_scalar' );
+							$answer = array_map( 'trim', $answer );
+							$answer = array_map( 'strip_tags', $answer );
+						} else {
+							$answer = is_scalar( $answer ) ? strip_tags( $answer ) : '';
+						}
+
 						$answers[ $question->ID ] = $answer;
 					}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5285,7 +5285,7 @@ class CampTix_Plugin {
 			$this->order['coupon'] = sanitize_text_field( $_REQUEST['tix_coupon'] );
 
 		if ( isset( $_REQUEST['tix_reservation_id'], $_REQUEST['tix_reservation_token'] ) ) {
-			$this->order['reservation_id'] = $_REQUEST['tix_reservation_id'];
+			$this->order['reservation_id']    = $_REQUEST['tix_reservation_id'];
 			$this->order['reservation_token'] = $_REQUEST['tix_reservation_token'];
 		}
 
@@ -6882,11 +6882,16 @@ class CampTix_Plugin {
 	 * Return a coupon object by the coupon name (title).
 	 */
 	function get_coupon_by_code( $code ) {
-		$code = trim( $code );
-		if ( empty( $code ) )
+		if ( ! is_string( $code ) ) {
 			return false;
+		}
 
-		$coupon = get_page_by_title( trim( $code ), OBJECT, 'tix_coupon' );
+		$code = trim( $code );
+		if ( empty( $code ) ) {
+			return false;
+		}
+
+		$coupon = get_page_by_title( $code, OBJECT, 'tix_coupon' );
 		if ( $coupon && $coupon->post_type == 'tix_coupon' ) {
 			return $coupon;
 		}
@@ -7279,7 +7284,7 @@ class CampTix_Plugin {
 		$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order', 10 );
 
 		// Let's check the coupon first.
-		if ( isset( $order['coupon'] ) && ! empty( $order['coupon'] ) ) {
+		if ( ! empty( $order['coupon'] ) ) {
 			$coupon = $this->get_coupon_by_code( $order['coupon'] );
 			if ( $coupon && $this->is_coupon_valid_for_use( $coupon->ID ) ) {
 				$coupon->tix_coupon_remaining = $this->get_remaining_coupons( $coupon->ID );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7073,9 +7073,10 @@ class CampTix_Plugin {
 		foreach( (array) $_POST['tix_attendee_info'] as $i => $attendee_info ) {
 			$attendee = new stdClass;
 
-			$$attendee_info = wp_unslash( $$attendee_info );
-			$attendee_info  = array_filter( $attendee_info, 'is_scalar' );
-			$attendee_info  = array_map( 'trim', $attendee_info );
+			$attendee_info = wp_unslash( $attendee_info );
+			$attendee_info = array_filter( $attendee_info, 'is_scalar' );
+			$attendee_info = array_map( 'strip_tags', $attendee_info );
+			$attendee_info = array_map( 'trim', $attendee_info );
 
 			if ( ! isset( $attendee_info['ticket_id'] ) || ! array_key_exists( $attendee_info['ticket_id'], $this->tickets_selected ) ) {
 				$this->error_flags['no_ticket_id'] = true;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7050,7 +7050,7 @@ class CampTix_Plugin {
 		$receipt_email = false;
 		$payment_method = false;
 
-		if ( isset( $_POST['tix_payment_method'] ) && array_key_exists( (string) $_POST['tix_payment_method'], $this->get_enabled_payment_methods() ) ) {
+		if ( isset( $_POST['tix_payment_method'] ) && is_string( $_POST['tix_payment_method'] ) && array_key_exists( $_POST['tix_payment_method'], $this->get_enabled_payment_methods() ) ) {
 			$payment_method = $_POST['tix_payment_method'];
 		} elseif ( ! empty( $this->order['total'] ) && $this->order['total'] > 0 ) {
 			$this->error_flags['invalid_payment_method'] = true;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6220,7 +6220,7 @@ class CampTix_Plugin {
 			$errors = array();
 
 			$new_ticket_info  = wp_unslash( $_POST['tix_ticket_info'] );
-			$$new_ticket_info = array_filter( $new_ticket_info, 'is_scalar' );
+			$new_ticket_info = array_filter( $new_ticket_info, 'is_scalar' );
 			$new_ticket_info  = array_map( 'strip_tags', $new_ticket_info );
 			$new_ticket_info  = array_map( 'trim', $new_ticket_info );
 


### PR DESCRIPTION
Pentesters on the Camptix checkout can cause a high number of warnings by providing junk input to many attendee fields.

Such as:
```
E_WARNING trim() expects parameter 1 to be string, array given
https://example.wordcamp.org/2020/tickets/?tix_action=checkout
plugins/camptix/camptix.php:7079

E_WARNING array_key_exists(): The first argument should be either a string or an integer
URL https://example.wordcamp.org/2022/tickets/?tix_action=checkout
File plugins/camptix/camptix.php:7068

E_WARNING strip_tags() expects parameter 1 to be string, array given
URL https://example.wordcamp.org/2020/tickets/?tix_action=checkout
File plugins/camptix/camptix.php:7099
```

This PR applies some sanitization and validation to the attendee data before processing. 