### PR TITLE
Update 'The organizing team' aiding text under Reminder Details of Organizer Reminder

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -15,7 +15,13 @@ defined( 'WPINC' ) || die();
 	<tbody>
 		<tr>
 			<th><input id="wcor_send_organizers" name="wcor_send_where[]" type="checkbox" value="wcor_send_organizers" <?php checked( in_array( 'wcor_send_organizers', $send_where ) ); ?>></th>
-			<td colspan="2"><label for="wcor_send_organizers">The organizing team</label> (typically <code>city@wordcamp.org</code>)</td>
+			<td colspan="2"><label for="wcor_send_organizers">The organizing team</label>
+			<br>
+			(Will send to 
+			1. <code>support@wordcamp.org</code>
+			2. If specified, the email address under WordCamp Information section on WordCamp edit page
+			3. If specified, the email address of the lead organizer)
+			</td>
 		</tr>
 
 		<tr>


### PR DESCRIPTION
See #1317

After testing, found that by selecting `The organizing team`, the email will also be sent to the lead organizer, so in this PR, 
 text is updated for better clarity.

![Screenshot 2024-05-21 at 06 53 34](https://github.com/WordPress/wordcamp.org/assets/18050944/ffd210b3-9f54-40c7-b6b3-ecacc665e328)
