### PR TITLE
Fix exchange rate issue with automated invoicing in qbo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,8 @@
 		"wpackagist-theme/twentyten": "*",
 		"wpackagist-theme/twentytwentytwo": "*",
 		"wpackagist-theme/twentytwentythree": "*",
-		"wpackagist-theme/twentytwentyfour": "*"
+		"wpackagist-theme/twentytwentyfour": "*",
+		"quickbooks/v3-php-sdk": "*"
 	},
 	"scripts": {
 		"format": "phpcbf -p",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19d53d6e6c833ee36baa1a7009fc3be1",
+    "content-hash": "b8c9bdae83998865f76c95f3926606f6",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -69,12 +69,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-parent-2021.git",
-                "reference": "d4e52af3e755c15787293e1fd1e25054af225eec"
+                "reference": "9e314d1c15b1826741808bd91589ee000c22ff38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/d4e52af3e755c15787293e1fd1e25054af225eec",
-                "reference": "d4e52af3e755c15787293e1fd1e25054af225eec",
+                "url": "https://api.github.com/repos/WordPress/wporg-parent-2021/zipball/9e314d1c15b1826741808bd91589ee000c22ff38",
+                "reference": "9e314d1c15b1826741808bd91589ee000c22ff38",
                 "shasum": ""
             },
             "type": "wordpress-theme",
@@ -82,7 +82,7 @@
                 "source": "https://github.com/WordPress/wporg-parent-2021/tree/build",
                 "issues": "https://github.com/WordPress/wporg-parent-2021/issues"
             },
-            "time": "2024-04-30T17:07:09+00:00"
+            "time": "2024-05-15T19:41:11+00:00"
         }
     ],
     "packages-dev": [
@@ -1219,22 +1219,22 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -1303,7 +1303,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-24T11:47:18+00:00"
+            "time": "2024-05-20T13:34:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1774,6 +1774,65 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
             "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "quickbooks/v3-php-sdk",
+            "version": "v6.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/intuit/QuickBooks-V3-PHP-SDK.git",
+                "reference": "a4039a8257633ed1481dfe1e50a7881016fa0b1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/intuit/QuickBooks-V3-PHP-SDK/zipball/a4039a8257633ed1481dfe1e50a7881016fa0b1d",
+                "reference": "a4039a8257633ed1481dfe1e50a7881016fa0b1d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.3",
+                "php-mock/php-mock-phpunit": "^2.6",
+                "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0 || ^8"
+            },
+            "suggest": {
+                "ext-curl": "Uses Curl to make HTTP Requests",
+                "guzzlehttp/guzzle": "Uses Guzzle to make HTTP Requests"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "QuickBooksOnline\\API\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "abisalehalliprasan",
+                    "email": "anil_kumar3@intuit.com"
+                }
+            ],
+            "description": "The Official PHP SDK for QuickBooks Online Accounting API",
+            "homepage": "http://developer.intuit.com",
+            "keywords": [
+                "api",
+                "http",
+                "quickbooks",
+                "rest",
+                "smallbusiness"
+            ],
+            "support": {
+                "issues": "https://github.com/intuit/QuickBooks-V3-PHP-SDK/issues",
+                "source": "https://github.com/intuit/QuickBooks-V3-PHP-SDK/tree/v6.1.2"
+            },
+            "time": "2023-08-02T04:48:35+00:00"
         },
         {
             "name": "react/event-loop",
@@ -3011,16 +3070,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.2",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877",
                 "shasum": ""
             },
             "require": {
@@ -3087,7 +3146,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-23T20:25:34+00:00"
+            "time": "2024-05-22T21:24:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -4392,14 +4451,14 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/classic-editor.zip?timestamp=1712364290"
+                "url": "https://downloads.wordpress.org/plugin/classic-editor.zip?timestamp=1715200405"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/classic-editor/",
-            "time": "2024-04-06T00:44:50+00:00"
+            "time": "2024-05-08T20:33:25+00:00"
         },
         {
             "name": "wpackagist-plugin/custom-content-width",
@@ -4458,15 +4517,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "18.2.0",
+            "version": "18.3.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/18.2.0"
+                "reference": "tags/18.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.18.2.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.18.3.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -4495,15 +4554,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "13.3.1",
+            "version": "13.4.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/13.3.1"
+                "reference": "tags/13.4.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.13.3.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.13.4.3.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -4641,15 +4700,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-super-cache",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-super-cache/",
-                "reference": "tags/1.12.0"
+                "reference": "tags/1.12.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-super-cache.1.12.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-super-cache.1.12.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -4753,12 +4812,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wporg-mu-plugins.git",
-                "reference": "1c01971a816aba069a1c9e5d9c200ac2e20c8dc6"
+                "reference": "9561a7d1574df1548407cd2bf67d9252ed95354a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/1c01971a816aba069a1c9e5d9c200ac2e20c8dc6",
-                "reference": "1c01971a816aba069a1c9e5d9c200ac2e20c8dc6",
+                "url": "https://api.github.com/repos/WordPress/wporg-mu-plugins/zipball/9561a7d1574df1548407cd2bf67d9252ed95354a",
+                "reference": "9561a7d1574df1548407cd2bf67d9252ed95354a",
                 "shasum": ""
             },
             "require": {
@@ -4799,7 +4858,7 @@
                 "source": "https://github.com/WordPress/wporg-mu-plugins/tree/build",
                 "issues": "https://github.com/WordPress/wporg-mu-plugins/issues"
             },
