### PR TITLE
Improve the logged-out ticket registration flow

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -14,9 +14,6 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 */
 	public function __construct() {
 		// Registration Information front-end screen
-		add_filter( 'camptix_register_button_classes',                array( $this, 'hide_register_form_elements' ) );
-		add_filter( 'camptix_coupon_link_classes',                    array( $this, 'hide_register_form_elements' ) );
-		add_filter( 'camptix_quantity_row_classes',                   array( $this, 'hide_register_form_elements' ) );
 		add_action( 'camptix_notices',                                array( $this, 'ticket_form_message' ), 8 );
 		add_filter( 'camptix_ask_questions',                          array( $this, 'hide_additional_attendee_questions_during_checkout' ), 10, 5 );
 		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'add_username_to_attendee_object' ), 10, 3 );
@@ -65,7 +62,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		}
 
 		if ( ! is_user_logged_in() && isset( $_REQUEST['tix_action'] ) ) {
-			wp_safe_redirect( wp_login_url( add_query_arg( $_REQUEST, $camptix->get_tickets_url() ) ) );
+			wp_safe_redirect( wp_login_url( $camptix->get_tickets_url() ) );
 			exit();
 		}
 		

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -13,7 +13,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 * Register hook callbacks
 	 */
 	public function __construct() {
-		// Registration Information front-end screen
+		// Registration Information front-end screen.
 		add_action( 'camptix_notices',                                array( $this, 'ticket_form_message' ), 8 );
 		add_filter( 'camptix_ask_questions',                          array( $this, 'hide_additional_attendee_questions_during_checkout' ), 10, 5 );
 		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'add_username_to_attendee_object' ), 10, 3 );
@@ -56,16 +56,37 @@ class CampTix_Require_Login extends CampTix_Addon {
 	public function block_unauthenticated_actions() {
 		/** @var $camptix CampTix_Plugin */
 		global $camptix;
-		// Bypass for payment webhook notifications.
-		if ( isset( $_REQUEST['tix_action'] ) && isset( $_REQUEST['tix_payment_token'] ) && $_REQUEST['tix_action'] == 'payment_notify' ) {
+		// Continue normal request, this is not a tickets page.
+		if ( ! isset( $_REQUEST['tix_action'] ) ) {
 			return;
 		}
 
-		if ( ! is_user_logged_in() && isset( $_REQUEST['tix_action'] ) ) {
-			wp_safe_redirect( add_query_arg( 'wcname', get_bloginfo( 'name' ), wp_login_url( $camptix->get_tickets_url() ) ) );
+		// Bypass for payment webhook notifications.
+		if ( 'payment_notify' === $_REQUEST['tix_action'] && isset( $_REQUEST['tix_payment_token'] ) ) {
+			return;
+		}
+
+		// Bypass for coupon validation- the `tix_coupon_submit` value is set when "Apply Coupon" button is clicked.
+		if ( 'attendee_info' === $_REQUEST['tix_action'] && isset( $_REQUEST['tix_coupon'], $_REQUEST['tix_coupon_submit'] ) ) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			$args = array();
+			// If this was a registration, pass through the selected tickets and coupon.
+			if ( 'attendee_info' === $_REQUEST['tix_action'] && isset( $_REQUEST['tix_tickets_selected'] ) ) {
+				$args['tix_action'] = $_REQUEST['tix_action'];
+				$args['tix_tickets_selected'] = $_REQUEST['tix_tickets_selected'];
+				if ( isset( $_REQUEST['tix_coupon'] ) ) {
+					$args['tix_coupon'] = $_REQUEST['tix_coupon'];
+				}
+			}
+
+			$tickets_url = add_query_arg( $args, $camptix->get_tickets_url() );
+
+			wp_safe_redirect( add_query_arg( 'wcname', get_bloginfo( 'name' ), wp_login_url( $tickets_url ) ) );
 			exit();
 		}
-		
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -62,7 +62,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		}
 
 		if ( ! is_user_logged_in() && isset( $_REQUEST['tix_action'] ) ) {
-			wp_safe_redirect( wp_login_url( $camptix->get_tickets_url() ) );
+			wp_safe_redirect( add_query_arg( 'wcname', get_bloginfo( 'name' ), wp_login_url( $camptix->get_tickets_url() ) ) );
 			exit();
 		}
 		


### PR DESCRIPTION
This changes two things:

* On the ticket purchase screen, the UI to purchase tickets is restored for logged-out users
* When a logged out user clicks the Register button, they'll be taken through the login/user registration process, and land back on the main ticket selection page after completing that flow

This doesn't solve all issues to do with logged-out ticket purchases, but it's an improvement on the current situation.

The main drawback is that any selected tickets or coupons are not saved when redirecting through the login/signup process; the user will have to re-enter their selections. That could certainly be improved, but as a short-term improvement this might be ok while we do more testing and iteration.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #1397 


