### PR TITLE
test: add unit test for the camptix stripe addon

### DIFF
--- a/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
@@ -14,7 +14,7 @@ class Test_Camptix_Payment_Stripe_Addon extends \WP_UnitTestCase {
 				'USD', 10, 1000, // 10USD should be 1000
 			),
 			array(
-				'EUR', 10, 1000, // 10USD should be 1000
+				'EUR', 10, 1000, // 10EUR should be 1000
 			),
 			array(
 				'JPY', 10, 10, // 10 JPY should be 10

--- a/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
@@ -1,0 +1,49 @@
+<?php
+defined( 'WPINC' ) || die();
+
+/**
+ * @covers CampTix_Payment_Method_Stripe
+ */
+class Test_Camptix_Payment_Stripe_Addon extends \WP_UnitTestCase {
+	/**
+	 * Provide a test case for the function "CampTix_Payment_Method_Stripe->get_fractional_unit_amount".
+	 **/
+	public function currencyAmountProvider() {
+		return array(
+			array(
+				'USD', 10, 1000, // 10USD should be 1000
+			),
+			array(
+				'EUR', 10, 1000, // 10USD should be 1000
+			),
+			array(
+				'JPY', 10, 10, // 10 JPY should be 10
+			),
+		);
+	}
+
+	/**
+	 * @covers CampTix_Payment_Method_Stripe->get_fractional_unit_amount
+	 * @dataProvider currencyAmountProvider
+	 */
+	public function test_get_fractional_unit_amount( $currency, $amount, $expected_result ) {
+		$client            = new CampTix_Payment_Method_Stripe();
+		$fractional_amount = $client->get_fractional_unit_amount( $currency, $amount );
+		$this->assertEquals( $expected_result, $fractional_amount);
+	}
+
+
+	/**
+	 * @covers CampTix_Payment_Method_Stripe->get_fractional_unit_amount
+	 * @expectedException Exception
+	 */
+	public function test_get_fractional_unit_amount_with_invalid_currency() {
+		$client = new CampTix_Payment_Method_Stripe();
+		try {
+			$client->get_fractional_unit_amount( 'DUMMY', 100 );
+			$this->fail( 'Exception should be thrown.' );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'Unknown currency multiplier for DUMMY.', $e->getMessage() );
+		}
+	}
+}


### PR DESCRIPTION
Add a new PHPUnit test case for the class `Camptix_Payment_Stripe_Addon` on the Camptix plugin.

### How to test the changes in this Pull Request:

1.  Run the `phpunit` command
2. If it's not failed, it's okay.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
