### PR TITLE
Show unconfirmed attendees

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -772,15 +772,15 @@ class CampTix_Require_Login extends CampTix_Addon {
 	public function hide_unconfirmed_attendees( $query_args ) {
 		$meta_query = array(
            		array(
-                		'key'     => 'tix_username',
-                		'value'   => self::UNCONFIRMED_USERNAME,
-                		'compare' => '!=',
-            		),
-            		'relation' => 'OR',
-            		array(
-                		'key' => 'tix_username',
-                		'compare' => 'NOT EXISTS',
-            		)
+				'key'     => 'tix_username',
+				'value'   => self::UNCONFIRMED_USERNAME,
+				'compare' => '!=',
+			),
+			'relation' => 'OR',
+			array(
+				'key' => 'tix_username',
+				'compare' => 'NOT EXISTS',
+			)
 		);
 
 		if ( isset( $query_args['meta_query'] ) ) {

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -771,9 +771,16 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 */
 	public function hide_unconfirmed_attendees( $query_args ) {
 		$meta_query = array(
-			'key'     => 'tix_username',
-			'value'   => self::UNCONFIRMED_USERNAME,
-			'compare' => '!='
+           		array(
+                		'key'     => 'tix_username',
+                		'value'   => self::UNCONFIRMED_USERNAME,
+                		'compare' => '!=',
+            		),
+            		'relation' => 'OR',
+            		array(
+                		'key' => 'tix_username',
+                		'compare' => 'NOT EXISTS',
+            		)
 		);
 
 		if ( isset( $query_args['meta_query'] ) ) {


### PR DESCRIPTION
Allow unconfirmed attendees to show, if `tix_username` doesn't exist.