### PR TITLE
Try caching get_remaining_tickets() in APCu to allow tickets to be 'reserved' during checkout, avoiding race condition

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6838,8 +6838,8 @@ class CampTix_Plugin {
 	 */
 	function get_remaining_tickets( $post_id, $via_reservation = false ) {
 		$remaining = 0;
-		$apcu_key  = 'remaining_tickets:' . get_current_blog_id() . ':' . $post_id . ':' . ( $via_reservation ?: '' );
-		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() ) {
+		$apcu_key  = 'remaining_tickets:' . get_current_blog_id() . ':' . $post_id;
+		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() && ! $via_reservation ) {
 			do {
 				if ( isset( $fetch_success ) ) {
 					// If we failed to fetch the value, wait 50ms before trying again.
@@ -6874,7 +6874,7 @@ class CampTix_Plugin {
 		// Can't have less than 0 remaining tickets.
 		$remaining = max( $remaining, 0 );
 
-		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() ) {
+		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() && ! $via_reservation ) {
 			apcu_store( $apcu_key, $remaining, 10 * MINUTE_IN_SECONDS );
 		}
 
@@ -7422,10 +7422,11 @@ class CampTix_Plugin {
 				function_exists( 'apcu_enabled' ) && apcu_enabled() &&
 				$reserve_tickets &&
 				empty( $this->error_flags[ 'tickets_excess' ] ) &&
-				$item['quantity']
+				$item['quantity'] &&
+				! $via_reservation
 			) {
 				// The key used in get_remaining_tickets() above.
-				$apcu_key              = 'remaining_tickets:' . get_current_blog_id() . ':' . $ticket->ID . ':' . ( $via_reservation ?: '' );
+				$apcu_key              = 'remaining_tickets:' . get_current_blog_id() . ':' . $ticket->ID;
 				$ticket->tix_remaining = apcu_dec( $apcu_key, $item['quantity'], $success );
 				if ( ! $success || $ticket->tix_remaining < 0 ) {
 					$item['quantity'] = max( 0, min( $ticket->tix_remaining, $ticket->tix_remaining ) );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7201,12 +7201,12 @@ class CampTix_Plugin {
 		if ( ! is_email( $receipt_email ) )
 			$this->error_flags['no_receipt_email'] = true;
 
+		$this->verify_order( $this->order, true /* reserve tickets */ );
+		
 		// If there's at least one error, don't proceed with checkout.
 		if ( $this->error_flags ) {
 			return $this->form_attendee_info();
 		}
-
-		$this->verify_order( $this->order, true /* reserve tickets */ );
 
 		$reservation_quantity = 0;
 		if ( isset( $this->reservation ) && $this->reservation )


### PR DESCRIPTION
**Draft PR** due to inability to properly test this right now, and unsure if it's the proper direction forward or worth it.

Ref: https://wordpress.slack.com/archives/C08M59V3P/p1712066063709249

WordCamp Sylhet ran into an issue where WordCamp tickets were oversold, due to a race condition during the checkout process.

The ticket are counted on every pageload, and in the event of a few hundred people attempting to checkout at the same instant, resulted in multiple tickets inserting tickets after the initial `do we have available tickets` check passed.

This PR attempts to add some caching/locking using APCu to the process.

This appears to work at first glance, but is not entirely complete.
 - failed payments locks a ticket for up-to 10 minutes (possibly a good thing?) (fixable)
 - changing the available tickets number doesn't reflect for the up-to 10 minutes (fixable)
 - Hard to test due to low requests/second sandbox throughput

While writing this PR, I've noticed something that was rather odd.
It appears that **some** of the order verification is checked after the check for errors, resulting in some of the validation being skipped during checkout, although it seems duplicative.. ba27a3a791b030fa7cc2813be53533deaffda295 moved that and I've split it into #1295 