### PR TITLE
Organizer Survey / Speaker Feedback: Limit actions to the current network

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-survey/wordcamp-organizer-survey.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-survey/wordcamp-organizer-survey.php
@@ -112,8 +112,10 @@ function get_site_ids() {
 			FROM $wpdb->blogs AS b
 			LEFT OUTER JOIN $wpdb->blogmeta AS m
 			ON b.blog_id = m.blog_id AND m.meta_value = %s
+   			WHERE b.site_id = %d
 			",
-			get_feature_id()
+			get_feature_id(),
+			get_current_network_id()
 		)
 	);
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -282,8 +282,7 @@ function get_site_ids_without_skip_flag() {
 
 	$blog_ids = $wpdb->get_col(
 		$wpdb->prepare(
-			"
-			SELECT b.blog_id
+			"SELECT b.blog_id
 			FROM $wpdb->blogs AS b
 			LEFT OUTER JOIN $wpdb->blogmeta AS m
 			ON b.blog_id = m.blog_id AND m.meta_key = 'wordcamp_skip_feature' AND m.meta_value = 'speaker_feedback'

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/wordcamp-speaker-feedback.php
@@ -280,13 +280,17 @@ function get_assets_url() {
 function get_site_ids_without_skip_flag() {
 	global $wpdb;
 
-	$blog_ids = $wpdb->get_col( "
-		SELECT b.blog_id
-		FROM $wpdb->blogs AS b
-		LEFT OUTER JOIN $wpdb->blogmeta AS m
-		ON b.blog_id = m.blog_id AND m.meta_key = 'wordcamp_skip_feature' AND m.meta_value = 'speaker_feedback'
-		WHERE m.meta_value IS NULL
-	" );
+	$blog_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"
+			SELECT b.blog_id
+			FROM $wpdb->blogs AS b
+			LEFT OUTER JOIN $wpdb->blogmeta AS m
+			ON b.blog_id = m.blog_id AND m.meta_key = 'wordcamp_skip_feature' AND m.meta_value = 'speaker_feedback'
+			WHERE b.site_id = %d AND m.meta_value IS NULL",
+			get_current_network_id()
+		)
+	);
 
 	return array_map( 'absint', $blog_ids );
 }


### PR DESCRIPTION
While working on #1490 I may have caused the Organizer Debrief / Speaker Feedback routines to run, which was not expected nor intended. I'm not sure if it actually processed anything, but regardless, these two plugins shouldn't attempt to operate on sites outside of their network when they're activated/deactivated network wide.