### PR TITLE
Various notice fixes

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5169,8 +5169,9 @@ class CampTix_Plugin {
 		}
 
 		// Allow [camptix attr="value"] but not [camptix_attendees] etc.
-		if ( ! preg_match( "#\\[camptix(\s[^\\]]+)?\\]#", $post->post_content, $matches ) )
+		if ( ! preg_match( "#\\[camptix(\s[^\\]]+)?\\]#", $post->post_content, $matches ) ) {
 			return;
+		}
 
 		// Keep this in the case where we'd like to remove things around the shortcode.
 		$this->shortcode_str = $matches[0];
@@ -5182,8 +5183,9 @@ class CampTix_Plugin {
 			$_REQUEST['tix_tickets_selected'] = array( $_REQUEST['tix_single_ticket_purchase'] => 1 );
 		}
 
-		if ( isset( $_POST ) && ! empty( $_POST ) )
+		if ( isset( $_POST ) && ! empty( $_POST ) ) {
 			$this->form_data = stripslashes_deep( $_POST );
+		}
 
 		$this->tickets = array();
 		$this->tickets_selected = array();
@@ -5191,11 +5193,12 @@ class CampTix_Plugin {
 		$via_reservation = false;
 		$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order', 10 );
 
-		if ( count( $this->get_enabled_payment_methods() ) < 1 )
+		if ( count( $this->get_enabled_payment_methods() ) < 1 ) {
 			$this->error_flags['no_payment_methods'] = true;
+		}
 
 		// Find the coupon.
-		if ( isset( $_REQUEST['tix_coupon'] ) && ! empty( $_REQUEST['tix_coupon'] ) ) {
+		if ( ! empty( $_REQUEST['tix_coupon'] ) ) {
 			$coupon = $this->get_coupon_by_code( $_REQUEST['tix_coupon'] );
 			if ( $coupon && $this->is_coupon_valid_for_use( $coupon->ID ) ) {
 				$coupon->tix_coupon_remaining = $this->get_remaining_coupons( $coupon->ID );
@@ -5256,7 +5259,7 @@ class CampTix_Plugin {
 		unset( $tickets, $ticket );
 
 		// Populate selected tickets from $_POST!
-		if ( isset( $_REQUEST['tix_tickets_selected'] ) ) {
+		if ( ! empty( $_REQUEST['tix_tickets_selected'] ) ) {
 			foreach ( $_REQUEST['tix_tickets_selected'] as $ticket_id => $count ) {
 				if ( isset( $this->tickets[ $ticket_id ] ) && intval( $count ) > 0 ) {
 					$this->tickets_selected[ $ticket_id ] = intval( $count );
@@ -5281,8 +5284,9 @@ class CampTix_Plugin {
 			}
 		}
 
-		if ( isset( $_REQUEST['tix_coupon'] ) )
+		if ( isset( $_REQUEST['tix_coupon'] ) ) {
 			$this->order['coupon'] = sanitize_text_field( $_REQUEST['tix_coupon'] );
+		}
 
 		if ( isset( $_REQUEST['tix_reservation_id'], $_REQUEST['tix_reservation_token'] ) ) {
 			$this->order['reservation_id']    = $_REQUEST['tix_reservation_id'];
@@ -5290,8 +5294,9 @@ class CampTix_Plugin {
 		}
 
 		// Check whether this is a valid order.
-		if ( ! empty( $this->order['items'] ) )
+		if ( ! empty( $this->order['items'] ) ) {
 			$this->verify_order( $this->order );
+		}
 
 		// Check selected tickets.
 		$tickets_excess = 0;
@@ -5312,22 +5317,26 @@ class CampTix_Plugin {
 				$tickets_excess += $count - $ticket->tix_remaining;
 
 				// Remove the ticket if count is 0.
-				if ( $this->tickets_selected[ $ticket_id ] < 1 )
+				if ( $this->tickets_selected[ $ticket_id ] < 1 ) {
 					unset( $this->tickets_selected[ $ticket_id ] );
+				}
 			}
 
 			// ref: #1002
-			if ( $ticket->tix_coupon_applied )
+			if ( $ticket->tix_coupon_applied ) {
 				$coupons_applied += $count;
+			}
 		}
 
 		$this->tickets_selected_count = 0;
-		foreach ( $this->tickets_selected as $ticket_id => $count )
+		foreach ( $this->tickets_selected as $ticket_id => $count ) {
 			$this->tickets_selected_count += $count;
+		}
 
 		// ref: #1001
-		if ( $tickets_excess > 0 )
+		if ( $tickets_excess > 0 ) {
 			$this->error_flags['tickets_excess'] = true;
+		}
 
 		// ref: #1002 @todo maybe strip the cheaper ones instead?
 		if ( $this->coupon && $coupons_applied > $this->coupon->tix_coupon_remaining ) {
@@ -5346,14 +5355,18 @@ class CampTix_Plugin {
 				}
 			}
 
-			if ( $extra > 0 )
+			if ( $extra > 0 ) {
 				$this->log( 'Something is terribly wrong, extra > 0 after stripping extra coupons', 0, null, 'critical' );
+			}
 		}
 
-		if ( isset( $_REQUEST['tix_tickets_selected'] ) ) {
+		if ( ! empty( $_REQUEST['tix_tickets_selected'] ) ) {
 			$this->error_flags['no_tickets_selected'] = true;
-			foreach ( $this->tickets_selected as $ticket_id => $count )
-				if ( $count > 0 ) unset( $this->error_flags['no_tickets_selected'] );
+			foreach ( $this->tickets_selected as $ticket_id => $count ) {
+				if ( $count > 0 ) {
+					unset( $this->error_flags['no_tickets_selected'] );
+				}
+			}
 		}
 
 		$this->did_template_redirect = true;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5260,7 +5260,7 @@ class CampTix_Plugin {
 
 		// Populate selected tickets from $_POST!
 		if ( ! empty( $_REQUEST['tix_tickets_selected'] ) ) {
-			foreach ( $_REQUEST['tix_tickets_selected'] as $ticket_id => $count ) {
+			foreach ( (array) $_REQUEST['tix_tickets_selected'] as $ticket_id => $count ) {
 				if ( isset( $this->tickets[ $ticket_id ] ) && intval( $count ) > 0 ) {
 					$this->tickets_selected[ $ticket_id ] = intval( $count );
 				}

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
@@ -106,11 +106,11 @@ function create_event_status_attachment( $message, $event_id, $title ) {
 function get_props_for_event( $event_id ) {
 	$user_ids = array();
 
-	$status_change_logs = get_post_meta( $event_id, '_status_change' ) ?: array();
+	$status_change_logs = get_post_meta( $event_id, '_status_change' );
 
 	$user_ids = array_merge( $user_ids, wp_list_pluck( $status_change_logs, 'user_id' ) );
 
-	$notes = get_post_meta( $event_id, '_note' ) ?: array();
+	$notes = get_post_meta( $event_id, '_note' );
 
 	$user_ids = array_merge( $user_ids, wp_list_pluck( $notes, 'user_id' ) );
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/notification.php
@@ -106,11 +106,11 @@ function create_event_status_attachment( $message, $event_id, $title ) {
 function get_props_for_event( $event_id ) {
 	$user_ids = array();
 
-	$status_change_logs = get_post_meta( $event_id, '_status_change' ) ?? array();
+	$status_change_logs = get_post_meta( $event_id, '_status_change' ) ?: array();
 
 	$user_ids = array_merge( $user_ids, wp_list_pluck( $status_change_logs, 'user_id' ) );
 
-	$notes = get_post_meta( $event_id, '_note' ) ?? array();
+	$notes = get_post_meta( $event_id, '_note' ) ?: array();
 
 	$user_ids = array_merge( $user_ids, wp_list_pluck( $notes, 'user_id' ) );
 

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -406,10 +406,10 @@ class WordCamp_Forms_To_Drafts {
 		) );
 
 		if ( $draft_id ) {
-			$first_time = strtolower( $all_values['Is this the first time you have volunteered at a WordPress event?'] ) ?? '';
+			$first_time = strtolower( $all_values['Is this the first time you have volunteered at a WordPress event?'] ?? '' );
 			$first_time = in_array( $first_time, array( 'yes', 'no', 'unsure' ), true ) ? $first_time : '';
 
-			update_post_meta( $draft_id, '_wcb_volunteer_email', is_email( $all_values['Email'] ) ?? '' );
+			update_post_meta( $draft_id, '_wcb_volunteer_email', is_email( $all_values['Email'] ?? '' ) );
 			update_post_meta( $draft_id, '_wcpt_user_name', $volunteer_user->user_login ?? '' );
 			update_post_meta( $draft_id, '_wcb_volunteer_first_time', $first_time );
 		}
@@ -477,7 +477,7 @@ class WordCamp_Forms_To_Drafts {
 			// The following if condition can be removed once we make sure that no more error messages are appearing.
 			$first_time = '';
 			if ( isset( $speaker['Is this your first time being a speaker at a WordPress event?'] ) ) {
-				$first_time = strtolower( $speaker['Is this your first time being a speaker at a WordPress event?'] ) ?? '';
+				$first_time = strtolower( $speaker['Is this your first time being a speaker at a WordPress event?'] ?? '' );
 			}
 			$first_time = in_array( $first_time, array( 'yes', 'no', 'unsure' ), true ) ? $first_time : '';
 			update_post_meta( $speaker_id, '_wcb_speaker_email', $speaker['Email Address'] ?? '' );


### PR DESCRIPTION
As usual, various code-formatting and notice fixes caused by pentester and search engine requests.

These are:
```
E_WARNING: Invalid argument supplied for foreach() in plugins/camptix/camptix.php:5260

E_NOTICE Undefined index: 'Is this the first time you have volunteered at a WordPress event?' in plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php:409
```

Code formatting was removing short-if's and converting `isset()` to `!empty()` when we expect a value, and removing cases where both were checked needlessly.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
