### PR TITLE
Allow skipping validation on URL

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -218,7 +218,7 @@ class WordCamp_Counts extends Base {
 	}
 
 	/**
- 	 * Simple method to check against URL field
+	 * Simple method to check against URL field
 	 *
 	 * @param int $wordcamp_id ID for the wordcamp post type.
 	 *
@@ -233,7 +233,7 @@ class WordCamp_Counts extends Base {
 		}
 		return true;
 	}
-	
+
 	/**
 	 * Query and parse the data for the report.
 	 *

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-counts.php
@@ -218,6 +218,23 @@ class WordCamp_Counts extends Base {
 	}
 
 	/**
+ 	 * Simple method to check against URL field
+	 *
+	 * @param int $wordcamp_id ID for the wordcamp post type.
+	 *
+	 * @return bool
+	 */
+	public function is_a_wordcamp_url( $wordcamp_id ) {
+		$url = get_post_meta( $wordcamp_id, 'URL', true );
+
+		// doaction sites are tracked but break the validate wordcamp site check.
+		if ( false !== strpos( $url, 'doaction' ) ) {
+			return false;
+		}
+		return true;
+	}
+	
+	/**
 	 * Query and parse the data for the report.
 	 *
 	 * @return array
@@ -246,6 +263,9 @@ class WordCamp_Counts extends Base {
 
 		foreach ( $wordcamp_ids as $wordcamp_id ) {
 			try {
+				if ( ! $this->is_a_wordcamp_url( $wordcamp_id ) ) {
+					continue;
+				}
 				$valid = validate_wordcamp_id( $wordcamp_id );
 
 				$data = array_merge( $data, $this->get_data_for_site( $valid->site_id, $valid->post_id ) );


### PR DESCRIPTION
adds method to skip URLs which are incompatible with report, i.e. doaction events.

Fixes #1412.