### PR TITLE
Transparency Report email automation

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -423,6 +423,15 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Global Sponsorship Grant'          => 'text',
 						'Running money through WPCS PBC'    => 'checkbox',
 					);
+
+					/*
+					 * The "Transparency Report Received" checkbox can only be checked or unchecked when the current user is admin or super admin.
+					 * See https://github.com/WordPress/wordcamp.org/issues/1280#issuecomment-2058571557.
+					 */
+					if ( current_user_can( 'manage_options' ) ) {
+						$retval['Transparency Report Received'] = 'checkbox';
+					}
+
 					break;
 
 				case 'all':
@@ -442,65 +451,79 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Global Sponsorship Grant Amount'   => 'number',
 						'Global Sponsorship Grant'          => 'text',
 						'Running money through WPCS PBC'    => 'checkbox',
-
-						'Organizer Name'                   => 'text',
-						'WordPress.org Username'           => 'text',
-						'Email Address'                    => 'text', // Lead organizer.
-						'Telephone'                        => 'text',
-						'Mailing Address'                  => 'textarea',
-						'Sponsor Wrangler Name'            => 'text',
-						'Sponsor Wrangler E-mail Address'  => 'text',
-						'Budget Wrangler Name'             => 'text',
-						'Budget Wrangler E-mail Address'   => 'text',
-						'Venue Wrangler Name'              => 'text',
-						'Venue Wrangler E-mail Address'    => 'text',
-						'Speaker Wrangler Name'            => 'text',
-						'Speaker Wrangler E-mail Address'  => 'text',
-						'Food/Beverage Wrangler Name'      => 'text',
-						'Food/Beverage Wrangler E-mail Address' => 'text',
-						'Swag Wrangler Name'               => 'text',
-						'Swag Wrangler E-mail Address'     => 'text',
-						'Volunteer Wrangler Name'          => 'text',
-						'Volunteer Wrangler E-mail Address' => 'text',
-						'Printing Wrangler Name'           => 'text',
-						'Printing Wrangler E-mail Address' => 'text',
-						'Design Wrangler Name'             => 'text',
-						'Design Wrangler E-mail Address'   => 'text',
-						'Website Wrangler Name'            => 'text',
-						'Website Wrangler E-mail Address'  => 'text',
-						'Social Media/Publicity Wrangler Name' => 'text',
-						'Social Media/Publicity Wrangler E-mail Address' => 'text',
-						'A/V Wrangler Name'                => 'text',
-						'A/V Wrangler E-mail Address'      => 'text',
-						'Party Wrangler Name'              => 'text',
-						'Party Wrangler E-mail Address'    => 'text',
-						'Travel Wrangler Name'             => 'text',
-						'Travel Wrangler E-mail Address'   => 'text',
-						'Safety Wrangler Name'             => 'text',
-						'Safety Wrangler E-mail Address'   => 'text',
-						'Mentor WordPress.org User Name'   => 'text',
-						'Mentor Name'                      => 'text',
-						'Mentor E-mail Address'            => 'text',
-
-						'Virtual event only'               => 'checkbox',
-						'Streaming account to use'         => 'select-streaming',
-						'Host region'                      => 'textarea',
-						'Venue Name'                       => 'text',
-						'Physical Address'                 => 'textarea',
-						'Maximum Capacity'                 => 'text',
-						'Available Rooms'                  => 'text',
-						'Website URL'                      => 'text',
-						'Contact Information'              => 'textarea',
-						'Exhibition Space Available'       => 'checkbox',
-
-						'Contributor Day'                  => 'checkbox',
-						'Contributor Day Date (YYYY-mm-dd)' => 'date',
-						'Contributor Venue Name'           => 'text',
-						'Contributor Venue Address'        => 'textarea',
-						'Contributor Venue Capacity'       => 'text',
-						'Contributor Venue Website URL'    => 'text',
-						'Contributor Venue Contact Info'   => 'textarea',
 					);
