### PR TITLE
Making the "$wordcamp is over. Check out the next edition" text translateable.

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -127,9 +127,9 @@ function show_notification_about_latest_site() {
 
 	echo '<div class="wordcamp-latest-site-notify"><p>' .
 		wp_sprintf(
-				__('%1$s is over. Check out <a href="%2$s">the next edition</a>!', 'wordcamporg' ),
-				esc_html( get_blog_details( $current_blog->blog_id )->blogname ),
-				esc_url( $latest_domain )
+			__('%1$s is over. Check out <a href="%2$s">the next edition</a>!', 'wordcamporg' ),
+			esc_html( get_blog_details( $current_blog->blog_id )->blogname ),
+			esc_url( $latest_domain )
 		) .
 	'</p></div>';
 }

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -126,7 +126,11 @@ function show_notification_about_latest_site() {
 	}
 
 	echo '<div class="wordcamp-latest-site-notify"><p>' .
-		wp_sprintf( '%s is over. Check out <a href="%s">the next edition</a>!', esc_html( get_blog_details( $current_blog->blog_id )->blogname ), esc_url( $latest_domain ) ) .
+		wp_sprintf(
+                __('%s is over. Check out <a href="%s">the next edition</a>!', 'wordcamporg' ),
+                esc_html( get_blog_details( $current_blog->blog_id )->blogname ),
+                esc_url( $latest_domain )
+        ) .
 	'</p></div>';
 }
 

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -127,10 +127,10 @@ function show_notification_about_latest_site() {
 
 	echo '<div class="wordcamp-latest-site-notify"><p>' .
 		wp_sprintf(
-                __('%s is over. Check out <a href="%s">the next edition</a>!', 'wordcamporg' ),
-                esc_html( get_blog_details( $current_blog->blog_id )->blogname ),
-                esc_url( $latest_domain )
-        ) .
+				__('%1$s is over. Check out <a href="%2$s">the next edition</a>!', 'wordcamporg' ),
+				esc_html( get_blog_details( $current_blog->blog_id )->blogname ),
+				esc_url( $latest_domain )
+		) .
 	'</p></div>';
 }
 


### PR DESCRIPTION
Some strings in the wordcamp.org sites are not translateable. 

This PR make the "$wordcamp is over. Check out the next edition", visible in all past WordCamps, translateable.

### Screenshots
![imagen](https://github.com/user-attachments/assets/6b75dbd9-3656-4911-8e9b-c842f17fe5cb)
