### PR TITLE
CampTix Indian Payments: Use form context for phone validation

### DIFF
--- a/public_html/wp-content/plugins/campt-indian-payment-gateway/assets/js/camptix-multi-popup.js
+++ b/public_html/wp-content/plugins/campt-indian-payment-gateway/assets/js/camptix-multi-popup.js
@@ -84,35 +84,30 @@ jQuery(document).ready(function ($) {
 	$('.razorpay-container').css('z-index', '2147483543');
 
 	/**
-	 * On form submit prevent submission for Razorpay only.
+	 * On form submit prevent submission if the phone number is invalid.
 	 */
-	$form.on('submit', function (e) {
-	    
-	    var phone = $('.mobile').val();
-        phone = phone.replace(/[^0-9]/g,'');
+	$form.on( 'submit', function( event ) {
+		let phone = $( '.mobile', $form ).val();
+		phone = phone.replace( /[^0-9]/g, '' );
 
-        if(!($.isNumeric(phone))){
-            $('.message').text('Please Enter Only Numbers');
-            $('.message').css('color','red');
-            $('.mobile').val('');
-            $('.mobile').focus();
-            e.preventDefault();
-		return false;
-        }else
-        if (phone.length < 10 )
-        {
-            //alert('Phone number must be 10 digits.');
-            $('.message').text('Please Enter correct Mobile Number Or Number with STD Code');
-            $('.message').css('color','red');
-            $('.mobile').val('');
-            $('.mobile').focus();
-            //alert();
-            e.preventDefault();
+		if ( ! $.isNumeric( phone ) ) {
+			$( '.message', $form ).text( 'Please Enter Only Numbers' );
+			$( '.message', $form ).css( 'color', 'red' );
+			$( '.mobile', $form ).val( '' );
+			$( '.mobile', $form ).focus();
 
-		return false;
+			event.preventDefault();
+			return false;
+		} else if ( phone.length < 10 ) {
+			$( '.message', $form ).text( 'Please Enter correct Mobile Number Or Number with STD Code' );
+			$( '.message', $form ).css( 'color', 'red' );
+			$( '.mobile', $form ).val( '' );
+			$( '.mobile', $form ).focus();
 
-        } 
-     	return true;
-		// Bailout.
-	});
-});
+			event.preventDefault();
+			return false;
+		}
+
+		return true;
+	} );
+} );

--- a/public_html/wp-content/plugins/campt-indian-payment-gateway/campt-indian-payment-gateway.php
+++ b/public_html/wp-content/plugins/campt-indian-payment-gateway/campt-indian-payment-gateway.php
@@ -178,7 +178,12 @@ class Camptix_Indian_Payments {
 			return;
 		}
 
-		wp_register_script( 'camptix-indian-payments-main-js', CAMPTIX_MULTI_URL . 'assets/js/camptix-multi-popup.js', array( 'jquery' ), false, CAMPTIX_INDIAN_PAYMENTS_VERSION );
+		wp_register_script(
+			'camptix-indian-payments-main-js',
+			plugins_url( 'assets/js/camptix-multi-popup.js', __FILE__ ),
+			array( 'jquery' ),
+			filemtime( __DIR__ . '/assets/js/camptix-multi-popup.js' ),
+		);
 		wp_enqueue_script( 'camptix-indian-payments-main-js' );
 
 		$data = apply_filters(


### PR DESCRIPTION
Fixes #1408 — When buying a ticket using the "Indian Payments" addon, a required phone number field is added. This field is then validated with some simple javascript, but previously the script would look for anything with the `mobile` class. On mobile devices, the admin bar has this class, so the first value found was always an empty string, an invalid value.

This was likely not a problem in the past, because logged-out users would not have an admin bar.

### How to test the changes in this Pull Request:

Test on a sandbox on kerala or dehli WordCamps (or https://events.wordpress.org/rentest/2024/test-events/) 

Set up locally:
1. Set up a site with CampTix and the CampTix Indian Payments
2. Enable the payment processor Instamojo
3. Create a ticket

To test:
1. Use a mobile device, or set the browser responsive design mode to use a phone user agent & touch controls
2. Log in to the site
3. Buy a ticket
4. Fill out the phone field with valid numbers using any format (only numbers, number and space, etc)
5. The form should not error with "Please enter only numbers"

You might see the 10-digit number error depending on what was entered.
