### PR TITLE
Move custom questions into being actual questions

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -192,5 +192,8 @@
 	<rule ref="WordPress-Extra">
 		<!-- I think it's better to have all the `use` statements come right after the namespace line. -->
 		<exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter" />
+
+		<!-- We're going to see more of ?? (which this doesn't cover), might as well allow ?: when suitable. -->
+		<exclude name="Universal.Operators.DisallowShortTernary" />
 	</rule>
 </ruleset>

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -40,11 +40,12 @@ class Accommodations_Field extends CampTix_Addon {
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 30 ); // 20 = allergy, 30 = accessibility, 40 = first time, 50 = CoC
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 30 );
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Notifications.
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
@@ -109,6 +110,19 @@ class Accommodations_Field extends CampTix_Addon {
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
 		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
+	}
+
+	/**
+	 * Update the stored value of the new field if it was changed in the Edit Info form.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 * @param array   $answers
+	 *
+	 * @return bool|int
+	 */
+	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
+		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/accommodations.php
@@ -38,20 +38,16 @@ class Accommodations_Field extends CampTix_Addon {
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
-		// Registration field
-		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 12, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ), 11 );
-		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
+		// Ask the question.
+		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 30 ); // 20 = allergy, 30 = accessibility, 40 = first time, 50 = CoC
+		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
+
+		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+
+		// Notifications.
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
-
-		// Edit info field
-		add_filter( 'camptix_form_edit_attendee_ticket_info', array( $this, 'populate_ticket_info_array' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'validate_save_ticket_info_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_after_questions', array( $this, 'render_ticket_info_field' ), 12 );
-
-		// Metabox
-		add_filter( 'camptix_metabox_attendee_info_additional_rows', array( $this, 'add_metabox_row' ), 12, 2 );
 
 		// Reporting
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
@@ -67,113 +63,40 @@ class Accommodations_Field extends CampTix_Addon {
 	}
 
 	/**
-	 * Render the field, used on both Registration and when editing an existing ticket.
+	 * Add the question to the list of questions.
 	 *
-	 * @param string $name
-	 * @param string $value
-	 * @param int    $ticket_id
-	 */
-	public function render_field( $name, $value, $ticket_id ) {
-		if ( apply_filters( 'camptix_accommodations_should_skip', false ) ) {
-			return;
-		}
-
-		$question = apply_filters( 'camptix_accommodations_question_text', $this->question, $ticket_id );
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $question ); ?>">
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="yes"
-							<?php checked( 'yes', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-					<br />
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="no"
-							<?php checked( 'no', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
-	}
-
-	/**
-	 * Render the new field for the registration form during checkout.
-	 *
-	 * @param array $form_data
-	 * @param int   $i
-	 */
-	public function render_registration_field( $form_data, $i ) {
-		$current_data = ( isset( $form_data['tix_attendee_info'][ $i ] ) )
-			? $form_data['tix_attendee_info'][ $i ]
-			: array();
-
-		$current_data = wp_parse_args( $current_data, array( self::SLUG => '' ) );
-
-		$this->render_field(
-			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
-			$current_data[ self::SLUG ],
-			$current_data['ticket_id']
-		);
-	}
-
-	/**
-	 * Validate the value of the new field submitted to the registration form during checkout.
-	 *
-	 * @param array $data
+	 * @param array $questions
 	 *
 	 * @return array
 	 */
-	public function validate_registration_field( $data ) {
-		/* @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		$skip_question = apply_filters( 'camptix_accommodations_should_skip', false );
-		if ( $skip_question ) {
-			return $data;
+	function add_question( $questions, $ticket_id ) {
+		if ( apply_filters( 'camptix_accommodations_should_skip', false ) ) {
+			return $questions;
 		}
 
-		if ( ! isset( $data[ self::SLUG ] ) || empty( $data[ self::SLUG ] ) ) {
-			$camptix->error_flags['required_fields'] = true;
-		} else {
-			$data[ self::SLUG ] = ( 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
-		}
+		$questions[ self::SLUG ] = (object) array(
+			// Immitate a WP_Post with metadata..
+			'ID' 	       => self::SLUG,
+			'post_title'   => apply_filters( 'camptix_accommodations_question_text', $this->question, $ticket_id ),
+			'tix_type'     => 'radio',
+			'tix_required' => true,
+			'tix_values'   => $this->options,
+		);
 
-		return $data;
+		return $questions;
 	}
 
 	/**
-	 * Add the value of the new field to the attendee object during checkout processing.
+	 * Add the new field to the questions order.
 	 *
-	 * @param WP_Post $attendee
-	 * @param array   $data
+	 * @param array $order
 	 *
-	 * @return WP_Post
+	 * @return array
 	 */
-	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = isset( $data[ self::SLUG ] ) ? $data[ self::SLUG ] : 'no';
+	function add_question_order( $order ) {
+		$order[] = self::SLUG;
 
-		return $attendee;
+		return $order;
 	}
 
 	/**
@@ -189,6 +112,25 @@ class Accommodations_Field extends CampTix_Addon {
 	}
 
 	/**
+	 * Retrieve the stored value of the new field for use when displaying the attendee info.
+	 *
+	 * Back-compat only, for where the field was stored outside of the question answers.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 *
+	 * @return array
+	 */
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$attendee = get_post( $attendee );
+		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+
+		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
+
+		return $ticket_info;
+	}
+
+	/**
 	 * Initialize email notifications after the ticket receipt email has been sent.
 	 *
 	 * @param int $attendee_id
@@ -200,98 +142,6 @@ class Accommodations_Field extends CampTix_Addon {
 		if ( $attendee instanceof WP_Post && 'tix_attendee' === $attendee->post_type ) {
 			$this->maybe_send_notification_email( $value, $attendee );
 		}
-	}
-
-	/**
-	 * Retrieve the stored value of the new field for use on the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 *
-	 * @return array
-	 */
-	public function populate_ticket_info_array( $ticket_info, $attendee ) {
-		$ticket_info[ self::SLUG ] = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		return $ticket_info;
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $data
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function validate_save_ticket_info_field( $data, $attendee ) {
-		$value = ( isset( $data[ self::SLUG ] ) && 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
-
-		$this->maybe_send_notification_email( $value, $attendee );
-
-		return update_post_meta( $attendee->ID, 'tix_' . self::SLUG, $value );
-	}
-
-	/**
-	 * Render the new field for the Edit Info form.
-	 *
-	 * @param array $ticket_info
-	 */
-	public function render_ticket_info_field( $ticket_info ) {
-		$current_data = wp_parse_args( $ticket_info, array( self::SLUG => 'no' ) );
-
-		$this->render_field(
-			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
-			$current_data[ self::SLUG ],
-			$current_data['ticket_id']
-		);
-	}
-
-	/**
-	 * Add a row to the Attendee Info metabox table for the new field and value.
-	 *
-	 * @param array   $rows
-	 * @param WP_Post $post
-	 *
-	 * @return mixed
-	 */
-	public function add_metabox_row( $rows, $post ) {
-		$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true );
-		if ( $value && isset( $this->options[ $value ] ) ) {
-			$value = $this->options[ $value ];
-		}
-		$question = apply_filters( 'camptix_accommodations_question_text', $this->question, $post->tix_ticket_id );
-		$new_row = array( $question, esc_html( $value ) );
-
-		add_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		$ticket_row = array_filter(
-			$rows,
-			function( $row ) {
-				if ( 'Ticket' === $row[0] ) {
-					return true;
-				}
-
-				return false;
-			}
-		);
-
-		remove_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		if ( ! empty( $ticket_row ) ) {
-			$ticket_row_key = key( $ticket_row );
-			$row_indexes    = array_keys( $rows );
-			$position       = array_search( $ticket_row_key, $row_indexes );
-
-			$slice = array_slice( $rows, $position );
-
-			array_unshift( $slice, $new_row );
-			array_splice( $rows, $position, count( $rows ), $slice );
-		} else {
-			$rows[] = $new_row;
-		}
-
-		return $rows;
 	}
 
 	/**
@@ -320,16 +170,16 @@ class Accommodations_Field extends CampTix_Addon {
 		}
 
 		$current_wordcamp = get_wordcamp_post();
-		$wordcamp_name    = get_wordcamp_name( get_wordcamp_site_id( $current_wordcamp ) );
+		$wordcamp_name    = get_wordcamp_name();
 		$post_type_object = get_post_type_object( $attendee->post_type );
 		$attendee_link    = add_query_arg( 'action', 'edit', admin_url( sprintf( $post_type_object->_edit_link, $attendee->ID ) ) );
 		$handbook_link    = 'https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/inclusive-and-welcoming-events/#requests-for-special-accommodations';
 		$recipients       = array(
-			$current_wordcamp->meta['Email Address'][0], // Lead organizer
-			$current_wordcamp->meta['E-mail Address'][0], // City address
+			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer
+			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address
 		);
 
-		$recipients = array_unique( $recipients );
+		$recipients = array_filter( array_unique( $recipients ) );
 
 		foreach ( $recipients as $recipient ) {
 			$subject = sprintf(
@@ -367,15 +217,6 @@ class Accommodations_Field extends CampTix_Addon {
 		);
 
 		update_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
-	}
-
-	/**
-	 * Filter: Set the locale to en_US.
-	 *
-	 * @return string
-	 */
-	public function set_locale_to_en_US() {
-		return 'en_US';
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -36,20 +36,16 @@ class Allergy_Field extends CampTix_Addon {
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
-		// Registration field
-		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 11, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ), 11 );
-		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
+		// Ask the question.
+		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 ); // 20 = allergy, 30 = accessibility, 40 = this, 50 = CoC
+		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
+
+		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+
+		// Email notifications
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
-
-		// Edit info field
-		add_filter( 'camptix_form_edit_attendee_ticket_info', array( $this, 'populate_ticket_info_array' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'validate_save_ticket_info_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_after_questions', array( $this, 'render_ticket_info_field' ), 11 );
-
-		// Metabox
-		add_filter( 'camptix_metabox_attendee_info_additional_rows', array( $this, 'add_metabox_row' ), 11, 2 );
 
 		// Reporting
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
@@ -64,114 +60,42 @@ class Allergy_Field extends CampTix_Addon {
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
 	}
 
-	/**
-	 * Render the field, used on both Registration and when editing an existing ticket.
-	 *
-	 * @param string $name
-	 * @param string $value
-	 * @param int    $ticket_id
-	 */
-	public function render_field( $name, $value, $ticket_id ) {
-		if ( apply_filters( 'camptix_allergy_should_skip', false ) ) {
-			return;
-		}
-
-		$question = apply_filters( 'camptix_allergy_question_text', $this->question, $ticket_id );
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $question ); ?>">
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="yes"
-							<?php checked( 'yes', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-					<br />
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="no"
-							<?php checked( 'no', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
-	}
 
 	/**
-	 * Render the new field for the registration form during checkout.
+	 * Add the question to the list of questions.
 	 *
-	 * @param array $form_data
-	 * @param int   $i
-	 */
-	public function render_registration_field( $form_data, $i ) {
-		$current_data = ( isset( $form_data['tix_attendee_info'][ $i ] ) )
-			? $form_data['tix_attendee_info'][ $i ]
-			: array();
-
-		$current_data = wp_parse_args( $current_data, array( self::SLUG => '' ) );
-
-		$this->render_field(
-			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
-			$current_data[ self::SLUG ],
-			$current_data['ticket_id']
-		);
-	}
-
-	/**
-	 * Validate the value of the new field submitted to the registration form during checkout.
-	 *
-	 * @param array $data
+	 * @param array $questions
 	 *
 	 * @return array
 	 */
-	public function validate_registration_field( $data ) {
-		/* @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		$skip_question = apply_filters( 'camptix_allergy_should_skip', false );
-		if ( $skip_question ) {
-			return $data;
+	function add_question( $questions, $ticket_id ) {
+		if ( apply_filters( 'camptix_allergy_should_skip', false ) ) {
+			return $questions;
 		}
 
-		if ( ! isset( $data[ self::SLUG ] ) || empty( $data[ self::SLUG ] ) ) {
-			$camptix->error_flags['required_fields'] = true;
-		} else {
-			$data[ self::SLUG ] = ( 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
-		}
+		$questions[ self::SLUG ] = (object) array(
+			// Immitate a WP_Post with metadata..
+			'ID' 	       => self::SLUG,
+			'post_title'   => apply_filters( 'camptix_allergy_question_text', $this->question, $ticket_id ),
+			'tix_type'     => 'radio',
+			'tix_required' => true,
+			'tix_values'   => $this->options,
+		);
 
-		return $data;
+		return $questions;
 	}
 
 	/**
-	 * Add the value of the new field to the attendee object during checkout processing.
+	 * Add the new field to the questions order.
 	 *
-	 * @param WP_Post $attendee
-	 * @param array   $data
+	 * @param array $order
 	 *
-	 * @return WP_Post
+	 * @return array
 	 */
-	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = isset( $data[ self::SLUG ] ) ? $data[ self::SLUG ] : 'no';
+	function add_question_order( $order ) {
+		$order[] = self::SLUG;
 
-		return $attendee;
+		return $order;
 	}
 
 	/**
@@ -187,6 +111,25 @@ class Allergy_Field extends CampTix_Addon {
 	}
 
 	/**
+	 * Retrieve the stored value of the new field for use when displaying the attendee info.
+	 *
+	 * Back-compat only, for where the field was stored outside of the question answers.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 *
+	 * @return array
+	 */
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$attendee = get_post( $attendee );
+		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+
+		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
+
+		return $ticket_info;
+	}
+
+	/**
 	 * Initialize email notifications after the ticket receipt email has been sent.
 	 *
 	 * @param int $attendee_id
@@ -198,98 +141,6 @@ class Allergy_Field extends CampTix_Addon {
 		if ( $attendee instanceof WP_Post && 'tix_attendee' === $attendee->post_type ) {
 			$this->maybe_send_notification_email( $value, $attendee );
 		}
-	}
-
-	/**
-	 * Retrieve the stored value of the new field for use on the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 *
-	 * @return array
-	 */
-	public function populate_ticket_info_array( $ticket_info, $attendee ) {
-		$ticket_info[ self::SLUG ] = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		return $ticket_info;
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $data
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function validate_save_ticket_info_field( $data, $attendee ) {
-		$value = ( isset( $data[ self::SLUG ] ) && 'yes' === $data[ self::SLUG ] ) ? 'yes' : 'no';
-
-		$this->maybe_send_notification_email( $value, $attendee );
-
-		return update_post_meta( $attendee->ID, 'tix_' . self::SLUG, $value );
-	}
-
-	/**
-	 * Render the new field for the Edit Info form.
-	 *
-	 * @param array $ticket_info
-	 */
-	public function render_ticket_info_field( $ticket_info ) {
-		$current_data = wp_parse_args( $ticket_info, array( self::SLUG => 'no' ) );
-
-		$this->render_field(
-			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
-			$current_data[ self::SLUG ],
-			$current_data['ticket_id']
-		);
-	}
-
-	/**
-	 * Add a row to the Attendee Info metabox table for the new field and value.
-	 *
-	 * @param array   $rows
-	 * @param WP_Post $post
-	 *
-	 * @return mixed
-	 */
-	public function add_metabox_row( $rows, $post ) {
-		$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true );
-		if ( $value && isset( $this->options[ $value ] ) ) {
-			$value = $this->options[ $value ];
-		}
-		$question = apply_filters( 'camptix_allergy_question_text', $this->question, $post->tix_ticket_id );
-		$new_row = array( $question, esc_html( $value ) );
-
-		add_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		$ticket_row = array_filter(
-			$rows,
-			function( $row ) {
-				if ( 'Ticket' === $row[0] ) {
-					return true;
-				}
-
-				return false;
-			}
-		);
-
-		remove_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		if ( ! empty( $ticket_row ) ) {
-			$ticket_row_key = key( $ticket_row );
-			$row_indexes    = array_keys( $rows );
-			$position       = array_search( $ticket_row_key, $row_indexes );
-
-			$slice = array_slice( $rows, $position );
-
-			array_unshift( $slice, $new_row );
-			array_splice( $rows, $position, count( $rows ), $slice );
-		} else {
-			$rows[] = $new_row;
-		}
-
-		return $rows;
 	}
 
 	/**
@@ -318,14 +169,16 @@ class Allergy_Field extends CampTix_Addon {
 		}
 
 		$current_wordcamp = get_wordcamp_post();
-		$wordcamp_name    = get_wordcamp_name( get_wordcamp_site_id( $current_wordcamp ) );
+		$wordcamp_name    = get_wordcamp_name();
 		$post_type_object = get_post_type_object( $attendee->post_type );
 		$attendee_link    = add_query_arg( 'action', 'edit', admin_url( sprintf( $post_type_object->_edit_link, $attendee->ID ) ) );
 		$handbook_link    = 'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/selling-tickets/life-threatening-allergies/';
 		$recipients       = array(
-			$current_wordcamp->meta['Email Address'][0], // Lead organizer
-			$current_wordcamp->meta['E-mail Address'][0], // City address
+			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer
+			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address
 		);
+
+		$recipients = array_unique( array_filter( $recipients ) );
 
 		foreach ( $recipients as $recipient ) {
 			$subject = sprintf(
@@ -363,15 +216,6 @@ class Allergy_Field extends CampTix_Addon {
 		);
 
 		update_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
-	}
-
-	/**
-	 * Filter: Set the locale to en_US.
-	 *
-	 * @return string
-	 */
-	public function set_locale_to_en_US() {
-		return 'en_US';
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -38,7 +38,7 @@ class Allergy_Field extends CampTix_Addon {
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 ); // 20 = allergy, 30 = accessibility, 40 = this, 50 = CoC
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 ); // 20 = allergy, 30 = accessibility, 40 = first time, 50 = CoC
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
@@ -59,7 +59,6 @@ class Allergy_Field extends CampTix_Addon {
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
 	}
-
 
 	/**
 	 * Add the question to the list of questions.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/allergy.php
@@ -38,11 +38,12 @@ class Allergy_Field extends CampTix_Addon {
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 ); // 20 = allergy, 30 = accessibility, 40 = first time, 50 = CoC
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 );
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Email notifications
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
@@ -107,6 +108,19 @@ class Allergy_Field extends CampTix_Addon {
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
 		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
+	}
+
+	/**
+	 * Update the stored value of the new field if it was changed in the Edit Info form.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 * @param array   $answers
+	 *
+	 * @return bool|int
+	 */
+	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
+		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
@@ -20,31 +20,31 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 	 * Hook into WordPress and Camptix.
 	 */
 	public function camptix_init() {
-		// Registration field
-		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 15, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
-		add_action( 'camptix_form_attendee_info_errors', array( $this, 'add_registration_field_validation_error' ) );
-		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
+
+		// Ask the question.
+		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 50 ); // 20 = allergy, 30 = accessibility, 40 = first time, 50 = CoC
+		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
+
+		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 
-		// Metabox
-		add_filter( 'camptix_metabox_attendee_info_additional_rows', array( $this, 'add_metabox_row' ), 15, 2 );
+		// Registration field
+		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
+		add_action( 'camptix_form_attendee_info_errors', array( $this, 'add_registration_field_validation_error' ) );
 	}
 
 	/**
-	 * Render the new field for the registration form during checkout.
+	 * Add the question to the list of questions.
 	 *
-	 * @param array $form_data
-	 * @param int   $i
+	 * @param array $questions
+	 *
+	 * @return array
 	 */
-	public function render_registration_field( $form_data, $i ) {
-		$current_data = $form_data['tix_attendee_info'][ $i ] ?? array();
-
-		$current_data = wp_parse_args( $current_data, array(
-			self::SLUG => false,
-		) );
-
-		$current_data[ self::SLUG ] = wp_validate_boolean( $current_data[ self::SLUG ] );
+	function add_question( $questions, $ticket_id ) {
+		if ( apply_filters( 'camptix_coc_should_skip', false ) ) {
+			return $questions;
+		}
 
 		$coc_url = $this->maybe_get_coc_url();
 		$question = __( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' );
@@ -56,25 +56,62 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 			);
 		}
 
-		?>
+		$questions[ self::SLUG ] = (object) array(
+			// Immitate a WP_Post with metadata..
+			'ID' 	       => self::SLUG,
+			'post_title'   => apply_filters( 'camptix_coc_question_text', $question, $ticket_id ),
+			'tix_type'     => 'checkbox',
+			'tix_required' => true,
+			'tix_values'   => [
+				'yes' => _x( 'Yes', 'ticket registration option', 'wordcamporg' ),
+			],
+		);
 
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo wp_kses_post( $question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
+		return $questions;
+	}
 
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( strip_tags( $question ) ); ?>">
-					<label>
-						<input name="tix_attendee_info[<?php echo esc_attr( $i ); ?>][<?php echo esc_attr( self::SLUG ); ?>]" type="checkbox" <?php checked( $current_data[ self::SLUG ] ); ?> required />
-						<?php echo esc_html_x( 'Yes', 'ticket registration option', 'wordcamporg' ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
+	/**
+	 * Add the new field to the questions order.
+	 *
+	 * @param array $order
+	 *
+	 * @return array
+	 */
+	function add_question_order( $order ) {
+		$order[] = self::SLUG;
 
-		<?php
+		return $order;
+	}
+
+	/**
+	 * Save the value of the new field to the attendee post upon completion of checkout.
+	 *
+	 * @param int     $post_id
+	 * @param WP_Post $attendee
+	 *
+	 * @return bool|int
+	 */
+	public function save_registration_field( $post_id, $attendee ) {
+		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
+	}
+
+	/**
+	 * Retrieve the stored value of the new field for use when displaying the attendee info.
+	 *
+	 * Back-compat only, for where the field was stored outside of the question answers.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 *
+	 * @return array
+	 */
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$attendee = get_post( $attendee );
+		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+
+		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
+
+		return $ticket_info;
 	}
 
 	/**
@@ -109,72 +146,6 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 		if ( isset( $error_flags[ self::SLUG . '_unchecked' ] ) ) {
 			$camptix->error( __( 'You must agree to follow the event Code of Conduct to obtain a ticket.', 'wordcamporg' ) );
 		}
-	}
-
-	/**
-	 * Add the value of the new field to the attendee object during checkout processing.
-	 *
-	 * @param WP_Post $attendee
-	 * @param array   $data
-	 *
-	 * @return WP_Post
-	 */
-	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = $data[ self::SLUG ];
-
-		return $attendee;
-	}
-
-	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function save_registration_field( $post_id, $attendee ) {
-		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
-	}
-
-	/**
-	 * Add a row to the Attendee Info metabox table for the new field and value.
-	 *
-	 * @param array   $rows
-	 * @param WP_Post $post
-	 *
-	 * @return mixed
-	 */
-	public function add_metabox_row( $rows, $post ) {
-		$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true ) ? _x( 'Yes', 'ticket registration option', 'wordcamporg' ) : '';
-		$new_row = array( __( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' ), esc_html( $value ) );
-
-		add_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		$ticket_row = array_filter( $rows, function( $row ) {
-			if ( 'Ticket' === $row[0] ) {
-				return true;
-			}
-
-			return false;
-		} );
-
-		remove_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		if ( ! empty( $ticket_row ) ) {
-			$ticket_row_key = key( $ticket_row );
-			$row_indexes    = array_keys( $rows );
-			$position       = array_search( $ticket_row_key, $row_indexes );
-
-			$slice = array_slice( $rows, $position );
-
-			array_unshift( $slice, $new_row );
-			array_splice( $rows, $position, count( $rows ), $slice );
-		} else {
-			$rows[] = $new_row;
-		}
-
-		return $rows;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/code-of-conduct.php
@@ -23,11 +23,12 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 50 ); // 20 = allergy, 30 = accessibility, 40 = first time, 50 = CoC
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 50 );
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Registration field
 		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
@@ -93,6 +94,19 @@ class Code_Of_Conduct_Field extends CampTix_Addon {
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
 		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
+	}
+
+	/**
+	 * Update the stored value of the new field if it was changed in the Edit Info form.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 * @param array   $answers
+	 *
+	 * @return bool|int
+	 */
+	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
+		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -109,7 +109,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 			return;
 		}
 
-		// If not overriden, use the slug as the filter.
+		// If not overriden, use the slug in the filters.
 		$this->filter_slug ??= static::SLUG;
 
 		// Ask the question.
@@ -185,15 +185,11 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 * @return bool|int
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
-		$answer = $attendee->answers[ static::SLUG ];
-		$key    = array_search( $answer, $this->options, true );
-
-		// For back-compat, we store the option key rather than the option value.
-		if ( $key ) {
-			$answer = $key;
+		if ( ! isset( $attendee->answers[ static::SLUG ] ) ) {
+			return false;
 		}
 
-		return update_post_meta( $post_id, 'tix_' . static::SLUG, $answer );
+		return $this->save_field( $post_id, $attendee->answers[ static::SLUG ] );
 	}
 
 	/**
@@ -206,7 +202,24 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 * @return bool|int
 	 */
 	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
-		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
+		return $this->save_field( $attendee->ID, $answers[ static::SLUG ] );
+	}
+
+	/**
+	 * Save the value of the field to the attendee postmeta for back-compat.
+	 *
+	 * @param int   $post_id
+	 * @param mixed $answer
+	 */
+	public function save_field( $post_id, $answer ) {
+		$key = array_search( $answer, $this->options, true );
+
+		// For back-compat, we store the option key rather than the option value.
+		if ( $key ) {
+			$answer = $key;
+		}
+
+		return update_post_meta( $post_id, 'tix_' . static::SLUG, $answer );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -1,0 +1,23 @@
+<?php
+namespace WordCamp\CampTix_Tweaks;
+use CampTix_Addon;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Abstraction class for extra fields.
+ */
+abstract class Extra_Field extends CampTix_Addon {
+	const SLUG = '';
+
+	public $label      = '';
+	public $a11y_label = null;
+	public $question   = '';
+	public $options    = array();
+
+	/**
+	 * Hook into WordPress and Camptix.
+	 */
+	public function camptix_init() {
+	}
+}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -7,17 +7,127 @@ defined( 'WPINC' ) || die();
 /**
  * Abstraction class for extra fields.
  */
-abstract class Extra_Field extends CampTix_Addon {
-	const SLUG = '';
+abstract class Extra_Fields extends CampTix_Addon {
+	const SLUG             = '';
+	protected $filter_slug = '';
 
-	public $label      = '';
-	public $a11y_label = null;
-	public $question   = '';
-	public $options    = array();
+	public $label          = '';
+	public $a11y_label     = null;
+	public $question       = '';
+	public $type           = 'radio';
+	public $options        = array();
+	public $required       = true;
+	public $question_order = 10;
 
 	/**
 	 * Hook into WordPress and Camptix.
 	 */
 	public function camptix_init() {
+		if ( ! static::SLUG ) {
+			return;
+		}
+
+		if ( is_callable( array( $this, 'init' ) ) ) {
+			$this->init();
+		}
+
+		if ( ! $this->question ) {
+			return;
+		}
+
+		// If not overriden, use the slug as the filter.
+		$this->filter_slug ??= static::SLUG;
+
+		// Ask the question.
+		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), $this->question_order );
+		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
+
+		// Save the answer as post meta.
+		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 	}
+
+	/**
+	 * Add the question to the list of questions.
+	 *
+	 * @param array $questions
+	 *
+	 * @return array
+	 */
+	function add_question( $questions, $ticket_id ) {
+		if ( apply_filters( "camptix_{$this->filter_slug}_should_skip", false ) ) {
+			return $questions;
+		}
+
+		$questions[ static::SLUG ] = (object) array(
+			// Immitate a WP_Post with metadata..
+			'ID' 	       => static::SLUG,
+			'post_title'   => apply_filters( "camptix_{$this->filter_slug}_question_text", $this->question, $ticket_id ),
+			'tix_type'     => $this->type,
+			'tix_required' => $this->required,
+			'tix_values'   => $this->options,
+		);
+
+		return $questions;
+	}
+
+	/**
+	 * Add the new field to the questions order.
+	 *
+	 * @param array $order
+	 *
+	 * @return array
+	 */
+	function add_question_order( $order ) {
+		$order[] = static::SLUG;
+
+		return $order;
+	}
+
+	/**
+	 * Save the value of the new field to the attendee post upon completion of checkout.
+	 *
+	 * @param int     $post_id
+	 * @param WP_Post $attendee
+	 *
+	 * @return bool|int
+	 */
+	public function save_registration_field( $post_id, $attendee ) {
+		return update_post_meta( $post_id, 'tix_' . static::SLUG, $attendee->{ static::SLUG } );
+	}
+
+	/**
+	 * Update the stored value of the new field if it was changed in the Edit Info form.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 * @param array   $answers
+	 *
+	 * @return bool|int
+	 */
+	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
+		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
+	}
+
+	/**
+	 * Retrieve the stored value of the new field for use when displaying the attendee info.
+	 *
+	 * Back-compat only, for where the field was stored outside of the question answers.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 *
+	 * @return array
+	 */
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$attendee = get_post( $attendee );
+		$value    = get_post_meta( $attendee->ID, 'tix_' . static::SLUG, true );
+
+		$ticket_info[ static::SLUG ] ??= $this->options[ $value ] ?? '';
+
+		return $ticket_info;
+	}
+
+
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -8,18 +8,89 @@ defined( 'WPINC' ) || die();
  * Abstraction class for extra fields.
  */
 abstract class Extra_Fields extends CampTix_Addon {
-	const SLUG             = '';
+	/**
+	 * The slug for the field.
+	 *
+	 * This is used to store the value in post meta, and to identify the field in the summary table.
+	 *
+	 * @var string
+	 */
+	const SLUG = '';
+
+	/**
+	 * The slug for the field, used in filter names.
+	 *
+	 * If not specified, will default to the value of `static::SLUG`.
+	 *
+	 * @var string
+	 */
 	protected $filter_slug = '';
 
-	public $label          = '';
-	public $a11y_label     = null;
-	public $question       = '';
-	public $type           = 'radio';
-	public $options        = array();
-	public $required       = true;
+	/**
+	 * The label for the column in the summary table.
+	 *
+	 * @var string
+	 */
+	public $column_label = '';
+
+	/**
+	 * The label for the field in the ticket form.
+	 *
+	 * Only required if the question contains complex HTML.
+	 *
+	 * @var string
+	 */
+	public $a11y_label = null;
+
+	/**
+	 * The question to ask.
+	 *
+	 * @var string
+	 */
+	public $question = '';
+
+	/**
+	 * The type of field to display.
+	 *
+	 * @var string
+	 */
+	public $type = 'radio';
+
+	/**
+	 * The options for the field, if limited choice.
+	 *
+	 * @var array
+	 */
+	public $options = array();
+
+	/**
+	 * Whether the field is required.
+	 *
+	 * @var bool
+	 */
+	public $required = true;
+
+	/**
+	 * The order in which the field should be displayed.
+	 *
+	 * Uses WordPress Hook priority system, lower number = higher priority.
+	 *
+	 * @var int
+	 */
 	public $question_order = 10;
 
-	public $enable_summary      = true;
+	/**
+	 * Whether to enable the field to be summarised by.
+	 *
+	 * @var bool
+	 */
+	public $enable_summary = true;
+
+	/**
+	 * Whether to enable the field to be exported & erased.
+	 *
+	 * @var bool
+	 */
 	public $enable_export_erase = true;
 
 	/**
@@ -51,7 +122,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Reporting.
-		if ( $this->enable_summary ) {
+		if ( $this->enable_summary && $this->column_label ) {
 			add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
 			add_action( 'camptix_summarize_by_' . static::SLUG, array( $this, 'summarize' ), 10, 2 );
 			add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
@@ -157,7 +228,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 * @return array
 	 */
 	public function add_summary_field( $fields ) {
-		$fields[ static::SLUG ] = $this->label;
+		$fields[ static::SLUG ] = $this->column_label;
 
 		return $fields;
 	}
@@ -189,7 +260,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 * @return array
 	 */
 	public function add_export_column( $columns ) {
-		$columns[ static::SLUG ] = $this->label;
+		$columns[ static::SLUG ] = $this->column_label;
 
 		return $columns;
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -185,7 +185,15 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 * @return bool|int
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
-		return update_post_meta( $post_id, 'tix_' . static::SLUG, $attendee->{ static::SLUG } );
+		$answer = $attendee->answers[ static::SLUG ];
+		$key    = array_search( $answer, $this->options, true );
+
+		// For back-compat, we store the option key rather than the option value.
+		if ( $key ) {
+			$answer = $key;
+		}
+
+		return update_post_meta( $post_id, 'tix_' . static::SLUG, $answer );
 	}
 
 	/**
@@ -215,7 +223,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 		$attendee = get_post( $attendee );
 		$value    = get_post_meta( $attendee->ID, 'tix_' . static::SLUG, true );
 
-		$ticket_info[ static::SLUG ] ??= $this->options[ $value ] ?? '';
+		$ticket_info[ static::SLUG ] ??= $this->options[ $value ] ?? $value;
 
 		return $ticket_info;
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -19,6 +19,9 @@ abstract class Extra_Fields extends CampTix_Addon {
 	public $required       = true;
 	public $question_order = 10;
 
+	public $enable_summary      = true;
+	public $enable_export_erase = true;
+
 	/**
 	 * Hook into WordPress and Camptix.
 	 */
@@ -46,6 +49,22 @@ abstract class Extra_Fields extends CampTix_Addon {
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
+
+		// Reporting.
+		if ( $this->enable_summary ) {
+			add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
+			add_action( 'camptix_summarize_by_' . static::SLUG, array( $this, 'summarize' ), 10, 2 );
+			add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
+			add_filter( 'camptix_attendee_report_column_value_' . static::SLUG, array( $this, 'add_export_column_value' ), 10, 2 );
+		}
+
+		// Privacy - Erase / Export features.
+		if ( $this->enable_export_erase ) {
+			add_filter( 'camptix_privacy_attendee_props_to_export', array( $this, 'attendee_props_to_export' ) );
+			add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
+			add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
+			add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
+		}
 	}
 
 	/**
@@ -64,6 +83,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 			// Immitate a WP_Post with metadata..
 			'ID' 	       => static::SLUG,
 			'post_title'   => apply_filters( "camptix_{$this->filter_slug}_question_text", $this->question, $ticket_id ),
+			'a11y_label'   => $this->a11y_label,
 			'tix_type'     => $this->type,
 			'tix_required' => $this->required,
 			'tix_values'   => $this->options,
@@ -129,5 +149,131 @@ abstract class Extra_Fields extends CampTix_Addon {
 		return $ticket_info;
 	}
 
+	/**
+	 * Add an option to the `Summarize by` dropdown.
+	 *
+	 * @param array $fields
+	 *
+	 * @return array
+	 */
+	public function add_summary_field( $fields ) {
+		$fields[ static::SLUG ] = $this->label;
 
+		return $fields;
+	}
+
+	/**
+	 * Callback to summarize the answers for this field.
+	 *
+	 * @param array   $summary
+	 * @param WP_Post $attendee
+	 */
+	public function summarize( &$summary, $attendee ) {
+		/** @var $camptix CampTix_Plugin */
+		global $camptix;
+
+		$answer = get_post_meta( $attendee->ID, 'tix_' . static::SLUG, true );
+
+		if ( isset( $this->options[ $answer ] ) ) {
+			$camptix->increment_summary( $summary, $this->options[ $answer ] );
+		} else {
+			$camptix->increment_summary( $summary, __( 'No answer', 'wordcamporg' ) );
+		}
+	}
+
+	/**
+	 * Add a column to the CSV export.
+	 *
+	 * @param array $columns
+	 *
+	 * @return array
+	 */
+	public function add_export_column( $columns ) {
+		$columns[ static::SLUG ] = $this->label;
+
+		return $columns;
+	}
+
+	/**
+	 * Add the human-readable value of the field to the CSV export.
+	 *
+	 * @param string  $value
+	 * @param WP_Post $attendee
+	 *
+	 * @return string
+	 */
+	public function add_export_column_value( $value, $attendee ) {
+		$value = get_post_meta( $attendee->ID, 'tix_' . static::SLUG, true );
+
+		return $this->options[ $value ] ?? '';
+	}
+
+	/**
+	 * Include the new field in the personal data exporter.
+	 *
+	 * @param array $props
+	 *
+	 * @return array
+	 */
+	public function attendee_props_to_export( $props ) {
+		$props[ 'tix_' . static::SLUG ] = $this->question;
+
+		return $props;
+	}
+
+	/**
+	 * Add the new field's value and label to the aggregated personal data for export.
+	 *
+	 * @param array   $export
+	 * @param string  $key
+	 * @param string  $label
+	 * @param WP_Post $post
+	 *
+	 * @return array
+	 */
+	public function export_attendee_prop( $export, $key, $label, $post ) {
+		if ( 'tix_' . static::SLUG === $key ) {
+			$value = get_post_meta( $post->ID, 'tix_' . static::SLUG, true );
+
+			if ( isset( $this->options[ $value ] ) ) {
+				$value = $this->options[ $value ];
+			}
+
+			if ( ! empty( $value ) ) {
+				$export[] = array(
+					'name'  => $label,
+					'value' => $value,
+				);
+			}
+		}
+
+		return $export;
+	}
+
+	/**
+	 * Include the new field in the personal data eraser.
+	 *
+	 * @param array $props
+	 *
+	 * @return array
+	 */
+	public function attendee_props_to_erase( $props ) {
+		$props[ 'tix_' . static::SLUG ] = 'camptix_yesno';
+
+		return $props;
+	}
+
+	/**
+	 * Anonymize the value of the new field during personal data erasure.
+	 *
+	 * @param string  $key
+	 * @param string  $type
+	 * @param WP_Post $post
+	 */
+	public function erase_attendee_prop( $key, $type, $post ) {
+		if ( 'tix_' . static::SLUG === $key ) {
+			$anonymized_value = wp_privacy_anonymize_data( $type );
+			update_post_meta( $post->ID, $key, $anonymized_value );
+		}
+	}
 }

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -74,14 +74,14 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 *
 	 * @return array
 	 */
