### PR TITLE
Alter application emails to include link to WC Central

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -281,7 +281,7 @@ abstract class Event_Application {
 			"---- Internal details for the Community Team ----\n\n
 			Name: %1\$s\n
 			Type: %2\$s\n
-			URL: : https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
+			URL: https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
 			$this->get_event_label(),
 			sanitize_text_field( $event_city ),
 			absint( $application_post ),

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -260,7 +260,7 @@ abstract class Event_Application {
 	 * @param string $event_city
 	 * @param int    $application_post id of post created on WC Central.
 	 */
-	public function notify_applicant_application_received( $email_address, $event_city, $application_post ) {
+	public function notify_applicant_application_received( $email_address, $event_city, $application_post = 0 ) {
 		//translators: Name of the event. E.g. WordCamp or meetup.
 		$subject = sprintf( __( "We've received your %s application", 'wordcamporg' ), $this->get_event_label() );
 		$headers = array(
@@ -280,12 +280,17 @@ abstract class Event_Application {
 		$message .= sprintf(
 			"---- Internal details for the Community Team ----\n\n
 			Name: %1\$s\n
-			Type: %2\$s\n
-			URL: https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
+			Type: %2\$s\n",
 			$this->get_event_label(),
 			sanitize_text_field( $event_city ),
-			absint( $application_post ),
 		);
+
+		if ( 0 !== $application_post ) {
+			$message .= sprintf(
+				"URL: https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
+				absint( $application_post )
+			);
+		}
 
 		wp_mail( $email_address, $subject, $message, $headers );
 	}

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -278,16 +278,16 @@ abstract class Event_Application {
 			sanitize_text_field( $event_city )
 		);
 		$message .= sprintf(
-			"---- Internal details for the Community Team ----\n\n
+			"---- Internal details for the Community Team ----\n
 			Name: %1\$s\n
-			Type: %2\$s\n",
+			Type: %2\$s",
 			$this->get_event_label(),
 			sanitize_text_field( $event_city ),
 		);
 
 		if ( 0 !== $application_post ) {
 			$message .= sprintf(
-				'URL: https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit',
+				"\nURL: https://central.wordcamp.org/wp-admin/post.php?post=%1\$d&amp;action=edit",
 				absint( $application_post )
 			);
 		}

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -132,10 +132,15 @@ abstract class Event_Application {
 			$message        = $application_data->get_error_message();
 			$notice_classes = 'notice-error';
 		} else {
-			$this->create_post( $application_data );
+			$application_post = $this->create_post( $application_data );
+			if ( is_wp_error( $application_post ) ) {
+				// Set application post to an int, rather than wp_error.
+				$application_post = 0;
+			}
 			$this->notify_applicant_application_received(
 				$this->get_organizer_email(),
-				$this->get_event_location()
+				$this->get_event_location(),
+				$application_post
 			);
 
 			$this->notify_new_application_in_slack();
@@ -253,8 +258,9 @@ abstract class Event_Application {
 	 *
 	 * @param string $email_address
 	 * @param string $event_city
+     * @param int $application_post id of post created on WC Central.
 	 */
-	public function notify_applicant_application_received( $email_address, $event_city ) {
+	public function notify_applicant_application_received( $email_address, $event_city, $application_post ) {
 		//translators: Name of the event. E.g. WordCamp or meetup.
 		$subject = sprintf( __( "We've received your %s application", 'wordcamporg' ), $this->get_event_label() );
 		$headers = array(
@@ -265,11 +271,20 @@ abstract class Event_Application {
 		//translators: 1: Name of the event. 2: City of the event.
 		$message = sprintf(
 			__(
-				"Thank you for applying to organize a %1\$s in %2\$s! We'll send you a follow-up e-mail once we've had a chance to review your application.",
+				"Thank you for applying to organize a %1\$s in %2\$s! We'll send you a follow-up e-mail once we've had a chance to review your application.\n\n",
 				'wordcamporg'
 			),
 			$this->get_event_label(),
 			sanitize_text_field( $event_city )
+		);
+		$message .= sprintf(
+				"---- Internal details for the Community Team ----\n\n
+				Name: %1\$s\n
+				Type: %2\$s\n
+				URL: : https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
+			$this->get_event_label(),
+			sanitize_text_field( $event_city ),
+			absint( $application_post ),
 		);
 
 		wp_mail( $email_address, $subject, $message, $headers );

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -258,7 +258,7 @@ abstract class Event_Application {
 	 *
 	 * @param string $email_address
 	 * @param string $event_city
-     * @param int $application_post id of post created on WC Central.
+	 * @param int $application_post id of post created on WC Central.
 	 */
 	public function notify_applicant_application_received( $email_address, $event_city, $application_post ) {
 		//translators: Name of the event. E.g. WordCamp or meetup.

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -287,7 +287,7 @@ abstract class Event_Application {
 
 		if ( 0 !== $application_post ) {
 			$message .= sprintf(
-				"URL: https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
+				'URL: https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit',
 				absint( $application_post )
 			);
 		}

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-application.php
@@ -258,7 +258,7 @@ abstract class Event_Application {
 	 *
 	 * @param string $email_address
 	 * @param string $event_city
-	 * @param int $application_post id of post created on WC Central.
+	 * @param int    $application_post id of post created on WC Central.
 	 */
 	public function notify_applicant_application_received( $email_address, $event_city, $application_post ) {
 		//translators: Name of the event. E.g. WordCamp or meetup.
@@ -278,10 +278,10 @@ abstract class Event_Application {
 			sanitize_text_field( $event_city )
 		);
 		$message .= sprintf(
-				"---- Internal details for the Community Team ----\n\n
-				Name: %1\$s\n
-				Type: %2\$s\n
-				URL: : https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
+			"---- Internal details for the Community Team ----\n\n
+			Name: %1\$s\n
+			Type: %2\$s\n
+			URL: : https://central.wordcamp.org/wp-admin/post.php?post=%3\$d&amp;action=edit",
 			$this->get_event_label(),
 			sanitize_text_field( $event_city ),
 			absint( $application_post ),

--- a/public_html/wp-content/plugins/wcpt/wcpt-events/class-events-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-events/class-events-application.php
@@ -145,7 +145,7 @@ class Events_Application extends WordCamp_Application {
 	 *
 	 * @param array $data
 	 *
-	 * @return bool|WP_Error
+	 * @return int|WP_Error
 	 */
 	public function create_post( $data ) {
 		// Create the post.
@@ -201,7 +201,7 @@ ADDRESS;
 
 		$this->post = get_post( $post_id );
 
-		return true;
+		return $post_id;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-application.php
@@ -207,7 +207,7 @@ class Meetup_Application extends Event_Application {
 	 *
 	 * @param array $data
 	 *
-	 * @return bool|WP_Error
+	 * @return int|WP_Error
 	 */
 	public function create_post( $data ) {
 		// Create the post.
@@ -264,7 +264,7 @@ ADDRESS;
 
 		$this->post = get_post( $post_id );
 
-		return true;
+		return $post_id;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -186,7 +186,7 @@ class WordCamp_Application extends Event_Application {
 	 *
 	 * @param array $data
 	 *
-	 * @return bool|\WP_Error
+	 * @return int|\WP_Error
 	 */
 	public function create_post( $data ) {
 		// Create the post.
@@ -259,7 +259,7 @@ class WordCamp_Application extends Event_Application {
 		);
 
 		$this->post = get_post( $post_id );
-		return true;
+		return $post_id;
 	}
 
 	/**


### PR DESCRIPTION
Changes general structure of `create_post` to return the post_id created (or wp_error).

Fixes #1415.

