### PR TITLE
Use 'Pay' in the Stripe checkout, as 'Book' can be translated to mean "Reserve a hotel"

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -891,7 +891,7 @@ class CampTix_Stripe_API_Client {
 
 		$args = array(
 			'mode'                => 'payment',
-			'submit_type'         => 'book',
+			'submit_type'         => 'pay',
 			'success_url'         => $return_url,
 			'cancel_url'          => $cancel_url,
 			'line_items'          => $line_items,


### PR DESCRIPTION
Change to 'Pay' for Stripe checkout, rather than 'Book', for simplicity and to ensure that the string is more likely translated "as expected" in all locales.

As raised on Slack by Sebastian Miśniakiewicz
https://wordpress.slack.com/archives/C08M59V3P/p1748500326852979
> Hi. How to change the title of the button when somebody is going to pay for the ticket? In English there is "Book" but in Polish it means reserving the place (like in a hotel)  or a book you can read :slightly_smiling_face: How to change from "Książka" to e.g. "Zapłać" (Pay) or "Rezerwuj" (Reserve)
![image](https://github.com/user-attachments/assets/57a7daae-8883-432e-b0aa-4e648f22e2fd)

