### PR TITLE
Allow doaction.org URLs for events

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -53,10 +53,10 @@ class WordCamp_New_Site {
 				$valid_url  = isset( $url['host'], $url['path'] );
 				$tld        = get_top_level_domain();
 				$network_id = $valid_url && "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
-				$doaction   = ( 'doaction.org' === $url['host'] );
+				$we_host_it = ( 'doaction.org' !== $url['host'] );
 				?>
 
-				<?php if ( $valid_url && ! $doaction && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>
+				<?php if ( $valid_url && $we_host_it && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>
 					<?php
 						$blog_details = get_blog_details(
 							array(
@@ -76,7 +76,7 @@ class WordCamp_New_Site {
 					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>/wp-admin/">Dashboard</a> |
 					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
 
-				<?php else if ( ! $doaction ) : ?>
+				<?php else if ( $we_host_it ) : ?>
 					<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ); ?>
 
 					<label for="<?php echo esc_attr( $checkbox_id ); ?>">
@@ -171,9 +171,9 @@ class WordCamp_New_Site {
 		$is_external_domain             = ! preg_match( "@ \.wordcamp\.$tld | \.buddycamp\.$tld | events\.wordpress\.$tld @ix", $domain );
 		$can_have_external_domain       = $wordcamp_id <= $last_permitted_external_domain || in_array( $wordcamp_id, $external_domain_exceptions );
 
-		// DoAction is not hosted within the WordCamp infrastructure, so we don't need to validate it.
+		// DoAction is not hosted within the WordCamp infrastructure, so can have an external domain.
 		if ( 'doaction.org' === $domain ) {
-			return true;
+			$can_have_external_domain = true;
 		}
 		
 		if ( $is_external_domain && $can_have_external_domain ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -53,9 +53,10 @@ class WordCamp_New_Site {
 				$valid_url  = isset( $url['host'], $url['path'] );
 				$tld        = get_top_level_domain();
 				$network_id = $valid_url && "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
+				$doaction   = ( 'doaction.org' === $url['host'] );
 				?>
 
-				<?php if ( $valid_url && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>
+				<?php if ( $valid_url && ! $doaction && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>
 					<?php
 						$blog_details = get_blog_details(
 							array(
@@ -75,7 +76,7 @@ class WordCamp_New_Site {
 					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>/wp-admin/">Dashboard</a> |
 					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
 
-				<?php else : ?>
+				<?php else if ( ! $doaction ) : ?>
 					<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ); ?>
 
 					<label for="<?php echo esc_attr( $checkbox_id ); ?>">
@@ -170,6 +171,11 @@ class WordCamp_New_Site {
 		$is_external_domain             = ! preg_match( "@ \.wordcamp\.$tld | \.buddycamp\.$tld | events\.wordpress\.$tld @ix", $domain );
 		$can_have_external_domain       = $wordcamp_id <= $last_permitted_external_domain || in_array( $wordcamp_id, $external_domain_exceptions );
 
+		// DoAction is not hosted within the WordCamp infrastructure, so we don't need to validate it.
+		if ( 'doaction.org' === $domain ) {
+			return true;
+		}
+		
 		if ( $is_external_domain && $can_have_external_domain ) {
 			// Many old camps had external websites.
 			return true;

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -53,7 +53,7 @@ class WordCamp_New_Site {
 				$valid_url  = isset( $url['host'], $url['path'] );
 				$tld        = get_top_level_domain();
 				$network_id = $valid_url && "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
-				$we_host_it = ( 'doaction.org' !== $url['host'] );
+				$we_host_it = $valid_url && 'doaction.org' !== $url['host'];
 				?>
 
 				<?php if ( $valid_url && $we_host_it && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -175,7 +175,7 @@ class WordCamp_New_Site {
 		if ( 'doaction.org' === $domain ) {
 			$can_have_external_domain = true;
 		}
-		
+
 		if ( $is_external_domain && $can_have_external_domain ) {
 			// Many old camps had external websites.
 			return true;

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -76,7 +76,7 @@ class WordCamp_New_Site {
 					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>/wp-admin/">Dashboard</a> |
 					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
 
-				<?php else if ( $we_host_it ) : ?>
+				<?php elseif ( $we_host_it ) : ?>
 					<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ); ?>
 
 					<label for="<?php echo esc_attr( $checkbox_id ); ?>">


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR (is untested) is intended to allow saving of `doaction.org` URL formats for Events.

This is not an ideal PR, as it's hacky in nature, as the existing post type infrastructure really assumes that the only events are going to be ones hosted by the networks, and doesn't really fully support externally hosted sites for new sites.

This PR simply avoids some of the UI for such urls, and allows it to be saved.

I'm sure this could be more tightly integrated with a proper url validation and whatnot, but this might be enough until the question of "what to do with doaction.org" is resolved.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1335

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
