### PR TITLE
Budget Tool: Don't allow access to the approved/working budget when still in the prelim state.

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/budget-tool.php
@@ -339,6 +339,11 @@ class WordCamp_Budget_Tool {
 			$view = 'prelim';
 		}
 
+		// Don't allow accessing a budget that's not yet available.
+		if ( ! isset( $budget[ $view ] ) ) {
+			$view = 'prelim';
+		}
+
 		if ( 'prelim' === $view && 'approved' === $budget['status'] ) {
 			$view = 'approved';
 		}


### PR DESCRIPTION

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

Attempting to access the Working/Approved budgets while still in the prelim/not-approved state causes a rather broken UI and attempting to save it hits many warnings. This just fixes the UI to see the prelim/approved budget when that's intended.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<img width="1560" alt="Screenshot 2025-02-12 at 12 42 33 pm" src="https://github.com/user-attachments/assets/5e2ee6f9-cf81-45d3-af0b-88a96a431b1b" />


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
