### PR TITLE
Remove required field restriction

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.js
+++ b/public_html/wp-content/plugins/camptix/camptix.js
@@ -147,10 +147,12 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 		if ( this.checked ) {
 			input_rows.each( function() {
 				$( this ).addClass( 'tix-hidden' );
+				$( this ).find( 'input' ).removeAttr( 'required' );
 			} );
 		} else {
 			input_rows.each( function() {
 				$( this ).removeClass( 'tix-hidden' );
+				$( this ).find( 'input' ).prop( 'required', true );
 			} );
 		}
 	}


### PR DESCRIPTION
When we hide a field, it should no longer be required.

This breaks additional ticket purchases.

Fixes: #1400