-            "time": "2024-04-30T16:50:57+00:00"
+            "time": "2024-05-22T20:33:40+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -493,6 +493,10 @@ class WordCamp_QBO {
 		 * for the first time, so we don't need any code to automatically activate them.
 		 */
 		if ( 'USD' != $currency_code ) {
+			/*
+			 * Fetch currency exchange rates from QBO.
+			 * No caching implemented since QBO updates rates every 4 hours and API calls are only triggered on invoice approval.
+			 */
 			$response = wp_remote_get(
 				sprintf(
 					'%s/v3/company/%d/exchangerate?sourcecurrencycode=%s',

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -493,9 +493,31 @@ class WordCamp_QBO {
 		 * for the first time, so we don't need any code to automatically activate them.
 		 */
 		if ( 'USD' != $currency_code ) {
+			$response = wp_remote_get(
+				sprintf(
+					'%s/v3/company/%d/exchangerate?sourcecurrencycode=%s',
+					self::$api_base_url,
+					rawurlencode( $realm_id ),
+					$currency_code,
+				),
+				array(
+					'timeout' => self::REMOTE_REQUEST_TIMEOUT,
+					'headers' => array(
+						'Authorization' => $oauth_header,
+						'Accept'        => 'application/json',
+						'Content-Type'  => 'application/json',
+					),
+				)
+			);
+
+			$body          = json_decode( wp_remote_retrieve_body( $response ), true );
+			$exchange_rate = $body['ExchangeRate']['Rate'];
+
 			$payload['CurrencyRef'] = array(
 				'value' => $currency_code,
 			);
+
+			$payload['ExchangeRate'] = $exchange_rate;
 		}
 
 		$request_url = sprintf(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

In the 2017 discussion mentioned in the issue, it can be seen that at that time, even if you didn't provide an exchange rate when calling the QBO API, QBO would automatically fill in the exchange rate for you. So I tested in this direction in the first place but then found that if you don't include the `ExchangeRate` in the API call now, QBO will automatically set the value to `1`: `"CurrencyRef":{"value":"EUR","name":"Euro"},"ExchangeRate":1`.

After searching, I found [discussions](https://help.developer.intuit.com/s/question/0D50f00005AZZ9DCAX/hi-how-can-i-set-quickbooks-to-update-the-exchange-rate-when-the-invoice-is-created-from-the-api) indicating that the QBO invoice API does not support automatically providing the `ExchangeRate` (perhaps they changed the rules at some point after 2017). You have to get the value yourself and include it in the payload. So here I used the get exchange rate [API](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/exchangerate#get-an-exchangerate-for-an-individual-currency-code) also from QBO (the sample on the page doesn't work, but the API actually works..).

In addition, the local QBO connection is also fixed. It turned out that the relevant SDK was missing, and installing it solved the issue.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1250

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

**Exchange rate now correctly displays**
|| Invoice manually created in QBO | Invoice sent from WordCamp |
|-|-|-|
| EUR | ![Screenshot 2024-05-23 at 20 44 34](https://github.com/WordPress/wordcamp.org/assets/18050944/1dacf36d-ae8a-4160-b458-47738d31f714) | ![Screenshot 2024-05-23 at 20 44 17](https://github.com/WordPress/wordcamp.org/assets/18050944/a4d69467-c5df-4af1-968c-1c3a07a643f5) |
| JPY | ![Screenshot 2024-05-23 at 20 57 58](https://github.com/WordPress/wordcamp.org/assets/18050944/f0b4b9ab-3cb8-46ba-b95f-30c2b184f051) | ![Screenshot 2024-05-23 at 20 57 43](https://github.com/WordPress/wordcamp.org/assets/18050944/01d24747-a78d-436b-8556-283e9f4d545c) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. `composer update`.
2. Follow https://github.com/WordPress/wordcamp.org/tree/production/public_html/wp-content/plugins/wordcamp-qbo#wordcamp-qbo to set up QBO locally.
3. Add a new sponsor invoice here in `/wp-admin/post-new.php?post_type=wcb_sponsor_invoice`.
    - If the community dropdown does not display any country options, click on "Delete Cache" and then refresh.
4. Approve the invoice you added in `/wp-admin/network/admin.php?page=sponsor-invoices-dashboard&section=submitted`
5. Go to https://app.sandbox.qbo.intuit.com/app/invoices and enter the invoice editing screen.
6. Check if exchanges are correct. (you can test with multiple currencies)

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
