### PR TITLE
Don't show login banner if no tickets exist.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -123,7 +123,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		}
 
 		// Warn users that they will need to login to purchase a ticket
-		if ( ! is_user_logged_in() && $camptix->has_tickets_available() && ! $this->user_is_editing_ticket()  ) {
+		if ( ! is_user_logged_in() && $camptix->has_tickets_available() && ! $this->user_is_editing_ticket() ) {
 			$camptix->notice( apply_filters(
 				'camptix_require_login_please_login_message',
 				sprintf(

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -122,7 +122,6 @@ class CampTix_Require_Login extends CampTix_Addon {
 			return;
 		}
 
-
 		// Warn users that they will need to login to purchase a ticket
 		if ( ! is_user_logged_in() && ! $this->user_is_editing_ticket() ) {
 			$camptix->notice( apply_filters(

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -122,6 +122,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 			return;
 		}
 
+
 		// Warn users that they will need to login to purchase a ticket
 		if ( ! is_user_logged_in() && ! $this->user_is_editing_ticket() ) {
 			$camptix->notice( apply_filters(

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -123,7 +123,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		}
 
 		// Warn users that they will need to login to purchase a ticket
-		if ( ! is_user_logged_in() && ! $this->user_is_editing_ticket() ) {
+		if ( ! is_user_logged_in() && $camptix->has_tickets_available() && ! $this->user_is_editing_ticket()  ) {
 			$camptix->notice( apply_filters(
 				'camptix_require_login_please_login_message',
 				sprintf(

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8586,6 +8586,15 @@ class CampTix_Plugin {
 		$wordcamp = get_wordcamp_post();
 		return 'wcpt-closed' === $wordcamp->post_status;
 	}
+
+	/**
+	* Return whether there are available tickets.
+	*
+	* @return bool
+	*/
+	public function has_tickets_available() {
+		 return $this->number_available_tickets() > 0;
+	}
 }
 
 // Initialize the $camptix global.

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8593,8 +8593,8 @@ class CampTix_Plugin {
 	* @return bool
 	*/
 	public function has_tickets_available() {
-		 return $this->number_available_tickets() > 0;
-   }
+		return $this->number_available_tickets() > 0;
+	}
 }
 
 // Initialize the $camptix global.

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8594,7 +8594,7 @@ class CampTix_Plugin {
 	*/
 	public function has_tickets_available() {
 		 return $this->number_available_tickets() > 0;
-	}
+   }
 }
 
 // Initialize the $camptix global.


### PR DESCRIPTION
We currently show the "Login" banner regardless of whether the camps are selling tickets. This is particularly problematic for past events.

Looking at WordCamp Asia 2024, you see:

<img width="879" alt="Screenshot 2024-10-21 at 10 22 27 AM" src="https://github.com/user-attachments/assets/26770866-333c-4e93-ad93-1a9e39554b47">

This PR makes it so we only show the banner when tickets are for sale.

## Future considerations

In the case where the WordCamp hasn't been completed and new tickets will be going on sale, we could provide a banner to suggest users create an account ahead of time. I don't think that will be a compelling call to action without a useful feature in return like maybe "Create an account to be notified when tickets are back on sale".

I'll also follow up with another PR that changes that ticket-for-sale message.
