### PR TITLE
Camptix Invoices: Avoid a PHP Notice if not yet setup.

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/camptix-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/camptix-invoices.php
@@ -90,6 +90,16 @@ function register_tix_invoice() {
 }
 
 /**
+ * Define the default values for options.
+ */
+function ctx_default_options( $options ) {
+	$options['invoice-vat-number'] = '';
+
+	return $options;
+}
+add_filter( 'camptix_default_options', 'ctx_default_options' );
+
+/**
  * Register invoice CPT custom update messages.
  */
 function ctx_set_invoice_updated_messages( $messages ) {
@@ -254,10 +264,11 @@ add_action( 'add_meta_boxes_tix_invoice', 'ctx_register_invoice_metabox' );
  * @param object $args The args.
  */
 function ctx_invoice_metabox_editable( $args ) {
+	global $camptix;
 
 	$order              = get_post_meta( $args->ID, 'original_order', true );
 	$metas              = get_post_meta( $args->ID, 'invoice_metas', true );
-	$opt                = get_option( 'camptix_options' );
+	$opt                = $camptix->get_options();
 	$invoice_vat_number = $opt['invoice-vat-number'] ?? '';
 
 	if ( ! is_array( $order ) ) {
@@ -282,10 +293,11 @@ function ctx_invoice_metabox_editable( $args ) {
  * @param object $args The args.
  */
 function ctx_invoice_metabox_sent( $args ) {
+	global $camptix;
 
 	$order              = get_post_meta( $args->ID, 'original_order', true );
 	$metas              = get_post_meta( $args->ID, 'invoice_metas', true );
-	$opt                = get_option( 'camptix_options' );
+	$opt                = $camptix->get_options();
 	$invoice_vat_number = $opt['invoice-vat-number'] ?? '';
 	$txn_id             = $metas['transaction_id'] ?? '';
 

--- a/public_html/wp-content/plugins/camptix-invoices/camptix-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/camptix-invoices.php
@@ -258,7 +258,7 @@ function ctx_invoice_metabox_editable( $args ) {
 	$order              = get_post_meta( $args->ID, 'original_order', true );
 	$metas              = get_post_meta( $args->ID, 'invoice_metas', true );
 	$opt                = get_option( 'camptix_options' );
-	$invoice_vat_number = $opt['invoice-vat-number'];
+	$invoice_vat_number = $opt['invoice-vat-number'] ?? '';
 
 	if ( ! is_array( $order ) ) {
 		$order = array();
@@ -286,8 +286,8 @@ function ctx_invoice_metabox_sent( $args ) {
 	$order              = get_post_meta( $args->ID, 'original_order', true );
 	$metas              = get_post_meta( $args->ID, 'invoice_metas', true );
 	$opt                = get_option( 'camptix_options' );
-	$invoice_vat_number = $opt['invoice-vat-number'];
-	$txn_id             = isset( $metas['transaction_id'] ) ? $metas['transaction_id'] : '';
+	$invoice_vat_number = $opt['invoice-vat-number'] ?? '';
+	$txn_id             = $metas['transaction_id'] ?? '';
 
 	include CTX_INV_DIR . '/includes/views/sent-invoice-metabox.php';
 }


### PR DESCRIPTION
A semi-annoying PHP Notice is being generated when creating an invoice on the WordCamp site, but the Camptix VAT ID field hasn't been set.

```
GET https://xxxxxxxxx.wordcamp.org/2024/wp-admin/post-new.php?post_type=tix_invoice

E_NOTICE: Undefined index: invoice-vat-number
File: wp-content/plugins/camptix-invoices/camptix-invoices.php:261
Stack Trace: require('wp-admin/edit-form-advanced.php'), do_meta_boxes, ctx_invoice_metabox_editable
```

This doesn't appear to indicate anything is wrong, just that the specific settings haven't yet been updated.