### PR TITLE
Check against post meta

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -646,7 +646,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		$stripe_session_id = get_post_meta( $attendee_id, '_stripe_checkout_session_id', true );
 		$payment_token     = get_post_meta( $attendee_id, 'tix_payment_token', true );
-		if ( ! $session_id || ! $payment_token ) {
+		if ( ! $stripe_session_id || ! $payment_token ) {
 			return;
 		}
 


### PR DESCRIPTION
Change check to use the post meta retrieved above, rather than $session_id, which doesn't exist.

From PHP notice:

```
Undefined variable: session_id
URL
https://europe.wordcamp.org/2024/wp-cron.php?doing_wp_cron=1710337138.6555919647216796875000
File
[..]plugins/camptix/addons/payment-stripe.php:649
```