-	function add_question( $questions, $ticket_id ) {
+	public function add_question( $questions, $ticket_id ) {
 		if ( apply_filters( "camptix_{$this->filter_slug}_should_skip", false ) ) {
 			return $questions;
 		}
 
 		$questions[ static::SLUG ] = (object) array(
 			// Immitate a WP_Post with metadata..
-			'ID' 	       => static::SLUG,
+			'ID'           => static::SLUG,
 			'post_title'   => apply_filters( "camptix_{$this->filter_slug}_question_text", $this->question, $ticket_id ),
 			'a11y_label'   => $this->a11y_label,
 			'tix_type'     => $this->type,
@@ -99,7 +99,7 @@ abstract class Extra_Fields extends CampTix_Addon {
 	 *
 	 * @return array
 	 */
-	function add_question_order( $order ) {
+	public function add_question_order( $order ) {
 		$order[] = static::SLUG;
 
 		return $order;

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields.php
@@ -208,8 +208,8 @@ abstract class Extra_Fields extends CampTix_Addon {
 	/**
 	 * Save the value of the field to the attendee postmeta for back-compat.
 	 *
-	 * @param int   $post_id
-	 * @param mixed $answer
+	 * @param int    $post_id
+	 * @param string $answer
 	 */
 	public function save_field( $post_id, $answer ) {
 		$key = array_search( $answer, $this->options, true );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
@@ -1,11 +1,11 @@
 <?php
-
 namespace WordCamp\CampTix_Tweaks;
-defined( 'WPINC' ) || die();
 
-use CampTix_Plugin, CampTix_Addon;
+use CampTix_Plugin;
 use WP_Post;
 use PHPMailer;
+
+defined( 'WPINC' ) || die();
 
 /**
  * Class Accommodations_Field.
@@ -16,7 +16,7 @@ use PHPMailer;
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Accommodations_Field extends CampTix_Addon {
+class Accommodations_Field extends Extra_Field {
 	const SLUG = 'accommodations';
 
 	public $label = '';

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
@@ -93,8 +93,8 @@ class Accommodations_Field extends Extra_Fields {
 		$attendee_link    = add_query_arg( 'action', 'edit', admin_url( sprintf( $post_type_object->_edit_link, $attendee->ID ) ) );
 		$handbook_link    = 'https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/inclusive-and-welcoming-events/#requests-for-special-accommodations';
 		$recipients       = array(
-			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer
-			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address
+			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer.
+			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address.
 		);
 
 		$recipients = array_filter( array_unique( $recipients ) );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
@@ -1,7 +1,6 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-use CampTix_Plugin;
 use WP_Post;
 use PHPMailer;
 
@@ -37,18 +36,6 @@ class Accommodations_Field extends Extra_Fields {
 
 		// Notifications.
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
-
-		// Reporting
-		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
-		add_action( 'camptix_summarize_by_' . self::SLUG, array( $this, 'summarize' ), 10, 2 );
-		add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
-		add_filter( 'camptix_attendee_report_column_value_' . self::SLUG, array( $this, 'add_export_column_value' ), 10, 2 );
-
-		// Privacy
-		add_filter( 'camptix_privacy_attendee_props_to_export', array( $this, 'attendee_props_to_export' ) );
-		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
-		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
-		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
 	}
 
 	/**
@@ -138,138 +125,6 @@ class Accommodations_Field extends Extra_Fields {
 		);
 
 		update_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
-	}
-
-	/**
-	 * Add an option to the `Summarize by` dropdown.
-	 *
-	 * @param array $fields
-	 *
-	 * @return array
-	 */
-	public function add_summary_field( $fields ) {
-		$fields[ self::SLUG ] = $this->label;
-
-		return $fields;
-	}
-
-	/**
-	 * Callback to summarize the answers for this field.
-	 *
-	 * @param array   $summary
-	 * @param WP_Post $attendee
-	 */
-	public function summarize( &$summary, $attendee ) {
-		/** @var $camptix CampTix_Plugin */
-		global $camptix;
-
-		$answer = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		if ( isset( $this->options[ $answer ] ) ) {
-			$camptix->increment_summary( $summary, $this->options[ $answer ] );
-		} else {
-			$camptix->increment_summary( $summary, __( 'No answer', 'wordcamporg' ) );
-		}
-	}
-
-	/**
-	 * Add a column to the CSV export.
-	 *
-	 * @param array $columns
-	 *
-	 * @return array
-	 */
-	public function add_export_column( $columns ) {
-		$columns[ self::SLUG ] = $this->label;
-
-		return $columns;
-	}
-
-	/**
-	 * Add the human-readable value of the field to the CSV export.
-	 *
-	 * @param string  $value
-	 * @param WP_Post $attendee
-	 *
-	 * @return string
-	 */
-	public function add_export_column_value( $value, $attendee ) {
-		$value = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		if ( isset( $this->options[ $value ] ) ) {
-			return $this->options[ $value ];
-		}
-
-		return '';
-	}
-
-	/**
-	 * Include the new field in the personal data exporter.
-	 *
-	 * @param array $props
-	 *
-	 * @return array
-	 */
-	public function attendee_props_to_export( $props ) {
-		$props[ 'tix_' . self::SLUG ] = $this->question;
-
-		return $props;
-	}
-
-	/**
-	 * Add the new field's value and label to the aggregated personal data for export.
-	 *
-	 * @param array   $export
-	 * @param string  $key
-	 * @param string  $label
-	 * @param WP_Post $post
-	 *
-	 * @return array
-	 */
-	public function export_attendee_prop( $export, $key, $label, $post ) {
-		if ( 'tix_' . self::SLUG === $key ) {
-			$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true );
-
-			if ( isset( $this->options[ $value ] ) ) {
-				$value = $this->options[ $value ];
-			}
-
-			if ( ! empty( $value ) ) {
-				$export[] = array(
-					'name'  => $label,
-					'value' => $value,
-				);
-			}
-		}
-
-		return $export;
-	}
-
-	/**
-	 * Include the new field in the personal data eraser.
-	 *
-	 * @param array $props
-	 *
-	 * @return array
-	 */
-	public function attendee_props_to_erase( $props ) {
-		$props[ 'tix_' . self::SLUG ] = 'camptix_yesno';
-
-		return $props;
-	}
-
-	/**
-	 * Anonymize the value of the new field during personal data erasure.
-	 *
-	 * @param string  $key
-	 * @param string  $type
-	 * @param WP_Post $post
-	 */
-	public function erase_attendee_prop( $key, $type, $post ) {
-		if ( 'tix_' . self::SLUG === $key ) {
-			$anonymized_value = wp_privacy_anonymize_data( $type );
-			update_post_meta( $post->ID, $key, $anonymized_value );
-		}
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
@@ -34,8 +34,11 @@ class Accommodations_Field extends Extra_Fields {
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
-		// Notifications.
+		// Notifications - During registration.
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
+
+		// Notifications - During edit.
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'after_attendee_edit' ), 20, 2 );
 	}
 
 	/**
@@ -50,6 +53,13 @@ class Accommodations_Field extends Extra_Fields {
 		if ( $attendee instanceof WP_Post && 'tix_attendee' === $attendee->post_type ) {
 			$this->maybe_send_notification_email( $value, $attendee );
 		}
+	}
+
+	/**
+	 * Detect if the attendee has later flagged an accessibility need.
+	 */
+	public function after_attendee_edit( $ticket_info, $attendee ) {
+		$this->after_email_receipt( $attendee->ID );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
@@ -24,7 +24,7 @@ class Accommodations_Field extends Extra_Fields {
 	public $question_order = 30;
 
 	/**
-	 * Hook into WordPress and Camptix.
+	 * Setup the question & options.
 	 */
 	public function init() {
 		$this->label    = __( 'Accessibility needs', 'wordcamporg' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/accommodations.php
@@ -16,36 +16,24 @@ defined( 'WPINC' ) || die();
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Accommodations_Field extends Extra_Field {
+class Accommodations_Field extends Extra_Fields {
 	const SLUG = 'accommodations';
 
-	public $label = '';
-
-	public $question = '';
-
-	public $options = array();
+	public $label          = '';
+	public $question       = '';
+	public $options        = array();
+	public $question_order = 30;
 
 	/**
 	 * Hook into WordPress and Camptix.
 	 */
-	public function camptix_init() {
-		$this->label = __( 'Accessibility needs', 'wordcamporg' );
-
+	public function init() {
+		$this->label    = __( 'Accessibility needs', 'wordcamporg' );
 		$this->question = __( 'Do you have any accessibility needs, such as a sign language interpreter or wheelchair access, to participate in WordCamp?', 'wordcamporg' );
-
-		$this->options = array(
+		$this->options  = array(
 			'yes' => _x( 'Yes (we will contact you)', 'ticket registration option', 'wordcamporg' ),
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
-
-		// Ask the question.
-		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 30 );
-		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
-
-		// Save the answer as post meta.
-		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Notifications.
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
@@ -61,87 +49,6 @@ class Accommodations_Field extends Extra_Field {
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
-	}
-
-	/**
-	 * Add the question to the list of questions.
-	 *
-	 * @param array $questions
-	 *
-	 * @return array
-	 */
-	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_accommodations_should_skip', false ) ) {
-			return $questions;
-		}
-
-		$questions[ self::SLUG ] = (object) array(
-			// Immitate a WP_Post with metadata..
-			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_accommodations_question_text', $this->question, $ticket_id ),
-			'tix_type'     => 'radio',
-			'tix_required' => true,
-			'tix_values'   => $this->options,
-		);
-
-		return $questions;
-	}
-
-	/**
-	 * Add the new field to the questions order.
-	 *
-	 * @param array $order
-	 *
-	 * @return array
-	 */
-	function add_question_order( $order ) {
-		$order[] = self::SLUG;
-
-		return $order;
-	}
-
-	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function save_registration_field( $post_id, $attendee ) {
-		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 * @param array   $answers
-	 *
-	 * @return bool|int
-	 */
-	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
-		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
-	}
-
-	/**
-	 * Retrieve the stored value of the new field for use when displaying the attendee info.
-	 *
-	 * Back-compat only, for where the field was stored outside of the question answers.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 *
-	 * @return array
-	 */
-	public function populate_attendee_answer( $ticket_info, $attendee ) {
-		$attendee = get_post( $attendee );
-		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
-
-		return $ticket_info;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -16,9 +16,6 @@ defined( 'WPINC' ) || die();
 class Allergy_Field extends Extra_Fields {
 	const SLUG = 'allergy';
 
-	public $label          = '';
-	public $question       = '';
-	public $options        = array();
 	public $question_order = 20;
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -25,9 +25,9 @@ class Allergy_Field extends Extra_Fields {
 	 * Setup the question & options.
 	 */
 	public function init() {
-		$this->label    = __( 'Severe allergy', 'wordcamporg' );
-		$this->question = __( 'Do you have a severe allergy that would affect your experience at WordCamp?', 'wordcamporg' );
-		$this->options  = array(
+		$this->column_label = __( 'Severe allergy', 'wordcamporg' );
+		$this->question     = __( 'Do you have a severe allergy that would affect your experience at WordCamp?', 'wordcamporg' );
+		$this->options      = array(
 			'yes' => _x( 'Yes (we will contact you)', 'ticket registration option', 'wordcamporg' ),
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -1,7 +1,6 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-use CampTix_Plugin;
 use WP_Post;
 use PHPMailer;
 
@@ -35,18 +34,6 @@ class Allergy_Field extends Extra_Fields {
 
 		// Email notifications
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
-
-		// Reporting
-		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
-		add_action( 'camptix_summarize_by_' . self::SLUG, array( $this, 'summarize' ), 10, 2 );
-		add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
-		add_filter( 'camptix_attendee_report_column_value_' . self::SLUG, array( $this, 'add_export_column_value' ), 10, 2 );
-
-		// Privacy
-		add_filter( 'camptix_privacy_attendee_props_to_export', array( $this, 'attendee_props_to_export' ) );
-		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
-		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
-		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
 	}
 
 	/**
@@ -136,138 +123,6 @@ class Allergy_Field extends Extra_Fields {
 		);
 
 		update_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
-	}
-
-	/**
-	 * Add an option to the `Summarize by` dropdown.
-	 *
-	 * @param array $fields
-	 *
-	 * @return array
-	 */
-	public function add_summary_field( $fields ) {
-		$fields[ self::SLUG ] = $this->label;
-
-		return $fields;
-	}
-
-	/**
-	 * Callback to summarize the answers for this field.
-	 *
-	 * @param array   $summary
-	 * @param WP_Post $attendee
-	 */
-	public function summarize( &$summary, $attendee ) {
-		/** @var $camptix CampTix_Plugin */
-		global $camptix;
-
-		$answer = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		if ( isset( $this->options[ $answer ] ) ) {
-			$camptix->increment_summary( $summary, $this->options[ $answer ] );
-		} else {
-			$camptix->increment_summary( $summary, __( 'No answer', 'wordcamporg' ) );
-		}
-	}
-
-	/**
-	 * Add a column to the CSV export.
-	 *
-	 * @param array $columns
-	 *
-	 * @return array
-	 */
-	public function add_export_column( $columns ) {
-		$columns[ self::SLUG ] = $this->label;
-
-		return $columns;
-	}
-
-	/**
-	 * Add the human-readable value of the field to the CSV export.
-	 *
-	 * @param string  $value
-	 * @param WP_Post $attendee
-	 *
-	 * @return string
-	 */
-	public function add_export_column_value( $value, $attendee ) {
-		$value = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		if ( isset( $this->options[ $value ] ) ) {
-			return $this->options[ $value ];
-		}
-
-		return '';
-	}
-
-	/**
-	 * Include the new field in the personal data exporter.
-	 *
-	 * @param array $props
-	 *
-	 * @return array
-	 */
-	public function attendee_props_to_export( $props ) {
-		$props[ 'tix_' . self::SLUG ] = $this->question;
-
-		return $props;
-	}
-
-	/**
-	 * Add the new field's value and label to the aggregated personal data for export.
-	 *
-	 * @param array   $export
-	 * @param string  $key
-	 * @param string  $label
-	 * @param WP_Post $post
-	 *
-	 * @return array
-	 */
-	public function export_attendee_prop( $export, $key, $label, $post ) {
-		if ( 'tix_' . self::SLUG === $key ) {
-			$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true );
-
-			if ( isset( $this->options[ $value ] ) ) {
-				$value = $this->options[ $value ];
-			}
-
-			if ( ! empty( $value ) ) {
-				$export[] = array(
-					'name'  => $label,
-					'value' => $value,
-				);
-			}
-		}
-
-		return $export;
-	}
-
-	/**
-	 * Include the new field in the personal data eraser.
-	 *
-	 * @param array $props
-	 *
-	 * @return array
-	 */
-	public function attendee_props_to_erase( $props ) {
-		$props[ 'tix_' . self::SLUG ] = 'camptix_yesno';
-
-		return $props;
-	}
-
-	/**
-	 * Anonymize the value of the new field during personal data erasure.
-	 *
-	 * @param string  $key
-	 * @param string  $type
-	 * @param WP_Post $post
-	 */
-	public function erase_attendee_prop( $key, $type, $post ) {
-		if ( 'tix_' . self::SLUG === $key ) {
-			$anonymized_value = wp_privacy_anonymize_data( $type );
-			update_post_meta( $post->ID, $key, $anonymized_value );
-		}
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -22,7 +22,7 @@ class Allergy_Field extends Extra_Fields {
 	public $question_order = 20;
 
 	/**
-	 * Hook into WordPress and Camptix.
+	 * Setup the question & options.
 	 */
 	public function init() {
 		$this->label    = __( 'Severe allergy', 'wordcamporg' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -32,8 +32,11 @@ class Allergy_Field extends Extra_Fields {
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
-		// Email notifications
+		// Notifications - During registration.
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
+
+		// Notifications - During edit.
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'after_attendee_edit' ), 20, 2 );
 	}
 
 	/**
@@ -48,6 +51,13 @@ class Allergy_Field extends Extra_Fields {
 		if ( $attendee instanceof WP_Post && 'tix_attendee' === $attendee->post_type ) {
 			$this->maybe_send_notification_email( $value, $attendee );
 		}
+	}
+
+	/**
+	 * Detect if the attendee has later flagged an accessibility need.
+	 */
+	public function after_attendee_edit( $ticket_info, $attendee ) {
+		$this->after_email_receipt( $attendee->ID );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -91,8 +91,8 @@ class Allergy_Field extends Extra_Fields {
 		$attendee_link    = add_query_arg( 'action', 'edit', admin_url( sprintf( $post_type_object->_edit_link, $attendee->ID ) ) );
 		$handbook_link    = 'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/selling-tickets/life-threatening-allergies/';
 		$recipients       = array(
-			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer
-			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address
+			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer.
+			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address.
 		);
 
 		$recipients = array_unique( array_filter( $recipients ) );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -1,53 +1,60 @@
 <?php
-
 namespace WordCamp\CampTix_Tweaks;
 
-use CampTix_Addon;
+use CampTix_Plugin;
 use WP_Post;
+use PHPMailer;
 
 defined( 'WPINC' ) || die();
 
 /**
- * Add an required attendee field asking if they've attended a WordCamp before.
+ * Class Allergy_Field.
+ *
+ * Add a non-optional attendee field indicating if they have a severe allergy.
+ *
+ * @package WordCamp\CampTix_Tweaks
  */
-class First_Time_Field extends CampTix_Addon {
-	const SLUG = 'first_time_attending_wp_event';
+class Allergy_Field extends Extra_Field {
+	const SLUG = 'allergy';
 
-	public $label    = '';
+	public $label = '';
+
 	public $question = '';
-	public $options  = array();
+
+	public $options = array();
 
 	/**
-	 * Hook into WordPress and CampTix.
+	 * Hook into WordPress and Camptix.
 	 */
 	public function camptix_init() {
-		$this->label    = __( 'First Time Attending', 'wordcamporg' );
-		$this->question = __( 'Will this be your first time attending a WordPress event?', 'wordcamporg' );
+		$this->label = __( 'Severe allergy', 'wordcamporg' );
+
+		$this->question = __( 'Do you have a severe allergy that would affect your experience at WordCamp?', 'wordcamporg' );
 
 		$this->options = array(
-			'yes' => _x( 'Yes', 'answer to question during ticket registration', 'wordcamporg' ),
-			'no'  => _x( 'No', 'answer to question during ticket registration', 'wordcamporg' ),
-
-			// Sometimes people buy tickets for others, and they may not know.
-			'unsure'  => _x( "I don't know", 'answer to question during ticket registration', 'wordcamporg' ),
+			'yes' => _x( 'Yes (we will contact you)', 'ticket registration option', 'wordcamporg' ),
+			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 );
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
-		// Reporting.
+		// Email notifications
+		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
+
+		// Reporting
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
 		add_action( 'camptix_summarize_by_' . self::SLUG, array( $this, 'summarize' ), 10, 2 );
 		add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
 		add_filter( 'camptix_attendee_report_column_value_' . self::SLUG, array( $this, 'add_export_column_value' ), 10, 2 );
 
-		// Privacy.
+		// Privacy
 		add_filter( 'camptix_privacy_attendee_props_to_export', array( $this, 'attendee_props_to_export' ) );
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
@@ -62,14 +69,14 @@ class First_Time_Field extends CampTix_Addon {
 	 * @return array
 	 */
 	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
+		if ( apply_filters( 'camptix_allergy_should_skip', false ) ) {
 			return $questions;
 		}
 
 		$questions[ self::SLUG ] = (object) array(
 			// Immitate a WP_Post with metadata..
 			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id ),
+			'post_title'   => apply_filters( 'camptix_allergy_question_text', $this->question, $ticket_id ),
 			'tix_type'     => 'radio',
 			'tix_required' => true,
 			'tix_values'   => $this->options,
@@ -133,6 +140,95 @@ class First_Time_Field extends CampTix_Addon {
 		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
 
 		return $ticket_info;
+	}
+
+	/**
+	 * Initialize email notifications after the ticket receipt email has been sent.
+	 *
+	 * @param int $attendee_id
+	 */
+	public function after_email_receipt( $attendee_id ) {
+		$attendee = get_post( $attendee_id );
+		$value    = get_post_meta( $attendee_id, 'tix_' . self::SLUG, true );
+
+		if ( $attendee instanceof WP_Post && 'tix_attendee' === $attendee->post_type ) {
+			$this->maybe_send_notification_email( $value, $attendee );
+		}
+	}
+
+	/**
+	 * Send a notification if it hasn't been sent already.
+	 *
+	 * @param string  $value
+	 * @param WP_Post $attendee
+	 */
+	protected function maybe_send_notification_email( $value, $attendee ) {
+		// Only send notifications for 'yes' answers.
+		if ( 'yes' !== $value ) {
+			return;
+		}
+
+		$already_sent = get_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
+
+		// Only send the notification once.
+		if ( $already_sent ) {
+			return;
+		}
+
+		global $phpmailer;
+		if ( $phpmailer instanceof PHPMailer ) {
+			// Clear out any lingering content from a previously sent message.
+			$phpmailer = new PHPMailer( true ); // phpcs:disable WordPress.WP.GlobalVariablesOverride
+		}
+
+		$current_wordcamp = get_wordcamp_post();
+		$wordcamp_name    = get_wordcamp_name();
+		$post_type_object = get_post_type_object( $attendee->post_type );
+		$attendee_link    = add_query_arg( 'action', 'edit', admin_url( sprintf( $post_type_object->_edit_link, $attendee->ID ) ) );
+		$handbook_link    = 'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/selling-tickets/life-threatening-allergies/';
+		$recipients       = array(
+			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer
+			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address
+		);
+
+		$recipients = array_unique( array_filter( $recipients ) );
+
+		foreach ( $recipients as $recipient ) {
+			$subject = sprintf(
+				/* translators: Email subject line. The %s placeholder is the name of a WordCamp. */
+				wp_strip_all_tags( __( 'An attendee who has a severe allergy has registered for %s', 'wordcamporg' ) ),
+				$wordcamp_name
+			);
+
+			$message_line_1 = wp_strip_all_tags( __( 'The following attendee has indicated that they have a severe allergy. Please note that this information is confidential.', 'wordcamporg' ) );
+
+			$message_line_2 = wp_strip_all_tags( __( 'Please follow the procedure outlined in the WordCamp Organizer Handbook to ensure the health and safety of this event\'s attendees.', 'wordcamporg' ) );
+
+			$message = sprintf(
+				"%s\n\n%s\n\n%s\n\n%s",
+				$message_line_1,
+				esc_url_raw( $attendee_link ), // Link to attendee post's Edit screen.
+				$message_line_2,
+				$handbook_link // Link to page in WordCamp Organizer Handbook.
+			);
+
+			wp_mail( $recipient, $subject, $message );
+		}
+
+		/**
+		 * Action: Fires when a notification is sent about a WordCamp attendee with a severe allergy.
+		 *
+		 * @param array $details Contains information about the WordCamp and the attendee.
+		 */
+		do_action(
+			'camptix_tweaks_allergy_notification',
+			array(
+				'wordcamp' => $current_wordcamp,
+				'attendee' => $attendee,
+			)
+		);
+
+		update_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
 	}
 
 	/**
@@ -248,7 +344,7 @@ class First_Time_Field extends CampTix_Addon {
 	 * @return array
 	 */
 	public function attendee_props_to_erase( $props ) {
-		$props[ 'tix_' . self::SLUG ] = 'camptix_yesnounsure';
+		$props[ 'tix_' . self::SLUG ] = 'camptix_yesno';
 
 		return $props;
 	}
@@ -268,4 +364,4 @@ class First_Time_Field extends CampTix_Addon {
 	}
 }
 
-camptix_register_addon( __NAMESPACE__ . '\First_Time_Field' );
+camptix_register_addon( __NAMESPACE__ . '\Allergy_Field' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -14,36 +14,24 @@ defined( 'WPINC' ) || die();
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Allergy_Field extends Extra_Field {
+class Allergy_Field extends Extra_Fields {
 	const SLUG = 'allergy';
 
-	public $label = '';
-
-	public $question = '';
-
-	public $options = array();
+	public $label          = '';
+	public $question       = '';
+	public $options        = array();
+	public $question_order = 20;
 
 	/**
 	 * Hook into WordPress and Camptix.
 	 */
-	public function camptix_init() {
-		$this->label = __( 'Severe allergy', 'wordcamporg' );
-
+	public function init() {
+		$this->label    = __( 'Severe allergy', 'wordcamporg' );
 		$this->question = __( 'Do you have a severe allergy that would affect your experience at WordCamp?', 'wordcamporg' );
-
-		$this->options = array(
+		$this->options  = array(
 			'yes' => _x( 'Yes (we will contact you)', 'ticket registration option', 'wordcamporg' ),
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
-
-		// Ask the question.
-		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 );
-		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
-
-		// Save the answer as post meta.
-		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Email notifications
 		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
@@ -59,87 +47,6 @@ class Allergy_Field extends Extra_Field {
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
-	}
-
-	/**
-	 * Add the question to the list of questions.
-	 *
-	 * @param array $questions
-	 *
-	 * @return array
-	 */
-	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_allergy_should_skip', false ) ) {
-			return $questions;
-		}
-
-		$questions[ self::SLUG ] = (object) array(
-			// Immitate a WP_Post with metadata..
-			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_allergy_question_text', $this->question, $ticket_id ),
-			'tix_type'     => 'radio',
-			'tix_required' => true,
-			'tix_values'   => $this->options,
-		);
-
-		return $questions;
-	}
-
-	/**
-	 * Add the new field to the questions order.
-	 *
-	 * @param array $order
-	 *
-	 * @return array
-	 */
-	function add_question_order( $order ) {
-		$order[] = self::SLUG;
-
-		return $order;
-	}
-
-	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function save_registration_field( $post_id, $attendee ) {
-		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 * @param array   $answers
-	 *
-	 * @return bool|int
-	 */
-	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
-		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
-	}
-
-	/**
-	 * Retrieve the stored value of the new field for use when displaying the attendee info.
-	 *
-	 * Back-compat only, for where the field was stored outside of the question answers.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 *
-	 * @return array
-	 */
-	public function populate_attendee_answer( $ticket_info, $attendee ) {
-		$attendee = get_post( $attendee );
-		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
-
-		return $ticket_info;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/allergy.php
@@ -16,7 +16,7 @@ defined( 'WPINC' ) || die();
 class Allergy_Field extends Extra_Fields {
 	const SLUG = 'allergy';
 
-	public $question_order = 20;
+	public $question_order = 30;
 
 	/**
 	 * Setup the question & options.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -38,12 +38,12 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 	}
 
 	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
+	 * Save the value of the field to the attendee postmeta for back-compat.
 	 *
 	 * @param int     $post_id
 	 * @param WP_Post $attendee
 	 */
-	public function save_registration_field( $post_id, $attendee ) {
+	public function save_field( $post_id, $answer ) {
 		// For back-compat, we only store a value of '1'.
 		return update_post_meta( $post_id, 'tix_' . static::SLUG, 1 );
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -1,7 +1,7 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-use CampTix_Plugin, CampTix_Addon;
+use CampTix_Plugin;
 use WP_Post;
 
 defined( 'WPINC' ) or die();
@@ -13,119 +13,36 @@ defined( 'WPINC' ) or die();
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Code_Of_Conduct_Field extends Extra_Field {
+class Code_Of_Conduct_Field extends Extra_Fields {
 	const SLUG = 'coc';
+
+	public $label          = '';
+	public $question       = '';
+	public $options        = array();
+	public $question_order = 100;
+	public $type           = 'checkbox';
 
 	/**
 	 * Hook into WordPress and Camptix.
 	 */
-	public function camptix_init() {
-
-		// Ask the question.
-		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 50 );
-		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
-
-		// Save the answer as post meta.
-		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
-
-		// Registration field
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
-		add_action( 'camptix_form_attendee_info_errors', array( $this, 'add_registration_field_validation_error' ) );
-	}
-
-	/**
-	 * Add the question to the list of questions.
-	 *
-	 * @param array $questions
-	 *
-	 * @return array
-	 */
-	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_coc_should_skip', false ) ) {
-			return $questions;
-		}
-
+	public function init() {
+		$this->label    = __( 'Code of Conduct', 'wordcamporg' );
+		$this->question = __( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' );
 		$coc_url = $this->maybe_get_coc_url();
-		$question = __( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' );
 		if ( $coc_url ) {
-			$question = sprintf(
+			$this->question = sprintf(
 				/* translators: %s placeholder is a URL */
 				__( 'Do you agree to follow the event <a href="%s" target="_blank">Code of Conduct</a>?', 'wordcamporg' ),
 				esc_url( $coc_url )
 			);
 		}
 
-		$questions[ self::SLUG ] = (object) array(
-			// Immitate a WP_Post with metadata..
-			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_coc_question_text', $question, $ticket_id ),
-			'tix_type'     => 'checkbox',
-			'tix_required' => true,
-			'tix_values'   => [
-				'yes' => _x( 'Yes', 'ticket registration option', 'wordcamporg' ),
-			],
-		);
+		// Empty options = Only a single YES required checkbox.
+		$this->options = array();
 
-		return $questions;
-	}
-
-	/**
-	 * Add the new field to the questions order.
-	 *
-	 * @param array $order
-	 *
-	 * @return array
-	 */
-	function add_question_order( $order ) {
-		$order[] = self::SLUG;
-
-		return $order;
-	}
-
-	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function save_registration_field( $post_id, $attendee ) {
-		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 * @param array   $answers
-	 *
-	 * @return bool|int
-	 */
-	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
-		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
-	}
-
-	/**
-	 * Retrieve the stored value of the new field for use when displaying the attendee info.
-	 *
-	 * Back-compat only, for where the field was stored outside of the question answers.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 *
-	 * @return array
-	 */
-	public function populate_attendee_answer( $ticket_info, $attendee ) {
-		$attendee = get_post( $attendee );
-		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
-
-		return $ticket_info;
+		// Registration field
+		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
+		add_action( 'camptix_form_attendee_info_errors', array( $this, 'add_registration_field_validation_error' ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -20,7 +20,7 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 	public $type           = 'checkbox';
 
 	// No need to summarize this field, since it's just a yes checkbox.
-	public $enable_summary = false;
+	public $enable_summary      = false;
 	public $enable_export_erase = false;
 
 	/**
@@ -40,44 +40,6 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 
 		// Empty options = Only a single YES required checkbox.
 		$this->options = array();
-
-		// Registration field
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
-		add_action( 'camptix_form_attendee_info_errors', array( $this, 'add_registration_field_validation_error' ) );
-	}
-
-	/**
-	 * Validate the value of the new field submitted to the registration form during checkout.
-	 *
-	 * @param array $data
-	 *
-	 * @return array
-	 */
-	public function validate_registration_field( $data ) {
-		/* @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		$data[ self::SLUG ] = wp_validate_boolean( $data[ self::SLUG ] ?? false );
-
-		if ( true !== $data[ self::SLUG ] ) {
-			$camptix->error_flags[ self::SLUG . '_unchecked' ] = true;
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Add a validation message when the checkbox isn't checked.
-	 *
-	 * @param array $error_flags
-	 */
-	public function add_registration_field_validation_error( $error_flags ) {
-		/* @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		if ( isset( $error_flags[ self::SLUG . '_unchecked' ] ) ) {
-			$camptix->error( __( 'You must agree to follow the event Code of Conduct to obtain a ticket.', 'wordcamporg' ) );
-		}
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -13,12 +13,8 @@ defined( 'WPINC' ) || die();
 class Code_Of_Conduct_Field extends Extra_Fields {
 	const SLUG = 'coc';
 
-	public $label          = '';
-	public $question       = '';
-	public $options        = array();
-	public $question_order = 100;
-	public $type           = 'checkbox';
-
+	public $question_order      = 100;
+	public $type                = 'checkbox';
 	public $enable_summary      = false;
 	public $enable_export_erase = false;
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -26,7 +26,6 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 	 * Setup the question & options.
 	 */
 	public function init() {
-		$this->label    = __( 'Code of Conduct', 'wordcamporg' );
 		$this->question = __( 'Do you agree to follow the event Code of Conduct?', 'wordcamporg' );
 		$coc_url = $this->maybe_get_coc_url();
 		if ( $coc_url ) {

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -40,8 +40,8 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 	/**
 	 * Save the value of the field to the attendee postmeta for back-compat.
 	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
+	 * @param int    $post_id
+	 * @param string $answer
 	 */
 	public function save_field( $post_id, $answer ) {
 		// For back-compat, we only store a value of '1'.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -1,10 +1,10 @@
 <?php
-
 namespace WordCamp\CampTix_Tweaks;
-defined( 'WPINC' ) or die();
 
 use CampTix_Plugin, CampTix_Addon;
 use WP_Post;
+
+defined( 'WPINC' ) or die();
 
 /**
  * Class Code_Of_Conduct_Field.
@@ -13,7 +13,7 @@ use WP_Post;
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Code_Of_Conduct_Field extends CampTix_Addon {
+class Code_Of_Conduct_Field extends Extra_Field {
 	const SLUG = 'coc';
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -32,8 +32,32 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 			);
 		}
 
-		// Empty options = Only a single YES required checkbox.
-		$this->options = array();
+		$this->options = array(
+			'yes' => _x( 'Yes', 'ticket registration option', 'wordcamporg' ),
+		);
+	}
+
+	/**
+	 * Save the value of the new field to the attendee post upon completion of checkout.
+	 *
+	 * @param int     $post_id
+	 * @param WP_Post $attendee
+	 */
+	public function save_registration_field( $post_id, $attendee ) {
+		// For back-compat, we only store a value of '1'.
+		return update_post_meta( $post_id, 'tix_' . static::SLUG, 1 );
+	}
+
+	/**
+	 * All tickets are required to have the Code of Conduct checkbox set.
+	 *
+	 * @param array $ticket_info
+	 * @param int   $attendee
+	 */
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$ticket_info[ static::SLUG ] = __( 'Yes', 'wordcamporg' );
+
+		return $ticket_info;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -19,12 +19,11 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 	public $question_order = 100;
 	public $type           = 'checkbox';
 
-	// No need to summarize this field, since it's just a yes checkbox.
 	public $enable_summary      = false;
 	public $enable_export_erase = false;
 
 	/**
-	 * Hook into WordPress and Camptix.
+	 * Setup the question & options.
 	 */
 	public function init() {
 		$this->label    = __( 'Code of Conduct', 'wordcamporg' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -1,7 +1,7 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-defined( 'WPINC' ) or die();
+defined( 'WPINC' ) || die();
 
 /**
  * Class Code_Of_Conduct_Field.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/code-of-conduct.php
@@ -1,9 +1,6 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-use CampTix_Plugin;
-use WP_Post;
-
 defined( 'WPINC' ) or die();
 
 /**
@@ -21,6 +18,10 @@ class Code_Of_Conduct_Field extends Extra_Fields {
 	public $options        = array();
 	public $question_order = 100;
 	public $type           = 'checkbox';
+
+	// No need to summarize this field, since it's just a yes checkbox.
+	public $enable_summary = false;
+	public $enable_export_erase = false;
 
 	/**
 	 * Hook into WordPress and Camptix.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -1,60 +1,51 @@
 <?php
-
 namespace WordCamp\CampTix_Tweaks;
+
+use WP_Post;
+
 defined( 'WPINC' ) || die();
 
-use CampTix_Plugin, CampTix_Addon;
-use WP_Post;
-use PHPMailer;
-
 /**
- * Class Allergy_Field.
- *
- * Add a non-optional attendee field indicating if they have a severe allergy.
- *
- * @package WordCamp\CampTix_Tweaks
+ * Add an required attendee field asking if they've attended a WordCamp before.
  */
-class Allergy_Field extends CampTix_Addon {
-	const SLUG = 'allergy';
+class First_Time_Field extends Extra_Field {
+	const SLUG = 'first_time_attending_wp_event';
 
-	public $label = '';
-
+	public $label    = '';
 	public $question = '';
-
-	public $options = array();
+	public $options  = array();
 
 	/**
-	 * Hook into WordPress and Camptix.
+	 * Hook into WordPress and CampTix.
 	 */
 	public function camptix_init() {
-		$this->label = __( 'Severe allergy', 'wordcamporg' );
-
-		$this->question = __( 'Do you have a severe allergy that would affect your experience at WordCamp?', 'wordcamporg' );
+		$this->label    = __( 'First Time Attending', 'wordcamporg' );
+		$this->question = __( 'Will this be your first time attending a WordPress event?', 'wordcamporg' );
 
 		$this->options = array(
-			'yes' => _x( 'Yes (we will contact you)', 'ticket registration option', 'wordcamporg' ),
-			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
+			'yes' => _x( 'Yes', 'answer to question during ticket registration', 'wordcamporg' ),
+			'no'  => _x( 'No', 'answer to question during ticket registration', 'wordcamporg' ),
+
+			// Sometimes people buy tickets for others, and they may not know.
+			'unsure'  => _x( "I don't know", 'answer to question during ticket registration', 'wordcamporg' ),
 		);
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 20 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 );
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
-		// Email notifications
-		add_action( 'camptix_ticket_emailed', array( $this, 'after_email_receipt' ) );
-
-		// Reporting
+		// Reporting.
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
 		add_action( 'camptix_summarize_by_' . self::SLUG, array( $this, 'summarize' ), 10, 2 );
 		add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
 		add_filter( 'camptix_attendee_report_column_value_' . self::SLUG, array( $this, 'add_export_column_value' ), 10, 2 );
 
-		// Privacy
+		// Privacy.
 		add_filter( 'camptix_privacy_attendee_props_to_export', array( $this, 'attendee_props_to_export' ) );
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
@@ -69,14 +60,14 @@ class Allergy_Field extends CampTix_Addon {
 	 * @return array
 	 */
 	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_allergy_should_skip', false ) ) {
+		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
 			return $questions;
 		}
 
 		$questions[ self::SLUG ] = (object) array(
 			// Immitate a WP_Post with metadata..
 			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_allergy_question_text', $this->question, $ticket_id ),
+			'post_title'   => apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id ),
 			'tix_type'     => 'radio',
 			'tix_required' => true,
 			'tix_values'   => $this->options,
@@ -140,95 +131,6 @@ class Allergy_Field extends CampTix_Addon {
 		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
 
 		return $ticket_info;
-	}
-
-	/**
-	 * Initialize email notifications after the ticket receipt email has been sent.
-	 *
-	 * @param int $attendee_id
-	 */
-	public function after_email_receipt( $attendee_id ) {
-		$attendee = get_post( $attendee_id );
-		$value    = get_post_meta( $attendee_id, 'tix_' . self::SLUG, true );
-
-		if ( $attendee instanceof WP_Post && 'tix_attendee' === $attendee->post_type ) {
-			$this->maybe_send_notification_email( $value, $attendee );
-		}
-	}
-
-	/**
-	 * Send a notification if it hasn't been sent already.
-	 *
-	 * @param string  $value
-	 * @param WP_Post $attendee
-	 */
-	protected function maybe_send_notification_email( $value, $attendee ) {
-		// Only send notifications for 'yes' answers.
-		if ( 'yes' !== $value ) {
-			return;
-		}
-
-		$already_sent = get_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
-
-		// Only send the notification once.
-		if ( $already_sent ) {
-			return;
-		}
-
-		global $phpmailer;
-		if ( $phpmailer instanceof PHPMailer ) {
-			// Clear out any lingering content from a previously sent message.
-			$phpmailer = new PHPMailer( true ); // phpcs:disable WordPress.WP.GlobalVariablesOverride
-		}
-
-		$current_wordcamp = get_wordcamp_post();
-		$wordcamp_name    = get_wordcamp_name();
-		$post_type_object = get_post_type_object( $attendee->post_type );
-		$attendee_link    = add_query_arg( 'action', 'edit', admin_url( sprintf( $post_type_object->_edit_link, $attendee->ID ) ) );
-		$handbook_link    = 'https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/selling-tickets/life-threatening-allergies/';
-		$recipients       = array(
-			$current_wordcamp->meta['Email Address'][0] ?? '', // Lead organizer
-			$current_wordcamp->meta['E-mail Address'][0] ?? '', // City address
-		);
-
-		$recipients = array_unique( array_filter( $recipients ) );
-
-		foreach ( $recipients as $recipient ) {
-			$subject = sprintf(
-				/* translators: Email subject line. The %s placeholder is the name of a WordCamp. */
-				wp_strip_all_tags( __( 'An attendee who has a severe allergy has registered for %s', 'wordcamporg' ) ),
-				$wordcamp_name
-			);
-
-			$message_line_1 = wp_strip_all_tags( __( 'The following attendee has indicated that they have a severe allergy. Please note that this information is confidential.', 'wordcamporg' ) );
-
-			$message_line_2 = wp_strip_all_tags( __( 'Please follow the procedure outlined in the WordCamp Organizer Handbook to ensure the health and safety of this event\'s attendees.', 'wordcamporg' ) );
-
-			$message = sprintf(
-				"%s\n\n%s\n\n%s\n\n%s",
-				$message_line_1,
-				esc_url_raw( $attendee_link ), // Link to attendee post's Edit screen.
-				$message_line_2,
-				$handbook_link // Link to page in WordCamp Organizer Handbook.
-			);
-
-			wp_mail( $recipient, $subject, $message );
-		}
-
-		/**
-		 * Action: Fires when a notification is sent about a WordCamp attendee with a severe allergy.
-		 *
-		 * @param array $details Contains information about the WordCamp and the attendee.
-		 */
-		do_action(
-			'camptix_tweaks_allergy_notification',
-			array(
-				'wordcamp' => $current_wordcamp,
-				'attendee' => $attendee,
-			)
-		);
-
-		update_post_meta( $attendee->ID, '_tix_notify_' . self::SLUG, true );
 	}
 
 	/**
@@ -344,7 +246,7 @@ class Allergy_Field extends CampTix_Addon {
 	 * @return array
 	 */
 	public function attendee_props_to_erase( $props ) {
-		$props[ 'tix_' . self::SLUG ] = 'camptix_yesno';
+		$props[ 'tix_' . self::SLUG ] = 'camptix_yesnounsure';
 
 		return $props;
 	}
@@ -364,4 +266,4 @@ class Allergy_Field extends CampTix_Addon {
 	}
 }
 
-camptix_register_addon( __NAMESPACE__ . '\Allergy_Field' );
+camptix_register_addon( __NAMESPACE__ . '\First_Time_Field' );

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -18,7 +18,7 @@ class First_Time_Field extends Extra_Fields {
 	public $question_order = 20;
 
 	/**
-	 * Hook into WordPress and CampTix.
+	 * Setup the question & options.
 	 */
 	public function init() {
 		$this->label    = __( 'First Time Attending', 'wordcamporg' );
@@ -30,19 +30,6 @@ class First_Time_Field extends Extra_Fields {
 			// Sometimes people buy tickets for others, and they may not know.
 			'unsure'  => _x( "I don't know", 'answer to question during ticket registration', 'wordcamporg' ),
 		);
-	}
-
-	/**
-	 * Include the new field in the personal data eraser.
-	 *
-	 * @param array $props
-	 *
-	 * @return array
-	 */
-	public function attendee_props_to_erase( $props ) {
-		$props[ 'tix_' . self::SLUG ] = 'camptix_yesnounsure';
-
-		return $props;
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -10,7 +10,7 @@ class First_Time_Field extends Extra_Fields {
 	const SLUG = 'first_time_attending_wp_event';
 
 	protected $filter_slug = 'first_time';
-	public $question_order = 20;
+	public $question_order = 40;
 
 	/**
 	 * Setup the question & options.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -10,11 +10,6 @@ class First_Time_Field extends Extra_Fields {
 	const SLUG = 'first_time_attending_wp_event';
 
 	protected $filter_slug = 'first_time';
-
-	public $label    = '';
-	public $question = '';
-	public $options  = array();
-
 	public $question_order = 20;
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -8,8 +8,10 @@ defined( 'WPINC' ) || die();
 /**
  * Add an required attendee field asking if they've attended a WordCamp before.
  */
-class First_Time_Field extends Extra_Field {
+class First_Time_Field extends Extra_Fields {
 	const SLUG = 'first_time_attending_wp_event';
+
+	protected $filter_slug = 'first_time';
 
 	public $label    = '';
 	public $question = '';
@@ -18,26 +20,16 @@ class First_Time_Field extends Extra_Field {
 	/**
 	 * Hook into WordPress and CampTix.
 	 */
-	public function camptix_init() {
+	public function init() {
 		$this->label    = __( 'First Time Attending', 'wordcamporg' );
 		$this->question = __( 'Will this be your first time attending a WordPress event?', 'wordcamporg' );
-
-		$this->options = array(
+		$this->options  = array(
 			'yes' => _x( 'Yes', 'answer to question during ticket registration', 'wordcamporg' ),
 			'no'  => _x( 'No', 'answer to question during ticket registration', 'wordcamporg' ),
 
 			// Sometimes people buy tickets for others, and they may not know.
 			'unsure'  => _x( "I don't know", 'answer to question during ticket registration', 'wordcamporg' ),
 		);
-
-		// Ask the question.
-		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 );
-		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
-
-		// Save the answer as post meta.
-		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Reporting.
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
@@ -50,87 +42,6 @@ class First_Time_Field extends Extra_Field {
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
-	}
-
-	/**
-	 * Add the question to the list of questions.
-	 *
-	 * @param array $questions
-	 *
-	 * @return array
-	 */
-	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
-			return $questions;
-		}
-
-		$questions[ self::SLUG ] = (object) array(
-			// Immitate a WP_Post with metadata..
-			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id ),
-			'tix_type'     => 'radio',
-			'tix_required' => true,
-			'tix_values'   => $this->options,
-		);
-
-		return $questions;
-	}
-
-	/**
-	 * Add the new field to the questions order.
-	 *
-	 * @param array $order
-	 *
-	 * @return array
-	 */
-	function add_question_order( $order ) {
-		$order[] = self::SLUG;
-
-		return $order;
-	}
-
-	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function save_registration_field( $post_id, $attendee ) {
-		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 * @param array   $answers
-	 *
-	 * @return bool|int
-	 */
-	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
-		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
-	}
-
-	/**
-	 * Retrieve the stored value of the new field for use when displaying the attendee info.
-	 *
-	 * Back-compat only, for where the field was stored outside of the question answers.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 *
-	 * @return array
-	 */
-	public function populate_attendee_answer( $ticket_info, $attendee ) {
-		$attendee = get_post( $attendee );
-		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
-
-		return $ticket_info;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -21,9 +21,9 @@ class First_Time_Field extends Extra_Fields {
 	 * Setup the question & options.
 	 */
 	public function init() {
-		$this->label    = __( 'First Time Attending', 'wordcamporg' );
-		$this->question = __( 'Will this be your first time attending a WordPress event?', 'wordcamporg' );
-		$this->options  = array(
+		$this->column_label = __( 'First Time Attending', 'wordcamporg' );
+		$this->question     = __( 'Will this be your first time attending a WordPress event?', 'wordcamporg' );
+		$this->options      = array(
 			'yes' => _x( 'Yes', 'answer to question during ticket registration', 'wordcamporg' ),
 			'no'  => _x( 'No', 'answer to question during ticket registration', 'wordcamporg' ),
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/first-time.php
@@ -1,8 +1,6 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-use WP_Post;
-
 defined( 'WPINC' ) || die();
 
 /**
@@ -17,6 +15,8 @@ class First_Time_Field extends Extra_Fields {
 	public $question = '';
 	public $options  = array();
 
+	public $question_order = 20;
+
 	/**
 	 * Hook into WordPress and CampTix.
 	 */
@@ -30,123 +30,6 @@ class First_Time_Field extends Extra_Fields {
 			// Sometimes people buy tickets for others, and they may not know.
 			'unsure'  => _x( "I don't know", 'answer to question during ticket registration', 'wordcamporg' ),
 		);
-
-		// Reporting.
-		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
-		add_action( 'camptix_summarize_by_' . self::SLUG, array( $this, 'summarize' ), 10, 2 );
-		add_filter( 'camptix_attendee_report_extra_columns', array( $this, 'add_export_column' ) );
-		add_filter( 'camptix_attendee_report_column_value_' . self::SLUG, array( $this, 'add_export_column_value' ), 10, 2 );
-
-		// Privacy.
-		add_filter( 'camptix_privacy_attendee_props_to_export', array( $this, 'attendee_props_to_export' ) );
-		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
-		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
-		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
-	}
-
-	/**
-	 * Add an option to the `Summarize by` dropdown.
-	 *
-	 * @param array $fields
-	 *
-	 * @return array
-	 */
-	public function add_summary_field( $fields ) {
-		$fields[ self::SLUG ] = $this->label;
-
-		return $fields;
-	}
-
-	/**
-	 * Callback to summarize the answers for this field.
-	 *
-	 * @param array   $summary
-	 * @param WP_Post $attendee
-	 */
-	public function summarize( &$summary, $attendee ) {
-		/** @var $camptix CampTix_Plugin */
-		global $camptix;
-
-		$answer = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		if ( isset( $this->options[ $answer ] ) ) {
-			$camptix->increment_summary( $summary, $this->options[ $answer ] );
-		} else {
-			$camptix->increment_summary( $summary, __( 'No answer', 'wordcamporg' ) );
-		}
-	}
-
-	/**
-	 * Add a column to the CSV export.
-	 *
-	 * @param array $columns
-	 *
-	 * @return array
-	 */
-	public function add_export_column( $columns ) {
-		$columns[ self::SLUG ] = $this->label;
-
-		return $columns;
-	}
-
-	/**
-	 * Add the human-readable value of the field to the CSV export.
-	 *
-	 * @param string  $value
-	 * @param WP_Post $attendee
-	 *
-	 * @return string
-	 */
-	public function add_export_column_value( $value, $attendee ) {
-		$value = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-
-		if ( isset( $this->options[ $value ] ) ) {
-			return $this->options[ $value ];
-		}
-
-		return '';
-	}
-
-	/**
-	 * Include the new field in the personal data exporter.
-	 *
-	 * @param array $props
-	 *
-	 * @return array
-	 */
-	public function attendee_props_to_export( $props ) {
-		$props[ 'tix_' . self::SLUG ] = $this->question;
-
-		return $props;
-	}
-
-	/**
-	 * Add the new field's value and label to the aggregated personal data for export.
-	 *
-	 * @param array   $export
-	 * @param string  $key
-	 * @param string  $label
-	 * @param WP_Post $post
-	 *
-	 * @return array
-	 */
-	public function export_attendee_prop( $export, $key, $label, $post ) {
-		if ( 'tix_' . self::SLUG === $key ) {
-			$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true );
-
-			if ( isset( $this->options[ $value ] ) ) {
-				$value = $this->options[ $value ];
-			}
-
-			if ( ! empty( $value ) ) {
-				$export[] = array(
-					'name'  => $label,
-					'value' => $value,
-				);
-			}
-		}
-
-		return $export;
 	}
 
 	/**
@@ -160,20 +43,6 @@ class First_Time_Field extends Extra_Fields {
 		$props[ 'tix_' . self::SLUG ] = 'camptix_yesnounsure';
 
 		return $props;
-	}
-
-	/**
-	 * Anonymize the value of the new field during personal data erasure.
-	 *
-	 * @param string  $key
-	 * @param string  $type
-	 * @param WP_Post $post
-	 */
-	public function erase_attendee_prop( $key, $type, $post ) {
-		if ( 'tix_' . self::SLUG === $key ) {
-			$anonymized_value = wp_privacy_anonymize_data( $type );
-			update_post_meta( $post->ID, $key, $anonymized_value );
-		}
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -19,7 +19,7 @@ class Privacy_Field extends Extra_Fields {
 	public $options = array();
 	public $a11y_label;
 
-	$enable_summary = false;
+	public $enable_summary = false;
 
 	/**
 	 * Setup the question & options.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -19,11 +19,10 @@ class Privacy_Field extends Extra_Fields {
 	public $options = array();
 	public $a11y_label;
 
-	// No need to summarize this field.
-	public $enable_summary = false;
+	$enable_summary = false;
 
 	/**
-	 * Hook into WordPress and Camptix.
+	 * Setup the question & options.
 	 */
 	public function init() {
 		$this->a11y_label = __( 'Do you want to be listed on the public Attendees page?', 'wordcamporg' );
@@ -74,19 +73,6 @@ class Privacy_Field extends Extra_Fields {
 	}
 
 	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $ticket_info
-	 * @param WP_Post $attendee
-	 * @param array   $answers
-	 *
-	 * @return bool|int
-	 */
-	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
-		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
-	}
-
-	/**
 	 * Retrieve the stored value of the new field for use when displaying the attendee info.
 	 *
 	 * Back-compat only, for where the field was stored outside of the question answers.
@@ -97,11 +83,9 @@ class Privacy_Field extends Extra_Fields {
 	 * @return array
 	 */
 	public function populate_attendee_answer( $ticket_info, $attendee ) {
-		$attendee = get_post( $attendee );
-		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
-		$value    = ( 'private' === $value ) ? 'no' : 'yes';
+		$ticket_info = parent::populate_attendee_answer( $ticket_info, $attendee );
 
-		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
+		$ticket_info[ self::SLUG ] = in_array( $ticket_info[ self::SLUG ], [ 'private', 'no' ] ) ? 'no' : 'yes';
 
 		return $ticket_info;
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -1,7 +1,6 @@
 <?php
 namespace WordCamp\CampTix_Tweaks;
 
-use CampTix_Plugin;
 use WP_Post;
 
 defined( 'WPINC' ) || die();
@@ -19,6 +18,9 @@ class Privacy_Field extends Extra_Fields {
 	public $question = '';
 	public $options = array();
 	public $a11y_label;
+
+	// No need to summarize this field.
+	public $enable_summary = false;
 
 	/**
 	 * Hook into WordPress and Camptix.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -60,10 +60,12 @@ class Privacy_Field extends Extra_Fields {
 	 * @return bool|int
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
-		if ( true === wp_validate_boolean( $attendee->{ self::SLUG } ) ) {
-			$result = delete_post_meta( $post_id, 'tix_' . self::SLUG );
-		} else {
+		if ( in_array( $attendee->answers[ self::SLUG ], [ 'no', $this->options['no'] ] ) ) {
+			// Privacy; No = "do NOT show" = set as private.
 			$result = update_post_meta( $post_id, 'tix_' . self::SLUG, 'private' );
+		} else {
+			// Privacy: Yes = "Show me on attendees page" = delete the meta.
+			$result = delete_post_meta( $post_id, 'tix_' . self::SLUG );
 		}
 
 		return $result;
@@ -82,7 +84,7 @@ class Privacy_Field extends Extra_Fields {
 	public function populate_attendee_answer( $ticket_info, $attendee ) {
 		$ticket_info = parent::populate_attendee_answer( $ticket_info, $attendee );
 
-		$ticket_info[ self::SLUG ] = in_array( $ticket_info[ self::SLUG ], [ 'private', 'no' ] ) ? 'no' : 'yes';
+		$ticket_info[ self::SLUG ] = in_array( $ticket_info[ self::SLUG ], [ 'private', 'no' ] ) ? $this->options['no'] : $this->options['yes'];
 
 		return $ticket_info;
 	}

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -15,10 +15,7 @@ defined( 'WPINC' ) || die();
 class Privacy_Field extends Extra_Fields {
 	const SLUG = 'privacy';
 
-	public $question = '';
-	public $options = array();
-	public $a11y_label;
-
+	public $question_order = 11;
 	public $enable_summary = false;
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -52,15 +52,13 @@ class Privacy_Field extends Extra_Fields {
 	}
 
 	/**
-	 * Save the value of the new field to the attendee post upon completion of checkout.
+	 * Save the value of the field to the attendee postmeta for back-compat.
 	 *
-	 * @param int     $post_id
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
+	 * @param int   $post_id
+	 * @param mixed $answer
 	 */
-	public function save_registration_field( $post_id, $attendee ) {
-		if ( in_array( $attendee->answers[ self::SLUG ], [ 'no', $this->options['no'] ] ) ) {
+	public function save_field( $post_id, $answer ) {
+		if ( in_array( $answer, [ 'no', $this->options['no'] ] ) ) {
 			// Privacy; No = "do NOT show" = set as private.
 			$result = update_post_meta( $post_id, 'tix_' . self::SLUG, 'private' );
 		} else {

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -13,7 +13,7 @@ defined( 'WPINC' ) || die();
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Privacy_Field extends Extra_Field {
+class Privacy_Field extends Extra_Fields {
 	const SLUG = 'privacy';
 
 	public $question = '';
@@ -23,8 +23,11 @@ class Privacy_Field extends Extra_Field {
 	/**
 	 * Hook into WordPress and Camptix.
 	 */
-	public function camptix_init() {
-		if ( $attendees_url = $this->maybe_get_attendees_url() ) {
+	public function init() {
+		$this->a11y_label = __( 'Do you want to be listed on the public Attendees page?', 'wordcamporg' );
+
+		$attendees_url = $this->maybe_get_attendees_url();
+		if ( $attendees_url ) {
 			$this->question = sprintf(
 				/* translators: 1: placeholder for URL to Attendees page; 2: placeholder for URL to privacy policy page. */
 				__( 'Do you want to be listed on the public <a href="%1$s" target="_blank">Attendees page</a>? <a href="%2$s" target="_blank">Learn more.</a>', 'wordcamporg' ),
@@ -38,63 +41,16 @@ class Privacy_Field extends Extra_Field {
 				esc_url( get_privacy_policy_url() )
 			);
 		}
-		$this->a11y_label = __( 'Do you want to be listed on the public Attendees page?', 'wordcamporg' );
 
 		$this->options = array(
 			'yes' => _x( 'Yes', 'ticket registration option', 'wordcamporg' ),
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
-		// Ask the question.
-		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 10 );
-		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
-
-		// Save the answer as post meta.
-		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
-
 		// Delete cached attendees lists when an attendee privacy setting changes.
 		add_action( 'added_post_meta', array( $this, 'invalidate_attendees_cache' ), 10, 3 );
 		add_action( 'updated_post_meta', array( $this, 'invalidate_attendees_cache' ), 10, 3 );
 		add_action( 'deleted_post_meta', array( $this, 'invalidate_attendees_cache' ), 10, 3 );
-	}
-
-	/**
-	 * Add the question to the list of questions.
-	 *
-	 * @param array $questions
-	 *
-	 * @return array
-	 */
-	function add_question( $questions, $ticket_id ) {
-		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
-			return $questions;
-		}
-
-		$questions[ self::SLUG ] = (object) array(
-			// Immitate a WP_Post with metadata..
-			'ID' 	       => self::SLUG,
-			'post_title'   => apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id ),
-			'tix_type'     => 'radio',
-			'tix_required' => true,
-			'tix_values'   => $this->options,
-		);
-
-		return $questions;
-	}
-
-	/**
-	 * Add the new field to the questions order.
-	 *
-	 * @param array $order
-	 *
-	 * @return array
-	 */
-	function add_question_order( $order ) {
-		$order[] = self::SLUG;
-
-		return $order;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/extra-fields/privacy.php
@@ -1,10 +1,10 @@
 <?php
-
 namespace WordCamp\CampTix_Tweaks;
-defined( 'WPINC' ) or die();
 
-use CampTix_Plugin, CampTix_Addon;
+use CampTix_Plugin;
 use WP_Post;
+
+defined( 'WPINC' ) || die();
 
 /**
  * Class Privacy_Field.
@@ -13,7 +13,7 @@ use WP_Post;
  *
  * @package WordCamp\CampTix_Tweaks
  */
-class Privacy_Field extends CampTix_Addon {
+class Privacy_Field extends Extra_Field {
 	const SLUG = 'privacy';
 
 	public $question = '';

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
@@ -2,10 +2,10 @@
 
 namespace WordCamp\CampTix_Tweaks;
 
-defined( 'WPINC' ) || die();
-
 use CampTix_Addon;
 use WP_Post;
+
+defined( 'WPINC' ) || die();
 
 /**
  * Add an required attendee field asking if they've attended a WordCamp before.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
@@ -34,11 +34,12 @@ class First_Time_Field extends CampTix_Addon {
 
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
-		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 ); // 20 = allergy, 30 = accessibility, 40 = this, 50 = CoC
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 );
 		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Reporting.
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
@@ -100,6 +101,19 @@ class First_Time_Field extends CampTix_Addon {
 	 */
 	public function save_registration_field( $post_id, $attendee ) {
 		return update_post_meta( $post_id, 'tix_' . self::SLUG, $attendee->{ self::SLUG } );
+	}
+
+	/**
+	 * Update the stored value of the new field if it was changed in the Edit Info form.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 * @param array   $answers
+	 *
+	 * @return bool|int
+	 */
+	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
+		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
@@ -17,7 +17,6 @@ class First_Time_Field extends CampTix_Addon {
 	public $question = '';
 	public $options  = array();
 
-
 	/**
 	 * Hook into WordPress and CampTix.
 	 */
@@ -36,20 +35,10 @@ class First_Time_Field extends CampTix_Addon {
 		// Ask the question.
 		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
 		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 ); // 20 = allergy, 30 = accessibility, 40 = this, 50 = CoC
+		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
-		// Registration field.
-		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 12, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ), 11 );
-		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
+		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
-
-		// Edit info field.
-		add_filter( 'camptix_form_edit_attendee_ticket_info', array( $this, 'populate_ticket_info_array' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'validate_save_ticket_info_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_after_questions', array( $this, 'render_ticket_info_field' ), 12 );
-
-		// Metabox.
-		add_filter( 'camptix_metabox_attendee_info_additional_rows', array( $this, 'add_metabox_row' ), 12, 2 );
 
 		// Reporting.
 		add_filter( 'camptix_summary_fields', array( $this, 'add_summary_field' ) );
@@ -102,128 +91,6 @@ class First_Time_Field extends CampTix_Addon {
 	}
 
 	/**
-	 * Render the field, used on both Registration and when editing an existing ticket.
-	 *
-	 * @param string $name
-	 * @param string $value
-	 * @param int    $ticket_id
-	 */
-	public function render_field( $name, $value, $ticket_id ) {
-		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
-			return;
-		}
-
-		$question = apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id );
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-required tix-left">
-				<?php echo esc_html( $question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $question ); ?>">
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="yes"
-							<?php checked( 'yes', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-
-					<br />
-
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="no"
-							<?php checked( 'no', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-
-					<br />
-
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="unsure"
-							<?php checked( 'unsure', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['unsure'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
-	}
-
-	/**
-	 * Render the new field for the registration form during checkout.
-	 *
-	 * @param array $form_data
-	 * @param int   $i
-	 */
-	public function render_registration_field( $form_data, $i ) {
-		$current_data = $form_data['tix_attendee_info'][ $i ] ?? array();
-		$current_data = wp_parse_args( $current_data, array( self::SLUG => '' ) );
-
-		$this->render_field(
-			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
-			$current_data[ self::SLUG ],
-			$current_data['ticket_id']
-		);
-	}
-
-	/**
-	 * Validate the value of the new field submitted to the registration form during checkout.
-	 *
-	 * @param array $data
-	 *
-	 * @return array
-	 */
-	public function validate_registration_field( $data ) {
-		/** @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		$skip_question = apply_filters( 'camptix_first_time_should_skip', false );
-		if ( $skip_question ) {
-			return $data;
-		}
-
-		$data[ self::SLUG ] = $this->validate_value( $data[ self::SLUG ] ?? '' );
-
-		if ( empty( $data[ self::SLUG ] ) ) {
-			$camptix->error_flags['required_fields'] = true;
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Add the value of the new field to the attendee object during checkout processing.
-	 *
-	 * @param WP_Post $attendee
-	 * @param array   $data
-	 *
-	 * @return WP_Post
-	 */
-	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = $data[ self::SLUG ] ?? '';
-
-		return $attendee;
-	}
-
-	/**
 	 * Save the value of the new field to the attendee post upon completion of checkout.
 	 *
 	 * @param int     $post_id
@@ -236,119 +103,22 @@ class First_Time_Field extends CampTix_Addon {
 	}
 
 	/**
-	 * Retrieve the stored value of the new field for use on the Edit Info form.
+	 * Retrieve the stored value of the new field for use when displaying the attendee info.
+	 *
+	 * Back-compat only, for where the field was stored outside of the question answers.
 	 *
 	 * @param array   $ticket_info
 	 * @param WP_Post $attendee
 	 *
 	 * @return array
 	 */
-	public function populate_ticket_info_array( $ticket_info, $attendee ) {
-		$ticket_info[ self::SLUG ] = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$attendee = get_post( $attendee );
+		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+
+		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
 
 		return $ticket_info;
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $data
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function validate_save_ticket_info_field( $data, $attendee ) {
-		if ( empty( $data[ self::SLUG ] ) ) {
-			return true;
-		}
-
-		$value = $this->validate_value( $data[ self::SLUG ] );
-
-		return update_post_meta( $attendee->ID, 'tix_' . self::SLUG, $value );
-	}
-
-	/**
-	 * Validate the given value against the valid options.
-	 */
-	public function validate_value( $value ) {
-		if ( ! in_array( $value, array_keys( $this->options ), true ) ) {
-			$value = '';
-		}
-
-		return $value;
-	}
-
-	/**
-	 * Render the new field for the Edit Info form.
-	 *
-	 * @param array $ticket_info
-	 */
-	public function render_ticket_info_field( $ticket_info ) {
-		$current_data = wp_parse_args( $ticket_info, array( self::SLUG => '' ) );
-
-		$this->render_field(
-			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
-			$current_data[ self::SLUG ],
-			$current_data['ticket_id']
-		);
-	}
-
-	/**
-	 * Add a row to the Attendee Info metabox table for the new field and value.
-	 *
-	 * @param array   $rows
-	 * @param WP_Post $post
-	 *
-	 * @return mixed
-	 */
-	public function add_metabox_row( $rows, $post ) {
-		$label = '';
-		$value = get_post_meta( $post->ID, 'tix_' . self::SLUG, true );
-
-		if ( $value && isset( $this->options[ $value ] ) ) {
-			$label = $this->options[ $value ];
-		}
-
-		$question = apply_filters( 'camptix_first_time_question_text', $this->question, $post->tix_ticket_id );
-		$new_row  = array( $question, esc_html( $label ) );
-
-		add_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		$ticket_row = array_filter(
-			$rows,
-			function( $row ) {
-				if ( 'Ticket' === $row[0] ) {
-					return true;
-				}
-
-				return false;
-			}
-		);
-
-		remove_filter( 'locale', array( $this, 'set_locale_to_en_US' ) );
-
-		if ( ! empty( $ticket_row ) ) {
-			$ticket_row_key = key( $ticket_row );
-			$row_indexes    = array_keys( $rows );
-			$position       = array_search( $ticket_row_key, $row_indexes, true );
-			$slice          = array_slice( $rows, $position );
-
-			array_unshift( $slice, $new_row );
-			array_splice( $rows, $position, count( $rows ), $slice );
-		} else {
-			$rows[] = $new_row;
-		}
-
-		return $rows;
-	}
-
-	/**
-	 * Filter: Set the locale to en_US.
-	 *
-	 * @return string
-	 */
-	public function set_locale_to_en_US() {
-		return 'en_US';
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/first-time.php
@@ -33,6 +33,10 @@ class First_Time_Field extends CampTix_Addon {
 			'unsure'  => _x( "I don't know", 'answer to question during ticket registration', 'wordcamporg' ),
 		);
 
+		// Ask the question.
+		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 40 ); // 20 = allergy, 30 = accessibility, 40 = this, 50 = CoC
+
 		// Registration field.
 		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 12, 2 );
 		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ), 11 );
@@ -58,6 +62,43 @@ class First_Time_Field extends CampTix_Addon {
 		add_filter( 'camptix_privacy_export_attendee_prop', array( $this, 'export_attendee_prop' ), 10, 4 );
 		add_filter( 'camptix_privacy_attendee_props_to_erase', array( $this, 'attendee_props_to_erase' ) );
 		add_action( 'camptix_privacy_erase_attendee_prop', array( $this, 'erase_attendee_prop' ), 10, 3 );
+	}
+
+	/**
+	 * Add the question to the list of questions.
+	 *
+	 * @param array $questions
+	 *
+	 * @return array
+	 */
+	function add_question( $questions, $ticket_id ) {
+		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
+			return $questions;
+		}
+
+		$questions[ self::SLUG ] = (object) array(
+			// Immitate a WP_Post with metadata..
+			'ID' 	       => self::SLUG,
+			'post_title'   => apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id ),
+			'tix_type'     => 'radio',
+			'tix_required' => true,
+			'tix_values'   => $this->options,
+		);
+
+		return $questions;
+	}
+
+	/**
+	 * Add the new field to the questions order.
+	 *
+	 * @param array $order
+	 *
+	 * @return array
+	 */
+	function add_question_order( $order ) {
+		$order[] = self::SLUG;
+
+		return $order;
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
@@ -45,16 +45,13 @@ class Privacy_Field extends CampTix_Addon {
 			'no'  => _x( 'No', 'ticket registration option', 'wordcamporg' ),
 		);
 
-		// Registration field.
-		add_action( 'camptix_attendee_form_after_questions', array( $this, 'render_registration_field' ), 10, 2 );
-		add_filter( 'camptix_checkout_attendee_info', array( $this, 'validate_registration_field' ) );
-		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'populate_attendee_object' ), 10, 2 );
-		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		// Ask the question.
+		add_filter( 'camptix_ticket_questions', array( $this, 'add_question' ), 10, 2 );
+		add_filter( 'camptix_ticket_questions_order', array( $this, 'add_question_order' ), 10 );
+		add_filter( 'camptix_get_attendee_answers', array( $this, 'populate_attendee_answer' ), 10, 2 );
 
-		// Edit info field.
-		add_filter( 'camptix_form_edit_attendee_ticket_info', array( $this, 'populate_ticket_info_array' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'validate_save_ticket_info_field' ), 10, 2 );
-		add_action( 'camptix_form_edit_attendee_after_questions', array( $this, 'render_ticket_info_field' ), 10 );
+		// Save the answer as post meta.
+		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
 
 		// Delete cached attendees lists when an attendee privacy setting changes.
 		add_action( 'added_post_meta', array( $this, 'invalidate_attendees_cache' ), 10, 3 );
@@ -63,101 +60,40 @@ class Privacy_Field extends CampTix_Addon {
 	}
 
 	/**
-	 * Render the field, used on both Registration and when editing an existing ticket.
+	 * Add the question to the list of questions.
 	 *
-	 * @param string $name
-	 * @param string $value
-	 */
-	public function render_field( $name, $value ) {
-		?>
-
-		<tr class="tix-row-<?php echo esc_attr( self::SLUG ); ?>">
-			<td class="tix-left">
-				<?php echo wp_kses_post( $this->question ); ?>
-				<span aria-hidden="true" class="tix-required-star">*</span>
-			</td>
-
-			<td class="tix-right">
-				<fieldset class="tix-screen-reader-fieldset" aria-label="<?php echo esc_attr( $this->a11y_label ); ?>">
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="yes"
-							<?php checked( 'yes', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['yes'] ); ?>
-					</label>
-					<br />
-					<label>
-						<input
-							name="<?php echo esc_attr( $name ); ?>"
-							type="radio"
-							value="no"
-							<?php checked( 'no', $value ); ?>
-							required
-						/>
-						<?php echo esc_html( $this->options['no'] ); ?>
-					</label>
-				</fieldset>
-			</td>
-		</tr>
-
-		<?php
-	}
-
-	/**
-	 * Render the new field for the registration form during checkout.
-	 *
-	 * @param array $form_data
-	 * @param int   $i
-	 */
-	public function render_registration_field( $form_data, $i ) {
-		$current_data = $form_data['tix_attendee_info'][ $i ] ?? array();
-
-		$current_data = wp_parse_args( $current_data, array(
-			self::SLUG => '',
-		) );
-
-		$this->render_field(
-			sprintf( 'tix_attendee_info[%d][%s]', $i, self::SLUG ),
-			$current_data[ self::SLUG ]
-		);
-	}
-
-	/**
-	 * Validate the value of the new field submitted to the registration form during checkout.
-	 *
-	 * @param array $data
+	 * @param array $questions
 	 *
 	 * @return array
 	 */
-	public function validate_registration_field( $data ) {
-		/* @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		if ( ! isset( $data[ self::SLUG ] ) || empty( $data[ self::SLUG ] ) ) {
-			$camptix->error_flags['required_fields'] = true;
-		} else {
-			$data[ self::SLUG ] = ( 'yes' === $data[ self::SLUG ] ) ? true : false;
+	function add_question( $questions, $ticket_id ) {
+		if ( apply_filters( 'camptix_first_time_should_skip', false ) ) {
+			return $questions;
 		}
 
-		return $data;
+		$questions[ self::SLUG ] = (object) array(
+			// Immitate a WP_Post with metadata..
+			'ID' 	       => self::SLUG,
+			'post_title'   => apply_filters( 'camptix_first_time_question_text', $this->question, $ticket_id ),
+			'tix_type'     => 'radio',
+			'tix_required' => true,
+			'tix_values'   => $this->options,
+		);
+
+		return $questions;
 	}
 
 	/**
-	 * Add the value of the new field to the attendee object during checkout processing.
+	 * Add the new field to the questions order.
 	 *
-	 * @param WP_Post $attendee
-	 * @param array   $data
+	 * @param array $order
 	 *
-	 * @return WP_Post
+	 * @return array
 	 */
-	public function populate_attendee_object( $attendee, $data ) {
-		$attendee->{ self::SLUG } = $data[ self::SLUG ] ?? null;
+	function add_question_order( $order ) {
+		$order[] = self::SLUG;
 
-		return $attendee;
+		return $order;
 	}
 
 	/**
@@ -178,60 +114,25 @@ class Privacy_Field extends CampTix_Addon {
 		return $result;
 	}
 
+
 	/**
-	 * Retrieve the stored value of the new field for use on the Edit Info form.
+	 * Retrieve the stored value of the new field for use when displaying the attendee info.
+	 *
+	 * Back-compat only, for where the field was stored outside of the question answers.
 	 *
 	 * @param array   $ticket_info
 	 * @param WP_Post $attendee
 	 *
 	 * @return array
 	 */
-	public function populate_ticket_info_array( $ticket_info, $attendee ) {
-		$raw_value = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+	public function populate_attendee_answer( $ticket_info, $attendee ) {
+		$attendee = get_post( $attendee );
+		$value    = get_post_meta( $attendee->ID, 'tix_' . self::SLUG, true );
+		$value    = ( 'private' === $value ) ? 'no' : 'yes';
 
-		if ( 'private' === $raw_value ) {
-			$ticket_info[ self::SLUG ] = 'no';
-		} else {
-			$ticket_info[ self::SLUG ] = 'yes';
-		}
+		$ticket_info[ self::SLUG ] ??= $this->options[ $value ] ?? '';
 
 		return $ticket_info;
-	}
-
-	/**
-	 * Update the stored value of the new field if it was changed in the Edit Info form.
-	 *
-	 * @param array   $data
-	 * @param WP_Post $attendee
-	 *
-	 * @return bool|int
-	 */
-	public function validate_save_ticket_info_field( $data, $attendee ) {
-		$data = $this->validate_registration_field( $data );
-
-		if ( true === wp_validate_boolean( $data[ self::SLUG ] ) ) {
-			$result = delete_post_meta( $attendee->ID, 'tix_' . self::SLUG );
-		} else {
-			$result = update_post_meta( $attendee->ID, 'tix_' . self::SLUG, 'private' );
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Render the new field for the Edit Info form.
-	 *
-	 * @param array $ticket_info
-	 */
-	public function render_ticket_info_field( $ticket_info ) {
-		$current_data = wp_parse_args( $ticket_info, array(
-			self::SLUG => 'yes',
-		) );
-
-		$this->render_field(
-			sprintf( 'tix_ticket_info[%s]', self::SLUG ),
-			$current_data[ self::SLUG ]
-		);
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/addons/privacy.php
@@ -52,6 +52,7 @@ class Privacy_Field extends CampTix_Addon {
 
 		// Save the answer as post meta.
 		add_action( 'camptix_checkout_update_post_meta', array( $this, 'save_registration_field' ), 10, 2 );
+		add_action( 'camptix_form_edit_attendee_update_post_meta', array( $this, 'edit_attendee_data' ), 10, 3 );
 
 		// Delete cached attendees lists when an attendee privacy setting changes.
 		add_action( 'added_post_meta', array( $this, 'invalidate_attendees_cache' ), 10, 3 );
@@ -114,6 +115,18 @@ class Privacy_Field extends CampTix_Addon {
 		return $result;
 	}
 
+	/**
+	 * Update the stored value of the new field if it was changed in the Edit Info form.
+	 *
+	 * @param array   $ticket_info
+	 * @param WP_Post $attendee
+	 * @param array   $answers
+	 *
+	 * @return bool|int
+	 */
+	public function edit_attendee_data( $ticket_info, $attendee, $answers ) {
+		return $this->save_registration_field( $attendee->ID, (object) compact( 'answers' ) );
+	}
 
 	/**
 	 * Retrieve the stored value of the new field for use when displaying the attendee info.

--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -549,12 +549,14 @@ function load_addons( $addons ) {
  */
 function load_custom_addons() {
 	// Extra fields.
-	require_once __DIR__ . '/addons/allergy.php';
-	require_once __DIR__ . '/addons/accommodations.php';
-	require_once __DIR__ . '/addons/code-of-conduct.php';
-	require_once __DIR__ . '/addons/first-time.php';
+	require_once __DIR__ . '/addons/extra-fields.php';
+	require_once __DIR__ . '/addons/extra-fields/allergy.php';
+	require_once __DIR__ . '/addons/extra-fields/accommodations.php';
+	require_once __DIR__ . '/addons/extra-fields/code-of-conduct.php';
+	require_once __DIR__ . '/addons/extra-fields/first-time.php';
+	require_once __DIR__ . '/addons/extra-fields/privacy.php';
+
 	require_once __DIR__ . '/addons/health-advisory.php';
-	require_once __DIR__ . '/addons/privacy.php';
 
 	// Miscellaneous.
 	require_once __DIR__ . '/addons/spam-prevention.php';

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -922,9 +922,9 @@ class CampTix_Plugin {
 	}
 
 	/**
-	 * Get all questions. Returns an assoc array where the key is a
-	 * sanitized questions (as stored in the database) and the value is
-	 * the question array.
+	 * Get all questions.
+	 *
+	 * @return WP_Post[] The list of questions as a WP_Post object.
 	 */
 	function get_all_questions() {
 		$questions = get_posts( array(

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4550,10 +4550,10 @@ class CampTix_Plugin {
 										<?php echo esc_html( apply_filters( 'the_title', $question->post_title ) ); ?>
 
 										<input type="hidden" data-model-attribute="post_id" value="<?php echo absint( $question->ID ); ?>" />
-										<input type="hidden" data-model-attribute="type" value="<?php echo esc_attr( get_post_meta( $question->ID, 'tix_type', true ) ); ?>" />
+										<input type="hidden" data-model-attribute="type" value="<?php echo esc_attr( $question->tix_type ); ?>" />
 										<input type="hidden" data-model-attribute="question" value="<?php echo esc_attr( $question->post_title ); ?>" />
-										<input type="hidden" data-model-attribute="required" value="<?php echo intval( get_post_meta( $question->ID, 'tix_required', true ) ); ?>" />
-										<input type="hidden" data-model-attribute="values" value="<?php echo esc_attr( implode( ', ', (array) get_post_meta( $question->ID, 'tix_values', true ) ) ); ?>" />
+										<input type="hidden" data-model-attribute="required" value="<?php echo intval( $question->tix_required ); ?>" />
+										<input type="hidden" data-model-attribute="values" value="<?php echo esc_attr( implode( ', ', (array) $question->tix_values ?: [] ) ); ?>" />
 									</label>
 								</li>
 								<?php endforeach; ?>
@@ -4596,10 +4596,10 @@ class CampTix_Plugin {
 			<?php foreach ( $questions as $question ) : ?>
 				camptix.questions.add( new camptix.models.Question( {
 					post_id: <?php echo esc_js( $question->ID ); ?>,
-					type: '<?php echo esc_js( get_post_meta( $question->ID, 'tix_type', true ) ); ?>',
+					type: '<?php echo esc_js( $question->tix_type ); ?>',
 					question: '<?php echo esc_js( apply_filters( 'the_title', $question->post_title ) ); ?>',
-					required: <?php echo esc_js( (int) (bool) get_post_meta( $question->ID, 'tix_required', true ) ); ?>,
-					values: '<?php echo esc_js( implode( ', ', (array) get_post_meta( $question->ID, 'tix_values', true ) ) ); ?>'
+					required: <?php echo esc_js( (int) $question->tix_required ); ?>,
+					values: '<?php echo esc_js( implode( ', ', (array) $question->tix_values ?: [] ) ); ?>'
 				} ) );
 			<?php endforeach; ?>
 			}(jQuery));
@@ -6029,7 +6029,6 @@ class CampTix_Plugin {
 											$value      = isset( $this->form_data['tix_attendee_questions'][ $i ][ $question->ID ] ) ? $this->form_data['tix_attendee_questions'][ $i ][ $question->ID ] : '';
 											$type       = $question->tix_type;
 											$required   = $question->tix_required;
-											$values     = $question->tix_values;
 											$class_name = 'tix-row-question-' . $question->ID;
 										?>
 
@@ -6041,7 +6040,7 @@ class CampTix_Plugin {
 												</label>
 											</td>
 											<td class="tix-right">
-												<?php do_action( "camptix_question_field_{$type}", $name, $value, $question, $required, $values ); ?>
+												<?php do_action( "camptix_question_field_{$type}", $name, $value, $question, $required ); ?>
 											</td>
 										</tr>
 									<?php endforeach; ?>
@@ -6342,7 +6341,7 @@ class CampTix_Plugin {
 
 				// @todo maybe check $user_values against $type and $question_values
 
-				if ( (bool) get_post_meta( $question->ID, 'tix_required', true ) && empty( $new_answers[ $question->ID ] ) ) {
+				if ( $question->tix_required && empty( $new_answers[ $question->ID ] ) ) {
 					$errors[] = __( 'Please fill in all required fields.', 'wordcamporg' );
 				}
 			}
@@ -6448,8 +6447,8 @@ class CampTix_Plugin {
 								<?php
 									$name       = sprintf( 'tix_ticket_questions[%d]', $question->ID );
 									$value      = isset( $answers[ $question->ID ] ) ? $answers[ $question->ID ] : '';
-									$type       = get_post_meta( $question->ID, 'tix_type', true );
-									$required   = get_post_meta( $question->ID, 'tix_required', true );
+									$type       = $question->tix_type;
+									$required   = $question->tix_required;
 									$class_name = 'tix-row-question-' . $question->ID;
 								?>
 
@@ -7247,7 +7246,7 @@ class CampTix_Plugin {
 						$answers[ $question->ID ] = $answer;
 					}
 
-					if ( (bool) get_post_meta( $question->ID, 'tix_required', true ) && empty( $answers[ $question->ID ] ) ) {
+					if ( $question->tix_required && empty( $answers[ $question->ID ] ) ) {
 						$this->error_flags['required_fields'] = true;
 						break;
 					}

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4360,7 +4360,7 @@ class CampTix_Plugin {
 	 * A drop-down select for a question.
 	 */
 	function question_field_select( $name, $user_value, $question, $required = false ) {
-		$values = get_post_meta( $question->ID, 'tix_values', true );
+		$values = $question->tix_values ?: [];
 		?>
 		<select
 			id="<?php echo esc_attr( $this->get_field_id( $name ) ); ?>"
@@ -4378,7 +4378,7 @@ class CampTix_Plugin {
 	 * A single or multiple checkbox for a question.
 	 */
 	function question_field_checkbox( $name, $user_value, $question, $required = false ) {
-		$values = get_post_meta( $question->ID, 'tix_values', true );
+		$values         = $question->tix_values ?: [];
 		$user_value_esc = array_map( 'esc_attr', (array) $user_value );
 		?>
 		<fieldset
@@ -4424,7 +4424,7 @@ class CampTix_Plugin {
 	 * A radio input for questions.
 	 */
 	function question_field_radio( $name, $user_value, $question, $required = false ) {
-		$values = get_post_meta( $question->ID, 'tix_values', true );
+		$values = $question->tix_values ?: [];
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"
@@ -6027,8 +6027,9 @@ class CampTix_Plugin {
 										<?php
 											$name       = sprintf( 'tix_attendee_questions[%d][%s]', $i, $question->ID );
 											$value      = isset( $this->form_data['tix_attendee_questions'][ $i ][ $question->ID ] ) ? $this->form_data['tix_attendee_questions'][ $i ][ $question->ID ] : '';
-											$type       = get_post_meta( $question->ID, 'tix_type', true );
-											$required   = get_post_meta( $question->ID, 'tix_required', true );
+											$type       = $question->tix_type;
+											$required   = $question->tix_required;
+											$values     = $question->tix_values;
 											$class_name = 'tix-row-question-' . $question->ID;
 										?>
 
@@ -6040,7 +6041,7 @@ class CampTix_Plugin {
 												</label>
 											</td>
 											<td class="tix-right">
-												<?php do_action( "camptix_question_field_{$type}", $name, $value, $question, $required ); ?>
+												<?php do_action( "camptix_question_field_{$type}", $name, $value, $question, $required, $values ); ?>
 											</td>
 										</tr>
 									<?php endforeach; ?>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -959,6 +959,23 @@ class CampTix_Plugin {
 			'post__in' => $question_ids,
 		) );
 
+		/**
+		 * Filter the questions for a ticket.
+		 *
+		 * @var array $questions
+		 * @var int $ticket_id
+		 */
+		$questions = apply_filters( 'camptix_ticket_questions', $questions, $ticket_id );
+
+		/**
+		 * Filter the question sort order.
+		 *
+		 * @var array $order
+		 * @var int $ticket_id
+		 * @var array $questions
+		 */
+		$order = apply_filters( 'camptix_ticket_questions_order', $order, $ticket_id, $questions );
+
 		$questions_with_keys = array();
 
 		foreach ( $questions as $question ) {
@@ -976,11 +993,6 @@ class CampTix_Plugin {
 		}
 
 		unset( $questions );
-
-		/**
-		 * Filter the sorted questions.
-		 */
-		$questions_sorted = apply_filters( 'camptix_ticket_questions', $questions_sorted, $ticket_id );
 
 		return $questions_sorted;
 	}

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4383,7 +4383,7 @@ class CampTix_Plugin {
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"
-			aria-label="<?php echo esc_attr( apply_filters( 'the_title', $question->post_title ) ); ?>"
+			aria-label="<?php echo esc_attr( strip_tags( apply_filters( 'the_title', $question->post_title ) ) ); ?>"
 		>
 		<?php if ( $values ) : ?>
 			<?php foreach ( (array) $values as $question_value ) : ?>
@@ -4423,12 +4423,12 @@ class CampTix_Plugin {
 	/**
 	 * A radio input for questions.
 	 */
-	function question_field_radio( $name, $user_value, $question, $required = false ) {
+	function question_field_radio( $name, $user_value, $question, $required = false  ) {
 		$values = $question->tix_values ?: [];
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"
-			aria-label="<?php echo esc_attr( apply_filters( 'the_title', $question->post_title ) ); ?>"
+			aria-label="<?php echo esc_attr( strip_tags( apply_filters( 'the_title', $question->post_title ) ) ); ?>"
 		>
 			<?php foreach ( (array) $values as $question_value ) : ?>
 				<label>
@@ -6030,12 +6030,25 @@ class CampTix_Plugin {
 											$type       = $question->tix_type;
 											$required   = $question->tix_required;
 											$class_name = 'tix-row-question-' . $question->ID;
+
+											// Questions can have minimal HTML in the question.
+											$question_text = apply_filters( 'the_title', $question->post_title );
+											$question_text = make_clickable( $question_text );
+											$question_text = wp_kses(
+												$question_text,
+												array(
+													'a' => array(
+														'href'   => array(),
+														'target' => array(),
+													),
+												)
+											);
 										?>
 
 										<tr class="<?php echo esc_attr( $class_name ); ?>">
 											<td class="<?php if ( $required ) echo 'tix-required'; ?> tix-left">
 												<label for="<?php echo in_array( $type, array( 'radio', 'checkbox' ) ) ? '' : $this->get_field_id( $name ); ?>">
-													<?php echo make_clickable( esc_html( apply_filters( 'the_title', $question->post_title ) ) ); ?>
+													<?php echo $question_text; ?>
 													<?php if ( $required ) echo ' <span aria-hidden="true" class="tix-required-star">*</span>'; ?>
 												</label>
 											</td>
@@ -6450,17 +6463,30 @@ class CampTix_Plugin {
 									$type       = $question->tix_type;
 									$required   = $question->tix_required;
 									$class_name = 'tix-row-question-' . $question->ID;
+
+									// Questions can have minimal HTML in the question.
+									$question_text = apply_filters( 'the_title', $question->post_title );
+									$question_text = make_clickable( $question_text );
+									$question_text = wp_kses(
+										$question_text,
+										array(
+											'a' => array(
+												'href'   => array(),
+												'target' => array(),
+											),
+										)
+									);
 								?>
 
 								<tr class="<?php echo esc_attr( $class_name ); ?>">
 									<td class="<?php if ( $required ) echo 'tix-required'; ?> tix-left">
 										<label for="<?php echo in_array( $type, array( 'radio', 'checkbox' ) ) ? '' : $this->get_field_id( $name ); ?>">
-											<?php echo esc_html( apply_filters( 'the_title', $question->post_title ) ); ?>
+											<?php echo $question_text; ?>
 											<?php if ( $required ) echo ' <span aria-hidden="true" class="tix-required-star">*</span>'; ?>
 										</label>
 									</td>
 									<td class="tix-right">
-										<?php do_action( "camptix_question_field_{$type}", $name, $value, $question ); ?>
+										<?php do_action( "camptix_question_field_{$type}", $name, $value, $question, $required ); ?>
 									</td>
 								</tr>
 							<?php endforeach; ?>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4394,6 +4394,7 @@ class CampTix_Plugin {
 						name="<?php echo esc_attr( $name ); ?>[<?php echo esc_attr( sanitize_title_with_dashes( $question_value ) ); ?>]"
 						type="checkbox"
 						value="<?php echo esc_attr( $question_value ); ?>"
+						<?php if ( $required ) echo 'required'; ?>
 					/>
 					<?php echo esc_html( $question_value ); ?>
 				</label><br />

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4380,7 +4380,7 @@ class CampTix_Plugin {
 	function question_field_checkbox( $name, $user_value, $question, $required = false ) {
 		$values         = $question->tix_values ?: [];
 		$user_value_esc = array_map( 'esc_attr', (array) $user_value );
-		$a11y_label     = $question->a11y_label ?: strip_tags( apply_filters( 'the_title', $question->post_title ) );
+		$a11y_label     = $question->a11y_label ?? strip_tags( apply_filters( 'the_title', $question->post_title ) );
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"
@@ -4427,7 +4427,7 @@ class CampTix_Plugin {
 	 */
 	function question_field_radio( $name, $user_value, $question, $required = false  ) {
 		$values     = $question->tix_values ?: [];
-		$a11y_label = $question->a11y_label ?: strip_tags( apply_filters( 'the_title', $question->post_title ) );
+		$a11y_label = $question->a11y_label ?? strip_tags( apply_filters( 'the_title', $question->post_title ) );
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6374,7 +6374,7 @@ class CampTix_Plugin {
 				update_post_meta( $attendee->ID, 'tix_email', sanitize_email( $new_ticket_info['email'] ) );
 				update_post_meta( $attendee->ID, 'tix_questions', wp_slash( $new_answers ) );
 
-				do_action( 'camptix_form_edit_attendee_update_post_meta', $new_ticket_info, $attendee );
+				do_action( 'camptix_form_edit_attendee_update_post_meta', $new_ticket_info, $attendee, $new_answers );
 
 				wp_update_post( $attendee ); // triggers save_attendee
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -977,6 +977,11 @@ class CampTix_Plugin {
 
 		unset( $questions );
 
+		/**
+		 * Filter the sorted questions.
+		 */
+		$questions_sorted = apply_filters( 'camptix_ticket_questions', $questions_sorted, $ticket_id );
+
 		return $questions_sorted;
 	}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -948,8 +948,9 @@ class CampTix_Plugin {
 		$order = (array) get_post_meta( $ticket_id, 'tix_questions_order', true );
 
 		// Make sure we have at least some questions
-		if ( empty( $question_ids ) )
+		if ( empty( $question_ids ) ) {
 			return array();
+		}
 
 		$questions = get_posts( array(
 			'post_type' => 'tix_question',
@@ -960,16 +961,19 @@ class CampTix_Plugin {
 
 		$questions_with_keys = array();
 
-		foreach ( $questions as $question )
+		foreach ( $questions as $question ) {
 			$questions_with_keys[ $question->ID ] = $question;
+		}
 
 		$questions = $questions_with_keys;
 		unset( $questions_with_keys );
 
 		$questions_sorted = array();
-		foreach ( $order as $question_id )
-			if ( isset( $questions[ $question_id ] ) )
+		foreach ( $order as $question_id ) {
+			if ( isset( $questions[ $question_id ] ) ) {
 				$questions_sorted[] = $questions[ $question_id ];
+			}
+		}
 
 		unset( $questions );
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -478,7 +478,7 @@ class CampTix_Plugin {
 			return;
 
 		$key = substr( $summarize_by, 6 );
-		$answers = (array) get_post_meta( $attendee->ID, 'tix_questions', true );
+		$answers = $this->get_attendee_answers( $attendee->ID );
 
 		if ( isset( $answers[ $key ] ) && ! empty( $answers[ $key ] ) )
 			$this->increment_summary( $summary, $answers[ $key ] );
@@ -1540,7 +1540,7 @@ class CampTix_Plugin {
 			) ) ) {
 				foreach ( $attendees as $attendee ) {
 					$new_answers = array();
-					$answers = (array) get_post_meta( $attendee->ID, 'tix_questions', true );
+					$answers     = $camtix->get_attendee_answers( $attendee->ID );
 
 					// Just in case the upgrade script runs more than once
 					$answers_backup = (array) get_post_meta( $attendee->ID, 'tix_questions_backup', true );
@@ -2904,7 +2904,7 @@ class CampTix_Plugin {
 					'payment_method' => $this->get_payment_method_name_by_attendee_id( $attendee_id ),
 				);
 
-				$answers = (array) get_post_meta( $attendee_id, 'tix_questions', true );
+				$answers = $camptix->get_attendee_answers( $attendee_id );
 
 				foreach ( $questions as $question ) {
 
@@ -3555,9 +3555,9 @@ class CampTix_Plugin {
 			// These conditions further filter the query.
 			foreach ( $post_query_conditions as $condition ) {
 				if ( preg_match( '#^tix-question-(\d+)$#', $condition['field'], $matches ) ) {
-					$question_id = $matches[1];
-					$answers = get_post_meta( $attendee_id, 'tix_questions', true );
-					$question = get_post( $question_id );
+					$question_id   = $matches[1];
+					$answers       = $this->get_attendee_answers( $attendee_id );
+					$question      = get_post( $question_id );
 					$question_type = get_post_meta( $question->ID, 'tix_type', true );
 
 					// Make sure the question is valid.
@@ -4778,9 +4778,9 @@ class CampTix_Plugin {
 		}
 
 		// Questions
-		$rows[] = array( __( 'Questions', 'wordcamporg' ), '' );
+		$rows[]    = array( __( 'Questions', 'wordcamporg' ), '' );
 		$questions = $this->get_sorted_questions( $ticket_id );
-		$answers = get_post_meta( $post->ID, 'tix_questions', true );
+		$answers   = $this->get_attendee_answers( $post->ID );
 
 		foreach ( $questions as $question ) {
 			if ( isset( $answers[ $question->ID ] ) ) {
@@ -6298,9 +6298,9 @@ class CampTix_Plugin {
 		if ( $attendee->post_status == 'pending' )
 			$this->notice( __( 'Please note that the payment for this ticket is still pending.', 'wordcamporg' ) );
 
-		$ticket = get_post( $ticket_id );
+		$ticket    = get_post( $ticket_id );
 		$questions = $this->get_sorted_questions( $ticket->ID );
-		$answers = (array) get_post_meta( $attendee->ID, 'tix_questions', true );
+		$answers   = $this->get_attendee_answers( $attendee->ID );
 
 		$ticket_info = array(
 			'first_name' => get_post_meta( $attendee->ID, 'tix_first_name', true ),
@@ -8035,6 +8035,21 @@ class CampTix_Plugin {
 	 */
 	public function get_attendee_email( $attendee_id ) {
 		return apply_filters( 'camptix_get_attendee_email', get_post_meta( $attendee_id, 'tix_email', true ), $attendee_id );
+	}
+
+	/**
+	 * Get the attendee's question answers.
+	 *
+	 * @param int $attendee_id
+	 * @return array
+	 */
+	public function get_attendee_answers( $attendee_id ) {
+		$answers = get_post_meta( $attendee_id, 'tix_questions', true );
+		if ( ! is_array( $answers ) ) {
+			$answers = array();
+		}
+
+		return apply_filters( 'camptix_get_attendee_answers', $answers, $attendee_id );
 	}
 
 	public function email_attendee_ticket_multiple_template( $attendee ) {

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4380,10 +4380,11 @@ class CampTix_Plugin {
 	function question_field_checkbox( $name, $user_value, $question, $required = false ) {
 		$values         = $question->tix_values ?: [];
 		$user_value_esc = array_map( 'esc_attr', (array) $user_value );
+		$a11y_label     = $question->a11y_label ?: strip_tags( apply_filters( 'the_title', $question->post_title ) );
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"
-			aria-label="<?php echo esc_attr( strip_tags( apply_filters( 'the_title', $question->post_title ) ) ); ?>"
+			aria-label="<?php echo esc_attr( $a11y_label ); ?>"
 		>
 		<?php if ( $values ) : ?>
 			<?php foreach ( (array) $values as $question_value ) : ?>
@@ -4424,11 +4425,12 @@ class CampTix_Plugin {
 	 * A radio input for questions.
 	 */
 	function question_field_radio( $name, $user_value, $question, $required = false  ) {
-		$values = $question->tix_values ?: [];
+		$values     = $question->tix_values ?: [];
+		$a11y_label = $question->a11y_label ?: strip_tags( apply_filters( 'the_title', $question->post_title ) );
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"
-			aria-label="<?php echo esc_attr( strip_tags( apply_filters( 'the_title', $question->post_title ) ) ); ?>"
+			aria-label="<?php echo esc_attr( $a11y_label ); ?>"
 		>
 			<?php foreach ( (array) $values as $question_value ) : ?>
 				<label>

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6458,7 +6458,7 @@ class CampTix_Plugin {
 						<?php if ( apply_filters( 'camptix_ask_questions', true, array( (int) $ticket_id => 1 ), (int) $ticket_id, 1, $questions ) ) : ?>
 							<?php foreach ( $questions as $question ) : ?>
 								<?php
-									$name       = sprintf( 'tix_ticket_questions[%d]', $question->ID );
+									$name       = sprintf( 'tix_ticket_questions[%s]', $question->ID );
 									$value      = isset( $answers[ $question->ID ] ) ? $answers[ $question->ID ] : '';
 									$type       = $question->tix_type;
 									$required   = $question->tix_required;


### PR DESCRIPTION
IYKYK.

This moves a bunch of forced custom questions from being output on a hook, to being actual questions, which allows filtering of the shown questions.

This is a fairly large PR that became unwieldy pretty quickly, and has subsequently broken the git diff viewer.

Need to do more testing to verify no broken behaviour. Not sure it's worth anyone else attempting a code review. Drafting PR for github actions.