### PR TITLE
Require Login: Ensure that outgoing emails during multiple purchase use the correct email templates.

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -632,6 +632,10 @@ function modify_email_templates( $options ) {
 	);
 
 	foreach ( $templates_that_need_footers as $template ) {
+		if ( ! isset( $options[ $template ] ) ) {
+			continue;
+		}
+
 		// We can't add the string to the original option or it will keep getting added over and over again
 		// whenever the email templates are customized and saved.
 		$options[ $template . '_with_footer' ] = $options[ $template ] . $email_footer_string;

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -50,8 +50,8 @@ add_action( 'camptix_load_addons',                           __NAMESPACE__ . '\l
 add_filter( 'camptix_metabox_questions_default_fields_list', __NAMESPACE__ . '\modify_default_fields_list'          );
 add_filter( 'camptix_capabilities',                          __NAMESPACE__ . '\modify_capabilities'                 );
 add_filter( 'camptix_default_options',                       __NAMESPACE__ . '\modify_default_options'              );
-add_filter( 'camptix_options',                               __NAMESPACE__ . '\modify_email_templates'              );
-add_filter( 'camptix_email_tickets_template',                __NAMESPACE__ . '\switch_email_template'               );
+add_filter( 'camptix_options',                               __NAMESPACE__ . '\modify_email_templates',       20    );
+add_filter( 'camptix_email_tickets_template',                __NAMESPACE__ . '\switch_email_template',        20    );
 add_filter( 'camptix_html_message',                          __NAMESPACE__ . '\render_html_emails',           10, 2 );
 add_action( 'camptix_tshirt_report_intro',                   __NAMESPACE__ . '\tshirt_report_intro_message',  10, 3 );
 add_filter( 'camptix_stripe_checkout_image_url',             __NAMESPACE__ . '\stripe_default_checkout_image_url'   );
@@ -620,9 +620,15 @@ function modify_email_templates( $options ) {
 	$email_footer_string = "\n\n===\n\n$sponsors_string\n\n$donation_string";
 
 	$templates_that_need_footers = array(
+		// Regular templates.
 		'email_template_single_purchase',
 		'email_template_multiple_purchase',
 		'email_template_multiple_purchase_receipt',
+
+		// Require Login.
+		'email_template_multiple_purchase_receipt_unconfirmed_attendees',
+		'email_template_multiple_purchase_unknown_attendee',
+		'email_template_multiple_purchase_unconfirmed_attendee',
 	);
 
 	foreach ( $templates_that_need_footers as $template ) {
@@ -643,9 +649,15 @@ function modify_email_templates( $options ) {
  */
 function switch_email_template( $template_slug ) {
 	$templates_that_need_footers = array(
+		// Regular templates.
 		'email_template_single_purchase',
 		'email_template_multiple_purchase',
 		'email_template_multiple_purchase_receipt',
+
+		// Require Login.
+		'email_template_multiple_purchase_receipt_unconfirmed_attendees',
+		'email_template_multiple_purchase_unknown_attendee',
+		'email_template_multiple_purchase_unconfirmed_attendee',
 	);
 
 	if ( in_array( $template_slug, $templates_that_need_footers, true ) ) {

--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -19,7 +19,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'add_username_to_attendee_object' ), 10, 3 );
 		add_action( 'camptix_checkout_update_post_meta',              array( $this, 'save_checkout_username_meta' ), 10, 2 );
 		add_action( 'transition_post_status',                         array( $this, 'buyer_completed_registration' ), 10, 3 );
-		add_filter( 'camptix_email_tickets_template',                 array( $this, 'use_custom_email_templates' ), 10, 2 );
+		add_filter( 'camptix_email_tickets_template',                 array( $this, 'use_custom_email_templates' ), 5, 2 );
 		add_filter( 'camptix_get_attendee_email',                     array( $this, 'redirect_unknown_attendee_emails_to_buyer' ), 10, 2 );
 		add_action( 'camptix_attendee_form_before_input',             array( $this, 'inject_unknown_attendee_checkbox' ), 10, 3 );
 		add_filter( 'camptix_checkout_attendee_info',                 array( $this, 'add_unknown_attendee_info_stubs' ) );
@@ -32,7 +32,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		add_filter( 'camptix_attendee_report_extra_columns',          array( $this, 'get_attendee_report_extra_columns' ) );
 		add_filter( 'camptix_metabox_attendee_info_additional_rows',  array( $this, 'get_attendee_metabox_rows' ), 10, 2 );
 		add_filter( 'camptix_custom_email_templates',                 array( $this, 'register_custom_email_templates' ) );
-		add_filter( 'camptix_default_options',                        array( $this, 'custom_email_template_default_values' ) );
+		add_filter( 'camptix_options',                                array( $this, 'custom_email_template_option_values' ), 5 );
 
 		// Attendee Information front-end screen
 		add_action( 'camptix_form_edit_attendee_custom_error_flags',  array( $this, 'require_unique_usernames' ) );
@@ -455,10 +455,10 @@ class CampTix_Require_Login extends CampTix_Addon {
 	 *
 	 * @return array
 	 */
-	public function custom_email_template_default_values( $options ) {
-		$options['email_template_multiple_purchase_receipt_unconfirmed_attendees'] = __( "Hi there!\n\nYou have purchased the following tickets:\n\n[receipt]\n\nYou can view and edit your order at any time before the event, by visiting the following link:\n\n[ticket_url]\n\nThe other attendees that you purchased tickets for will need to confirm their registration by visiting a link that was sent to them by e-mail.\n\nLet us know if you have any questions!", 'wordcamporg' );
-		$options['email_template_multiple_purchase_unconfirmed_attendee']          = __( "Hi there!\n\nA ticket to [event_name] has been purchased for you by [buyer_full_name].\n\nPlease visit the following page and fill in your information to complete your registration:\n\n[ticket_url]\n\nLet us know if you have any questions!", 'wordcamporg' );
-		$options['email_template_multiple_purchase_unknown_attendee']              = __( "Hi there!\n\nThis e-mail is for the unknown attendee that you purchased a ticket for. When you decide who will be using the ticket, please forward the link below to them so that they can complete their registration.\n\n[ticket_url]\n\nLet us know if you have any questions!", 'wordcamporg' );
+	public function custom_email_template_option_values( $options ) {
+		$options['email_template_multiple_purchase_receipt_unconfirmed_attendees'] ??= __( "Hi there!\n\nYou have purchased the following tickets:\n\n[receipt]\n\nYou can view and edit your order at any time before the event, by visiting the following link:\n\n[ticket_url]\n\nThe other attendees that you purchased tickets for will need to confirm their registration by visiting a link that was sent to them by e-mail.\n\nLet us know if you have any questions!", 'wordcamporg' );
+		$options['email_template_multiple_purchase_unconfirmed_attendee']          ??= __( "Hi there!\n\nA ticket to [event_name] has been purchased for you by [buyer_full_name].\n\nPlease visit the following page and fill in your information to complete your registration:\n\n[ticket_url]\n\nLet us know if you have any questions!", 'wordcamporg' );
+		$options['email_template_multiple_purchase_unknown_attendee']              ??= __( "Hi there!\n\nThis e-mail is for the unknown attendee that you purchased a ticket for. When you decide who will be using the ticket, please forward the link below to them so that they can complete their registration.\n\n[ticket_url]\n\nLet us know if you have any questions!", 'wordcamporg' );
 
 		return $options;
 	}

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7849,11 +7849,13 @@ class CampTix_Plugin {
 		// Set the tmp receipt for shortcodes use.
 		$this->tmp( 'receipt', $receipt_content );
 
+		// Find the buyers name.
 		foreach ( $attendees as $attendee ) {
 			$attendee_email = $this->get_attendee_email( $attendee->ID );
 
-			if ( $attendee_email == $receipt_email ) {
+			if ( $attendee_email === $receipt_email ) {
 				$this->tmp( 'buyer_full_name', get_post_meta( $attendee->ID, 'tix_first_name', true ) . ' ' . get_post_meta( $attendee->ID, 'tix_last_name', true ) );
+				break;
 			}
 		}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6115,6 +6115,8 @@ class CampTix_Plugin {
 				),
 			),
 			'cache_results' => false,
+			'orderby' => 'ID',
+			'order' => 'ASC',
 		) );
 
 		if ( ! $attendees ) {
@@ -6153,6 +6155,8 @@ class CampTix_Plugin {
 					),
 				),
 				'cache_results' => false,
+				'orderby' => 'ID',
+				'order' => 'ASC',
 			) ) ) :
 
 				$attendee_ids = array();
@@ -7823,6 +7827,9 @@ class CampTix_Plugin {
 					'type' => 'CHAR',
 				),
 			),
+			// Ensure that the buyer is always first in the list.
+			'orderby' => 'ID',
+			'order'   => 'ASC',
 		) );
 
 		if ( ! $attendees )

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7860,7 +7860,7 @@ class CampTix_Plugin {
 		foreach ( $attendees as $attendee ) {
 			$attendee_email = $this->get_attendee_email( $attendee->ID );
 
-			if ( $attendee_email === $receipt_email ) {
+			if ( $attendee_email == $receipt_email ) {
 				$this->tmp( 'buyer_full_name', get_post_meta( $attendee->ID, 'tix_first_name', true ) . ' ' . get_post_meta( $attendee->ID, 'tix_last_name', true ) );
 				break;
 			}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1471

Part of this is ensuring that proper priority is used on the filters, I've chosen `5`,  and `20` here to go either side of `10`.

This should result in the following emails being sent:
Ticket bought for someone else:
```
Hi there!

A ticket to [event_name] has been purchased for you by [buyer_full_name].

Please visit the following page and fill in your information to complete your registration:

[ticket_url]

Let us know if you have any questions!
```

Unknown attendee (Sent to the ticket purchaser)
```
Hi there!

This e-mail is for the unknown attendee that you purchased a ticket for. When you decide who will be using the ticket, please forward the link below to them so that they can complete their registration.

[ticket_url]

Let us know if you have any questions!
```

And finally, the receipt email that the user gets should be this one:
```
Hi there!

You have purchased the following tickets:

[receipt]

You can view and edit your order at any time before the event, by visiting the following link:

[ticket_url]

The other attendees that you purchased tickets for will need to confirm their registration by visiting a link that was sent to them by e-mail.

Let us know if you have any questions!
```

That helps explain to the ticket purchaser that they need to perform extra actions.