### PR TITLE
Don't set the required attribute for checkboxes with multiple options.

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -4380,6 +4380,16 @@ class CampTix_Plugin {
 		$values         = $question->tix_values ?: [];
 		$user_value_esc = array_map( 'esc_attr', (array) $user_value );
 		$a11y_label     = $question->a11y_label ?? strip_tags( apply_filters( 'the_title', $question->post_title ) );
+
+		/*
+  		 * HTML doesn't support setting the required attribute on a group of checkboxes.
+     		 * Rely upon serverside form validation instead if there are multiple.
+		 *
+		 * @see https://www.w3.org/Bugs/Public/show_bug.cgi?id=9160#c1
+     		 */
+		if ( $required && count( $values ) > 1 ) {
+			$required = false;
+		}
 		?>
 		<fieldset
 			class="tix-screen-reader-fieldset"


### PR DESCRIPTION
In f590fce91207588f18fcaa19daf0cd1b3812adb8 (#1479) I broke the functionality for having a multiple-choice checkbox question which is marked as required.

This was reported on Slack:
https://wordpress.slack.com/archives/C08M59V3P/p1747843481404969

I had incorrectly believed that HTML treated a group of checkboxes marked as required the same as a radio selection, where validation only requires one of the fields to be selected.
I was wrong.

The W3 believes that there is no rationale for having a group of checkboxes where one would only be required to select one of the items, instead it's expected that you should have to select all.
https://www.w3.org/Bugs/Public/show_bug.cgi?id=9160#c1

This PR resolves this by turning off the required flag when there's multiple values, and relies upon the serverside logic instead.
This could be (and likely I'll do so) expanded with some Javascript to restore this functionality for this edge-case.