### PR TITLE
Add support for `campus.wordpress.org/{university-name}` as a event site.

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -147,7 +147,8 @@ function get_wordcamp_name( $site_id = 0 ) {
 /**
  * Extract pieces from a WordCamp.org URL
  *
- * @todo find other code that's doing this same task in an ad-hoc manner, and convert it to use this instead
+ * @todo find other code that's doing this same task in an ad-hoc manner, and convert it to use this instead.
+ * @todo Update this to handle events.wordpress.org, campusconnect, & campus.wordpress.org.
  *
  * @param string $site_url The root URL for the site, without any query string. It can include the site path
  *                         -- e.g., `https://narnia.wordcamp.org/2020` -- but should not include a post slug,

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordCamp\Sunrise\get_top_level_domain;
+
 use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_YEAR_DOT_CITY_DOMAIN_PATH };
 
 defined( 'WPINC' ) || die();
@@ -447,4 +449,27 @@ function is_wordcamp_virtual( $wordcamp ) {
 	restore_current_blog();
 
 	return $is_virtual;
+}
+
+/**
+ * Get the Network Admin URL for a given network + path.
+ *
+ * @param int    $network_id The ID of the network.
+ * @param string $path       The path to append to the URL.
+ * @return string The full URL for the network admin.
+ */
+function get_network_specific_network_url( int $network_id, string $path ): string {
+	$tld = get_top_level_domain();
+	$url = network_admin_url( $path );
+
+	$hostname = "wordcamp.$tld";
+	if ( $network_id === CAMPUS_NETWORK_ID ) {
+		$hostname = "campus.wordpress.$tld";
+	} elseif ( $network_id === EVENTS_NETWORK_ID ) {
+		$hostname = "events.wordpress.$tld";
+	}
+
+	$url = preg_replace( '^https?://[^/]+', "https://{$hostname}", $url );
+
+	return $url;
 }

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -470,7 +470,7 @@ function get_network_specific_network_url( int $network_id, string $path ): stri
 		$hostname = "events.wordpress.$tld";
 	}
 
-	$url = preg_replace( '^https?://[^/]+', "https://{$hostname}", $url );
+	$url = preg_replace( '!^https?://[^/]+!i', "https://{$hostname}", $url );
 
 	return $url;
 }

--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -464,9 +464,9 @@ function get_network_specific_network_url( int $network_id, string $path ): stri
 	$url = network_admin_url( $path );
 
 	$hostname = "wordcamp.$tld";
-	if ( $network_id === CAMPUS_NETWORK_ID ) {
+	if ( CAMPUS_NETWORK_ID === $network_id ) {
 		$hostname = "campus.wordpress.$tld";
-	} elseif ( $network_id === EVENTS_NETWORK_ID ) {
+	} elseif ( EVENTS_NETWORK_ID === $network_id ) {
 		$hostname = "events.wordpress.$tld";
 	}
 

--- a/public_html/wp-content/plugins/camptix-network-tools/network-dashboard.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/network-dashboard.php
@@ -43,7 +43,7 @@ class CampTix_Network_Dashboard {
 		}
 
 		// The cron job may be fired from a site that doesn't have CampTix loaded, so only run if it is loaded
-		if ( method_exists( $camptix, 'generate_revenue_report_data' ) ) {
+		if ( isset( $camptix ) && method_exists( $camptix, 'generate_revenue_report_data' ) ) {
 			$remaining_blogs = get_site_option( 'camptix_nt_revenue_report_blog_ids', array() );
 			if ( empty( $remaining_blogs ) ) {
 				$remaining_blogs = $wpdb->get_col( $wpdb->prepare( "

--- a/public_html/wp-content/plugins/wcpt/css/applications/admin.css
+++ b/public_html/wp-content/plugins/wcpt/css/applications/admin.css
@@ -38,6 +38,11 @@ body.wp-admin.post-type-wp_meetup .postbox textarea {
 	width: 18rem;
 }
 
+/* Hide the create checkbox if the field has changed */
+#post-body .field__type-wc-url input[type="text"].has-changed + label {
+	display: none;
+}
+
 .postbox-container .select2-container {
 	min-width: 25%;
 }

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -13,7 +13,9 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 			$mentorUserName = $( '#wcpt_mentor_wordpress_org_user_name' ),
 			hasContributor = $( '#wcpt_contributor_day' ),
 			$virtualEventCheckbox = $( '#wcpt_virtual_event_only' ),
-			$streamingSelection = $( '.field__type-select-streaming' );
+			$streamingSelection = $( '.field__type-select-streaming' ),
+			$wcUrlFields = $('input.field-wc-url-input'),
+			$secondarySiteWrap = $( 'input[name*="wcpt_secondary_site"]' ).parent();
 
 		// Sponsor region
 		createSiteCheckbox.change( self.toggleSponsorRegionRequired );
@@ -46,6 +48,26 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 			}
 		} );
 		$streamingSelection.find( 'select' ).trigger( 'change' );
+
+		// If the value has changed, mark it as dirty and disable the checkbox.
+		$wcUrlFields.on( 'change', function() {
+			var $this = $(this),
+			    origValue = $this.data( 'orig-value' ),
+			    newValue = $this.val();
+
+			$this.toggleClass( 'has-changed', origValue !== newValue );
+			$this.parent().find( 'input.has-changed + label input[type=checkbox]:checked' ).prop('checked', false );
+		} );
+
+		// Allow adding additional secondary sites fields.
+		$secondarySiteWrap.find( 'a.add' ).on( 'click', function( event ) {
+			event.preventDefault();
+			var inputNumber = $secondarySiteWrap.find( 'input[type=text]' ).length;
+			var $newField = $secondarySiteWrap.find( 'input[type=text][name*="0"]' ).first().clone();
+			$newField.val( '' );
+			$newField.attr( 'name', $newField.attr( 'name' ).replace( /0/g, inputNumber ) );
+			$newField.insertBefore( $( this ) ).focus();
+		} );
 	};
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -72,7 +72,7 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 	/**
 	 * Toggle whether the Sponsor Region field is required or not.
 	 *
-	 * \WordCamp_New_Site::maybe_create_new_site() requires it to be set to create a new site.
+	 * \WordCamp_New_Site::maybe_create_new_sites() requires it to be set to create a new site.
 	 *
 	 * @param {object} event
 	 */

--- a/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
+++ b/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
@@ -12,11 +12,44 @@ defined( 'WPINC' ) || die();
  */
 function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_capability ) {
 	$wcpt = get_post_type_object( $event_type );
+
+	$event_subtype  = $post->event_subtype ?: $event_type;
+	$event_subtypes = $event_admin->get_event_subtypes();
 	?>
 
 	<div id="submitpost" class="wcb submitbox">
 		<div id="minor-publishing">
 			<div id="misc-publishing-actions">
+			<div class="misc-pub-section misc-pub-post-status">
+					<label>
+						<?php echo $label; ?> Type:
+
+						<?php if ( current_user_can( $edit_capability ) ) : ?>
+
+							<span id="post-status-display">
+							<select name="event_subtype">
+								<?php
+								foreach ( $event_subtypes as $key => $event_subtype_label ) {
+									printf(
+										'<option %s value="%s">%s</option>',
+										selected( $event_subtype, $key, false ),
+										esc_attr( $key ),
+										esc_html( $event_subtype_label )
+									);
+								}
+								?>
+							</select>
+						</span>
+
+						<?php else : ?>
+
+							<span id="post-status-display">
+							<?php echo esc_html( $event_subtypes[ $event_subtype ] ); ?>
+						</span>
+
+						<?php endif; ?>
+					</label>
+				</div>
 				<div class="misc-pub-section misc-pub-post-status">
 					<label>
 						<?php echo $label; ?> Status:
@@ -27,7 +60,7 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 							<select name="post_status">
 								<?php $transitions = $event_admin->get_valid_status_transitions( $post->post_status );
 								?>
-								<?php foreach ( $event_admin->get_post_statuses() as $key => $label ) : ?>
+								<?php foreach ( $event_admin->get_post_statuses() as $key => $post_status_label ) : ?>
 									<?php $status = get_post_status_object( $key ); ?>
 									<option value="<?php echo esc_attr( $status->name ); ?>" <?php
 									if ( $post->post_status == $status->name ) {

--- a/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
+++ b/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
@@ -22,7 +22,7 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 			<div id="misc-publishing-actions">
 			<div class="misc-pub-section misc-pub-post-status">
 					<label>
-						<?php echo $label; ?> Type:
+						<?php echo esc_html( $label ); ?> Type:
 
 						<?php if ( current_user_can( $edit_capability ) ) : ?>
 
@@ -52,7 +52,7 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 				</div>
 				<div class="misc-pub-section misc-pub-post-status">
 					<label>
-						<?php echo $label; ?> Status:
+						<?php echo esc_html( $label ); ?> Status:
 
 						<?php if ( current_user_can( $edit_capability ) ) : ?>
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -973,5 +973,12 @@ abstract class Event_Admin {
 		endforeach;
 	}
 
-	abstract function get_event_subtypes();
+	/**
+	 * Returns the list of Event Subtypes.
+	 *
+	 * This is generally 'WordCamp', 'DoAction', 'Other Event', 'Campus Connect', etc.
+	 *
+	 * @return array
+	 */
+	abstract public function get_event_subtypes();
 }

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -472,6 +472,12 @@ abstract class Event_Admin {
 			}
 		}
 
