### PR TITLE
Default coupon discount text to 0%.

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -5675,8 +5675,9 @@ class CampTix_Plugin {
 									<?php if ( $this->coupon ) : ?>
 										<input type="hidden" name="tix_coupon" value="<?php echo esc_attr( $this->coupon->post_title ); ?>" />
 										<?php
-										$discount_price = (float) $this->coupon->tix_discount_price;
+										$discount_price   = (float) $this->coupon->tix_discount_price;
 										$discount_percent = (float) $this->coupon->tix_discount_percent;
+										$discount_text    = '0%';
 										if ( $discount_price > 0 ) {
 											$discount_text = $this->append_currency( $discount_price );
 										} elseif ( $discount_percent > 0 ) {


### PR DESCRIPTION
Some WordCamps include coupons for tracking purposes, that doesn't actually change the ticketed price.

Resolves
```
E_NOTICE: Undefined variable: discount_text
```
