### PR TITLE
Add local env to nextgen events sites

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -78,9 +78,5 @@ jobs:
       run: |
         bash .docker/bin/install-wp-tests.sh wcorg_test root root 127.0.0.1 latest
 
-    - name: Install required plugins
-      run: |
-        svn export https://plugins.svn.wordpress.org/jetpack/trunk public_html/wp-content/plugins/jetpack
-
     - name: Running unit tests
       run: ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist

--- a/public_html/wp-content/themes/wporg-events-2023/.gitignore
+++ b/public_html/wp-content/themes/wporg-events-2023/.gitignore
@@ -1,0 +1,30 @@
+/**/.DS_STORE
+/**/.idea
+/**/.svn
+/**/build
+/**/node_modules
+/vendor
+*.map
+backstop_data
+
+# Allow local environment overrides.
+.wp-env.override.json
+wp-cli.local.yml
+
+# Configs from wporg-repo-tools.
+.eslintrc.js
+.prettierrc.js
+phpcs.xml.dist
+
+# Ignore everything in src...
+/src/wp-content/*
+/src/wp-content/themes/*
+/src/wp-content/mu-plugins/*
+
+# ...except the actual src of this project.
+!/src/wp-content/tests
+!/src/wp-content/themes
+!/src/wp-content/themes/wporg-main-2022
+!/src/wp-content/mu-plugins
+!/src/wp-content/mu-plugins/theme-switcher.php
+lighthouse.html

--- a/public_html/wp-content/themes/wporg-events-2023/.gitignore
+++ b/public_html/wp-content/themes/wporg-events-2023/.gitignore
@@ -20,11 +20,3 @@ phpcs.xml.dist
 /src/wp-content/*
 /src/wp-content/themes/*
 /src/wp-content/mu-plugins/*
-
-# ...except the actual src of this project.
-!/src/wp-content/tests
-!/src/wp-content/themes
-!/src/wp-content/themes/wporg-main-2022
-!/src/wp-content/mu-plugins
-!/src/wp-content/mu-plugins/theme-switcher.php
-lighthouse.html

--- a/public_html/wp-content/themes/wporg-events-2023/.gitignore
+++ b/public_html/wp-content/themes/wporg-events-2023/.gitignore
@@ -17,6 +17,4 @@ wp-cli.local.yml
 phpcs.xml.dist
 
 # Ignore everything in src...
-/src/wp-content/*
-/src/wp-content/themes/*
-/src/wp-content/mu-plugins/*
+/wp-content

--- a/public_html/wp-content/themes/wporg-events-2023/.wp-env.json
+++ b/public_html/wp-content/themes/wporg-events-2023/.wp-env.json
@@ -13,17 +13,17 @@
 	},
 	"core": "WordPress/WordPress#master",
 	"plugins": [
-		"./src/wp-content/plugins/gutenberg",
-		"./src/wp-content/plugins/jetpack",
-		"./src/wp-content/plugins/wordpress-importer"
+		"./wp-content/plugins/gutenberg",
+		"./wp-content/plugins/jetpack",
+		"./wp-content/plugins/wordpress-importer"
 	],
 	"themes": [
 		"./",
-		"./src/wp-content/themes/wporg-parent-2021"
+		"./wp-content/themes/wporg-parent-2021"
 	],
     "mappings": {
 		"env": "./env",
-		"wp-content/mu-plugins": "./src/wp-content/mu-plugins",
+		"wp-content/mu-plugins": "./wp-content/mu-plugins",
 		"wp-content/mu-plugins/0-sandbox.php": "./env/0-sandbox.php",
 		"wp-cli.yml": "./wp-cli.yml"
 	}

--- a/public_html/wp-content/themes/wporg-events-2023/.wp-env.json
+++ b/public_html/wp-content/themes/wporg-events-2023/.wp-env.json
@@ -1,0 +1,30 @@
+{
+	"config": {
+		"WP_DEBUG": true,
+		"SCRIPT_DEBUG": true,
+		"WP_DEBUG_LOG": "/tmp/wp-errors.log",
+		"FS_METHOD": "direct",
+		"WP_ENVIRONMENT_TYPE": "local",
+		"JETPACK_DEV_DEBUG": true,
+		"WPORG_SANDBOXED": true,
+        "WORDCAMP_DEV_GOOGLE_MAPS_API_KEY": "",
+        "EVENTS_NETWORK_ID": 1,
+        "WORDCAMP_ROOT_BLOG_ID": 1
+	},
+	"core": "WordPress/WordPress#master",
+	"plugins": [
+		"./src/wp-content/plugins/gutenberg",
+		"./src/wp-content/plugins/jetpack",
+		"./src/wp-content/plugins/wordpress-importer"
+	],
+	"themes": [
+		"./",
+		"./src/wp-content/themes/wporg-parent-2021"
+	],
+    "mappings": {
+		"env": "./env",
+		"wp-content/mu-plugins": "./src/wp-content/mu-plugins",
+		"wp-content/mu-plugins/0-sandbox.php": "./env/0-sandbox.php",
+		"wp-cli.yml": "./wp-cli.yml"
+	}
+}

--- a/public_html/wp-content/themes/wporg-events-2023/README.md
+++ b/public_html/wp-content/themes/wporg-events-2023/README.md
@@ -1,3 +1,10 @@
 # wporg-events-2023
 
-You must run the `build` task for this to be recognized as a valid theme by WP.
+## Local Env Setup
+
+1. `yarn`
+1. `yarn build`
+1. `composer install`
+1. Set your `WORDCAMP_DEV_GOOGLE_MAPS_API_KEY` in `.wp-env.json` if you want to test Google Map.
+1. `yarn wp-env start`
+1. `yarn setup:wp`

--- a/public_html/wp-content/themes/wporg-events-2023/README.md
+++ b/public_html/wp-content/themes/wporg-events-2023/README.md
@@ -1,6 +1,6 @@
 # wporg-events-2023
 
-## Local Env Setup
+### Local Env Setup
 
 1. `yarn`
 1. `yarn build`
@@ -8,3 +8,35 @@
 1. Set your `WORDCAMP_DEV_GOOGLE_MAPS_API_KEY` in `.wp-env.json` if you want to test Google Map.
 1. `yarn wp-env start`
 1. `yarn setup:wp`
+
+### Environment management
+
+* Stop the environment.
+
+    ```bash
+    yarn wp-env stop
+    ```
+
+* Restart the environment.
+
+    ```bash
+    yarn wp-env start
+    ```
+
+* Open a shell inside the docker container.
+
+    ```bash
+    yarn wp-env run wordpress bash
+    ```
+
+* Run wp-cli commands. Keep the wp-cli command in quotes so that the flags are passed correctly.
+
+    ```bash
+    yarn wp-env run cli "post list --post_status=publish"
+    ```
+
+* Watch for PCSS/JS changes and rebuild them as needed.
+
+    ```bash
+    yarn run watch
+    ```

--- a/public_html/wp-content/themes/wporg-events-2023/composer.json
+++ b/public_html/wp-content/themes/wporg-events-2023/composer.json
@@ -20,13 +20,13 @@
 	},
 	"extra": {
 		"installer-paths": {
-			"src/wp-content/mu-plugins/{$name}/": [
+			"wp-content/mu-plugins/{$name}/": [
 				"type:wordpress-muplugin"
 			],
-			"src/wp-content/plugins/{$name}/": [
+			"wp-content/plugins/{$name}/": [
 				"type:wordpress-plugin"
 			],
-			"src/wp-content/themes/{$name}/": [
+			"wp-content/themes/{$name}/": [
 				"type:wordpress-theme"
 			]
 		}

--- a/public_html/wp-content/themes/wporg-events-2023/composer.json
+++ b/public_html/wp-content/themes/wporg-events-2023/composer.json
@@ -1,0 +1,110 @@
+{
+	"name": "wporg/wporg-main-2022",
+	"description": "",
+	"homepage": "https://wordpress.org",
+	"license": "GPL-2.0-or-later",
+	"support": {
+		"issues": "https://github.com/WordPress/wporg-main-2022/issues"
+	},
+	"config": {
+		"platform": {
+			"php": "7.4"
+		},
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"preferred-install": {
+			"wporg/*": "source"
+		}
+	},
+	"extra": {
+		"installer-paths": {
+			"src/wp-content/mu-plugins/{$name}/": [
+				"type:wordpress-muplugin"
+			],
+			"src/wp-content/plugins/{$name}/": [
+				"type:wordpress-plugin"
+			],
+			"src/wp-content/themes/{$name}/": [
+				"type:wordpress-theme"
+			]
+		}
+	},
+	"repositories": [
+		{
+			"type": "composer",
+			"url": "https://wpackagist.org/"
+		},
+		{
+			"type": "vcs",
+			"url": "git@github.com:WordPress/wporg-repo-tools.git"
+		},
+		{
+			"type": "vcs",
+			"url": "git@github.com:WordPress/wporg-mu-plugins.git"
+		},
+		{
+			"type": "vcs",
+			"url": "git@github.com:WordPress/wporg-parent-2021.git"
+		},
+		{
+			"type": "package",
+			"package": [
+				{
+					"name": "wordpress-meta/wporg",
+					"type": "wordpress-theme",
+					"version": "1",
+					"source": {
+						"type": "svn",
+						"url": "https://meta.svn.wordpress.org/sites/",
+						"reference": "trunk/wordpress.org/public_html/wp-content/themes/pub/wporg/"
+					}
+				},
+				{
+					"name": "wordpress-meta/wporg-main",
+					"type": "wordpress-theme",
+					"version": "1",
+					"source": {
+						"type": "svn",
+						"url": "https://meta.svn.wordpress.org/sites/",
+						"reference": "trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-main/"
+					}
+				},
+				{
+					"name": "wordpress-meta/pub",
+					"type": "wordpress-muplugin",
+					"version": "1",
+					"source": {
+						"type": "svn",
+						"url": "https://meta.svn.wordpress.org/sites/",
+						"reference": "trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/"
+					}
+				}
+			]
+		}
+	],
+	"require": {},
+	"require-dev": {
+		"composer/installers": "~1.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"phpunit/phpunit": "^7.5.20",
+		"wordpress-meta/pub": "1",
+		"wordpress-meta/wporg": "1",
+		"wordpress-meta/wporg-main": "1",
+		"wp-coding-standards/wpcs": "2.*",
+		"wp-phpunit/wp-phpunit": "^5.4",
+		"wpackagist-plugin/gutenberg": "*",
+		"wpackagist-plugin/jetpack": "*",
+		"wpackagist-plugin/wordpress-importer": "*",
+		"wporg/wporg-repo-tools": "dev-trunk",
+		"wporg/wporg-mu-plugins": "dev-build",
+		"wporg/wporg-parent-2021": "dev-build",
+		"yoast/phpunit-polyfills": "^1.1"
+	},
+	"scripts": {
+		"format": "phpcbf -p",
+		"lint": "phpcs"
+	}
+}

--- a/public_html/wp-content/themes/wporg-events-2023/env/0-sandbox.php
+++ b/public_html/wp-content/themes/wporg-events-2023/env/0-sandbox.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * These are stubs for closed source code, or things that only apply to local environments.
+ */
+
+defined( 'WPINC' ) || die();
+
+require_once WPMU_PLUGIN_DIR . '/wporg-mu-plugins/mu-plugins/loader.php';
+
+// Google Maps API Key as used in the wporg/google-map block.
+add_filter(
+	'wporg_google_map_apikey',
+	function () {
+		return WORDCAMP_DEV_GOOGLE_MAPS_API_KEY;
+	}
+);
+
+/**
+ * Get the list of countries.
+ */
+function wcorg_get_countries() {
+	return array();
+}

