### PR TITLE
fix: Update camptix code to resolve the issue of Stripe Payment Inten…

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -994,6 +994,7 @@ class CampTix_Stripe_API_Client {
 
 			// Trim the key to 40 chars.
 			$key = $this->trim_string( $key, 40, '' );
+			$key = str_replace( [ '[' , ']' ], [ '(', ')' ], $key );
 
 			// Trim the val to 500 chars.
 			$val = $this->trim_string( $val );

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -992,11 +992,11 @@ class CampTix_Stripe_API_Client {
 				return $cleaned;
 			}
 
-			// Trim the key to 40 chars.
-			$key = $this->trim_string( $key, 40, '' );
-
 			// Remove unsupported characters from the key.
 			$key = str_replace( array( '[', ']' ), '', $key );
+			
+			// Trim the key to 40 chars.
+			$key = $this->trim_string( $key, 40, '' );
 
 			// Trim the val to 500 chars.
 			$val = $this->trim_string( $val );

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -994,7 +994,9 @@ class CampTix_Stripe_API_Client {
 
 			// Trim the key to 40 chars.
 			$key = $this->trim_string( $key, 40, '' );
-			$key = str_replace( array( '[', ']' ), array( '(', ')' ), $key );
+
+			// Remove unsupported characters from the key.
+			$key = str_replace( array( '[', ']' ), '', $key );
 
 			// Trim the val to 500 chars.
 			$val = $this->trim_string( $val );

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -994,7 +994,7 @@ class CampTix_Stripe_API_Client {
 
 			// Trim the key to 40 chars.
 			$key = $this->trim_string( $key, 40, '' );
-			$key = str_replace( [ '[' , ']' ], [ '(', ')' ], $key );
+			$key = str_replace( array( '[', ']' ), array( '(', ')' ), $key );
 
 			// Trim the val to 500 chars.
 			$val = $this->trim_string( $val );


### PR DESCRIPTION
It's a patch for this issue: #1270 .

When calling the Stripe API, including a string with '[' in the metadata key can cause unexpected behavior.
Therefore, I added a process to replace '[' with '('.

Fixes #1270