### PR TITLE
Avoid a PHP Warning when accessing the submitted-badges confirmation page upon refresh

### DIFF
--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-badges.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-badges.php
@@ -11,7 +11,7 @@ use WordPressdotorg\Profiles;
  */
 function process_badges() {
 
-	if ( ! current_user_can( 'manage_options' ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'badge-submission' ) ) {
+	if ( ! current_user_can( 'manage_options' ) || empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'badge-submission' ) ) {
 		return __( 'Invalid request', 'wordcamporg' );
 	}
 
@@ -48,7 +48,7 @@ function process_badges() {
  * Outputs manage badge admin screen, and allows processing of submit.
  */
 function menu_badges() {
-	if ( isset( $_GET['badge-submit'] ) && ( 1 == $_GET['badge-submit'] ) ) {
+	if ( ! empty( $_POST ) ) {
 		$output = process_badges();
 		wp_admin_notice( $output );
 	}
@@ -59,7 +59,7 @@ function menu_badges() {
 		<h1><?php esc_html_e( 'Profile Badge Management', 'wordcamporg' ); ?></h1>
 		<p><?php esc_html_e( 'This tool allows a limited number of badges to be managed on wordpress.org profiles', 'wordcamporg' ); ?></p>
 	</div>
-	<form method="post" action="<?php echo esc_url( add_query_arg( 'badge-submit', '1' ) ); ?>">
+	<form method="post">
 		<div>
 			<select name="badge_name">
 				<option value="wordcamp-volunteer"><?php esc_html_e( 'WordCamp Volunteer', 'wordcamporg' ); ?></option>

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-badges.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-badges.php
@@ -48,6 +48,7 @@ function process_badges() {
  * Outputs manage badge admin screen, and allows processing of submit.
  */
 function menu_badges() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing
 	if ( ! empty( $_POST ) ) {
 		$output = process_badges();
 		wp_admin_notice( $output );


### PR DESCRIPTION

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
```
E_WARNING: Undefined array key "_wpnonce"
wp-content/plugins/camptix/inc/class-camptix-badges.php:14

URL: https://asia.wordcamp.org/2025/wp-admin/edit.php?post_type=tix_ticket&page=camptix_badges&badge-submit=1
```

Reloading / Accessing the URL  above causes PHP Warnings to be thrown, and `Invalid Request` to be shown in the UI.. when seemingly it probably shouldn't have attempted to perform any actions.

@pkevan this is untested, but I don't see the need to use an extra query-var here, and the existence of the POST data is probably enough, is there something I'm missing?


<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