+		// Save the Event Subtype.
+		if ( isset( $_POST['event_subtype'] ) && current_user_can( $this->get_edit_capability() ) ) {
+			$event_subtype = sanitize_text_field( wp_unslash( $_POST['event_subtype'] ) );
+			update_post_meta( $post_id, 'event_subtype', $event_subtype );
+		}
+
 		$meta_keys        = $this->meta_keys();
 		$orig_meta_values = get_post_meta( $post_id );
 		$is_virtual_event = WordCamp_admin::is_virtual_event( $post_id );
@@ -967,5 +973,5 @@ abstract class Event_Admin {
 		endforeach;
 	}
 
-
+	abstract function get_event_subtypes();
 }

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -698,6 +698,17 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 		}
 
 		/**
+		 * Return a list of valid Event Subtypes.
+		 *
+		 * @return array
+		 */
+		public function get_event_subtypes() {
+			return array(
+				'wp_meetup' => __( 'WordPress Meetup', 'wordcamporg' ),
+			);
+		}
+
+		/**
 		 * Schedule cron job for updating data from meetup API
 		 */
 		public function schedule_cron_jobs() {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1139,6 +1139,20 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		}
 
 		/**
+		 * Return a list of valid Event Subtypes.
+		 *
+		 * @return array
+		 */
+		public function get_event_subtypes() {
+			return array(
+				'wordcamp'      => __( 'WordCamp', 'wordcamporg' ),
+				'doaction'      => __( 'DoAction', 'wordcamporg' ),
+				'campusconnect' => __( 'Campus Connect', 'wordcamporg' ),
+				'other'         => __( 'Other Event', 'wordcamporg' ),
+			);
+		}
+
+		/**
 		 * Schedule cron jobs
 		 */
 		public function schedule_cron_jobs() {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -413,6 +413,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Event Timezone'                    => 'select-timezone',
 						'Location'                          => 'text',
 						'URL'                               => 'wc-url',
+						'Secondary Site'                    => 'wc-url', // Any "secondary" site for an event, ie. Second language site or a private team site.
 						'E-mail Address'                    => 'text', // The entire organizing team.
 						'Twitter'                           => 'text',
 						'WordCamp Hashtag'                  => 'text',
@@ -442,6 +443,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Event Timezone'                    => 'select-timezone',
 						'Location'                          => 'text',
 						'URL'                               => 'wc-url',
+						'Secondary Site'                    => 'wc-url', // Any "secondary" site for an event, ie. Second language site or a private team site.
 						'E-mail Address'                    => 'text', // The entire organizing team.
 						'Twitter'                           => 'text',
 						'WordCamp Hashtag'                  => 'text',

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -232,7 +232,6 @@ class WordCamp_New_Site {
 			foreach ( array_diff( $existing_stored_values, $existing_site_ids ) as $old_site_id ) {
 				delete_post_meta( $wordcamp_id, $site_id_meta_key, absint( $old_site_id ) );
 			}
-
 		} else {
 			$url = $validate_url( $url );
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -5,7 +5,7 @@
 
 use \WordCamp\Logger;
 
-use function WordCamp\Sunrise\get_top_level_domain;
+use function WordCamp\Sunrise\{ get_top_level_domain, get_domain_network_id };
 
 use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH };
 
@@ -51,8 +51,7 @@ class WordCamp_New_Site {
 				$url        = trailingslashit( get_post_meta( $post_id, $key, true ) );
 				$url        = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) );
 				$valid_url  = isset( $url['host'], $url['path'] );
