### PR TITLE
Sunrise: EU and US domains should load the 2025 editions, even if the 2026 site is published.

### DIFF
--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -631,14 +631,14 @@ function get_canonical_year_url( $domain, $path ) {
 	// See also `WordCamp\Sunrise\Latest_Site_Hints\get_latest_home_url()`.
 	switch ( $domain ) {
 		case "europe.wordcamp.$tld":
-			if ( time() <= strtotime( '2024-06-20' ) ) {
-				return "https://europe.wordcamp.$tld/2024/";
+			if ( time() <= strtotime( '2025-06-21' ) ) {
+				return "https://europe.wordcamp.$tld/2025/";
 			}
 			break;
 
 		case "us.wordcamp.$tld":
-			if ( time() <= strtotime( '2024-09-25' ) ) {
-				return "https://us.wordcamp.$tld/2024/";
+			if ( time() <= strtotime( '2025-09-15' ) ) {
+				return "https://us.wordcamp.$tld/2025/";
 			}
 			break;
 


### PR DESCRIPTION
EU and US domains should load the 2025 editions, even if the 2026 site is published.

that's to say, accessing https://europe.wordcamp.org/ should redirect to https://europe.wordcamp.org/2025/ even when /2026/ is live, if 2025 isn't completely over yet.

This should apply for at least 2 weeks post-event.
