### PR TITLE
Sunrise: Redirect domain to latest year site that is not deleted.

### DIFF
--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -636,8 +636,12 @@ function get_latest_site( string $domain ) {
 		SELECT `blog_id`, `domain`, `path`
 		FROM $wpdb->blogs
 		WHERE
-			( domain =    %s AND path != '/' ) OR -- Match city/year format.
-			( domain LIKE %s AND path  = '/' )    -- Match year.city format.
+  			( public AND NOT deleted ) -- Deleted sites should be skipped
+     			AND
+			(
+   				( domain =    %s AND path != '/' ) OR -- Match city/year format.
+				( domain LIKE %s AND path  = '/' )    -- Match year.city format.
+			)
 		ORDER BY path DESC, domain DESC
 		LIMIT 1;",
 		$domain,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

https://wordpress.slack.com/archives/C08M59V3P/p1728017732714399

As reported here, accessing the root-domain for kolkata is redirecting to a incorrect URL, this happens as a duplicate 2025 site was accidentally created with a space after it:

```
$ curl -I https://kolkata.wordcamp.org/
HTTP/1.1 302 Found
....
Location: https://kolkata.wordcamp.org/2025/%20/
```

After this change, it correctly references the non-deleted site:

```
$ curl -I https://kolkata.wordcamp.org/
HTTP/1.1 302 Found
...
Location: https://kolkata.wordcamp.org/2025/
```