### PR TITLE
Consider draft tickets sold for the purposes of ticketing.

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6881,7 +6881,7 @@ class CampTix_Plugin {
 		$attendees = new WP_Query( array(
 			'post_type' => 'tix_attendee',
 			'posts_per_page' => 1,
-			'post_status' => array( 'publish', 'pending' ),
+			'post_status' => array( 'publish', 'pending', 'draft' ),
 			'meta_query' => $meta_query,
 		) );
 


### PR DESCRIPTION
This is partially related to #1296 - that only tickets in the published+pending state are considered sold, resulting in payment gateways that leave the ticket as draft during the checkout (Which I think includes Stripe?), allowing for overselling of tickets.

If a ticket didn't complete the transaction, it would stay as draft for 24hrs and then move to `timeout`, and the ticket would become available again.

Edit: 'pending' is a payment thats completed, but is "pending completion" ie. a Bank transfer via Paypal. This status isn't used by stripe. It doesn't make sense that a payment would be pending during the transaction redirect.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #1301

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
