### PR TITLE
Stripe: Check the correct status for completed checkout sessions.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -658,7 +658,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		// Uh oh, we've hit timeout on a ticket, but the linked checkout session succeeded.
-		if ( 'succeeded' === $session['status'] && 'paid' === $session['payment_status'] ) {
+		if ( 'complete' === $session['status'] && 'paid' === $session['payment_status'] ) {
 			$camptix->log( 'Stripe checkout timed out, but order succeeded.', $attendee_id, $session );
 
 			$transaction_id = $session['payment_intent']['latest_charge'] ?? '';


### PR DESCRIPTION
In #1256 the code 'succeeded' was used, instead of the documented 'complete'.

https://docs.stripe.com/api/checkout/sessions/object#checkout_session_object-status

This appears to have resulted in this code branch never having worked.