### PR TITLE
Notify: Allow segmenting the Notification functionality by ticket confirmed/unconfirmed status.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -46,7 +46,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		add_filter( 'camptix_attendees_shortcode_query_args',         array( $this, 'hide_unconfirmed_attendees' ) );
 		add_filter( 'camptix_private_attendees_parameters',           array( $this, 'prevent_unknown_attendees_viewing_private_content' ) );
 
-		// Camptix Notify
+		// Camptix Notify.
 		add_filter( 'camptix_notify_segment_fields',                  array( $this, 'camptix_notify_segment_fields' ) );
 		add_filter( 'camptix_notify_segment_query',                   array( $this, 'camptix_notify_segment_query' ), 10, 2 );
 	}
@@ -961,7 +961,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 					'caption' => __( 'Unconfirmed', 'wordcamporg' ),
 					'value'   => 'unconfirmed',
 				],
-			]
+			],
 		];
 
 		return $segments;
@@ -997,7 +997,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 							'key' => 'tix_email',
 							'value' => $this->get_unknown_attendee_info()['email'],
 							'compare' => '='
-						)
+						),
 					);
 				} elseif ( 'confirmed' === $condition['value'] ) {
 					// Username is something other than the unconfirmed username.

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -940,22 +940,6 @@ class CampTix_Require_Login extends CampTix_Addon {
 		return $query_args;
 	}
 
-	/*
-	 * Prevent unknown attendees from viewing private content.
-	 *
-	 * The name/email used for unknown attendees is revealed not secret, so anyone could use them to login to a
-	 * page with [camptix_private] content.
-	 */
-	public function prevent_unknown_attendees_viewing_private_content( $parameters ) {
-		$parameters['meta_query'][] = array(
-			'key'     => 'tix_email',
-			'value'   => self::UNKNOWN_ATTENDEE_EMAIL,
-			'compare' => '!='
-		);
-
-		return $parameters;
-	}
-
 	/**
 	 * Add the ability to filter camptix notify segments by confirmed status.
 	 *
@@ -993,15 +977,57 @@ class CampTix_Require_Login extends CampTix_Addon {
 	public function camptix_notify_segment_query( $query, $conditions ) {
 		foreach ( $conditions as $condition ) {
 			if ( 'ticket_status' == $condition['option_value'] ) {
-				$query['meta_query'][] = array(
-					'key'     => 'tix_username',
-					'value'   => self::UNCONFIRMED_USERNAME,
-					'compare' => ( 'confirmed' === $condition['value'] ? '=' : '!=' )
-				);
+				if ( 'unconfirmed' === $condition['value'] ) {
+					$query['meta_query'][] = array(
+						// All of these are unconfirmed.
+						'relation' => 'or',
+						// Unconfirmed username listed.
+						array(
+							'key' => 'tix_username',
+							'value' => self::UNCONFIRMED_USERNAME,
+							'compare' => '='
+						),
+						// Has no username linked.
+						array(
+							'key' => 'tix_username',
+							'compare' => 'NOT EXISTS',
+						),
+						// The email is the standard unknown attendee.
+						array(
+							'key' => 'tix_email',
+							'value' => $this->get_unknown_attendee_info()['email'],
+							'compare' => '='
+						)
+					);
+				} elseif ( 'confirmed' === $condition['value'] ) {
+					// Username is something other than the unconfirmed username.
+					$query['meta_query'][] = array(
+						'key' => 'tix_username',
+						'value' => self::UNCONFIRMED_USERNAME,
+						'compare' => '!='
+					);
+				}
+
 			}
 		}
 
 		return $query;
+	}
+
+	/*
+	 * Prevent unknown attendees from viewing private content.
+	 *
+	 * The name/email used for unknown attendees is revealed not secret, so anyone could use them to login to a
+	 * page with [camptix_private] content.
+	 */
+	public function prevent_unknown_attendees_viewing_private_content( $parameters ) {
+		$parameters['meta_query'][] = array(
+			'key'     => 'tix_email',
+			'value'   => self::UNKNOWN_ATTENDEE_EMAIL,
+			'compare' => '!='
+		);
+
+		return $parameters;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -45,6 +45,10 @@ class CampTix_Require_Login extends CampTix_Addon {
 		add_action( 'template_redirect',                              array( $this, 'block_unauthenticated_actions' ), 7 );    // before CampTix_Plugin->template_redirect()
 		add_filter( 'camptix_attendees_shortcode_query_args',         array( $this, 'hide_unconfirmed_attendees' ) );
 		add_filter( 'camptix_private_attendees_parameters',           array( $this, 'prevent_unknown_attendees_viewing_private_content' ) );
+
+		// Camptix Notify
+		add_filter( 'camptix_notify_segment_fields',                  array( $this, 'camptix_notify_segment_fields' ) );
+		add_filter( 'camptix_notify_segment_query',                   array( $this, 'camptix_notify_segment_query' ), 10, 2 );
 	}
 
 	/**
@@ -950,6 +954,54 @@ class CampTix_Require_Login extends CampTix_Addon {
 		);
 
 		return $parameters;
+	}
+
+	/**
+	 * Add the ability to filter camptix notify segments by confirmed status.
+	 *
+	 * @param array $segments
+	 * @return array
+	 */
+	public function camptix_notify_segment_fields( $segments ) {
+		$segments[] = [
+			'caption'      => 'Ticket Status',
+			'option_value' => 'ticket_status',
+			'type'         => 'select',
+			'ops'          => [ 'is' ],
+			'values'       => [
+				[
+					'caption' => __( 'Confirmed', 'wordcamporg' ),
+					'value'   => 'confirmed',
+				],
+				[
+					'caption' => __( 'Unconfirmed', 'wordcamporg' ),
+					'value'   => 'unconfirmed',
+				],
+			]
+		];
+
+		return $segments;
+	}
+
+	/**
+	 * Add the ability to filter camptix notify segments by confirmed status.
+	 *
+	 * @param array $query      The posts query arguments.
+	 * @param array $conditions The conditions to filter by.
+	 * @return array
+	 */
+	public function camptix_notify_segment_query( $query, $conditions ) {
+		foreach ( $conditions as $condition ) {
+			if ( 'ticket_status' == $condition['option_value'] ) {
+				$query['meta_query'][] = array(
+					'key'     => 'tix_username',
+					'value'   => self::UNCONFIRMED_USERNAME,
+					'compare' => ( 'confirmed' === $condition['value'] ? '=' : '!=' )
+				);
+			}
+		}
+
+		return $query;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -976,7 +976,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 */
 	public function camptix_notify_segment_query( $query, $conditions ) {
 		foreach ( $conditions as $condition ) {
-			if ( 'ticket_status' == $condition['option_value'] ) {
+			if ( 'ticket_status' === $condition['field'] ) {
 				if ( 'unconfirmed' === $condition['value'] ) {
 					$query['meta_query'][] = array(
 						// All of these are unconfirmed.
@@ -985,7 +985,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 						array(
 							'key' => 'tix_username',
 							'value' => self::UNCONFIRMED_USERNAME,
-							'compare' => '='
+							'compare' => '=',
 						),
 						// Has no username linked.
 						array(
@@ -996,7 +996,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 						array(
 							'key' => 'tix_email',
 							'value' => $this->get_unknown_attendee_info()['email'],
-							'compare' => '='
+							'compare' => '=',
 						),
 					);
 				} elseif ( 'confirmed' === $condition['value'] ) {
@@ -1004,10 +1004,9 @@ class CampTix_Require_Login extends CampTix_Addon {
 					$query['meta_query'][] = array(
 						'key' => 'tix_username',
 						'value' => self::UNCONFIRMED_USERNAME,
-						'compare' => '!='
+						'compare' => '!=',
 					);
 				}
-
 			}
 		}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -3394,6 +3394,16 @@ class CampTix_Plugin {
 				?>
 			}));
 
+			<?php
+				// Allow other code to add additional segmentation fields.
+				$additional_segments = apply_filters( 'camptix_notify_segment_fields', array() );
+				foreach ( $additional_segments as $segment ) {
+					printf(
+						'camptix.collections.segmentFields.add( new camptix.models.SegmentField( %s ) );',
+						wp_json_encode( $segment )
+					);
+				}
+			?>
 
 			// Add POST'ed conditions.
 			<?php if ( ! empty( $conditions ) ) : ?>
@@ -3453,8 +3463,9 @@ class CampTix_Plugin {
 		$post_query_conditions = array();
 
 		$relation = strtolower( $relation );
-		if ( ! in_array( $relation, array( 'and', 'or' ) ) )
+		if ( ! in_array( $relation, array( 'and', 'or' ) ) ) {
 			return $segment;
+		}
 
 		$query = array(
 			'post_type' => 'tix_attendee',
@@ -3542,6 +3553,9 @@ class CampTix_Plugin {
 				continue;
 			}
 		}
+
+		// Allow others to filter the query as needed.
+		$query = apply_filters( 'camptix_notify_segment_query', $query, $conditions, $relation );
 
 		$post_query_segment = get_posts( $query );
 


### PR DESCRIPTION
The intention of this is to allow WordCamps an easy way to bulk notify attendees whose tickets have not yet been confirmed (linked to a WordPress.org user, and properly filled out)

### Screenshots

<img width="849" alt="Screenshot 2025-05-01 at 4 10 55 pm" src="https://github.com/user-attachments/assets/69c137cd-2244-40df-a481-6ae0fa07405d" />
