### PR TITLE
Require Login: On the ticket overview page, include login links to edit links.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -667,7 +667,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		if ( $assigned_to_someone ) {
 			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . sprintf( __( 'Login as %s to edit information', 'wordcamporg' ), esc_html( $attendee_username ) ) . '</a>';
 
-		// 3 - NOOP.
+		// 3 - NOOP, user already has a different ticket.
 		// 4 - Login to claim
 		} elseif ( $login_to_claim ) {
 			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . __( 'Login to edit information', 'wordcamporg' ) . '</a>';

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -663,7 +663,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 
 		$current_user_ticket  = ( $current_user->user_login == $attendee_username );
 		$assigned_to_someone  = ( self::UNCONFIRMED_USERNAME != $attendee_username );
-		$assigned_to_no_one   = ( ( self::UNCONFIRMED_USERNAME == $attendee_username  ) || $is_unknown_attendee );
+		$assigned_to_no_one   = ( ( self::UNCONFIRMED_USERNAME == $attendee_username ) || $is_unknown_attendee );
 		$this_user_has_ticket = is_user_logged_in() && ! $current_user_ticket && $this->get_ticket_of_user( $current_user );
 		$login_to_claim       = $assigned_to_no_one && ! is_user_logged_in();
 		$can_claim_ticket     = $assigned_to_no_one && is_user_logged_in() && ! $this_user_has_ticket;

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -614,26 +614,68 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 * The buyer is no longer responsible for editing attendee info, but they are responsible
 	 * for ensuring that the unknown/unconfirmed attendees complete registration.
 	 *
-	 * @param string $content
+	 * @param string $edit_link_html
 	 * @param WP_Post $attendee
 	 *
 	 * @return string
 	 */
-	public function show_buyer_attendee_status_instead_of_edit_link( $content, $attendee ) {
+	public function show_buyer_attendee_status_instead_of_edit_link( $edit_link_html, $attendee ) {
 		$current_user          = wp_get_current_user();
 		$attendee_username     = get_post_meta( $attendee->ID, 'tix_username', true );
 		$unknown_attendee_info = $this->get_unknown_attendee_info();
 
-		if ( $attendee_username != $current_user->user_login ) {
-			$content = 'Status: ';
+		// Display the ticket status for all other tickets.
+		if ( get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email'] ) {
+			$content = _x( 'Status: Unknown', 'WordCamp ticket status.', 'wordcamporg' );
+		} elseif ( self::UNCONFIRMED_USERNAME == $attendee_username ) {
+			$content = _x( 'Status: Unconfirmed', 'WordCamp ticket status.', 'wordcamporg' );
+		} else {
+			$content = _x( 'Status: Confirmed', 'WordCamp ticket status.', 'wordcamporg' );
+		}
 
-			if ( get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email'] ) {
-				$content .= 'Unknown';
-			} elseif ( self::UNCONFIRMED_USERNAME == $attendee_username ) {
-				$content .= 'Unconfirmed';
-			} else {
-				$content .= 'Confirmed';
-			}
+		// Add a login link to simplify the edit experience.
+		// After logging in as the correct user, they'll come back to this page, where they should find an edit link.
+		// Note: This does not redirect them to the ticket, incase they login with the incorrect user.
+
+		$login_link = wp_login_url();
+		// If the ticket owner is known, add a hint to the url to prefill the login form.
+		if ( $attendee_username !== self::UNCONFIRMED_USERNAME ) {
+			$login_link = add_query_arg( 'user', wp_slash( $attendee_username ), $login_link );
+		}
+
+		// If the user is currently logged in, they'll need to logout first to login.
+		if ( is_user_logged_in() ) {
+			$login_link = wp_logout_url( $login_link );
+		}
+
+		// Several states:
+		// 1. The ticket is assigned to someone, but they are not logged in.
+		// 2. The ticket is assigned to someone other than the current user.
+		// 3. The ticket is assigned to no-one, but the current user has a ticket already. DO NOTHING.
+		// 4. The ticket is assigned to no-one, but the current user is not logged in.
+		// 5. The ticket is assigned to no-one, and the current user does not have a ticket (They can claim it)
+		// 6. The ticket is assigned to the current user.
+
+		$current_user_ticket  = ( $attendee_username == $current_user->user_login );
+		$assigned_to_someone  = ( $attendee_username !== self::UNCONFIRMED_USERNAME );
+		$assigned_to_no_one   = ( $attendee_username == self::UNCONFIRMED_USERNAME || get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email']);
+		$this_user_has_ticket = is_user_logged_in() && ! $current_user_ticket && $this->get_ticket_of_user( $current_user );
+		$login_to_claim       = $assigned_to_no_one && ! is_user_logged_in();
+		$can_claim_ticket     = $assigned_to_no_one && is_user_logged_in() && ! $this_user_has_ticket;
+
+		// 1 & 2 - Login to edit this ticeket.
+		if ( $assigned_to_someone ) {
+			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . sprintf( __( 'Login as %s to edit information', 'wordcamporg' ), esc_html( $attendee_username ) ) . '</a>';
+
+		// 3 - NOOP.
+		// 4 - Login to claim
+		} elseif ( $login_to_claim ) {
+			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . __( 'Login to edit information', 'wordcamporg' ) . '</a>';
+
+		// 5 - Claim the ticket, since you don't have one.
+		// 6 - Current user owns ticket, edit away.
+		} elseif ( $can_claim_ticket || $current_user_ticket ) {
+			$content .= '<br>' . $edit_link_html;
 		}
 
 		return $content;
@@ -909,6 +951,32 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 */
 	protected function user_must_confirm_ticket( $attendee_id ) {
 		return isset( $attendee_id ) && self::UNCONFIRMED_USERNAME == get_post_meta( $attendee_id, 'tix_username', true );
+	}
+
+	/**
+	 * Retrieve the ticket associated with the given user.
+	 *
+	 * @param WP_User $user The user object for whom to retrieve the ticket.
+	 * @return bool|WP_Post The ticket post object if found, false otherwise.
+	 */
+	protected function get_ticket_of_user( WP_User $user ) {
+		if ( empty( $user->user_login ) ) {
+			return false;
+		}
+
+		$ticket = get_posts( array(
+			'posts_per_page' => 1,
+			'post_type'      => 'tix_attendee',
+			'post_status'    => 'publish',
+			'meta_query'     => array(
+				array(
+					'key'   => 'tix_username',
+					'value' => $user->user_login,
+				),
+			),
+		) );
+
+		return $ticket ? reset( $ticket ) : false;
 	}
 } // CampTix_Require_Login
 

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -632,6 +632,8 @@ class CampTix_Require_Login extends CampTix_Addon {
 		} else {
 			$content = _x( 'Status: Confirmed', 'WordCamp ticket status.', 'wordcamporg' );
 		}
+		// Use a non-breaking space to prevent the text from wrapping.
+		$content = str_replace( ' ', '&nbsp;', $content );
 
 		// Add a login link to simplify the edit experience.
 		// After logging in as the correct user, they'll come back to this page, where they should find an edit link.
@@ -664,7 +666,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		$can_claim_ticket     = $assigned_to_no_one && is_user_logged_in() && ! $this_user_has_ticket;
 
 		// 1 & 2 - Login to edit this ticeket.
-		if ( $assigned_to_someone ) {
+		if ( $assigned_to_someone && ! $current_user_ticket ) {
 			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . sprintf( __( 'Login as %s to edit information', 'wordcamporg' ), esc_html( $attendee_username ) ) . '</a>';
 
 		// 3 - NOOP, user already has a different ticket.

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -81,9 +81,9 @@ class CampTix_Require_Login extends CampTix_Addon {
 			}
 
 			$args = $this->get_sanitized_tix_parameters( $_REQUEST );
-			$tickets_url = add_query_arg( $args, $camptix->get_tickets_url() );
+			$tickets_url = add_query_arg( urlencode_deep( $args ), $camptix->get_tickets_url() );
 
-			wp_safe_redirect( add_query_arg( 'wcname', get_bloginfo( 'name' ), wp_login_url( $tickets_url ) ) );
+			wp_safe_redirect( add_query_arg( 'wcname', urlencode( get_bloginfo( 'name' ) ), wp_login_url( $tickets_url ) ) );
 			exit();
 		}
 	}
@@ -180,7 +180,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 				'camptix_require_login_please_login_message',
 				sprintf(
 					__( 'Please <a href="%1$s">log in</a> or <a href="%2$s">create an account</a> to purchase your tickets.', 'wordcamporg' ),
-					wp_login_url( add_query_arg( $_REQUEST, $this->get_redirect_return_url() ) ),
+					wp_login_url( add_query_arg( urlencode_deep( $_REQUEST ), $this->get_redirect_return_url() ) ),
 					wp_registration_url()
 				)
 			) );
@@ -620,12 +620,15 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 * @return string
 	 */
 	public function show_buyer_attendee_status_instead_of_edit_link( $edit_link_html, $attendee ) {
+		global $camptix;
+
 		$current_user          = wp_get_current_user();
 		$attendee_username     = get_post_meta( $attendee->ID, 'tix_username', true );
 		$unknown_attendee_info = $this->get_unknown_attendee_info();
+		$is_unknown_attendee   = ( get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email'] );
 
 		// Display the ticket status for all other tickets.
-		if ( get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email'] ) {
+		if ( $is_unknown_attendee ) {
 			$content = _x( 'Status: Unknown', 'WordCamp ticket status.', 'wordcamporg' );
 		} elseif ( self::UNCONFIRMED_USERNAME == $attendee_username ) {
 			$content = _x( 'Status: Unconfirmed', 'WordCamp ticket status.', 'wordcamporg' );
@@ -639,10 +642,13 @@ class CampTix_Require_Login extends CampTix_Addon {
 		// After logging in as the correct user, they'll come back to this page, where they should find an edit link.
 		// Note: This does not redirect them to the ticket, incase they login with the incorrect user.
 
-		$login_link = wp_login_url();
+		$args = $this->get_sanitized_tix_parameters( $_REQUEST );
+		$tickets_url = add_query_arg( urlencode_deep( $args ), $camptix->get_tickets_url() );
+
+		$login_link = wp_login_url( $tickets_url );
 		// If the ticket owner is known, add a hint to the url to prefill the login form.
 		if ( $attendee_username !== self::UNCONFIRMED_USERNAME ) {
-			$login_link = add_query_arg( 'user', wp_slash( $attendee_username ), $login_link );
+			$login_link = add_query_arg( 'user', urlencode( $attendee_username ), $login_link );
 		}
 
 		// If the user is currently logged in, they'll need to logout first to login.
@@ -660,7 +666,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 
 		$current_user_ticket  = ( $attendee_username == $current_user->user_login );
 		$assigned_to_someone  = ( $attendee_username !== self::UNCONFIRMED_USERNAME );
-		$assigned_to_no_one   = ( $attendee_username == self::UNCONFIRMED_USERNAME || get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email']);
+		$assigned_to_no_one   = ( $attendee_username == self::UNCONFIRMED_USERNAME || $is_unknown_attendee );
 		$this_user_has_ticket = is_user_logged_in() && ! $current_user_ticket && $this->get_ticket_of_user( $current_user );
 		$login_to_claim       = $assigned_to_no_one && ! is_user_logged_in();
 		$can_claim_ticket     = $assigned_to_no_one && is_user_logged_in() && ! $this_user_has_ticket;

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -614,7 +614,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 * The buyer is no longer responsible for editing attendee info, but they are responsible
 	 * for ensuring that the unknown/unconfirmed attendees complete registration.
 	 *
-	 * @param string $edit_link_html
+	 * @param string  $edit_link_html
 	 * @param WP_Post $attendee
 	 *
 	 * @return string
@@ -644,7 +644,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		$login_link  = wp_login_url( $tickets_url );
 
 		// If the ticket owner is known, add a hint to the url to prefill the login form.
-		if ( $attendee_username != self::UNCONFIRMED_USERNAME ) {
+		if ( self::UNCONFIRMED_USERNAME != $attendee_username ) {
 			$login_link = add_query_arg( 'user', urlencode( $attendee_username ), $login_link );
 		}
 
@@ -661,9 +661,9 @@ class CampTix_Require_Login extends CampTix_Addon {
 		// 5. The ticket is assigned to no-one, and the current user does not have a ticket (They can claim it)
 		// 6. The ticket is assigned to the current user.
 
-		$current_user_ticket  = ( $attendee_username == $current_user->user_login );
-		$assigned_to_someone  = ( $attendee_username != self::UNCONFIRMED_USERNAME );
-		$assigned_to_no_one   = ( $attendee_username == self::UNCONFIRMED_USERNAME || $is_unknown_attendee );
+		$current_user_ticket  = ( $current_user->user_login == $attendee_username );
+		$assigned_to_someone  = ( self::UNCONFIRMED_USERNAME != $attendee_username );
+		$assigned_to_no_one   = ( ( self::UNCONFIRMED_USERNAME == $attendee_username  ) || $is_unknown_attendee );
 		$this_user_has_ticket = is_user_logged_in() && ! $current_user_ticket && $this->get_ticket_of_user( $current_user );
 		$login_to_claim       = $assigned_to_no_one && ! is_user_logged_in();
 		$can_claim_ticket     = $assigned_to_no_one && is_user_logged_in() && ! $this_user_has_ticket;
@@ -672,13 +672,13 @@ class CampTix_Require_Login extends CampTix_Addon {
 		if ( $assigned_to_someone && ! $current_user_ticket ) {
 			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . sprintf( __( 'Login as %s to edit information', 'wordcamporg' ), esc_html( $attendee_username ) ) . '</a>';
 
-		// 3 - NOOP, user already has a different ticket.
-		// 4 - Login to claim
+			// 3 - NOOP, user already has a different ticket.
+			// 4 - Login to claim
 		} elseif ( $login_to_claim ) {
 			$content .= '<br><a href="' . esc_url( $login_link ) . '">' . __( 'Login to edit information', 'wordcamporg' ) . '</a>';
 
-		// 5 - Claim the ticket, since you don't have one.
-		// 6 - Current user owns ticket, edit away.
+			// 5 - Claim the ticket, since you don't have one.
+			// 6 - Current user owns ticket, edit away.
 		} elseif ( $can_claim_ticket || $current_user_ticket ) {
 			$content .= '<br>' . $edit_link_html;
 		}

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -609,7 +609,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 	}
 
 	/**
-	 * Show the buyer the status of other tickets instead of an 'Edit Information' link.
+	 * Show the buyer the status of the ticket, and a login link, instead of an 'Edit Information' link.
 	 *
 	 * The buyer is no longer responsible for editing attendee info, but they are responsible
 	 * for ensuring that the unknown/unconfirmed attendees complete registration.
@@ -627,7 +627,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		$unknown_attendee_info = $this->get_unknown_attendee_info();
 		$is_unknown_attendee   = ( get_post_meta( $attendee->ID, 'tix_email', true ) == $unknown_attendee_info['email'] );
 
-		// Display the ticket status for all other tickets.
+		// Display the ticket status.
 		if ( $is_unknown_attendee ) {
 			$content = _x( 'Status: Unknown', 'WordCamp ticket status.', 'wordcamporg' );
 		} elseif ( self::UNCONFIRMED_USERNAME == $attendee_username ) {
@@ -638,16 +638,13 @@ class CampTix_Require_Login extends CampTix_Addon {
 		// Use a non-breaking space to prevent the text from wrapping.
 		$content = str_replace( ' ', '&nbsp;', $content );
 
-		// Add a login link to simplify the edit experience.
-		// After logging in as the correct user, they'll come back to this page, where they should find an edit link.
-		// Note: This does not redirect them to the ticket, incase they login with the incorrect user.
-
-		$args = $this->get_sanitized_tix_parameters( $_REQUEST );
+		// Redirect back to this same overview, as they may not login with the correct username.
+		$args        = $this->get_sanitized_tix_parameters( $_REQUEST );
 		$tickets_url = add_query_arg( urlencode_deep( $args ), $camptix->get_tickets_url() );
+		$login_link  = wp_login_url( $tickets_url );
 
-		$login_link = wp_login_url( $tickets_url );
 		// If the ticket owner is known, add a hint to the url to prefill the login form.
-		if ( $attendee_username !== self::UNCONFIRMED_USERNAME ) {
+		if ( $attendee_username != self::UNCONFIRMED_USERNAME ) {
 			$login_link = add_query_arg( 'user', urlencode( $attendee_username ), $login_link );
 		}
 
@@ -665,7 +662,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		// 6. The ticket is assigned to the current user.
 
 		$current_user_ticket  = ( $attendee_username == $current_user->user_login );
-		$assigned_to_someone  = ( $attendee_username !== self::UNCONFIRMED_USERNAME );
+		$assigned_to_someone  = ( $attendee_username != self::UNCONFIRMED_USERNAME );
 		$assigned_to_no_one   = ( $attendee_username == self::UNCONFIRMED_USERNAME || $is_unknown_attendee );
 		$this_user_has_ticket = is_user_logged_in() && ! $current_user_ticket && $this->get_ticket_of_user( $current_user );
 		$login_to_claim       = $assigned_to_no_one && ! is_user_logged_in();


### PR DESCRIPTION
Currently the Edit Information links in post-purchase emails do not suggest to the user to login, this may be causing the frustration of attendees failing to update their details.

For example, having purchased two tickets while logged in and then clicking on the **receipt** email in my inbox later on when I'm no longer logged in, I'll see this:

<img width="644" alt="Screenshot 2025-05-01 at 12 17 28 pm" src="https://github.com/user-attachments/assets/ad228b5a-fb4f-4055-b146-3aeacafd3535" />

This isn't helpful, as there's no suggestion to the user that they need to login to edit the ticket.


This partially helps with #1451 