-				$tld        = get_top_level_domain();
-				$network_id = $valid_url && "events.wordpress.$tld" === $url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
+				$network_id = $valid_url ? get_domain_network_id( $url['host'] ) : false;
 				$we_host_it = $valid_url && 'doaction.org' !== $url['host'];
 				?>
 
@@ -65,11 +64,7 @@ class WordCamp_New_Site {
 							),
 							true
 						);
-						$edit_url     = add_query_arg( 'id', $blog_details->blog_id, network_admin_url( 'site-info.php' ) );
-
-					if ( "events.wordpress.$tld" === $url['host'] ) {
-						$edit_url = str_replace( '://wordcamp.', '://events.wordpress.', $edit_url );
-					}
+						$edit_url     = add_query_arg( 'id', $blog_details->blog_id, get_site_network_url( $network_id, 'site-info.php' ) );
 					?>
 
 					<a target="_blank" href="<?php echo esc_url( $edit_url ); ?>">Edit</a> |
@@ -144,8 +139,7 @@ class WordCamp_New_Site {
 		update_post_meta( $wordcamp_id, $key, esc_url( $url ) );
 
 		// If this site exists make sure we update the _site_id mapping.
-		$tld              = get_top_level_domain();
-		$network_id       = "events.wordpress.$tld" === $parsed_url['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID;
+		$network_id       = get_domain_network_id( $parsed_url['host'] );
 		$existing_site_id = domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
 
 		if ( $existing_site_id ) {
@@ -168,7 +162,7 @@ class WordCamp_New_Site {
 		$tld                            = get_top_level_domain();
 		$last_permitted_external_domain = 2341;
 		$external_domain_exceptions     = array( 169459 );
-		$is_external_domain             = ! preg_match( "@ \.wordcamp\.$tld | \.buddycamp\.$tld | events\.wordpress\.$tld @ix", $domain );
+		$is_external_domain             = ! preg_match( "@ \.wordcamp\.$tld | \.buddycamp\.$tld | events\.wordpress\.$tld | campus\.wordpress\.$tld @ix", $domain );
 		$can_have_external_domain       = $wordcamp_id <= $last_permitted_external_domain || in_array( $wordcamp_id, $external_domain_exceptions );
 
 		// DoAction is not hosted within the WordCamp infrastructure, so can have an external domain.
@@ -250,14 +244,12 @@ class WordCamp_New_Site {
 			$blog_name .= wp_date( ' Y', $wordcamp->{'Start Date (YYYY-mm-dd)'} );
 		}
 
-		$tld = get_top_level_domain();
-
 		$this->new_site_id = wp_insert_site( array(
-			'network_id' => "events.wordpress.$tld" === $url_components['host'] ? EVENTS_NETWORK_ID : WORDCAMP_NETWORK_ID,
-			'domain'  => $url_components['host'],
-			'path'    => $path,
-			'title'   => $blog_name,
-			'user_id' => $lead_organizer->ID,
+			'network_id' => get_domain_network_id( $url_components['host'] ),
+			'domain'     => $url_components['host'],
+			'path'       => $path,
+			'title'      => $blog_name,
+			'user_id'    => $lead_organizer->ID,
 		) );
 
 		if ( is_int( $this->new_site_id ) ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -63,13 +63,42 @@ class WordCamp_New_Site {
 			}
 		}
 
+		if ( $is_primary_site ) {
+			$value = get_post_meta( $post_id, $key, true );
+			$this->_render_site_url_field( $post_id, $key, $field_type, $object_name, $value, $placeholder, $is_primary_site );
+		} else {
+			// Multiple.
+			$values = get_post_meta( $post_id, $key ) ?: [ '' ]; // At least one value.
+			foreach ( $values as $i => $value ) {
+				$key = $value ?: $i;
+				$this->_render_site_url_field( $post_id, $key, $field_type, "{$object_name}[{$key}]", $value, $placeholder );
+			}
+
+			// Render the 'Add another' link.
+			echo '<a class="add" style="display: block; cursor: pointer">+ Add</a>';
+		}
+
+	}
+
+	/**
+	 * Render the site URL field input
+	 *
+	 * @param int    $post_id      The WordCamp post ID.
+	 * @param string $key          The meta key.
+	 * @param string $field_type   The field type.
+	 * @param string $object_name  The name of the object.
+	 * @param string $value        The current value of the field.
+	 * @param string $placeholder  The placeholder text for the input.
+	 */
+	public function _render_site_url_field( $post_id, $key, $field_type, $object_name, $value, $placeholder ) {
 		?>
 		<input
 			type="text"
 			size="36"
+			class="field-wc-url-input"
 			name="<?php echo esc_attr( $object_name ); ?>"
-			id="<?php echo esc_attr( $object_name ); ?>"
-			value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"
+			value="<?php echo esc_attr( $value ); ?>"
+			data-orig-value="<?php echo esc_attr( $value ); ?>"
 			placeholder="<?php echo esc_attr( $placeholder ); ?>"
 		/>
 
@@ -79,8 +108,7 @@ class WordCamp_New_Site {
 		}
 
 		// Add the checkbox to create the site, if applicable.
-
-		$url        = trailingslashit( get_post_meta( $post_id, $key, true ) );
+		$url        = $value;
 		$url        = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) );
 		$valid_url  = isset( $url['host'], $url['path'] );
 		$network_id = $valid_url ? get_domain_network_id( $url['host'] ) : false;
@@ -104,7 +132,7 @@ class WordCamp_New_Site {
 			<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
 
 		<?php elseif ( $we_host_it ) : ?>
-			<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network' . ( ! $is_primary_site ? '-secondary' : '' ), 'wcpt_' ); ?>
+			<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network-' . $object_name, 'wcpt_' ); ?>
 
 			<label for="<?php echo esc_attr( $checkbox_id ); ?>">
 				<input id="<?php echo esc_attr( $checkbox_id ); ?>" type="checkbox" name="<?php echo esc_attr( $checkbox_id ); ?>" />
@@ -152,32 +180,74 @@ class WordCamp_New_Site {
 			return;
 		}
 
+		$validate_url = static function( $url ) {
+			$url = str_starts_with( $url, 'http' ) ? $url : 'http://' . $url;
+			$url = set_url_scheme( esc_url_raw( $url ), 'https' );
+
+			$url = filter_var( $url, FILTER_VALIDATE_URL );
+
+			if ( ! $url ) {
+				return false;
+			}
+
+			$url        = trailingslashit( $url );
+			$parsed_url = wp_parse_url( $url );
+
+			if ( ! self::url_matches_expected_format( $parsed_url['host'], $parsed_url['path'], $wordcamp_id ) ) {
+				wp_die( "The URL doesn't match the expected format. It should be either <code>city.wordcamp.org/year/</code>, <code>events.wordpress.org/city/year/type/</code>, or <code>campus.wordpress.org/campus-name/</code>. Please press the back button and update it." );
+			}
+
+			return esc_url( $url );
+		};
+		$find_existing_site = static function( $url ) {
+			if ( ! $url ) {
+				return false;
+			}
+
+			$parsed_url = wp_parse_url( $url );
+			$network_id = get_domain_network_id( $parsed_url['host'] );
+
+			return domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
+		};
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
-		$url = strtolower( substr( $_POST[ $field_name ], 0, 4 ) ) == 'http' ? $_POST[ $field_name ] : 'http://' . $_POST[ $field_name ];
-		$url = set_url_scheme( esc_url_raw( $url ), 'https' );
-		$url = filter_var( $url, FILTER_VALIDATE_URL );
+		$url = $_POST[ $field_name ] ?? '';
+		if ( is_array( $url ) ) {
+			$urls = array_filter( array_map( $validate_url, $url ) ); // Remove any invalid URLs.
 
-		if ( ! $url ) {
-			return;
-		}
+			// Store the URLs, as individual post meta values for query purposes.
+			$existing_stored_urls = get_post_meta( $wordcamp_id, $key, false );
+			foreach ( array_diff( $urls, $existing_stored_urls ) as $new_url ) {
+				add_post_meta( $wordcamp_id, $key, esc_url( $new_url ) );
+			}
+			foreach ( array_diff( $existing_stored_urls, $urls ) as $old_url ) {
+				delete_post_meta( $wordcamp_id, $key, esc_url( $old_url ) );
+			}
 
-		$url        = trailingslashit( $url );
-		$parsed_url = wp_parse_url( $url );
+			// Now, find the matching sites for those URLs.
+			$existing_site_ids      = array_filter( array_map( $find_existing_site, $urls ) );
+			$existing_stored_values = get_post_meta( $wordcamp_id, $site_id_meta_key, false );
+			foreach ( array_diff( $existing_site_ids, $existing_stored_values ) as $new_site_id ) {
+				add_post_meta( $wordcamp_id, $site_id_meta_key, absint( $new_site_id ) );
+			}
+			foreach ( array_diff( $existing_stored_values, $existing_site_ids ) as $old_site_id ) {
+				delete_post_meta( $wordcamp_id, $site_id_meta_key, absint( $old_site_id ) );
+			}
 
-		if ( ! self::url_matches_expected_format( $parsed_url['host'], $parsed_url['path'], $wordcamp_id ) ) {
-			wp_die( "The URL doesn't match the expected format. It should be either <code>city.wordcamp.org/year/</code> or <code>events.wordpress.org/city/year/type/</code>. Please press the back button and update it." );
-		}
-
-		update_post_meta( $wordcamp_id, $key, esc_url( $url ) );
-
-		// If this site exists make sure we update the _site_id mapping.
-		$network_id       = get_domain_network_id( $parsed_url['host'] );
-		$existing_site_id = domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
-
-		if ( $existing_site_id ) {
-			update_post_meta( $wordcamp_id, $site_id_meta_key, absint( $existing_site_id ) );
 		} else {
-			delete_post_meta( $wordcamp_id, $site_id_meta_key );
+			$url = $validate_url( $url );
+
+			// Store it.
+			update_post_meta( $wordcamp_id, $key, esc_url( $url ) );
+
+			// Find the Site ID for the URL.
+			$existing_site_id = $find_existing_site( $url );
+
+			if ( $existing_site_id ) {
+				update_post_meta( $wordcamp_id, $site_id_meta_key, absint( $existing_site_id ) );
+			} else {
+				delete_post_meta( $wordcamp_id, $site_id_meta_key );
+			}
 		}
 	}
 
@@ -260,26 +330,42 @@ class WordCamp_New_Site {
 
 		$url = get_post_meta( $wordcamp_id, 'URL', true );
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
-		if ( $url && isset( $_POST[ wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ) ] ) ) {
-			$this->_maybe_create_site( $wordcamp, '_site_id', $url );
+		if ( $url && isset( $_POST[ wcpt_key_to_str( 'create-site-in-network-wcpt_url', 'wcpt_' ) ] ) ) {
+			$site_id = $this->_create_site( $wordcamp, $url );
+			if ( $site_id ) {
+				// `_site_id` is used in other plugins to map the `wordcamp` post to it's corresponding site.
+				update_post_meta( $wordcamp_id, '_site_id', $site_id );
+			}
 		}
 
-		$secondary_url = get_post_meta( $wordcamp_id, 'Secondary Site', true );
+		$secondary_urls = get_post_meta( $wordcamp_id, 'Secondary Site', false );
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
-		if ( $secondary_url && isset( $_POST[ wcpt_key_to_str( 'create-site-in-network-secondary', 'wcpt_' ) ] ) ) {
-			$this->_maybe_create_site( $wordcamp, '_secondary_site_id', $secondary_url );
+		if ( $secondary_urls && isset( $_POST[ wcpt_key_to_str( 'create-site-in-network-wcpt_secondary_site', 'wcpt_' ) ] ) ) {
+			$url_keys = array();
+			foreach ( $secondary_urls as $i => $url ) {
+				$url_keys[ wcpt_key_to_str( $url ) ] = $url;
+			}
+
+			foreach ( $_POST[ wcpt_key_to_str( 'create-site-in-network-wcpt_secondary_site', 'wcpt_' ) ] as $url => $value ) {
+				$url = $url_keys[ $url ] ?? ( $secondary_urls[ $url ] ?? '' );
+				if ( 'on' === strtolower( $value ) && $url ) {
+					$site_id = $this->_create_site( $wordcamp, $url );
+					if ( $site_id ) {
+						add_post_meta( $wordcamp_id, '_secondary_site_id', $site_id );
+					}
+				}
+			}
 		}
 	}
 
 	/**
-	 * Maybe create a new site in the network.
+	 * Create a new site in the network.
 	 *
-	 * @param WP_Post $wordcamp         The WordCamp post object.
-	 * @param string  $site_id_meta_key The meta key to use for the site id.
-	 * @param string  $url              The URL to create the site at.
+	 * @param WP_Post $wordcamp The WordCamp post object.
+	 * @param string  $url      The URL to create the site at.
 	 * @return void
 	 */
-	protected function _maybe_create_site( $wordcamp, $site_id_meta_key, $url ) {
+	protected function _create_site( $wordcamp, $url ) {
 		$wordcamp_id = $wordcamp->ID;
 
 		$url_components = wp_parse_url( $url );
@@ -306,8 +392,6 @@ class WordCamp_New_Site {
 		) );
 
 		if ( is_int( $this->new_site_id ) ) {
-			// `_site_id` is used in other plugins to map the `wordcamp` post to it's corresponding site.
-			update_post_meta( $wordcamp_id, $site_id_meta_key, $this->new_site_id );
 			do_action( 'wcor_wordcamp_site_created', $wordcamp_id );
 
 			add_post_meta(
@@ -328,6 +412,8 @@ class WordCamp_New_Site {
 			$new_site_id = $this->new_site_id;
 			Logger\log( 'no_site_id', compact( 'wordcamp_id', 'url', 'lead_organizer', 'new_site_id', 'blog_name' ) );
 		}
+
+		return $this->new_site_id;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -77,7 +77,6 @@ class WordCamp_New_Site {
 			// Render the 'Add another' link.
 			echo '<a class="add" style="display: block; cursor: pointer">+ Add</a>';
 		}
-
 	}
 
 	/**
@@ -180,7 +179,7 @@ class WordCamp_New_Site {
 			return;
 		}
 
-		$validate_url = static function( $url ) {
+		$validate_url = static function ( $url ) {
 			$url = str_starts_with( $url, 'http' ) ? $url : 'http://' . $url;
 			$url = set_url_scheme( esc_url_raw( $url ), 'https' );
 
@@ -199,7 +198,7 @@ class WordCamp_New_Site {
 
 			return esc_url( $url );
 		};
-		$find_existing_site = static function( $url ) {
+		$find_existing_site = static function ( $url ) {
 			if ( ! $url ) {
 				return false;
 			}
@@ -346,6 +345,7 @@ class WordCamp_New_Site {
 				$url_keys[ wcpt_key_to_str( $url ) ] = $url;
 			}
 
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 			foreach ( $_POST[ wcpt_key_to_str( 'create-site-in-network-wcpt_secondary_site', 'wcpt_' ) ] as $url => $value ) {
 				$url = $url_keys[ $url ] ?? ( $secondary_urls[ $url ] ?? '' );
 				if ( 'on' === strtolower( $value ) && $url ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -5,7 +5,7 @@
 
 use \WordCamp\Logger;
 
-use function WordCamp\Sunrise\get_top_level_domain;
+use function WordCamp\Sunrise\{ get_top_level_domain, get_domain_network_id };
 
 use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH, PATTERN_CITY_PATH };
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -7,7 +7,7 @@ use \WordCamp\Logger;
 
 use function WordCamp\Sunrise\get_top_level_domain;
 
-use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH };
+use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH, PATTERN_CITY_PATH };
 
 class WordCamp_New_Site {
 	protected $new_site_id;
@@ -36,6 +36,15 @@ class WordCamp_New_Site {
 	public function render_site_url_field( $key, $field_type, $object_name ) {
 		global $post_id;
 
+		$event_subtype = get_post( $post_id )->event_subtype ?: 'wordcamp';
+
+		$placeholder = 'https://city.wordcamp.org/' . wp_date( 'Y' ) . '/';
+		if ( 'other' === $event_subtype ) {
+			$placeholder = 'https://events.wordpress.org/city/' . wp_date( 'Y' ) . '/type/';
+		} elseif ( 'campusconnect' === $event_subtype ) {
+			$placeholder = 'https://events.wordpress.org/campusconnect/' . wp_date( 'Y' ) . '/city/';
+		}
+
 		if ( 'URL' == $key && 'wc-url' == $field_type ) : ?>
 			<input
 				type="text"
@@ -43,7 +52,7 @@ class WordCamp_New_Site {
 				name="<?php echo esc_attr( $object_name ); ?>"
 				id="<?php echo esc_attr( $object_name ); ?>"
 				value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"
-				placeholder="https://city.wordcamp.org/<?php echo esc_attr( wp_date( 'Y' ) ); ?>/"
+				placeholder="<?php echo esc_attr( $placeholder ); ?>"
 			/>
 
 			<?php if ( current_user_can( 'manage_sites' ) ) : ?>
@@ -177,6 +186,8 @@ class WordCamp_New_Site {
 
 		if ( "events.wordpress.$tld" === $domain ) {
 			$match = preg_match( PATTERN_CITY_YEAR_TYPE_PATH, $path );
+		} elseif ( "campus.wordpress.$tld" === $domain ) {
+			$match = preg_match( PATTERN_CITY_PATH, $path );
 		} else {
 			$match = preg_match( PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, $domain . $path );
 		}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -18,10 +18,10 @@ class WordCamp_New_Site {
 	public function __construct() {
 		$this->new_site_id = false;
 
-		add_action( 'wcpt_metabox_value',     array( $this, 'render_site_url_field' ), 10, 3 );
-		add_action( 'wcpt_metabox_save',      array( $this, 'save_site_url_field'   ), 10, 3 );
-		add_action( 'wcpt_metabox_save_done', array( $this, 'maybe_create_new_site' ), 10, 1 );
-		add_action( 'wcpt_metabox_save_done', array( $this, 'maybe_push_mes'        ), 10, 1 );
+		add_action( 'wcpt_metabox_value',     array( $this, 'render_site_url_field'  ), 10, 3 );
+		add_action( 'wcpt_metabox_save',      array( $this, 'save_site_url_field'    ), 10, 3 );
+		add_action( 'wcpt_metabox_save_done', array( $this, 'maybe_create_new_sites' ), 10, 1 );
+		add_action( 'wcpt_metabox_save_done', array( $this, 'maybe_push_mes'         ), 10, 1 );
 	}
 
 	/**
@@ -36,67 +36,88 @@ class WordCamp_New_Site {
 	public function render_site_url_field( $key, $field_type, $object_name ) {
 		global $post_id;
 
-		$event_subtype = get_post( $post_id )->event_subtype ?: 'wordcamp';
-
-		$placeholder = 'https://city.wordcamp.org/' . wp_date( 'Y' ) . '/';
-		if ( 'other' === $event_subtype ) {
-			$placeholder = 'https://events.wordpress.org/city/' . wp_date( 'Y' ) . '/type/';
-		} elseif ( 'campusconnect' === $event_subtype ) {
-			$placeholder = 'https://events.wordpress.org/campusconnect/' . wp_date( 'Y' ) . '/city/';
+		if (
+			'wc-url' != $field_type ||
+			! in_array( $key, array( 'URL', 'Secondary Site' ) )
+		) {
+			return;
 		}
 
-		if ( 'URL' == $key && 'wc-url' == $field_type ) : ?>
-			<input
-				type="text"
-				size="36"
-				name="<?php echo esc_attr( $object_name ); ?>"
-				id="<?php echo esc_attr( $object_name ); ?>"
-				value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"
-				placeholder="<?php echo esc_attr( $placeholder ); ?>"
-			/>
+		$is_primary_site = ( 'URL' === $key );
 
-			<?php if ( current_user_can( 'manage_sites' ) ) : ?>
-				<?php
-				$url        = trailingslashit( get_post_meta( $post_id, $key, true ) );
-				$url        = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) );
-				$valid_url  = isset( $url['host'], $url['path'] );
-				$network_id = $valid_url ? get_domain_network_id( $url['host'] ) : false;
-				$we_host_it = $valid_url && 'doaction.org' !== $url['host'];
-				?>
+		$event_subtype = get_post( $post_id )->event_subtype ?: 'wordcamp';
 
-				<?php if ( $valid_url && $we_host_it && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>
-					<?php
-						$blog_details = get_blog_details(
-							array(
-								'domain' => $url['host'],
-								'path'   => $url['path'],
-							),
-							true
-						);
-						$edit_url     = add_query_arg( 'id', $blog_details->blog_id, get_network_specific_network_url( $network_id, 'site-info.php' ) );
-					?>
+		if ( $is_primary_site ) {
+			$placeholder = 'https://city.wordcamp.org/' . wp_date( 'Y' ) . '/';
+			if ( 'other' === $event_subtype ) {
+				$placeholder = 'https://events.wordpress.org/city/' . wp_date( 'Y' ) . '/type/';
+			} elseif ( 'campusconnect' === $event_subtype ) {
+				$placeholder = 'https://events.wordpress.org/campusconnect/' . wp_date( 'Y' ) . '/city/';
+			}
+		} else {
+			$placeholder = 'https://city.wordcamp.org/' . wp_date( 'Y' ) . '-locale/';
+			if ( 'other' === $event_subtype ) {
+				$placeholder = 'https://events.wordpress.org/city/' . wp_date( 'Y' ) . '/type/';
+			} elseif ( 'campusconnect' === $event_subtype ) {
+				$placeholder = 'https://campus.wordpress.org/city-or-university/';
+			}
+		}
 
-					<a target="_blank" href="<?php echo esc_url( $edit_url ); ?>">Edit</a> |
-					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>/wp-admin/">Dashboard</a> |
-					<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
+		?>
+		<input
+			type="text"
+			size="36"
+			name="<?php echo esc_attr( $object_name ); ?>"
+			id="<?php echo esc_attr( $object_name ); ?>"
+			value="<?php echo esc_attr( get_post_meta( $post_id, $key, true ) ); ?>"
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		/>
 
-				<?php elseif ( $we_host_it ) : ?>
-					<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ); ?>
+		<?php
+		if ( ! current_user_can( 'manage_sites' ) ) {
+			return;
+		}
 
-					<label for="<?php echo esc_attr( $checkbox_id ); ?>">
-						<input id="<?php echo esc_attr( $checkbox_id ); ?>" type="checkbox" name="<?php echo esc_attr( $checkbox_id ); ?>" />
-						Create site in network
-					</label>
-				<?php endif; // Domain exists. ?>
+		// Add the checkbox to create the site, if applicable.
 
-				<?php if ( $valid_url && ! self::url_matches_expected_format( $url['host'], $url['path'], $post_id ) ) : ?>
-					<br /><br />
+		$url        = trailingslashit( get_post_meta( $post_id, $key, true ) );
+		$url        = wp_parse_url( filter_var( $url, FILTER_VALIDATE_URL ) );
+		$valid_url  = isset( $url['host'], $url['path'] );
+		$network_id = $valid_url ? get_domain_network_id( $url['host'] ) : false;
+		$we_host_it = $valid_url && 'doaction.org' !== $url['host'];
+		?>
 
-					<span class="notice notice-large notice-warning">
-						Warning: This URL doesn't match the expected format. It should be either <code>city.wordcamp.org/year/</code> or <code>events.wordpress.org/city/year/type/</code>.
-					</span>
-				<?php endif; ?>
-			<?php endif; // User can manage sites. ?>
+		<?php if ( $valid_url && $we_host_it && domain_exists( $url['host'], $url['path'], $network_id ) ) : ?>
+			<?php
+				$blog_details = get_blog_details(
+					array(
+						'domain' => $url['host'],
+						'path'   => $url['path'],
+					),
+					true
+				);
+				$edit_url     = add_query_arg( 'id', $blog_details->blog_id, get_network_specific_network_url( $network_id, 'site-info.php' ) );
+			?>
+
+			<a target="_blank" href="<?php echo esc_url( $edit_url ); ?>">Edit</a> |
+			<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>/wp-admin/">Dashboard</a> |
+			<a target="_blank" href="<?php echo esc_url( $blog_details->siteurl ); ?>">Visit</a>
+
+		<?php elseif ( $we_host_it ) : ?>
+			<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network' . ( ! $is_primary_site ? '-secondary' : '' ), 'wcpt_' ); ?>
+
+			<label for="<?php echo esc_attr( $checkbox_id ); ?>">
+				<input id="<?php echo esc_attr( $checkbox_id ); ?>" type="checkbox" name="<?php echo esc_attr( $checkbox_id ); ?>" />
+				Create site in network
+			</label>
+		<?php endif; // Domain exists. ?>
+
+		<?php if ( $valid_url && ! self::url_matches_expected_format( $url['host'], $url['path'], $post_id ) ) : ?>
+			<br /><br />
+
+			<span class="notice notice-large notice-warning">
+				Warning: This URL doesn't match the expected format. It should be either <code>city.wordcamp.org/year/</code> or <code>events.wordpress.org/city/year/type/</code>.
+			</span>
 		<?php endif;
 	}
 
@@ -111,21 +132,23 @@ class WordCamp_New_Site {
 		global $switched;
 
 		// No updating if the blog has been switched.
-		if ( $switched || 1 !== did_action( 'wcpt_metabox_save' ) ) {
+		if ( $switched || did_action( 'wcpt_metabox_save_done' ) > 1 ) {
 			return;
 		}
 
-		$field_name = wcpt_key_to_str( $key, 'wcpt_' );
+		$is_primary_site  = ( 'URL' === $key );
+		$field_name       = wcpt_key_to_str( $key, 'wcpt_' );
+		$site_id_meta_key = $is_primary_site ? '_site_id' : '_secondary_site_id';
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
-		if ( 'URL' !== $key || 'wc-url' !== $field_type || ! isset( $_POST[ $field_name ] ) ) {
+		if ( ! in_array( $key, array( 'URL', 'Secondary Site' ) ) || 'wc-url' !== $field_type || ! isset( $_POST[ $field_name ] ) ) {
 			return;
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
 		if ( empty( $_POST[ $field_name ] ) ) {
-			delete_post_meta( $wordcamp_id, 'URL' );
-			delete_post_meta( $wordcamp_id, '_site_id' );
+			delete_post_meta( $wordcamp_id, $key );
+			delete_post_meta( $wordcamp_id, $site_id_meta_key );
 			return;
 		}
 
@@ -152,9 +175,9 @@ class WordCamp_New_Site {
 		$existing_site_id = domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
 
 		if ( $existing_site_id ) {
-			update_post_meta( $wordcamp_id, '_site_id', absint( $existing_site_id ) );
+			update_post_meta( $wordcamp_id, $site_id_meta_key, absint( $existing_site_id ) );
 		} else {
-			delete_post_meta( $wordcamp_id, '_site_id' );
+			delete_post_meta( $wordcamp_id, $site_id_meta_key );
 		}
 	}
 
@@ -200,7 +223,7 @@ class WordCamp_New_Site {
 	 *
 	 * @param int $wordcamp_id
 	 */
-	public function maybe_create_new_site( $wordcamp_id ) {
+	public function maybe_create_new_sites( $wordcamp_id ) {
 		$wordcamp = get_post( $wordcamp_id );
 
 		if ( ! $wordcamp instanceof WP_Post || WCPT_POST_TYPE_ID !== $wordcamp->post_type ) {
@@ -233,12 +256,31 @@ class WordCamp_New_Site {
 			return;
 		}
 
+		// Two different fields can be used to create a site, depending on whether it's the primary or secondary site.
+
 		$url = get_post_meta( $wordcamp_id, 'URL', true );
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
-		if ( ! isset( $_POST[ wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ) ] ) || empty( $url ) ) {
-			Logger\log( 'return_no_request_or_url', compact( 'wordcamp_id', 'url' ) );
-			return;
+		if ( $url && isset( $_POST[ wcpt_key_to_str( 'create-site-in-network', 'wcpt_' ) ] ) ) {
+			$this->_maybe_create_site( $wordcamp, '_site_id', $url );
 		}
+
+		$secondary_url = get_post_meta( $wordcamp_id, 'Secondary Site', true );
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- see note at top of file
+		if ( $secondary_url && isset( $_POST[ wcpt_key_to_str( 'create-site-in-network-secondary', 'wcpt_' ) ] ) ) {
+			$this->_maybe_create_site( $wordcamp, '_secondary_site_id', $secondary_url );
+		}
+	}
+
+	/**
+	 * Maybe create a new site in the network.
+	 *
+	 * @param WP_Post $wordcamp         The WordCamp post object.
+	 * @param string  $site_id_meta_key The meta key to use for the site id.
+	 * @param string  $url              The URL to create the site at.
+	 * @return void
+	 */
+	protected function _maybe_create_site( $wordcamp, $site_id_meta_key, $url ) {
+		$wordcamp_id = $wordcamp->ID;
 
 		$url_components = wp_parse_url( $url );
 		if ( ! $url_components || empty( $url_components['scheme'] ) || empty( $url_components['host'] ) ) {
@@ -265,7 +307,7 @@ class WordCamp_New_Site {
 
 		if ( is_int( $this->new_site_id ) ) {
 			// `_site_id` is used in other plugins to map the `wordcamp` post to it's corresponding site.
-			update_post_meta( $wordcamp_id, '_site_id', $this->new_site_id );
+			update_post_meta( $wordcamp_id, $site_id_meta_key, $this->new_site_id );
 			do_action( 'wcor_wordcamp_site_created', $wordcamp_id );
 
 			add_post_meta(

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -5,7 +5,7 @@
 
 use \WordCamp\Logger;
 
-use function WordCamp\Sunrise\{ get_top_level_domain, get_domain_network_id };
+use function WordCamp\Sunrise\get_top_level_domain;
 
 use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH };
 
@@ -64,7 +64,7 @@ class WordCamp_New_Site {
 							),
 							true
 						);
-						$edit_url     = add_query_arg( 'id', $blog_details->blog_id, get_site_network_url( $network_id, 'site-info.php' ) );
+						$edit_url     = add_query_arg( 'id', $blog_details->blog_id, get_network_specific_network_url( $network_id, 'site-info.php' ) );
 					?>
 
 					<a target="_blank" href="<?php echo esc_url( $edit_url ); ?>">Edit</a> |

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -55,9 +55,10 @@ function get_redirect_url( string $request_uri ): string {
 /**
  * Determine the current network and site.
  *
- * This is needed to achieve the `events.wordpress.org/{year}/{event-type}{city}` URL structure.
- *
- * This also supports the `campus.wordpress.org/{city}` URL structure.
+ * This is needed to achieve the various URL structures we use, including:
+ *  - `events.wordpress.org/{city}/{year}/{event-type}`
+ *  - `events.wordpress.org/campusconnect/{year}/{city}`
+ *  - `campus.wordpress.org/{city}`
  *
  * @see https://paulund.co.uk/wordpress-multisite-with-nested-folder-paths
  *

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -97,7 +97,6 @@ function set_network_and_site() {
 		if ( ! $current_blog ) {
 			$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
 		}
-
 	} else {
 		$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
 	}

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -5,7 +5,7 @@ use WP_Network, WP_Site;
 use function WordCamp\Sunrise\{ get_top_level_domain };
 
 defined( 'WPINC' ) || die();
-use const WordCamp\Sunrise\PATTERN_CITY_YEAR_TYPE_PATH;
+use const WordCamp\Sunrise\{ PATTERN_CITY_YEAR_TYPE_PATH, PATTERN_CITY_PATH };
 
 main();
 
@@ -57,6 +57,8 @@ function get_redirect_url( string $request_uri ): string {
  *
  * This is needed to achieve the `events.wordpress.org/{year}/{event-type}{city}` URL structure.
  *
+ * This also supports the `campus.wordpress.org/{city}` URL structure.
+ *
  * @see https://paulund.co.uk/wordpress-multisite-with-nested-folder-paths
  *
  * phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- WP is designed in a way that requires this.
@@ -78,6 +80,15 @@ function set_network_and_site() {
 		list( $path ) = explode( '?', $path );
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 3 );
+
+	} elseif ( 1 === preg_match( PATTERN_CITY_PATH, $path ) ) {
+		if ( is_admin() ) {
+			$path = preg_replace( '#(.*)/wp-admin/.*#', '$1/', $path );
+		}
+
+		list( $path ) = explode( '?', $path );
+
+		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
 
 	} else {
 		$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -69,7 +69,7 @@ function set_network_and_site() {
 	global $current_site, $current_blog, $blog_id, $site_id, $domain, $path, $public;
 
 	// Originally WP referred to networks as "sites" and sites as "blogs".
-	$current_site = WP_Network::get_instance( EVENTS_NETWORK_ID );
+	$current_site = WP_Network::get_instance( SITE_ID_CURRENT_SITE );
 	$site_id      = $current_site->id;
 	$path         = stripslashes( $_SERVER['REQUEST_URI'] );
 
@@ -82,7 +82,10 @@ function set_network_and_site() {
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 3 );
 
-	} elseif ( 1 === preg_match( PATTERN_CITY_PATH, $path ) ) {
+	} elseif (
+		CAMPUS_NETWORK_ID === $site_id &&
+		1 === preg_match( PATTERN_CITY_PATH, $path )
+	) {
 		if ( is_admin() ) {
 			$path = preg_replace( '#(.*)/wp-admin/.*#', '$1/', $path );
 		}
@@ -90,6 +93,10 @@ function set_network_and_site() {
 		list( $path ) = explode( '?', $path );
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
+
+		if ( ! $current_blog ) {
+			$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
+		}
 
 	} else {
 		$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -98,7 +98,6 @@ function set_network_and_site() {
 			header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
 			exit;
 		}
-
 	} elseif ( CAMPUS_NETWORK_ID === $site_id ) {
 		// If the request doesn't match a site, redirect to the campus connect page.
 		header( 'Location: ' . NOBLOGREDIRECT, true, 302 );

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -58,7 +58,7 @@ function get_redirect_url( string $request_uri ): string {
  * This is needed to achieve the various URL structures we use, including:
  *  - `events.wordpress.org/{city}/{year}/{event-type}`
  *  - `events.wordpress.org/campusconnect/{year}/{city}`
- *  - `campus.wordpress.org/{city}`
+ *  - `campus.wordpress.org/{university-city}`
  *
  * @see https://paulund.co.uk/wordpress-multisite-with-nested-folder-paths
  *
@@ -93,10 +93,17 @@ function set_network_and_site() {
 		list( $path ) = explode( '?', $path );
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
-
 		if ( ! $current_blog ) {
-			$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
+			// If the request doesn't match a site, redirect to the campus connect page.
+			header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
+			exit;
 		}
+
+	} elseif ( CAMPUS_NETWORK_ID === $site_id ) {
+		// If the request doesn't match a site, redirect to the campus connect page.
+		header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
+		exit;
+
 	} else {
 		$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
 	}

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -88,6 +88,8 @@ const PATTERN_CITY_PATH = '
  */
 function load_network_sunrise() {
 	switch ( SITE_ID_CURRENT_SITE ) {
+		case CAMPUS_NETWORK_ID:
+			// Intentional Fall through. Load Events plugins for now.
 		case EVENTS_NETWORK_ID:
 			require __DIR__ . '/sunrise-events.php';
 			break;
@@ -106,6 +108,46 @@ function load_network_sunrise() {
  */
 function get_top_level_domain() {
 	return 'local' === WORDCAMP_ENVIRONMENT ? 'test' : 'org';
+}
+
+/**
+ * Get the Network ID for a given domain.
+ *
+ * @param string $domain The domain to check.
+ * @return int The Network ID.
+ */
+function get_domain_network_id( string $domain ): int {
+	$tld = get_top_level_domain();
+
+	switch( $domain ) {
+		case "campus.wordpress.{$tld}":
+			return CAMPUS_NETWORK_ID;
+
+		case "events.wordpress.{$tld}":
+			return EVENTS_NETWORK_ID;
+
+		default:
+			return WORDCAMP_NETWORK_ID;
+	}
+}
+
+/**
+ * Get the Network Admin URL for a given network + path.
+ */
+function get_site_network_url( int $network_id, string $path ): string {
+	$tld = get_top_level_domain();
+	$url = network_admin_url( $path );
+
+	$hostname = "wordcamp.$tld";
+	if ( $network_id === CAMPUS_NETWORK_ID ) {
+		$hostname = "campus.wordpress.$tld";
+	} elseif ( $network_id === EVENTS_NETWORK_ID ) {
+		$hostname = "events.wordpress.$tld";
+	}
+
+	$url = preg_replace( '^https?://[^/]+', "https://{$hostname}", $url );
+
+	return $url;
 }
 
 

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -131,24 +131,4 @@ function get_domain_network_id( string $domain ): int {
 	}
 }
 
-/**
- * Get the Network Admin URL for a given network + path.
- */
-function get_site_network_url( int $network_id, string $path ): string {
-	$tld = get_top_level_domain();
-	$url = network_admin_url( $path );
-
-	$hostname = "wordcamp.$tld";
-	if ( $network_id === CAMPUS_NETWORK_ID ) {
-		$hostname = "campus.wordpress.$tld";
-	} elseif ( $network_id === EVENTS_NETWORK_ID ) {
-		$hostname = "events.wordpress.$tld";
-	}
-
-	$url = preg_replace( '^https?://[^/]+', "https://{$hostname}", $url );
-
-	return $url;
-}
-
-
 load_network_sunrise();

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -70,6 +70,19 @@ const PATTERN_CITY_YEAR_TYPE_PATH = '
 	@ix
 ';
 
+/*
+ * Matches a URL path like '/vancouver/`.
+ *
+ * These are used by the `campus.wordpress.org` network.
+ */
+const PATTERN_CITY_PATH = '
+	@ ^
+	/
+	( [\w-]+ )    # Capture the city.
+	/?
+	@ix
+';
+
 /**
  * Load the sunrise file for the current network.
  */

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -119,7 +119,7 @@ function get_top_level_domain() {
 function get_domain_network_id( string $domain ): int {
 	$tld = get_top_level_domain();
 
-	switch( $domain ) {
+	switch ( $domain ) {
 		case "campus.wordpress.{$tld}":
 			return CAMPUS_NETWORK_ID;
 


### PR DESCRIPTION
This URL structure is designed to be for a private network of campusconnect sites.

~For now, it's within the `events.wordpress.org` Multisite network, but might be shifted into it's own network ID later on.~

It's given it's own network for plugin loading functionalities, but is currently loading the events sunrise/plugins.

See #1490 