### PR TITLE
Show draft and published Sponsors in sponsorship agreement dropdown

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -9,7 +9,7 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 	public function form_prefill_select( $data ) {
 		$sponsors = get_posts( array(
 			'post_type'      => 'wcb_sponsor',
-			'post_status'    => 'publish',
+			'post_status'    => array( 'publish', 'draft' ),
 			'posts_per_page' => 500,
 		) );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

I was helping organise a local WordCamp, and we tripped over a situation where the Sponsorship Agreement doc generator only lists published sponsors. However, the handbook recommends that sponsors are only published after they have made payment. But that normally follows well after a sponsorship agreement has been signed. This changes makes it possible to generate sponsorship agreements for draft Sponsor posts.

### How to test the changes in this Pull Request:

_I wasn't able to get a Docker setup working on my machine, but this is a pretty straightforward change to the `get_posts()` arguments. So I have not been able to test this myself._

1. Ensure that you have a test system with a Sponsor set as a draft. (You can create one via the _Sponsors_ -> _Add New_ menu on the left.)
2. Navigate to the _Docs_ section in the left nav.
3. Select "Sponsorship Agreement" in the dropdown and click on the "Next" button.
4. Expand the "Sponsor" dropdown, and verify that your draft sponsor is visible.