### PR TITLE
Replace 'country_of_residency' with 'passport_issuing_country'

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-docs/templates/attendee-visa.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/attendee-visa.php
@@ -11,7 +11,7 @@ class WordCamp_Docs_Template_Attendee_Visa implements WordCamp_Docs_Template {
 		$data = wp_parse_args( $data, array(
 			'attendee_first_name' => '',
 			'attendee_last_name' => '',
-			'country_of_residency' => '',
+			'passport_issuing_country' => '',
 			'passport_number' => '',
 
 			'wordcamp_name'       => $wordcamp->post_title          ?? '',
@@ -57,8 +57,8 @@ class WordCamp_Docs_Template_Attendee_Visa implements WordCamp_Docs_Template {
 			<label><?php _e( 'Attendee Last Name:', 'wordcamporg' ); ?></label>
 			<input name="attendee_last_name" value="<?php echo esc_attr( $data['attendee_last_name'] ); ?>" />
 
-			<label><?php _e( 'Country of Residency:', 'wordcamporg' ); ?></label>
-			<input name="country_of_residency" value="<?php echo esc_attr( $data['country_of_residency'] ); ?>" />
+			<label><?php _e( 'Passport Issuing Country:', 'wordcamporg' ); ?></label>
+			<input name="passport_issuing_country" value="<?php echo esc_attr( $data['passport_issuing_country'] ); ?>" />
 
 			<label><?php _e( 'Passport Number:', 'wordcamporg' ); ?></label>
 			<input name="passport_number" value="<?php echo esc_attr( $data['passport_number'] ); ?>" />
@@ -172,7 +172,7 @@ h2 {
 		<p>To Whom It May Concern:</p>
 
 		<p>This letter is to confirm that <?php echo esc_html( $data['attendee_first_name'] ); ?> <?php echo esc_html( $data['attendee_last_name'] ); ?>
-		<?php echo esc_html( $data['country_of_residency'] ); ?> passport number <?php echo esc_html( $data['passport_number'] ); ?>,
+		<?php echo esc_html( $data['passport_issuing_country'] ); ?> passport number <?php echo esc_html( $data['passport_number'] ); ?>,
 		has purchased a ticket to attend <?php echo esc_html( $data['wordcamp_name'] ); ?>, a community-organized event focusing on WordPress
 		development and technology.</p>
 
@@ -206,7 +206,7 @@ h2 {
 		foreach ( array(
 			'attendee_first_name',
 			'attendee_last_name',
-			'country_of_residency',
+			'passport_issuing_country',
 			'passport_number',
 			'wordcamp_name',
 			'wordcamp_location',

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/attendee-visa.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/attendee-visa.php
@@ -47,40 +47,40 @@ class WordCamp_Docs_Template_Attendee_Visa implements WordCamp_Docs_Template {
 		</style>
 
 		<h2>
-			<?php _e( 'Attendee Visa Letter', 'wordcamporg' ); ?>
+			<?php esc_html( 'Attendee Visa Letter', 'wordcamporg' ); ?>
 		</h2>
 
 		<div class="wcorg-docs-form">
-			<label><?php _e( 'Attendee First Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Attendee First Name:', 'wordcamporg' ); ?></label>
 			<input name="attendee_first_name" value="<?php echo esc_attr( $data['attendee_first_name'] ); ?>" />
 
-			<label><?php _e( 'Attendee Last Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Attendee Last Name:', 'wordcamporg' ); ?></label>
 			<input name="attendee_last_name" value="<?php echo esc_attr( $data['attendee_last_name'] ); ?>" />
 
-			<label><?php _e( 'Passport Issuing Country:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Passport Issuing Country:', 'wordcamporg' ); ?></label>
 			<input name="passport_issuing_country" value="<?php echo esc_attr( $data['passport_issuing_country'] ); ?>" />
 
-			<label><?php _e( 'Passport Number:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Passport Number:', 'wordcamporg' ); ?></label>
 			<input name="passport_number" value="<?php echo esc_attr( $data['passport_number'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Name:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_name" value="<?php echo esc_attr( $data['wordcamp_name'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Location:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Location:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_location" value="<?php echo esc_attr( $data['wordcamp_location'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Date Start:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Date Start:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_date_start" value="<?php echo esc_attr( $data['wordcamp_date_start'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Date End:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Date End:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_date_end" value="<?php echo esc_attr( $data['wordcamp_date_end'] ); ?>" />
 
-			<label><?php _e( 'Organizer Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Organizer Name:', 'wordcamporg' ); ?></label>
 			<input name="organizer_name" value="<?php echo esc_attr( $data['organizer_name'] ); ?>" />
 
-			<label><?php _e( 'Organizer Contacts:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Organizer Contacts:', 'wordcamporg' ); ?></label>
 			<textarea name="organizer_contacts"><?php echo esc_textarea( $data['organizer_contacts'] ); ?></textarea>
-			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
+			<span class="description"><?php esc_html_e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
 		</div>
 
 		<?php

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/speaker-visa.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/speaker-visa.php
@@ -51,34 +51,34 @@ class WordCamp_Docs_Template_Speaker_Visa implements WordCamp_Docs_Template {
 		</h2>
 
 		<div class="wcorg-docs-form">
-			<label><?php _e( 'Speaker First Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Speaker First Name:', 'wordcamporg' ); ?></label>
 			<input name="speaker_first_name" value="<?php echo esc_attr( $data['speaker_first_name'] ); ?>" />
 
-			<label><?php _e( 'Speaker Last Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Speaker Last Name:', 'wordcamporg' ); ?></label>
 			<input name="speaker_last_name" value="<?php echo esc_attr( $data['speaker_last_name'] ); ?>" />
 
-			<label><?php _e( 'Passport Issuing Country:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Passport Issuing Country:', 'wordcamporg' ); ?></label>
 			<input name="passport_issuing_country" value="<?php echo esc_attr( $data['passport_issuing_country'] ); ?>" />
 
-			<label><?php _e( 'Passport Number:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Passport Number:', 'wordcamporg' ); ?></label>
 			<input name="passport_number" value="<?php echo esc_attr( $data['passport_number'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Name:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_name" value="<?php echo esc_attr( $data['wordcamp_name'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Location:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Location:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_location" value="<?php echo esc_attr( $data['wordcamp_location'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Date Start:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Date Start:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_date_start" value="<?php echo esc_attr( $data['wordcamp_date_start'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Date End:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Date End:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_date_end" value="<?php echo esc_attr( $data['wordcamp_date_end'] ); ?>" />
 
-			<label><?php _e( 'Organizer Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Organizer Name:', 'wordcamporg' ); ?></label>
 			<input name="organizer_name" value="<?php echo esc_attr( $data['organizer_name'] ); ?>" />
 
-			<label><?php _e( 'Organizer Contacts:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Organizer Contacts:', 'wordcamporg' ); ?></label>
 			<textarea name="organizer_contacts"><?php echo esc_textarea( $data['organizer_contacts'] ); ?></textarea>
 			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
 		</div>

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/speaker-visa.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/speaker-visa.php
@@ -11,7 +11,7 @@ class WordCamp_Docs_Template_Speaker_Visa implements WordCamp_Docs_Template {
 		$data = wp_parse_args( $data, array(
 			'speaker_first_name'   => '',
 			'speaker_last_name'    => '',
-			'country_of_residency' => '',
+			'passport_issuing_country' => '',
 			'passport_number' => '',
 
 			'wordcamp_name'       => $wordcamp->post_title          ?? '',
@@ -57,8 +57,8 @@ class WordCamp_Docs_Template_Speaker_Visa implements WordCamp_Docs_Template {
 			<label><?php _e( 'Speaker Last Name:', 'wordcamporg' ); ?></label>
 			<input name="speaker_last_name" value="<?php echo esc_attr( $data['speaker_last_name'] ); ?>" />
 
-			<label><?php _e( 'Country of Residency:', 'wordcamporg' ); ?></label>
-			<input name="country_of_residency" value="<?php echo esc_attr( $data['country_of_residency'] ); ?>" />
+			<label><?php _e( 'Passport Issuing Country:', 'wordcamporg' ); ?></label>
+			<input name="passport_issuing_country" value="<?php echo esc_attr( $data['passport_issuing_country'] ); ?>" />
 
 			<label><?php _e( 'Passport Number:', 'wordcamporg' ); ?></label>
 			<input name="passport_number" value="<?php echo esc_attr( $data['passport_number'] ); ?>" />
@@ -172,7 +172,7 @@ h2 {
 		<p>To Whom It May Concern:</p>
 
 		<p>This letter is to confirm that <?php echo esc_html( $data['speaker_first_name'] ); ?> <?php echo esc_html( $data['speaker_last_name'] ); ?>
-		<?php echo esc_html( $data['country_of_residency'] ); ?> passport number <?php echo esc_html( $data['passport_number'] ); ?>,
+		<?php echo esc_html( $data['passport_issuing_country'] ); ?> passport number <?php echo esc_html( $data['passport_number'] ); ?>,
 		has been invited to speak at <?php echo esc_html( $data['wordcamp_name'] ); ?>, a community-organized event focusing on WordPress
 		development and technology.</p>
 
@@ -206,7 +206,7 @@ h2 {
 		foreach ( array(
 			'speaker_first_name',
 			'speaker_last_name',
-			'country_of_residency',
+			'passport_issuing_country',
 			'passport_number',
 			'wordcamp_name',
 			'wordcamp_location',

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -108,31 +108,31 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		</style>
 
 		<div class="wcorg-sponsorship-agreement-form">
-			<label><?php _e( 'Sponsor Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsor Name:', 'wordcamporg' ); ?></label>
 			<input name="sponsor_name" value="<?php echo esc_attr( $data['sponsor_name'] ); ?>" />
 
-			<label><?php _e( 'Sponsor Representative Name:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsor Representative Name:', 'wordcamporg' ); ?></label>
 			<input name="sponsor_rep_name" value="<?php echo esc_attr( $data['sponsor_rep_name'] ); ?>" />
 
-			<label><?php _e( 'Sponsor Representative Title:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsor Representative Title:', 'wordcamporg' ); ?></label>
 			<input name="sponsor_rep_title" value="<?php echo esc_attr( $data['sponsor_rep_title'] ); ?>" />
 
-			<label><?php _e( 'Agreement Date:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Agreement Date:', 'wordcamporg' ); ?></label>
 			<input name="agreement_date" value="<?php echo esc_attr( $data['agreement_date'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Date:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Date:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_date" value="<?php echo esc_attr( $data['wordcamp_date'] ); ?>" />
 
-			<label><?php _e( 'WordCamp Location:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'WordCamp Location:', 'wordcamporg' ); ?></label>
 			<input name="wordcamp_location" value="<?php echo esc_attr( $data['wordcamp_location'] ); ?>" />
 
-			<label><?php _e( 'Sponsorship Amount (in words, including the currency):', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsorship Amount (in words, including the currency):', 'wordcamporg' ); ?></label>
 			<input name="sponsorship_amount" value="<?php echo esc_attr( $data['sponsorship_amount'] ); ?>" />
 
-			<label><?php _e( 'Sponsorship Amount (in numbers, including the currency symbol):', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsorship Amount (in numbers, including the currency symbol):', 'wordcamporg' ); ?></label>
 			<input name="sponsorship_amount_num" value="<?php echo esc_attr( $data['sponsorship_amount_num'] ); ?>" />
 
-			<label><?php _e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
+			<label><?php esc_html_e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
 			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ); ?></textarea>
 			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
 		</div>

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -134,7 +134,7 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 
 			<label><?php esc_html_e( 'Sponsorship Benefits:', 'wordcamporg' ); ?></label>
 			<textarea name="sponsorship_benefits"><?php echo esc_textarea( $data['sponsorship_benefits'] ); ?></textarea>
-			<span class="description"><?php _e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
+			<span class="description"><?php esc_html_e( 'Use multiple lines.', 'wordcamporg' ); ?></span>
 		</div>
 
 		<?php


### PR DESCRIPTION
The 'country_of_residency' field in both 'speaker-visa.php' and 'attendee-visa.php' templates has been changed to 'passport_issuing_country'. This more accurately represents the data input and provides clearer information about where the passport was issued.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1277

<!-- List out anyone who helped with this task. -->
Props pbearne shawnhooper