+
+					/*
+					 * The "Transparency Report Received" checkbox can only be checked or unchecked when the current user is admin or super admin.
+					 * See https://github.com/WordPress/wordcamp.org/issues/1280#issuecomment-2058571557.
+					 */
+					if ( current_user_can( 'manage_options' ) ) {
+						$retval['Transparency Report Received'] = 'checkbox';
+					}
+
+					$retval = array_merge(
+						$retval,
+						array(
+							'Organizer Name'                   => 'text',
+							'WordPress.org Username'           => 'text',
+							'Email Address'                    => 'text', // Lead organizer.
+							'Telephone'                        => 'text',
+							'Mailing Address'                  => 'textarea',
+							'Sponsor Wrangler Name'            => 'text',
+							'Sponsor Wrangler E-mail Address'  => 'text',
+							'Budget Wrangler Name'             => 'text',
+							'Budget Wrangler E-mail Address'   => 'text',
+							'Venue Wrangler Name'              => 'text',
+							'Venue Wrangler E-mail Address'    => 'text',
+							'Speaker Wrangler Name'            => 'text',
+							'Speaker Wrangler E-mail Address'  => 'text',
+							'Food/Beverage Wrangler Name'      => 'text',
+							'Food/Beverage Wrangler E-mail Address' => 'text',
+							'Swag Wrangler Name'               => 'text',
+							'Swag Wrangler E-mail Address'     => 'text',
+							'Volunteer Wrangler Name'          => 'text',
+							'Volunteer Wrangler E-mail Address' => 'text',
+							'Printing Wrangler Name'           => 'text',
+							'Printing Wrangler E-mail Address' => 'text',
+							'Design Wrangler Name'             => 'text',
+							'Design Wrangler E-mail Address'   => 'text',
+							'Website Wrangler Name'            => 'text',
+							'Website Wrangler E-mail Address'  => 'text',
+							'Social Media/Publicity Wrangler Name' => 'text',
+							'Social Media/Publicity Wrangler E-mail Address' => 'text',
+							'A/V Wrangler Name'                => 'text',
+							'A/V Wrangler E-mail Address'      => 'text',
+							'Party Wrangler Name'              => 'text',
+							'Party Wrangler E-mail Address'    => 'text',
+							'Travel Wrangler Name'             => 'text',
+							'Travel Wrangler E-mail Address'   => 'text',
+							'Safety Wrangler Name'             => 'text',
+							'Safety Wrangler E-mail Address'   => 'text',
+							'Mentor WordPress.org User Name'   => 'text',
+							'Mentor Name'                      => 'text',
+							'Mentor E-mail Address'            => 'text',
+
+							'Virtual event only'               => 'checkbox',
+							'Streaming account to use'         => 'select-streaming',
+							'Host region'                      => 'textarea',
+							'Venue Name'                       => 'text',
+							'Physical Address'                 => 'textarea',
+							'Maximum Capacity'                 => 'text',
+							'Available Rooms'                  => 'text',
+							'Website URL'                      => 'text',
+							'Contact Information'              => 'textarea',
+							'Exhibition Space Available'       => 'checkbox',
+
+							'Contributor Day'                  => 'checkbox',
+							'Contributor Day Date (YYYY-mm-dd)' => 'date',
+							'Contributor Venue Name'           => 'text',
+							'Contributor Venue Address'        => 'textarea',
+							'Contributor Venue Capacity'       => 'text',
+							'Contributor Venue Website URL'    => 'text',
+							'Contributor Venue Contact Info'   => 'textarea',
+						)
+					);
+
 					break;
 
 			}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -191,7 +191,7 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 	 */
 	public function data_timed_messages_sent() {
 		return array(
-			// Before the camp starts
+			// Before the camp starts.
 			array(
 				'wcor_send_before',
 				'wcor_send_days_before',
@@ -199,28 +199,28 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 				strtotime( 'now + 3 days' ),
 			),
 
-			// After the camp ends
+			// After the camp ends.
 			array(
 				'wcor_send_after',
 				'wcor_send_days_after',
 				3,
-				strtotime( 'now - 3 days' )
+				strtotime( 'now - 3 days' ),
 			),
 
-			// After added to the pending schedule
+			// After added to the pending schedule.
 			array(
 				'wcor_send_after_pending',
 				'wcor_send_days_after_pending',
 				3,
-				strtotime( 'now - 3 days' )
+				strtotime( 'now - 3 days' ),
 			),
 
-			// After the camp ends and no transparency report is received
+			// After the camp ends and no transparency report is received.
 			array(
 				'wcor_send_after_and_no_report',
 				'wcor_send_days_after_and_no_report',
 				3,
-				strtotime( 'now - 3 days' )
+				strtotime( 'now - 3 days' ),
 			),
 		);
 	}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -162,7 +162,7 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 		update_post_meta( self::$timed_reminder_post_id, 'wcor_send_when',  $send_when      );
 		update_post_meta( self::$timed_reminder_post_id, $send_when_period, $send_when_days );
 
