### PR TITLE
Verify the order before checking for error flags

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7172,12 +7172,12 @@ class CampTix_Plugin {
 		if ( ! is_email( $receipt_email ) )
 			$this->error_flags['no_receipt_email'] = true;
 
+		$this->verify_order( $this->order );
+		
 		// If there's at least one error, don't proceed with checkout.
 		if ( $this->error_flags ) {
 			return $this->form_attendee_info();
 		}
-
-		$this->verify_order( $this->order );
 
 		$reservation_quantity = 0;
 		if ( isset( $this->reservation ) && $this->reservation )


### PR DESCRIPTION
While looking at the checkout process as part of #1296 I noticed that `verify_order()` is run after the check for error_flags, which means if `verify_order()` flags any issues with the order, the checkout still proceeds.

Some of the checks within the `verify_order()` method is duplicated within the checkout process already, but this ensures that any issues encountered during validation do properly stop the checkout process.

This might reduce the number of `ticket_excess` issues that some WordCamps can run into during high ticket loads.