--- a/public_html/wp-content/themes/wporg-events-2023/env/setup.sh
+++ b/public_html/wp-content/themes/wporg-events-2023/env/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+root=$( dirname $( wp config path ) )
+
+wp theme activate wporg-events-2023
+
+wp rewrite structure '/%year%/%monthnum%/%postname%/'
+wp rewrite flush --hard
+
+wp option update blogname "WordPress Events"
+wp option update blogdescription "Blog Tool, Publishing Platform, and CMS"
+
+wp db query < "${root}/env/wporg_events_dev.sql"
+wp db query < "${root}/env/wporg_blogs_dev.sql"
+
+wp post create --post_type=page --post_title="Upcoming Events" --post_name=upcoming --post_status=publish
+wp post create --post_type=page --post_title="Organize Events" --post_name=organize-events --post_status=publish

--- a/public_html/wp-content/themes/wporg-events-2023/env/wporg_blogs_dev.sql
+++ b/public_html/wp-content/themes/wporg-events-2023/env/wporg_blogs_dev.sql
@@ -1,0 +1,76 @@
+-- phpMyAdmin SQL Dump
+-- version 5.0.2
+-- https://www.phpmyadmin.net/
+--
+-- Generation Time: Dec 06, 2023 at 04:01 AM
+-- Server version: 10.2.44-MariaDB-log
+-- PHP Version: 7.4.33
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `wordpress`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `wporg_blogs`
+--
+
+CREATE TABLE `wporg_blogs` (
+  `blog_id` bigint(20) NOT NULL,
+  `site_id` bigint(20) NOT NULL DEFAULT 0,
+  `domain` varchar(200) NOT NULL DEFAULT '',
+  `path` varchar(100) NOT NULL DEFAULT '',
+  `registered` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `last_updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `public` tinyint(2) NOT NULL DEFAULT 1,
+  `archived` tinyint(2) NOT NULL DEFAULT 0,
+  `mature` tinyint(2) NOT NULL DEFAULT 0,
+  `spam` tinyint(2) NOT NULL DEFAULT 0,
+  `deleted` tinyint(2) NOT NULL DEFAULT 0,
+  `lang_id` int(11) NOT NULL DEFAULT 0
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `wporg_blogs`
+--
+
+INSERT INTO `wporg_blogs` (`blog_id`, `site_id`, `domain`, `path`, `registered`, `last_updated`, `public`, `archived`, `mature`, `spam`, `deleted`, `lang_id`) VALUES
+(1, 1, 'localhost', '/', '2010-07-07 18:06:22', '2023-11-15 19:05:40', 1, 0, 0, 0, 0, 0);
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `wporg_blogs`
+--
+ALTER TABLE `wporg_blogs`
+  ADD PRIMARY KEY (`blog_id`),
+  ADD KEY `domain` (`domain`(50),`path`(5)),
+  ADD KEY `lang_id` (`lang_id`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `wporg_blogs`
+--
+ALTER TABLE `wporg_blogs`
+  MODIFY `blog_id` bigint(20) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=731;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/public_html/wp-content/themes/wporg-events-2023/package.json
+++ b/public_html/wp-content/themes/wporg-events-2023/package.json
@@ -18,8 +18,7 @@
 	},
 	"prettier": "../../../../.prettierrc.js",
 	"scripts": {
-		"start": "yarn run watch",
-		"watch": "wp-scripts start & yarn run build:css -- --watch",
+		"watch": "wp-scripts start & yarn run build:css --watch",
 		"build": "wp-scripts build && yarn run build:css",
 		"build:css": "postcss postcss/style.pcss postcss/editor.pcss --dir . --ext css",
 		"lint:js": "wp-scripts lint-js 'src/**/*.js'",

--- a/public_html/wp-content/themes/wporg-events-2023/package.json
+++ b/public_html/wp-content/themes/wporg-events-2023/package.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"devDependencies": {
 		"@wordpress/scripts": "^26.18.0",
+		"@wordpress/env": "5.8.0",
 		"cssnano": "^6.0.1",
 		"postcss": "^8.4.31",
 		"postcss-cli": "^10.1.0",
@@ -17,11 +18,13 @@
 	},
 	"prettier": "../../../../.prettierrc.js",
 	"scripts": {
-		"start": "npm run watch",
-		"watch": "wp-scripts start & npm run build:css -- --watch",
-		"build": "wp-scripts build && npm run build:css",
+		"start": "yarn run watch",
+		"watch": "wp-scripts start & yarn run build:css -- --watch",
+		"build": "wp-scripts build && yarn run build:css",
 		"build:css": "postcss postcss/style.pcss postcss/editor.pcss --dir . --ext css",
 		"lint:js": "wp-scripts lint-js 'src/**/*.js'",
-		"lint:css": "wp-scripts lint-style 'postcss/*.pcss'"
+		"lint:css": "wp-scripts lint-style 'postcss/*.pcss'",
+		"setup:wp": "wp-env run cli \"bash env/setup.sh\"",
+		"wp-env": "wp-env"	
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,11 @@ The platform also includes tools for program volunteers and administrators to ma
 
 ## Setup
 
+### Central & Original WordCamp Sites
 Follow the instructions for [setting up a Docker environment](.docker/readme.md).
 
+### Next Generation Events Sites
+Follow the instructions for [setting up a local env with testing data](public_html/wp-content/themes/wporg-events-2023/README.md).
 
 ## Support
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Incorporate test data into the local environment for next-generation event sites. 
Update the method for obtaining Google API keys.

<!-- List out anyone who helped with this task. -->
Props @StevenDufresne for creating the test data and setting up the initial env template.

<!-- Don't forget to update the title with something descriptive. -->


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

Follow the [setup steps](https://github.com/WordPress/wordcamp.org/blob/a96c2c616437c92bd922c9b86da112226f889e1f/public_html/wp-content/themes/wporg-events-2023/README.md).

cc @hideokamoto @candy02058912 

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