-		if ( in_array( $send_when, array( 'wcor_send_before', 'wcor_send_after' ) ) ) {
+		if ( in_array( $send_when, array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_and_no_report' ) ) ) {
 			update_post_meta( self::$wordcamp_dayton_post_id, 'Start Date (YYYY-mm-dd)', $compare_date );
 		} elseif ( 'wcor_send_after_pending' === $send_when ) {
 			update_post_meta( self::$wordcamp_dayton_post_id, '_timestamp_added_to_planning_schedule', $compare_date );
@@ -211,6 +211,14 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			array(
 				'wcor_send_after_pending',
 				'wcor_send_days_after_pending',
+				3,
+				strtotime( 'now - 3 days' )
+			),
+
+			// After the camp ends and no transparency report is received
+			array(
+				'wcor_send_after_and_no_report',
+				'wcor_send_days_after_and_no_report',
 				3,
 				strtotime( 'now - 3 days' )
 			),

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -144,6 +144,15 @@ defined( 'WPINC' ) || die();
 		</tr>
 
 		<tr>
+			<th><input id="wcor_send_after_and_no_report" name="wcor_send_when" type="radio" value="wcor_send_after_and_no_report" <?php checked( $post->wcor_send_when, 'wcor_send_after_and_no_report' ); ?>></th>
+			<td><label for="wcor_send_after_and_no_report">after the camp ends and no transparency report is received: </label></td>
+			<td>
+				<input id="wcor_send_days_after_and_no_report" name="wcor_send_days_after_and_no_report" type="text" class="small-text" value="<?php echo esc_attr( $post->wcor_send_days_after_and_no_report ); ?>" />
+				<label for="wcor_send_days_after_and_no_report">days</label>
+			</td>
+		</tr>
+
+		<tr>
 			<th><input id="wcor_send_trigger" name="wcor_send_when" type="radio" value="wcor_send_trigger" <?php checked( $post->wcor_send_when, 'wcor_send_trigger' ); ?>></th>
 			<td><label for="wcor_send_trigger">on a trigger: </label></td>
 			<td>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -535,7 +535,7 @@ class WCOR_Mailer {
 			'meta_query'     => array(
 				array(
 					'key'     => 'wcor_send_when',
-					'value'   => array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending' ),
+					'value'   => array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending', 'wcor_send_after_and_no_report' ),
 					'compare' => 'IN'
 				),
 			),
@@ -622,6 +622,17 @@ class WCOR_Mailer {
 
 				if ( $days_after_pending && $timestamp_added_to_pending_schedule ) {
 					$execution_timestamp = $timestamp_added_to_pending_schedule + ( $days_after_pending * DAY_IN_SECONDS );
+
+					if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
+						$ready = true;
+					}
+				}
+			} elseif ( 'wcor_send_after_and_no_report' == $send_when ) {
+				$days_after_and_no_report = absint( get_post_meta( $email->ID, 'wcor_send_days_after_and_no_report', true ) );
+				$report_received          = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
+
+				if ( $end_date && $days_after_and_no_report && ! $report_received ) {
+					$execution_timestamp = $end_date + ( $days_after_and_no_report * DAY_IN_SECONDS );
 
 					if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
 						$ready = true;

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -194,7 +194,7 @@ class WCOR_Reminder {
 		}
 
 		if ( isset( $new_meta['wcor_send_when'] ) ) {
-			if ( in_array( $new_meta['wcor_send_when'], array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending', 'wcor_send_trigger' ) ) ) {
+			if ( in_array( $new_meta['wcor_send_when'], array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending', 'wcor_send_after_and_no_report', 'wcor_send_trigger' ) ) ) {
 				update_post_meta( $post->ID, 'wcor_send_when', $new_meta['wcor_send_when'] );
 			}
 		}
@@ -209,6 +209,10 @@ class WCOR_Reminder {
 
 		if ( isset( $new_meta['wcor_send_days_after_pending'] ) ) {
 			update_post_meta( $post->ID, 'wcor_send_days_after_pending', absint( $new_meta['wcor_send_days_after_pending'] ) );
+		}
+
+		if ( isset( $new_meta['wcor_send_days_after_and_no_report'] ) ) {
+			update_post_meta( $post->ID, 'wcor_send_days_after_and_no_report', absint( $new_meta['wcor_send_days_after_and_no_report'] ) );
 		}
 
 		if ( isset( $new_meta['wcor_which_trigger'] ) ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1280 

This PR adds a checkbox for admins and super admins to check to confirm whether the transparency report has been received. And integrates with the organizer reminder plugin, allowing users to set how many days after a camp ends a reminder email should be sent if the report has not been received.

### How to test the changes in this Pull Request:

1. Add 3 new Automated Reminders.
    * Content: random.
    * Who should this e-mail be sent to? The `organizing team (typically city@wordcamp.org)` & `The Budget Wrangler`.
    * When should this e-mail be sent? after the camp ends and no transparency report is received: `7` days & `14 days` & `21 days`.
2. Create two WordCamps (A reminder must be added before adding a wordcamp; otherwise, the reminder will not be triggered.)
    * You don't need to fill out all the information, just remember to fill in the `start date`, `end date`, and `the Budget Wrangler's email address`; these can be entered arbitrarily. Also, fill in the `URL` and check the `create a new site` checkbox. Then Publish.
    * Check if there's a `Transparency Report Received` checkbox at the bottom of the WordCamp Information section.
        * Switch to different user roles and check if only `super admin` and an `admin+wordcamp` author can see the checkbox. (ie. make sure a `wordcamp author` can't see the checkbox)
3. After WordCamps are created, change their status from `Need Vetting` to `In Pre-Planning`.
4. In your first WordCamp, make sure the `End Date` is NOT set to 7 days ago. Then, run `wp cron event run wcor_send_timed_emails --url=https://central.wordcamp.test/` in your docker container.
    * Remember not to set the `End Date` of the second WordCamp for 7, 14, or 21 days; leave it for future testing.
5. Shouldn't see any email sent on http://localhost:1080/.
6. Set the `End Date` to 7 days ago and run `wp cron event run wcor_send_timed_emails --url=https://central.wordcamp.test/` again.
7. Should see an email with the title and content you set in the reminder sent.
8. Set the `End Date` to 14 days and 21 days ago respectively and run `wp cron event run wcor_send_timed_emails --url=https://central.wordcamp.test/` again.
9. Should see two emails with the title and content you set in the reminder sent.
10. Now let's test the second case, which is when the organizer submits the transparency report, and then the super admin checks off the transparency report.
11. In your second WordCamp, set the `End Date` to 7 days ago. Then, run `wp cron event run wcor_send_timed_emails --url=https://central.wordcamp.test/` in your docker container.
12. Should see an email with the title and content you set in the reminder sent.
13. In your second WordCamp, check off the `Transparency Report Received` checkbox and set the `End Date` to 14 days ago. Run `wp cron event run wcor_send_timed_emails --url=https://central.wordcamp.test/`
14. Shouldn't see any email sent.

### Screenshots

**Organizer Reminder**
![Screenshot 2024-04-23 at 02 20 18](https://github.com/WordPress/wordcamp.org/assets/18050944/c6f8a607-720d-450e-8571-ec07e4f001cb)

**Three emails received**
![Screenshot 2024-04-23 at 02 19 44](https://github.com/WordPress/wordcamp.org/assets/18050944/6af13169-3388-4b61-9417-39ba2f3c9ecf)

**Transparency Report Received Checkbox**
![Markup on 2024-04-23 at 02:25:43](https://github.com/WordPress/wordcamp.org/assets/18050944/93e24a48-ba05-4981-ac98-f621945c0a7b)

**Four emails received**
![Screenshot 2024-04-23 at 02 26 59](https://github.com/WordPress/wordcamp.org/assets/18050944/0e0b84f0-a912-4713-a606-0a5f47485731)
