### PR TITLE
Log ticket purchases via usermeta on user profile

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8619,7 +8619,7 @@ class CampTix_Plugin {
 			$ticket_id = intval( get_post_meta( $attendee->ID, 'tix_ticket_id', true ) );
 			$ticket = get_post( $ticket_id );
 			$ticket_type = $ticket->post_title;
-			$purchase_date = esc_html( mysql2date( get_option( 'date_format' ), $attendee->post_date ) );
+			$purchase_date = $attendee->post_date;
 			$edit_token = get_post_meta( $attendee->ID, 'tix_edit_token', true );
 			$edit_link = $this->get_edit_attendee_link( $attendee->ID, $edit_token );
 			$total_price = $this->append_currency( (float) get_post_meta( $attendee->ID, 'tix_order_total', true ), false );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7674,6 +7674,7 @@ class CampTix_Plugin {
 
 			if ( self::PAYMENT_STATUS_COMPLETED == $result ) {
 				$attendee->post_status = 'publish';
+				$this->log_ticket_purchase_on_user_profile( $attendee );
 				wp_update_post( $attendee );
 			}
 
@@ -8595,6 +8596,58 @@ class CampTix_Plugin {
 	public function has_tickets_available() {
 		return $this->number_available_tickets() > 0;
 	}
+
+	/**
+	 * Log the purchased ticket information on the user's profile.
+	 *
+	 * @param object $attendee The attendee object containing ticket information.
+	 */
+	function log_ticket_purchase_on_user_profile( $attendee ) {
+		$user_id = get_current_user_id();
+		$purchase_history = get_user_meta( $user_id, 'wordcamp_ticket_history', true );
+
+		// Initialize the purchase history as an empty array if it's not already an array.
+		if ( ! is_array( $purchase_history ) ) {
+			$purchase_history = array();
+		}
+
+		// Check if the current attendee's ID is already in the purchase history.
+		$existing_attendee_ids = array_column( $purchase_history, 'id' );
+		if ( ! in_array( $attendee->ID, $existing_attendee_ids ) ) {
+			// Gather ticket details to log the purchase.
+			$ticket_id = intval( get_post_meta( $attendee->ID, 'tix_ticket_id', true ) );
+			$ticket = get_post( $ticket_id );
+			$ticket_type = $ticket->post_title;
+			$purchase_date = esc_html( mysql2date( get_option( 'date_format' ), $attendee->post_date ) );
+			$edit_token = get_post_meta( $attendee->ID, 'tix_edit_token', true );
+			$edit_link = $this->get_edit_attendee_link( $attendee->ID, $edit_token );
+			$total_price = $this->append_currency( (float) get_post_meta( $attendee->ID, 'tix_order_total', true ), false );
+			$access_token = get_post_meta( $attendee->ID, 'tix_access_token', true );
+			$access_link = $this->get_access_tickets_link( $access_token );
+
+			// Create a new purchase entry.
+			$new_purchase = array(
+				'id' => $attendee->ID,
+				'name' => get_wordcamp_name(),
+				'site_url' => site_url(),
+				'purchase_date' => $purchase_date,
+				'ticket_type' => $ticket_type,
+				'total_price' => $total_price,
+				'access_link' => $access_link,
+				'edit_link' => $edit_link,
+			);
+
+			// Add a refund link if the ticket is refundable.
+			if ( $this->is_refundable( $attendee->ID ) ) {
+				$new_purchase['refund_link'] = esc_url( $this->get_refund_tickets_link( $access_token ) );
+			}
+
+			$purchase_history[] = $new_purchase;
+
+			update_user_meta( $user_id, 'wordcamp_ticket_history', $purchase_history );
+		}
+	}
+
 }
 
 // Initialize the $camptix global.

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7674,8 +7674,8 @@ class CampTix_Plugin {
 
 			if ( self::PAYMENT_STATUS_COMPLETED == $result ) {
 				$attendee->post_status = 'publish';
-				$this->log_ticket_purchase_on_user_profile( $attendee );
 				wp_update_post( $attendee );
+				$this->log_ticket_purchase_on_user_profile( $attendee );
 			}
 
 			if ( self::PAYMENT_STATUS_PENDING == $result ) {
@@ -7688,6 +7688,7 @@ class CampTix_Plugin {
 				wp_update_post( $attendee );
 				update_post_meta( $attendee->ID, 'tix_refund_transaction_id', $refund_transaction_id );
 				update_post_meta( $attendee->ID, 'tix_refund_transaction_details', $refund_transaction_details );
+				$this->update_ticket_status_on_user_profile( $attendee->ID, $attendee->post_status );
 				$this->log( sprintf( 'Refunded %s by user request in %s.', $transaction_id, $refund_transaction_id ), $attendee->ID, $data, 'refund' );
 			}
 
@@ -8624,17 +8625,19 @@ class CampTix_Plugin {
 			$total_price = $this->append_currency( (float) get_post_meta( $attendee->ID, 'tix_order_total', true ), false );
 			$access_token = get_post_meta( $attendee->ID, 'tix_access_token', true );
 			$access_link = $this->get_access_tickets_link( $access_token );
+			$ticket_status = $attendee->post_status;
 
 			// Create a new purchase entry.
 			$new_purchase = array(
 				'id' => $attendee->ID,
-				'name' => get_wordcamp_name(),
+				'wordcamp_name' => get_wordcamp_name(),
 				'site_url' => site_url(),
 				'purchase_date' => $purchase_date,
 				'ticket_type' => $ticket_type,
 				'total_price' => $total_price,
 				'access_link' => $access_link,
 				'edit_link' => $edit_link,
+				'ticket_status' => $ticket_status,
 			);
 
 			// Add a refund link if the ticket is refundable.
@@ -8648,6 +8651,29 @@ class CampTix_Plugin {
 		}
 	}
 
+	/**
+	 * Update purchased ticket status on the user's profile.
+	 *
+	 * @param int $attendee_id The ID of the rufunded attendee.
+	 * @param string $ticket_status Ticket status.
+	 */
+	function update_ticket_status_on_user_profile( $attendee_id, $ticket_status ) {
+		$user_id = get_current_user_id();
+		$purchase_history = get_user_meta( $user_id, 'wordcamp_ticket_history', true );
+
+		// If there's no purchase history or it's not an array, nothing to udpate.
+		if ( ! is_array( $purchase_history ) || empty( $purchase_history ) ) {
+			return;
+		}
+
+		foreach ( $purchase_history as $index => $ticket ) {
+			if ( isset( $ticket['id'] ) && intval( $ticket['id'] ) === intval( $attendee_id ) ) {
+				$purchase_history[ $index ]['ticket_status'] = $ticket_status;
+				update_user_meta( $user_id, 'wordcamp_ticket_history', $purchase_history );
+				return;
+			}
+		}
+	}
 }
 
 // Initialize the $camptix global.

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8619,10 +8619,10 @@ class CampTix_Plugin {
 			$ticket_id = intval( get_post_meta( $attendee->ID, 'tix_ticket_id', true ) );
 			$ticket = get_post( $ticket_id );
 			$ticket_type = $ticket->post_title;
+			$ticket_price = $this->append_currency( (float) get_post_meta( $attendee->ID, 'tix_ticket_price', true ), false );
 			$purchase_date = $attendee->post_date;
 			$edit_token = get_post_meta( $attendee->ID, 'tix_edit_token', true );
 			$edit_link = $this->get_edit_attendee_link( $attendee->ID, $edit_token );
-			$total_price = $this->append_currency( (float) get_post_meta( $attendee->ID, 'tix_order_total', true ), false );
 			$access_token = get_post_meta( $attendee->ID, 'tix_access_token', true );
 			$access_link = $this->get_access_tickets_link( $access_token );
 			$ticket_status = $attendee->post_status;
@@ -8634,7 +8634,7 @@ class CampTix_Plugin {
 				'site_url' => site_url(),
 				'purchase_date' => $purchase_date,
 				'ticket_type' => $ticket_type,
-				'total_price' => $total_price,
+				'ticket_price' => $ticket_price,
 				'access_link' => $access_link,
 				'edit_link' => $edit_link,
 				'ticket_status' => $ticket_status,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR tries to update the usermeta upon ticket purchase completion, enabling the purchased tickets to be displayed on the user profile. It also updates the display to reflect the corresponding status after a refund.

Currently, during a transfer (changing the name via Edit), there is no field to specify the transferee's .org account, so after the transfer, the ticket still appears in the purchaser's profile.

And if multiple tickets are purchased at once, though they are displayed in separate rows on the profile, pressing refund on one of these tickets will refund all tickets purchased in that transaction.

For the mobile UI, switching to a card-style layout could improve the design.

Any thoughts or suggestions?

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
See #1411

### Screencasts


https://github.com/user-attachments/assets/ed8ea40b-9e1f-435f-bac8-9ecd6132884a

### Screenshots

<img width="1728" alt="Screenshot 2024-11-01 at 14 51 10" src="https://github.com/user-attachments/assets/d9dc8055-9e63-484b-8347-afd2b0158f1e">
<img width="1728" alt="Screenshot 2024-11-01 at 14 51 50" src="https://github.com/user-attachments/assets/90b359f4-bb60-404d-be1a-cdf60bd69ef4">



### How to test the changes in this Pull Request:

While sandboxed
1. Apply changes to `wp-content/plugins/camptix/camptix.php`
2. apply changes to `wporg-profiles/class-wporg-profiles.php`
3. apply changes to `single/profile.php`
4. Go to https://testing.wordcamp.org/2019/tickets/ and buy tickets
5. Check out https://profiles.wordpress.org/{user_name}/#content-events and try the actions.

<details>
<summary>wp-content/plugins/camptix/camptix.php</summary>

```
Index: wp-content/plugins/camptix/camptix.php
===================================================================
--- wp-content/plugins/camptix/camptix.php	(revision 4963)
+++ wp-content/plugins/camptix/camptix.php	(working copy)
@@ -7675,6 +7675,7 @@
 			if ( self::PAYMENT_STATUS_COMPLETED == $result ) {
 				$attendee->post_status = 'publish';
 				wp_update_post( $attendee );
+				$this->log_ticket_purchase_on_user_profile( $attendee );
 			}
 
 			if ( self::PAYMENT_STATUS_PENDING == $result ) {
@@ -7687,6 +7688,7 @@
 				wp_update_post( $attendee );
 				update_post_meta( $attendee->ID, 'tix_refund_transaction_id', $refund_transaction_id );
 				update_post_meta( $attendee->ID, 'tix_refund_transaction_details', $refund_transaction_details );
+				$this->update_ticket_status_on_user_profile( $attendee->ID, $attendee->post_status );
 				$this->log( sprintf( 'Refunded %s by user request in %s.', $transaction_id, $refund_transaction_id ), $attendee->ID, $data, 'refund' );
 			}
 
@@ -8595,6 +8597,83 @@
 	public function has_tickets_available() {
 		return $this->number_available_tickets() > 0;
 	}
+
+	/**
+	 * Log the purchased ticket information on the user's profile.
+	 *
+	 * @param object $attendee The attendee object containing ticket information.
+	 */
+	function log_ticket_purchase_on_user_profile( $attendee ) {
+		$user_id = get_current_user_id();
+		$purchase_history = get_user_meta( $user_id, 'wordcamp_ticket_history', true );
+
+		// Initialize the purchase history as an empty array if it's not already an array.
+		if ( ! is_array( $purchase_history ) ) {
+			$purchase_history = array();
+		}
+
+		// Check if the current attendee's ID is already in the purchase history.
+		$existing_attendee_ids = array_column( $purchase_history, 'id' );
+		if ( ! in_array( $attendee->ID, $existing_attendee_ids ) ) {
+			// Gather ticket details to log the purchase.
+			$ticket_id = intval( get_post_meta( $attendee->ID, 'tix_ticket_id', true ) );
+			$ticket = get_post( $ticket_id );
+			$ticket_type = $ticket->post_title;
+			$ticket_price = $this->append_currency( (float) get_post_meta( $attendee->ID, 'tix_ticket_price', true ), false );
+			$purchase_date = $attendee->post_date;
+			$edit_token = get_post_meta( $attendee->ID, 'tix_edit_token', true );
+			$edit_link = $this->get_edit_attendee_link( $attendee->ID, $edit_token );
+			$access_token = get_post_meta( $attendee->ID, 'tix_access_token', true );
+			$access_link = $this->get_access_tickets_link( $access_token );
+			$ticket_status = $attendee->post_status;
+
+			// Create a new purchase entry.
+			$new_purchase = array(
+				'id' => $attendee->ID,
+				'wordcamp_name' => get_wordcamp_name(),
+				'site_url' => site_url(),
+				'purchase_date' => $purchase_date,
+				'ticket_type' => $ticket_type,
+				'ticket_price' => $ticket_price,
+				'access_link' => $access_link,
+				'edit_link' => $edit_link,
+				'ticket_status' => $ticket_status,
+			);
+
+			// Add a refund link if the ticket is refundable.
+			if ( $this->is_refundable( $attendee->ID ) ) {
+				$new_purchase['refund_link'] = esc_url( $this->get_refund_tickets_link( $access_token ) );
+			}
+
+			$purchase_history[] = $new_purchase;
+
+			update_user_meta( $user_id, 'wordcamp_ticket_history', $purchase_history );
+		}
+	}
+
+	/**
+	 * Update purchased ticket status on the user's profile.
+	 *
+	 * @param int $attendee_id The ID of the rufunded attendee.
+	 * @param string $ticket_status Ticket status.
+	 */
+	function update_ticket_status_on_user_profile( $attendee_id, $ticket_status ) {
+		$user_id = get_current_user_id();
+		$purchase_history = get_user_meta( $user_id, 'wordcamp_ticket_history', true );
+
+		// If there's no purchase history or it's not an array, nothing to udpate.
+		if ( ! is_array( $purchase_history ) || empty( $purchase_history ) ) {
+			return;
+		}
+
+		foreach ( $purchase_history as $index => $ticket ) {
+			if ( isset( $ticket['id'] ) && intval( $ticket['id'] ) === intval( $attendee_id ) ) {
+				$purchase_history[ $index ]['ticket_status'] = $ticket_status;
+				update_user_meta( $user_id, 'wordcamp_ticket_history', $purchase_history );
+				return;
+			}
+		}
+	}
 }
 
 // Initialize the $camptix global.

```

</details>

<details>
<summary>wporg-profiles/class-wporg-profiles.php</summary>

```
Index: wporg-profiles/class-wporg-profiles.php
===================================================================
--- wporg-profiles/class-wporg-profiles.php	(revision 22903)
+++ wporg-profiles/class-wporg-profiles.php	(working copy)
@@ -70,7 +70,7 @@
 		$skip_components = array_flip( array( 'xprofile' ) );
 
 		// Types to skip.
-		$skip_types = array_flip( array( 'wordcamp_attendee_add' ) );
+		$skip_types = array_flip( array() );
 
 		$activities = $wpdb->get_results( $wpdb->prepare(
 			"SELECT *
@@ -1048,9 +1048,28 @@
 	 * @return array
 	 */
 	public function get_events() {
-		/* todo - implement this */
+		clean_user_cache( $this->user_id );
+		
+		$wordcamp_ticket_history = get_user_meta( $this->user_id, 'wordcamp_ticket_history', true );
 
-		return array( 'items' => array() );
+		// Sort ASC by purchase date.
+		usort( $wordcamp_ticket_history, function ($a, $b) { return strcmp( $b['purchase_date'], $a['purchase_date'] ); } );
+
+		// Update the 'ticket_status' to the user-friendly label.
+		$status_mapping = array(
+			'publish'  => 'Confirmed',
+			'refund' => 'Refunded',
+			'pending'  => 'Pending Confirmation',
+			'cancel' => 'Cancelled',
+			'failed' => 'Payment Failed',
+		);
+		foreach ( $wordcamp_ticket_history as &$ticket ) {
+			if ( isset( $ticket['ticket_status'] ) ) {
+				$ticket['ticket_status'] = $status_mapping[ $ticket['ticket_status'] ];
+			}
+		}
+
+		return array( 'items' => $wordcamp_ticket_history );
 	}
 
 	/**
```

</details>

<details>
<summary>single/profile.php</summary>

```
Index: single/profile.php
===================================================================
--- single/profile.php	(revision 22903)
+++ single/profile.php	(working copy)
@@ -216,7 +216,7 @@
 							</li>
 						<?php endif; ?>
 
-						<?php if ( count( $events['items'] ) ) : ?>
+						<?php if ( is_array( $events['items'] ) && count( $events['items'] ) ) : ?>
 							<li class="<?php echo 'events' == $active_class ? ' active' : 'inactive'; ?>">
 								<a href="#content-events">Events</a>
 							</li>
@@ -623,21 +623,47 @@
 						</div>
 					<?php } ?>
 
-					<?php if ( count( $events['items'] ) ) : ?>
+					<?php if ( is_array( $events['items'] ) && count( $events['items'] ) ) : ?>
 						<div id="content-events" class="info-group <?php echo 'events' == $active_class ? ' active' : 'inactive'; ?>">
-							<h4><?php echo bp_word_or_name( __( "My Events", 'buddypress' ), __( "%s's Events", 'buddypress' ), true, false ) ?></h4>
-
 							<ul>
-								<?php foreach ( $events['items'] as $event ) { ?>
-									<li>
-										<h3>
-											<a href="<?php echo esc_url( 'event url' ); ?>"><?php echo esc_html( 'event name' ); ?></a>
-										</h3>
-
-										<p>Event Description</p>
-									</li>
-
-								<?php } ?>
+								<li>
+									<table style="width:100%; border-collapse: collapse;">
+									<thead>
+										<tr style="background-color: #222; color: white; font-size: 14px;">
+										<th style="padding: 10px; border: 1px solid #444;">Event</th>
+										<th style="padding: 10px; border: 1px solid #444;">Purchase Date</th>
+										<th style="padding: 10px; border: 1px solid #444;">Ticket Type</th>
+										<th style="padding: 10px; border: 1px solid #444;">Total</th>
+										<th style="padding: 10px; border: 1px solid #444;">Actions</th>
+										<th style="padding: 10px; border: 1px solid #444;">Status</th>
+										</tr>
+									</thead>
+									<?php foreach ( $events['items'] as $ticket ) { ?>
+										<tbody>
+											<tr style="font-size: 14px;">
+											<td style="padding: 10px; border: 1px solid #444;">
+												<a href="<?php echo $ticket['site_url']; ?>"><?php echo $ticket['wordcamp_name'] ?></a>
+											</td>
+											<td style="padding: 10px; border: 1px solid #444;"><?php echo esc_html( mysql2date( get_option( 'date_format' ), $ticket['purchase_date'] ) ); ?>
+											<th style="padding: 10px; border: 1px solid #444;"><?php echo $ticket['ticket_type'] ?></th>
+											<td style="padding: 10px; border: 1px solid #444; text-wrap: nowrap;"><?php echo $ticket['ticket_price'] ?></td>
+											<td style="padding: 10px; border: 1px solid #444; text-wrap: nowrap; text-align: center;">
+												<?php if ( 'Confirmed' === $ticket['ticket_status']) { ?>
+													<a href="<?php echo esc_url( $ticket['access_link'] ); ?>">View</a>
+													/ <a href="<?php echo esc_url( $ticket['edit_link'] ); ?>">Edit</a>
+													<?php if ( ! empty( $ticket['refund_link'] ) ) { ?>
+														/ <a href="<?php echo esc_url( $ticket['refund_link'] ); ?>">Refund</a>
+													<?php } ?>
+												<?php } else { ?>
+													-
+												<?php } ?>
+											</td>
+											<td style="padding: 10px; border: 1px solid #444; text-wrap: nowrap;"><?php echo $ticket['ticket_status'] ?></td>
+											</tr>
+										</tbody>
+									<?php } ?>	
+									</table>
+								</li>
 							</ul>
 						</div>
 					<?php endif; ?>
```
</details>

