### PR TITLE
WordCamp Forms: Final PHP Warning from unset fields on forms.

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -271,6 +271,10 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int
 	 */
 	protected function get_user_id_from_username( $username ) {
+		if ( ! $username ) {
+			return 0;
+		}
+
 		$user = get_user_by( 'login', $username );
 
 		return empty( $user->ID ) ? 0 : $user->ID;
@@ -413,7 +417,7 @@ class WordCamp_Forms_To_Drafts {
 
 		$draft_id = wp_insert_post( array(
 			'post_type'    => 'wcb_volunteer',
-			'post_title'   => sanitize_text_field( $all_values['Name'] ),
+			'post_title'   => sanitize_text_field( $all_values['Name'] ?? '' ),
 			'post_status'  => 'draft',
 			'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
 		) );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
> E_WARNING Undefined array key "Name"
> File wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php:416

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
