### PR TITLE
Allow users to edit tickets without needing to log in.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -72,7 +72,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		}
 
 		// Temporary: We don't want to block users from editing tickets.
-		// See: https://github.com/WordPress/wordcamp.org/issues/1393
+		// See: https://github.com/WordPress/wordcamp.org/issues/1393.
 		$user_is_editing_ticket = in_array( $_REQUEST['tix_action'], array( 'access_tickets', 'edit_attendee' ) );
 
 		if ( ! is_user_logged_in() && ! $user_is_editing_ticket ) {

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -71,7 +71,11 @@ class CampTix_Require_Login extends CampTix_Addon {
 			return;
 		}
 
-		if ( ! is_user_logged_in() ) {
+		// Temporary: We don't want to block users from editing tickets.
+		// See: https://github.com/WordPress/wordcamp.org/issues/1393
+		$user_is_editing_ticket = in_array( $_REQUEST['tix_action'], array( 'access_tickets', 'edit_attendee' ) );
+
+		if ( ! is_user_logged_in() && ! $user_is_editing_ticket ) {
 			$args = array();
 			// If this was a registration, pass through the selected tickets and coupon.
 			if ( 'attendee_info' === $_REQUEST['tix_action'] && isset( $_REQUEST['tix_tickets_selected'] ) ) {


### PR DESCRIPTION
Related: https://github.com/WordPress/wordcamp.org/issues/1393

WordPress.org accounts were [added](https://github.com/WordPress/wordcamp.org/commit/14478e7575c6ca4e25f880fb4012f4812d122f70) as a requirement for purchasing tickets.

Since this feature was added after users purchased tickets _the old way,_ there can be a mismatch between the attendee associated with the ticket and the logged-in account. This PR removes the need to log in to edit the ticket. This returns it to previous functionality.

Props [MarcZijderveld](https://github.com/MarcZijderveld)

This should be removed in the future when there are no more tickets sold without wp.org accounts. 
