### PR TITLE
Add check to is_wordcamp_closed function

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8584,6 +8584,10 @@ class CampTix_Plugin {
 	 */
 	public function is_wordcamp_closed() {
 		$wordcamp = get_wordcamp_post();
+		// get_wordcamp_post() returns false if no post exists, so avoid breaking by returning here since it is not explicitly closed.
+		if ( false === $wordcamp ) {
+			return false;
+		}
 		return 'wcpt-closed' === $wordcamp->post_status;
 	}
 


### PR DESCRIPTION
When a `get_wordcamp_post()` cannot find a post, it return false, which then breaks the check against `post_status` - this stops that happening, and should also allow testing of tickets (when there is no post on central.wordcamp.org).

cc @StevenDufresne.

