### PR TITLE
Restore site creation sponsor region warning

### DIFF
--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -9,7 +9,7 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 	 * Initialize
 	 */
 	self.initialize = function() {
-		var createSiteCheckbox = $( '#wcpt_create-site-in-network' ),
+		var createSiteCheckboxes = $( '.create-site-checkbox' ),
 			$mentorUserName = $( '#wcpt_mentor_wordpress_org_user_name' ),
 			hasContributor = $( '#wcpt_contributor_day' ),
 			$virtualEventCheckbox = $( '#wcpt_virtual_event_only' ),
@@ -18,8 +18,8 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 			$secondarySiteWrap = $( 'input[name*="wcpt_secondary_site"]' ).parent();
 
 		// Sponsor region
-		createSiteCheckbox.change( self.toggleSponsorRegionRequired );
-		createSiteCheckbox.trigger( 'change' );
+		createSiteCheckboxes.change( self.toggleSponsorRegionRequired );
+		createSiteCheckboxes.trigger( 'change' );
 
 		// Contributor day info
 		hasContributor.change( self.toggleContributorInfo );

--- a/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
+++ b/public_html/wp-content/plugins/wcpt/javascript/wcpt-wordcamp/admin.js
@@ -101,7 +101,7 @@ window.wordCampPostType.WcptWordCamp = ( function( $ ) {
 	self.toggleSponsorRegionRequired = function( event ) {
 		var sponsorRegion = $( '#wcpt_multi-event_sponsor_region' );
 
-		if ( $( this ).is( ':checked' ) ) {
+		if ( $( '.create-site-checkbox:checked' ) ) {
 			sponsorRegion.prop( 'required', true );
 		} else {
 			sponsorRegion.prop( 'required', false );

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -135,7 +135,7 @@ class WordCamp_New_Site {
 			<?php $checkbox_id = wcpt_key_to_str( 'create-site-in-network-' . $object_name, 'wcpt_' ); ?>
 
 			<label for="<?php echo esc_attr( $checkbox_id ); ?>">
-				<input id="<?php echo esc_attr( $checkbox_id ); ?>" type="checkbox" name="<?php echo esc_attr( $checkbox_id ); ?>" />
+				<input id="<?php echo esc_attr( $checkbox_id ); ?>" class="create-site-checkbox" type="checkbox" name="<?php echo esc_attr( $checkbox_id ); ?>" />
 				Create site in network
 			</label>
 		<?php endif; // Domain exists. ?>


### PR DESCRIPTION
As part of #1488 the ID changed for the checkbox, as there can now be multiple 'create site' checkboxes.

When this code isn't run, a site may be requested to be created, but no error is shown, even though without a sponsor region the site creation failed to process.

This restores that.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
