### PR TITLE
Order by ID DESC

### DIFF
--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -108,7 +108,7 @@ class CampTix_Network_Tools {
 
 		$rows       = array();
 		$table_name = $wpdb->base_prefix . 'camptix_log';
-		$entries    = (array) $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table_name WHERE blog_id = %d AND object_id = %d ORDER BY id DESC;", get_current_blog_id(), $post->ID ) );
+		$entries    = (array) $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table_name WHERE blog_id = %d AND object_id = %d ORDER BY id DESC;", get_current_blog_id(), $post->ID ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		// Add entries as rows.
 		foreach ( $entries as $entry ) {

--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -108,7 +108,7 @@ class CampTix_Network_Tools {
 
 		$rows       = array();
 		$table_name = $wpdb->base_prefix . 'camptix_log';
-		$entries    = (array) $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table_name WHERE blog_id = %d AND object_id = %d ORDER BY id ASC;", get_current_blog_id(), $post->ID ) );
+		$entries    = (array) $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table_name WHERE blog_id = %d AND object_id = %d ORDER BY id DESC;", get_current_blog_id(), $post->ID ) );
 
 		// Add entries as rows.
 		foreach ( $entries as $entry ) {


### PR DESCRIPTION
order logs by ID DESC, so that the newest logs appear at the top of the metabox.

fixes #1389.