### PR TITLE
Add robots.txt handling that includes sitemaps for subsites on the domain

### DIFF
--- a/public_html/wp-content/mu-plugins/robots.php
+++ b/public_html/wp-content/mu-plugins/robots.php
@@ -1,20 +1,22 @@
 <?php
-
 namespace WordCamp\RobotsTxt;
 use Jetpack_Options;
 
 defined( 'WPINC' ) || die();
 
-add_action( 'template_redirect', __NAMESPACE__ . '\handle_request', 1 );
+add_action( 'template_redirect', __NAMESPACE__ . '\template_redirect', 1 );
 
-function handle_request() {
-	if ( $_SERVER['REQUEST_URI'] !== '/robots.txt' ) {
+/**
+ * Maybe serve the robots.txt file for this domain.
+ */
+function template_redirect() {
+	if ( '/robots.txt' !== $_SERVER['REQUEST_URI'] ) {
 		return;
 	}
 
 	$sites = get_sites( array(
-		//'network_id' => get_current_network_id(),
-		'domain'     => 'central.wordcamp.org', // get_blog_details()->domain,
+		'network_id' => get_current_network_id(),
+		'domain'     => get_blog_details()->domain,
 		'public'     => 1,
 		'deleted'    => 0,
 		'archived'   => 0,
@@ -24,13 +26,13 @@ function handle_request() {
 
 	$sitemaps            = '';
 	$path_allow_disallow = '';
-	foreach ( $sites as $site ){
+	foreach ( $sites as $site ) {
 		switch_to_blog( $site->blog_id );
 
 		// Note: We must create a new instance for each site.
 		$coming_soon_enabled = (
 			class_exists( 'WCCSP_Settings' ) &&
-			'on' === ( new \WCCSP_Settings )->get_settings()['enabled']
+			'on' === ( new \WCCSP_Settings() )->get_settings()['enabled']
 		);
 		if ( $coming_soon_enabled ) {
 			// Skip this site, don't even mention it for now.
@@ -41,7 +43,7 @@ function handle_request() {
 		$path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
 
 		// A non-public site should not be indexed.
-		if ( '1' != get_option( 'blog_public' )  ) {
+		if ( '1' != get_option( 'blog_public' ) ) {
 			$path_allow_disallow .= "Disallow: $path/\n";
 			continue;
 		}
@@ -53,16 +55,16 @@ function handle_request() {
 		// Are Jetpack Sitemaps enabled?
 		$using_jetpack_sitemaps = (
 			class_exists( 'Jetpack_Options' ) &&
-			in_array( 'sitemaps', Jetpack_Options::get_option( 'active_modules' ) ?: [], true )
+			in_array( 'sitemaps', (array) Jetpack_Options::get_option( 'active_modules' ), true )
 		);
 
 		// Add a sitemap link.
-		$sitemaps .= "Sitemap: " . esc_url( site_url( $using_jetpack_sitemaps ? 'sitemap.xml' : 'wp-sitemap.xml' ) ) . "\n";
+		$sitemaps .= 'Sitemap: ' . esc_url( site_url( $using_jetpack_sitemaps ? 'sitemap.xml' : 'wp-sitemap.xml' ) ) . "\n";
 	}
-
 
 	header( 'Content-Type: text/plain; charset=utf-8' );
 
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo "{$sitemaps}\nUser-agent: *\n{$path_allow_disallow}";
 
 	die();

--- a/public_html/wp-content/mu-plugins/robots.php
+++ b/public_html/wp-content/mu-plugins/robots.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WordCamp\RobotsTxt;
+use Jetpack_Options;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'template_redirect', __NAMESPACE__ . '\handle_request', 1 );
+
+function handle_request() {
+	if ( $_SERVER['REQUEST_URI'] !== '/robots.txt' ) {
+		return;
+	}
+
+	$sites = get_sites( array(
+		//'network_id' => get_current_network_id(),
+		'domain'     => 'central.wordcamp.org', // get_blog_details()->domain,
+		'public'     => 1,
+		'deleted'    => 0,
+		'archived'   => 0,
+		'orderby'    => 'registered',
+		'order'      => 'desc',
+	) );
+
+	$sitemaps            = '';
+	$path_allow_disallow = '';
+	foreach ( $sites as $site ){
+		switch_to_blog( $site->blog_id );
+
+		// Note: We must create a new instance for each site.
+		$coming_soon_enabled = (
+			class_exists( 'WCCSP_Settings' ) &&
+			'on' === ( new \WCCSP_Settings )->get_settings()['enabled']
+		);
+		if ( $coming_soon_enabled ) {
+			// Skip this site, don't even mention it for now.
+			continue;
+		}
+
+		$site_url = parse_url( site_url() );
+		$path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
+
+		// A non-public site should not be indexed.
+		if ( '1' != get_option( 'blog_public' )  ) {
+			$path_allow_disallow .= "Disallow: $path/\n";
+			continue;
+		}
+
+		// Remove any wp-admin links from search indexing.
+		$path_allow_disallow .= "Disallow: $path/wp-admin/\n";
+		$path_allow_disallow .= "Allow: $path/wp-admin/admin-ajax.php\n";
+
+		// Are Jetpack Sitemaps enabled?
+		$using_jetpack_sitemaps = (
+			class_exists( 'Jetpack_Options' ) &&
+			in_array( 'sitemaps', Jetpack_Options::get_option( 'active_modules' ) ?: [], true )
+		);
+
+		// Add a sitemap link.
+		$sitemaps .= "Sitemap: " . esc_url( site_url( $using_jetpack_sitemaps ? 'sitemap.xml' : 'wp-sitemap.xml' ) ) . "\n";
+	}
+
+
+	header( 'Content-Type: text/plain; charset=utf-8' );
+
+	echo "{$sitemaps}\nUser-agent: *\n{$path_allow_disallow}";
+
+	die();
+}

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -56,7 +56,35 @@ function main() {
 	}
 	*/
 
+	if ( handle_robots_txt_request( $domain, $path ) ) {
+		return;
+	}
+
 	redirect_to_site( $domain, $path );
+}
+
+/**
+ * Check if the current request is for a robots.txt file, and handle it if so.
+ *
+ * @param string $domain
+ * @param string $path
+ *
+ * @return bool Whether the request will be handled as a robots.txt request.
+ */
+function handle_robots_txt_request( $domain, $path ) {
+	if ( '/' !== $path || '/robots.txt' !== $_SERVER['REQUEST_URI'] ) {
+		return false;
+	}
+
+	$latest_site = get_latest_site( $domain );
+	if ( ! $latest_site ) {
+		return false;
+	}
+
+	set_network_and_site( $latest_site );
+
+	// Abort redirects
+	return true;
 }
 
 /**

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -83,7 +83,7 @@ function handle_robots_txt_request( $domain, $path ) {
 
 	set_network_and_site( $latest_site );
 
-	// Abort redirects
+	// Abort redirects.
 	return true;
 }
 


### PR DESCRIPTION
The migration from  year.city.wordcamp.org domains caused us to loose robots.txt's, which also caused us to lose sitemap links.

This restores `/robots.txt` requests and adds sitemaps for all subsites.

This is a draft WIP without much testing.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #687 

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
