### PR TITLE
Allow cron to update post_status

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -826,7 +826,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				$wcpt = get_post_type_object( WCPT_POST_TYPE_ID );
 
 				// Only WordCamp Wranglers can change WordCamp statuses.
-				if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) && ! wp_doing_cron() ) {
+				if ( is_user_logged_in() && ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
 					$post_data['post_status'] = $post->post_status;
 				}
 
@@ -865,7 +865,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				foreach ( $required_needs_site_fields as $field ) {
 
 					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce check would have done in `metabox_save`.
-					$value = $_POST[ wcpt_key_to_str( $field, 'wcpt_' ) ];
+					$value = $_POST[ wcpt_key_to_str( $field, 'wcpt_' ) ] ?? '';
 
 					if ( empty( $value ) || 'null' == $value ) {
 						$post_data['post_status']     = 'wcpt-needs-email';
@@ -879,7 +879,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			if ( 'wcpt-scheduled' == $post_data['post_status'] && isset( $post_data_raw['ID'] ) && absint( $post_data_raw['ID'] ) > $min_site_id ) {
 				foreach ( $required_scheduled_fields as $field ) {
 					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce check would have done in `metabox_save`.
-					$value = $_POST[ wcpt_key_to_str( $field, 'wcpt_' ) ];
+					$value = $_POST[ wcpt_key_to_str( $field, 'wcpt_' ) ] ?? '';
 
 					if ( empty( $value ) || 'null' == $value ) {
 						$post_data['post_status']     = 'wcpt-needs-schedule';

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -826,7 +826,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				$wcpt = get_post_type_object( WCPT_POST_TYPE_ID );
 
 				// Only WordCamp Wranglers can change WordCamp statuses.
-				if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
+				if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) && ! wp_doing_cron() ) {
 					$post_data['post_status'] = $post->post_status;
 				}
 


### PR DESCRIPTION
Recently it's been discovered that WordCamp events have been moving from `Scheduled` to `Needs Scheduling` automatically. This is confusing, because there's no automation that would result in that.

This is a long winded explanation, as I was confused while trying to work it out.

This happened due to c914a9f077c01c01e5522283dd3e511fee3fb15a
Specifically, this:
```diff
- $post = get_post( $post_data_raw['post_ID'] );
+ $post = get_post( $post_data_raw['ID'] );
```

WordCamps are moved to closed by a cron job.
That cron job obviously runs without a user context. (This shows up as ‘WordCamp Bot’ in the logs, as that’s the text for “no user recorded”)
https://github.com/WordPress/wordcamp.org/blob/b8dea088c7bbc05ab6df8b15d31f7cd7995c488d/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php#L1129-L1166

Due to the above code change; that function now works.. it previously only worked when within a wp-admin context, as get_post( null ) would return the proper post, but during cron would return nothing.  After the above notice fix, it now returns the proper post in both contexts.

Next; The current user (which is not set) can’t modify the post, as such, when the cron tries to close it, the post_status is reset to the current status of wcpt-scheduled
That’s fine; That should mean zero changes happen, right? Kind of.
https://github.com/WordPress/wordcamp.org/blob/b8dea088c7bbc05ab6df8b15d31f7cd7995c488d/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php#L827-L831

When a post is updated, and it’s being moved to scheduled it checks to see if the appropriate post_meta is set, and if not, pushes it back to `needs-scheduling`.
That checks `$_POST` and not the post object, because the post_meta might not yet exist.
When running as cron, `$_POST` won’t be set with the post meta, so it fails, and it get pushed back to needs-scheduling.
https://github.com/WordPress/wordcamp.org/blob/b8dea088c7bbc05ab6df8b15d31f7cd7995c488d/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php#L845-L893

And that’s how it’s been going from `wcpt-scheduled` -> `wcpt-needs-scheduling`, because it’s actually been going `scheduled` -> (`closed` -> `scheduled` -> `needs-scheduling`)

---

This is a long-winded way to say; The code that enforces the post_status, just needs to acknowledge that during cron, a WordCamp post may change status, and that a user is not required to be present for that.

The alternative option, is that we could `wp_set_current_user( wordcamp )` during the `close wordcamp` routines, but I think checking for cron is enough here, as this isn't the primary authentication, this is just a just-in-case validation check.