### PR TITLE
Use Oracle Linux mysql for arm64 support

### DIFF
--- a/.docker/Dockerfile.mysql
+++ b/.docker/Dockerfile.mysql
@@ -1,9 +1,8 @@
 FROM mysql:8.0
 
-RUN apt-get update \
-    && apt-get install -y \
-        nano \
-        vim
+RUN microdnf install -y \
+      nano \
+      vim
 
 # Set default password
 ENV MYSQL_ROOT_PASSWORD=mysql

--- a/.docker/Dockerfile.mysql
+++ b/.docker/Dockerfile.mysql
@@ -1,4 +1,4 @@
-FROM mysql:8.0-debian
+FROM mysql:8.0
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
See https://github.com/WordPress/wordcamp.org/pull/1261 https://github.com/WordPress/wordcamp.org/pull/1229 for background

It seems that didn't actually work as expected; as although it's now using Mysql 8, it's not actually using a arm64 image.

This PR changes it to use the oracle linux version of the mysql docker image, which does support arm64. The debian version doesn't.

Props @renintw for pushing me to look at this again