### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,10 +174,12 @@
 		"phpcbf": "phpcbf -p",
 		"tw": "@test:watch",
 		"twg": "@test:watch:group",
-		"post-update-cmd": [
+		"cleanup": [
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/*",
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || mv public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/mu-plugins/* public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/"
-		]
+		],
+		"post-update-cmd": "@cleanup",
+		"post-install-cmd": "@cleanup"
 	}
 }


### PR DESCRIPTION
I followed the install instructions for the WordCamp multisite during the contributor day at WCEU 2024. I faced an error when I tried to get a list of the websites for my "hosts" file. Looking into the composer.json I realized that some jobs were not executed.  Running `composer update` separately solved the problem.

My proposal is that:

post-update-cmd and post-install-cmd should share the same jobs.

@2ndkauboy @renintw @pkevan 