### PR TITLE
Forms to drafts: Update email sent to speaker after submission

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -450,9 +450,19 @@ class WordCamp_Forms_To_Drafts {
 		// Get the key from submitted data.
 		$form_key = $this->get_form_key_by_id( absint( $_POST['contact-form-id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
-		// Add speaker as a copy on the email.
+		// Update headers on call for speakers responses.
 		if ( 'call-for-speakers' === $form_key ) {
+			// Add speaker as a copy on the email.
 			$headers .= "Cc: {$reply_to_addr}\r\n";
+
+			$wordcamp = get_wordcamp_post();
+			$reply_to_header = sprintf(
+				'Reply-To: %s <%s>',
+				get_wordcamp_name(),
+				$wordcamp->meta['E-mail Address'][0]
+			);
+			// Swap out the current reply-to for the WordCamp's real email.
+			$headers = preg_replace( '/Reply-To: .*/', $reply_to_header, $headers);
 		}
 
 		return $headers;
@@ -504,7 +514,7 @@ class WordCamp_Forms_To_Drafts {
 
 			/* translators: %1$s: WordCamp name; %2$s: email address for organizing team; %3$s: original message. */
 			$message = sprintf(
-				__( 'Hello,<br/><br/>Thank you for your interest in speaking at %1$s! We have received your submission, and a copy is included below for your records.<br/><br/>Please do not reply to this email, as it is automatically generated. If you have any questions, send an email to %2$s.<br/>%3$s', 'wordcamporg' ),
+				__( 'Hello,<br/><br/>Thank you for your interest in speaking at %1$s! We have received your submission, and a copy is included below for your records.<br/><br/>If you have any questions, send an email to %2$s.<br/>%3$s', 'wordcamporg' ),
 				get_wordcamp_name(),
 				$wordcamp->meta['E-mail Address'][0],
 				$message

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -502,9 +502,10 @@ class WordCamp_Forms_To_Drafts {
 		if ( 'call-for-speakers' === $form_key ) {
 			$wordcamp = get_wordcamp_post();
 
-			/* translators: %1$s: email address for organizing team; %2$s: original message; */
+			/* translators: %1$s: WordCamp name; %2$s: email address for organizing team; %3$s: original message. */
 			$message = sprintf(
-				__( 'Hello,<br><br>Thank you for submitting on Call for Speakers! Here is an copy of your submission.<br/><br/>Please do not respond to this email, organizers will update you on the process. If you have any questions, send an email to organisers %1$s.<br/>%2$s', 'wordcamporg' ),
+				__( 'Hello,<br/><br/>Thank you for your interest in speaking at %1$s! We have received your submission, and a copy is included below for your records.<br/><br/>Please do not reply to this email, as it is automatically generated. If you have any questions, send an email to %2$s.<br/>%3$s', 'wordcamporg' ),
+				get_wordcamp_name(),
 				$wordcamp->meta['E-mail Address'][0],
 				$message
 			);


### PR DESCRIPTION
In https://github.com/WordPress/wordcamp.org/pull/1053, an email was added, sent to speakers when they submit a talk on the Call for Speakers form. This PR just updates the language of the email a little, to include the WordCamp name and fix a grammar mistake.

Props Kristin Smith on the WCUS team for flagging the current email.

### Screenshots

No screenshot, but here's what the new email will read:

> Hello,
>
> Thank you for your interest in speaking at [WordCamp City]! We have received your submission, and a copy is included below for your records.
>
> Please do not reply to this email, as it is automatically generated. If you have any questions, send an email to [city@wordcamp.org].
>
> [form submission]

### How to test the changes in this Pull Request:

1. Install an email catcher plugin or use mailcatcher (visit http://localhost:1080/ to view on Docker env)
2. Submit a talk using the Call for Speakers form
3. You should see an email go to the speaker's email address
4. It should look like above, with the bracketed content replaced with the current WordCamp details
