### PR TITLE
WordCamp Forms: Avoid a notice when submitting localised speaker applications

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -474,7 +474,7 @@ class WordCamp_Forms_To_Drafts {
 			$subject = sprintf(
 				__( 'Your %1$s Call for Speakers submission: %2$s', 'wordcamporg' ),
 				get_bloginfo( 'name' ),
-				sanitize_text_field( $all_values['Topic Title'] )
+				sanitize_text_field( $all_values['Topic Title'] ?? '' )
 			);
 		}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

This fixes the notices caused by localised speaker forms:
```
E_WARNING: Undefined array key "Topic Title"
wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php:477
```

This isn't ideal, in that many forms don't actually use the expected english titles, but avoiding the notice is worthwhile.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
