### PR TITLE
Make 100 max discount percentage

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5118,6 +5118,10 @@ class CampTix_Plugin {
 				update_post_meta( $post_id, 'tix_discount_price', $price );
 				delete_post_meta( $post_id, 'tix_discount_percent' );
 			} elseif ( $percent > 0 ) {
+				// Safeguard against percentages bigger than it is possible to discount against.
+				if ( $percent > 100 ) {
+					$percent = 100;
+				}
 				update_post_meta( $post_id, 'tix_discount_percent', $percent );
 				delete_post_meta( $post_id, 'tix_discount_price' );
 			} else {


### PR DESCRIPTION
Safeguard against percentages higher than 100, since it throws the reporting out - does not appear to affect payments (i.e. a refund for negative balance).

Fixed #1372.

See: https://wordpress.slack.com/archives/C08M59V3P/p1727101178232939
