### PR TITLE
Structured Event Data: Include the Event details on past years

### DIFF
--- a/public_html/wp-content/mu-plugins/structured-data.php
+++ b/public_html/wp-content/mu-plugins/structured-data.php
@@ -165,12 +165,17 @@ function get_event_status( WP_Post $wordcamp ) {
 	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-event/class-event-loader.php';
 	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-wordcamp/wordcamp-loader.php';
 
-	$active_statuses = WordCamp_Loader::get_active_wordcamp_statuses();
+	$active_statuses = array_merge(
+		WordCamp_Loader::get_active_wordcamp_statuses(), // Pre-schedule + Scheduled
+		WordCamp_Loader::get_public_post_statuses() // Scheduled + Closed
+	);
 
 	if ( 'wcpt-cancelled' === $wordcamp->post_status ) {
 		$status = 'https://schema.org/EventCancelled';
-	} else {
+	} elseif ( in_array( $wordcamp->post_status, $active_statuses, true ) ) {
 		$status = 'https://schema.org/EventScheduled';
+	} else {
+		return false;
 	}
 
 	return $status;

--- a/public_html/wp-content/mu-plugins/structured-data.php
+++ b/public_html/wp-content/mu-plugins/structured-data.php
@@ -166,8 +166,8 @@ function get_event_status( WP_Post $wordcamp ) {
 	require_once WP_PLUGIN_DIR . '/wcpt/wcpt-wordcamp/wordcamp-loader.php';
 
 	$active_statuses = array_merge(
-		WordCamp_Loader::get_active_wordcamp_statuses(), // Pre-schedule + Scheduled
-		WordCamp_Loader::get_public_post_statuses() // Scheduled + Closed
+		WordCamp_Loader::get_active_wordcamp_statuses(), // Pre-schedule + Scheduled.
+		WordCamp_Loader::get_public_post_statuses() // Scheduled + Closed.
 	);
 
 	if ( 'wcpt-cancelled' === $wordcamp->post_status ) {

--- a/public_html/wp-content/mu-plugins/structured-data.php
+++ b/public_html/wp-content/mu-plugins/structured-data.php
@@ -169,13 +169,8 @@ function get_event_status( WP_Post $wordcamp ) {
 
 	if ( 'wcpt-cancelled' === $wordcamp->post_status ) {
 		$status = 'https://schema.org/EventCancelled';
-	} elseif ( in_array( $wordcamp->post_status, $active_statuses, true ) ) {
-		$status = 'https://schema.org/EventScheduled';
 	} else {
-		// There isn't an `eventStatus` for completed events, they only want to show ones that are upcoming.
-		// @link https://schema.org/EventStatusType
-		// @link https://developers.google.com/search/docs/appearance/structured-data/event#structured-data-type-definitions.
-		return false;
+		$status = 'https://schema.org/EventScheduled';
 	}
 
 	return $status;


### PR DESCRIPTION
The code erroneously suggests that Scheduled should only be for future events, whereas the Scheduled state specifies:

https://schema.org/EventScheduled
> The event is taking place **or has taken place** on the startDate as scheduled

Therefor, Scheduled in the past is valid and should not be interpreted by clients as a future event.

This may help with search engines determining the year of the content they're linking to.

See https://wordpress.slack.com/archives/C08M59V3P/p1717047874905299?thread_ts=1717000539.205949&cid=C08M59V3P

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->


<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
