### PR TITLE
Treat UGX as a decimal based currency.

### DIFF
--- a/public_html/wp-content/mu-plugins/utilities/class-stripe-client.php
+++ b/public_html/wp-content/mu-plugins/utilities/class-stripe-client.php
@@ -191,7 +191,7 @@ class Stripe_Client {
 		$currency_multipliers = array(
 			// Zero-decimal currencies.
 			1   => array(
-				'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF',
+				'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'VND', 'VUV', 'XAF',
 				'XOF', 'XPF',
 			),
 			100 => array(
@@ -204,7 +204,7 @@ class Stripe_Client {
 				'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR',
 				'PLN', 'QAR', 'RON', 'RSD', 'RUB', 'SAR', 'SBD', 'SCR', 'SEK', 'SGD', 'SHP', 'SLL',
 				'SOS', 'SRD', 'STD', 'SZL', 'THB', 'TJS', 'TOP', 'TRY', 'TTD', 'TWD',
-				'TZS', 'UAH', 'USD', 'UYU', 'UZS', 'WST', 'XCD', 'YER', 'ZAR', 'ZMW',
+				'TZS', 'UAH', 'UGX', 'USD', 'UYU', 'UZS', 'WST', 'XCD', 'YER', 'ZAR', 'ZMW',
 			),
 		);
 


### PR DESCRIPTION
Stripe documents several currencies as Zero-decimal currencies,  these currencies should be charged as “$1 = 1” in the stripe API.

https://docs.stripe.com/currencies#zero-decimal

However, for backwards compatibility, specific zero-decimal currencies must be treated as decimal currencies, this includes UGX and ISK (which is not documented as a zero-decimal in the above documentation)

This means that when we've attempted to charge `1,000 UGX` we've actually charged `10.00 UGX = 10 UGX`.

### How to test the changes in this Pull Request:

1. Create a UGX Camptix ticket
2. Charge it, ensure that the ultimate Stripe charge is correct

or
1. Observe Stripe docs, make change :) 

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
