### PR TITLE
Add new condition for organizer reminder

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -167,7 +167,7 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			'post_status' => $wordcamp_post_status,
 		) );
 
-		if ( in_array( $send_when, array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_and_no_report' ) ) ) {
+		if ( in_array( $send_when, array( 'wcor_send_before', 'wcor_send_after' ) ) ) {
 			update_post_meta( self::$wordcamp_dayton_post_id, 'Start Date (YYYY-mm-dd)', $compare_date );
 		} elseif ( 'wcor_send_after_pending' === $send_when ) {
 			update_post_meta( self::$wordcamp_dayton_post_id, '_timestamp_added_to_planning_schedule', $compare_date );
@@ -231,15 +231,6 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			array(
 				'wcor_send_after_pending',
 				'wcor_send_days_after_pending',
-				3,
-				strtotime( 'now - 3 days' ),
-				'wcpt-scheduled',
-			),
-
-			// After the camp ends and no transparency report is received.
-			array(
-				'wcor_send_after_and_no_report',
-				'wcor_send_days_after_and_no_report',
 				3,
 				strtotime( 'now - 3 days' ),
 				'wcpt-scheduled',

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -124,8 +124,8 @@ defined( 'WPINC' ) || die();
 <table>
 	<tbody>
 		<tr>
-			<th><input id="wcor_transparency_report" name="wcor_transparency_report" type="checkbox" value="wcor_transparency_report" <?php checked( $post->wcor_transparency_report ); ?>></th>
-			<td><label for="wcor_transparency_report">For transparency report: triggered when <strong>NOT</strong> 'Running money through WPCS PBC'</label></td>
+			<th><input id="wcor_transparency_report" name="wcor_transparency_report" type="checkbox" value="wcor_transparency_report" <?php checked( $post->wcor_transparency_report, 'wcor_transparency_report' ); ?>></th>
+			<td><label for="wcor_transparency_report">For transparency report - triggered when <strong>NOT</strong> 'Running money through WPCS PBC'</label></td>
 		</tr>
 		
 		<tr>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -124,6 +124,11 @@ defined( 'WPINC' ) || die();
 <table>
 	<tbody>
 		<tr>
+			<input id="wcor_transparency_report" name="wcor_transparency_report" type="checkbox" value="wcor_transparency_report" <?php checked( $post->wcor_transparency_report ); ?>>
+			<label for="wcor_transparency_report">For transparency report: triggered only when the 'Running money through WPCS PBC' is <strong>NOT</strong> checked</label>
+		</tr>
+		
+		<tr>
 			<th><input id="wcor_send_before" name="wcor_send_when" type="radio" value="wcor_send_before" <?php checked( $post->wcor_send_when, 'wcor_send_before' ); ?>></th>
 			<td><label for="wcor_send_before">before the camp starts: </label></td>
 			<td>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -17,10 +17,11 @@ defined( 'WPINC' ) || die();
 			<th><input id="wcor_send_organizers" name="wcor_send_where[]" type="checkbox" value="wcor_send_organizers" <?php checked( in_array( 'wcor_send_organizers', $send_where ) ); ?>></th>
 			<td colspan="2"><label for="wcor_send_organizers">The organizing team</label>
 			<br>
-			(Will send to 
+			<span>(Will send to 
 			1. <code>support@wordcamp.org</code>
 			2. If specified, the email address under WordCamp Information section on WordCamp edit page
 			3. If specified, the email address of the lead organizer)
+			</span>
 			</td>
 		</tr>
 
@@ -151,7 +152,11 @@ defined( 'WPINC' ) || die();
 
 		<tr>
 			<th><input id="wcor_send_after_and_no_report" name="wcor_send_when" type="radio" value="wcor_send_after_and_no_report" <?php checked( $post->wcor_send_when, 'wcor_send_after_and_no_report' ); ?>></th>
-			<td><label for="wcor_send_after_and_no_report">after the camp ends and no transparency report is received: </label></td>
+			<td>
+				<label for="wcor_send_after_and_no_report">after the camp ends and no transparency report is received: </label>
+				<br>
+				<span>(This will only be triggered when the 'Running money through WPCS PBC' is <strong>NOT</strong> checked)</span>
+			</td>
 			<td>
 				<input id="wcor_send_days_after_and_no_report" name="wcor_send_days_after_and_no_report" type="text" class="small-text" value="<?php echo esc_attr( $post->wcor_send_days_after_and_no_report ); ?>" />
 				<label for="wcor_send_days_after_and_no_report">days</label>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -124,8 +124,8 @@ defined( 'WPINC' ) || die();
 <table>
 	<tbody>
 		<tr>
-			<input id="wcor_transparency_report" name="wcor_transparency_report" type="checkbox" value="wcor_transparency_report" <?php checked( $post->wcor_transparency_report ); ?>>
-			<label for="wcor_transparency_report">For transparency report: triggered only when the 'Running money through WPCS PBC' is <strong>NOT</strong> checked</label>
+			<th><input id="wcor_transparency_report" name="wcor_transparency_report" type="checkbox" value="wcor_transparency_report" <?php checked( $post->wcor_transparency_report ); ?>></th>
+			<td><label for="wcor_transparency_report">For transparency report: triggered when <strong>NOT</strong> 'Running money through WPCS PBC'</label></td>
 		</tr>
 		
 		<tr>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -156,19 +156,6 @@ defined( 'WPINC' ) || die();
 		</tr>
 
 		<tr>
-			<th><input id="wcor_send_after_and_no_report" name="wcor_send_when" type="radio" value="wcor_send_after_and_no_report" <?php checked( $post->wcor_send_when, 'wcor_send_after_and_no_report' ); ?>></th>
-			<td>
-				<label for="wcor_send_after_and_no_report">after the camp ends and no transparency report is received: </label>
-				<br>
-				<span>(This will only be triggered when the 'Running money through WPCS PBC' is <strong>NOT</strong> checked)</span>
-			</td>
-			<td>
-				<input id="wcor_send_days_after_and_no_report" name="wcor_send_days_after_and_no_report" type="text" class="small-text" value="<?php echo esc_attr( $post->wcor_send_days_after_and_no_report ); ?>" />
-				<label for="wcor_send_days_after_and_no_report">days</label>
-			</td>
-		</tr>
-
-		<tr>
 			<th><input id="wcor_send_trigger" name="wcor_send_when" type="radio" value="wcor_send_trigger" <?php checked( $post->wcor_send_when, 'wcor_send_trigger' ); ?>></th>
 			<td><label for="wcor_send_trigger">on a trigger: </label></td>
 			<td>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -634,21 +634,16 @@ class WCOR_Mailer {
 			$days_after          = absint( get_post_meta( $email->ID, 'wcor_send_days_after', true ) );
 			$transparency_report = get_post_meta( $email->ID, 'wcor_transparency_report', true );
 
-			if ( $transparency_report ) {
-				$report_received = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
+			if ( $end_date && $days_after ) {
+				$send_date = $end_date + ( $days_after * DAY_IN_SECONDS );
 
-				if ( $end_date && $days_after && ! $report_received ) {
-					$execution_timestamp = $end_date + ( $days_after * DAY_IN_SECONDS );
-
-					if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
-						$ready = true;
-					}
-				}
-			} else {
-				if ( $end_date && $days_after ) {
-					$send_date = $end_date + ( $days_after * DAY_IN_SECONDS );
-
-					if ( $send_date <= current_time( 'timestamp' ) ) {
+				if ( $send_date <= current_time( 'timestamp' ) ) {
+					if ( $transparency_report ) {
+						$report_received = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
+						if ( ! $report_received ) {
+							$ready = true;
+						}
+					} else {
 						$ready = true;
 					}
 				}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -595,6 +595,15 @@ class WCOR_Mailer {
 			return $ready;
 		}
 
+		/**
+		 * Do not send emails if it's for transparency report and the camp is running money through WPCS PBC.
+		 */
+		$transparency_report = get_post_meta( $email->ID, 'wcor_transparency_report', true );
+		$through_wpcs_pbc    = get_post_meta( $wordcamp->ID, 'Running money through WPCS PBC', true );
+		if ( $transparency_report && $through_wpcs_pbc ) {
+			return $ready;
+		}
+
 		$send_when  = get_post_meta( $email->ID, 'wcor_send_when', true );
 		$start_date = get_post_meta( $wordcamp->ID, 'Start Date (YYYY-mm-dd)', true );
 		$end_date   = get_post_meta( $wordcamp->ID, 'End Date (YYYY-mm-dd)', true );
@@ -622,19 +631,12 @@ class WCOR_Mailer {
 				return $ready;
 			}
 
-			$transparency_report = get_post_meta( $email->ID, 'wcor_transparency_report', true );
 			$days_after          = absint( get_post_meta( $email->ID, 'wcor_send_days_after', true ) );
+			$transparency_report = get_post_meta( $email->ID, 'wcor_transparency_report', true );
+
 			if ( $transparency_report ) {
-				$through_wpcs_pbc = get_post_meta( $wordcamp->ID, 'Running money through WPCS PBC', true );
-
-				/**
-				 * Do not send emails with "send X days after the camp ends" trigger if the camp is running money through WPCS PBC.
-				 */
-				if ( $through_wpcs_pbc ) {
-					return $ready;
-				}
-
 				$report_received = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
+
 				if ( $end_date && $days_after && ! $report_received ) {
 					$execution_timestamp = $end_date + ( $days_after * DAY_IN_SECONDS );
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -631,8 +631,7 @@ class WCOR_Mailer {
 				return $ready;
 			}
 
-			$days_after          = absint( get_post_meta( $email->ID, 'wcor_send_days_after', true ) );
-			$transparency_report = get_post_meta( $email->ID, 'wcor_transparency_report', true );
+			$days_after = absint( get_post_meta( $email->ID, 'wcor_send_days_after', true ) );
 
 			if ( $end_date && $days_after ) {
 				$send_date = $end_date + ( $days_after * DAY_IN_SECONDS );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -637,6 +637,9 @@ class WCOR_Mailer {
 				$send_date = $end_date + ( $days_after * DAY_IN_SECONDS );
 
 				if ( $send_date <= current_time( 'timestamp' ) ) {
+					/**
+					 * If this reminder is for transparency report, only send if the report hasn't been received yet.
+					 */
 					if ( $transparency_report ) {
 						$report_received = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
 						if ( ! $report_received ) {

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -535,7 +535,7 @@ class WCOR_Mailer {
 			'meta_query'     => array(
 				array(
 					'key'     => 'wcor_send_when',
-					'value'   => array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending', 'wcor_send_after_and_no_report' ),
+					'value'   => array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending' ),
 					'compare' => 'IN'
 				),
 			),
@@ -657,23 +657,6 @@ class WCOR_Mailer {
 
 			if ( $days_after_pending && $timestamp_added_to_pending_schedule ) {
 				$execution_timestamp = $timestamp_added_to_pending_schedule + ( $days_after_pending * DAY_IN_SECONDS );
-
-				if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
-					$ready = true;
-				}
-			}
-		} elseif ( 'wcor_send_after_and_no_report' == $send_when ) {
-			$through_wpcs_pbc = get_post_meta( $wordcamp->ID, 'Running money through WPCS PBC', true );
-
-			if ( $through_wpcs_pbc ) {
-				return $ready;
-			}
-
-			$days_after_and_no_report = absint( get_post_meta( $email->ID, 'wcor_send_days_after_and_no_report', true ) );
-			$report_received          = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
-
-			if ( $end_date && $days_after_and_no_report && ! $report_received ) {
-				$execution_timestamp = $end_date + ( $days_after_and_no_report * DAY_IN_SECONDS );
 
 				if ( $execution_timestamp <= current_time( 'timestamp' ) ) {
 					$ready = true;

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -641,6 +641,12 @@ class WCOR_Mailer {
 				}
 			}
 		} elseif ( 'wcor_send_after_and_no_report' == $send_when ) {
+			$through_wpcs_pbc = get_post_meta( $wordcamp->ID, 'Running money through WPCS PBC', true );
+
+			if ( $through_wpcs_pbc ) {
+				return $ready;
+			}
+
 			$days_after_and_no_report = absint( get_post_meta( $email->ID, 'wcor_send_days_after_and_no_report', true ) );
 			$report_received          = get_post_meta( $wordcamp->ID, 'Transparency Report Received', true );
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -199,6 +199,10 @@ class WCOR_Reminder {
 			}
 		}
 
+		if ( isset( $new_meta['wcor_transparency_report'] ) ) {
+			update_post_meta( $post->ID, 'wcor_transparency_report', $new_meta['wcor_transparency_report'] );
+		}
+
 		if ( isset( $new_meta['wcor_send_days_before'] ) ) {
 			update_post_meta( $post->ID, 'wcor_send_days_before', absint( $new_meta['wcor_send_days_before'] ) );
 		}

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -201,7 +201,7 @@ class WCOR_Reminder {
 
 		delete_post_meta( $post->ID, 'wcor_transparency_report' );
 		if ( isset( $new_meta['wcor_transparency_report'] ) ) {
-			update_post_meta( $post->ID, 'wcor_transparency_report', $new_meta['wcor_transparency_report'] );
+			update_post_meta( $post->ID, 'wcor_transparency_report', sanitize_text_field( $new_meta['wcor_transparency_report'] ) );
 		}
 
 		if ( isset( $new_meta['wcor_send_days_before'] ) ) {

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -194,7 +194,7 @@ class WCOR_Reminder {
 		}
 
 		if ( isset( $new_meta['wcor_send_when'] ) ) {
-			if ( in_array( $new_meta['wcor_send_when'], array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending', 'wcor_send_after_and_no_report', 'wcor_send_trigger' ) ) ) {
+			if ( in_array( $new_meta['wcor_send_when'], array( 'wcor_send_before', 'wcor_send_after', 'wcor_send_after_pending', 'wcor_send_trigger' ) ) ) {
 				update_post_meta( $post->ID, 'wcor_send_when', $new_meta['wcor_send_when'] );
 			}
 		}
@@ -213,10 +213,6 @@ class WCOR_Reminder {
 
 		if ( isset( $new_meta['wcor_send_days_after_pending'] ) ) {
 			update_post_meta( $post->ID, 'wcor_send_days_after_pending', absint( $new_meta['wcor_send_days_after_pending'] ) );
-		}
-
-		if ( isset( $new_meta['wcor_send_days_after_and_no_report'] ) ) {
-			update_post_meta( $post->ID, 'wcor_send_days_after_and_no_report', absint( $new_meta['wcor_send_days_after_and_no_report'] ) );
 		}
 
 		if ( isset( $new_meta['wcor_which_trigger'] ) ) {

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -199,6 +199,7 @@ class WCOR_Reminder {
 			}
 		}
 
+		delete_post_meta( $post->ID, 'wcor_transparency_report' );
 		if ( isset( $new_meta['wcor_transparency_report'] ) ) {
 			update_post_meta( $post->ID, 'wcor_transparency_report', $new_meta['wcor_transparency_report'] );
 		}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Closes #1327

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->


## Description
In this PR, the checkbox `For transparency report - triggered when NOT 'Running money through WPCS PBC'` is added. As long as this option is checked, the reminder will determine whether the current WordCamp is running money through WPCS PBC. If not, it will send the email according to the time set below.

![image](https://github.com/WordPress/wordcamp.org/assets/18050944/f1f7b76c-b80f-4b25-b4bd-e42126f4e2be)
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/e609588c-1bf9-4f4a-9a7c-6d23c2bef6f0)


## Testing Cases

1. `For transparency report - triggered when NOT 'Running money through WPCS PBC'` is **CHECKED**
- -30 days: 
  - Running money through WPCS PBC -> Email is NOT sent.
  - NOT Running money through WPCS PBC -> Email is sent.
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/c6462634-984c-4eb0-9abe-393a0c82c0da)
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/ab16bbd5-5b97-4465-b171-94437b971732)

- 7 days: 
  - Running money through WPCS PBC -> Email is NOT sent.
  - NOT Running money through WPCS PBC & "Transparency Report Received" checked  -> Email is NOT sent.
  - NOT Running money through WPCS PBC & "Transparency Report Received" NOT checked  -> Email is sent.
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/dadcbfa3-1724-4129-a22b-b0a4ff1d5e9b)
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/fcd8edce-2a39-4cf5-9935-804fae11347a)

- 14 days:
  - Running money through WPCS PBC -> Email is NOT sent.
  - NOT Running money through WPCS PBC & "Transparency Report Received" checked  -> Email is NOT sent.
  - NOT Running money through WPCS PBC & "Transparency Report Received" NOT checked  -> Email is sent.
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/a80d5948-7746-4ebc-98d2-b01eb59b1a2f)
![image](https://github.com/WordPress/wordcamp.org/assets/18050944/d49e7892-050d-4bc4-bbcb-933a1cd3336b)

2. `For transparency report - triggered when NOT 'Running money through WPCS PBC'` is first **CHECKED**

The test here is to ensure that if `For transparency report - triggered when NOT 'Running money through WPCS PBC` is not checked, then this reminder email should be sent regardless of whether "Running money through WPCS PBC" is checked or not.

- Running money through WPCS PBC -> Email is NOT sent.

Then **NOT CHECKED**

- Running money through WPCS PBC -> Email is sent.

![image](https://github.com/WordPress/wordcamp.org/assets/18050944/9f58b91b-29ac-4689-a431-a1b9c38c14e0)



### How to test the changes in this Pull Request:

Same as https://github.com/WordPress/wordcamp.org/pull/1290#issue-2255190075
