### PR TITLE
Require Login: When landing on the tickets screen, allow the buyer to mark additional tickets as "unknown attendee".

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -525,7 +525,7 @@ class CampTix_Require_Login extends CampTix_Addon {
 		global $camptix;
 
 		// This first attendee can't be unknown
-		if ( empty( $form_data['tix_tickets_selected'] ) || $this->current_row_is_buyer( $form_data['tix_tickets_selected'], $ticket, $i ) ) {
+		if ( $this->current_row_is_buyer( $form_data['tix_tickets_selected'] ?? [], $ticket, $i ) ) {
 			return;
 		}
 


### PR DESCRIPTION
It should be possible to mark a ticket as "I don’t know who will use this ticket yet" even when there's no form data.

This can happen after the login redirect, as the page you're redirected back to **will not** have any form data (POST data).

The form was correctly hiding questions, but not allowing a empty name/email dataset.

Eg; https://testing.wordcamp.org/2025/tickets/?tix_action=attendee_info&tix_tickets_selected[993]=2

Logging in, and going back to the start of the ticket flow would not hit this edge case.