### PR TITLE
Avoid a PHP Notice: Undefined index: tix_attendee_id

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -76,7 +76,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 			// Temporary: We don't want to block users from editing tickets unless they are unconfirmed.
 			// See: https://github.com/WordPress/wordcamp.org/issues/1393.
 			// See: https://github.com/WordPress/wordcamp.org/issues/1420.
-			if ( $this->user_is_editing_ticket() && ! $this->user_must_confirm_ticket( $_REQUEST['tix_attendee_id'] ) ) {
+			if ( $this->user_is_editing_ticket() && ! $this->user_must_confirm_ticket( $_REQUEST['tix_attendee_id'] ?? null ) ) {
 				return;
 			}
 
@@ -200,7 +200,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		}
 
 		// Ask the attendee to confirm their registration
-		if ( $this->user_is_editing_ticket() && $this->user_must_confirm_ticket( $_REQUEST['tix_attendee_id'] ) ) {
+		if ( $this->user_is_editing_ticket() && $this->user_must_confirm_ticket( $_REQUEST['tix_attendee_id'] ?? null ) ) {
 			$tickets_selected = array( get_post_meta( $_REQUEST['tix_attendee_id'], 'tix_ticket_id', true ) => 1 );  // mimic $_REQUEST['tix_tickets_selected']
 
 			if ( $this->tickets_have_questions( $tickets_selected ) ) {


### PR DESCRIPTION
As we're temporarily allowing users to edit tickets without a connected user, we're hitting the above notice on every ticket edit action.

The `user_must_confirm_ticket()` method first does an `isset()` to return early if `null` is passed in, which is the default behaviour when referring to a array item that does not exist.

This change should have no logic changes as a result, but should result in the PHP Notice ceasing to exist.

```
Undefined index: tix_attendee_id
URL: https://example.wordcamp.org/2025/tickets/?tix_action=access_tickets&tix_access_token=MyTicketTokenHere
File: wp-content/plugins/camptix/addons/require-login.php:79
File: wp-content/plugins/camptix/addons/require-login.php:203
```