### PR TITLE
Blocks: Bring back display settings for custom post type blocks

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/variations/organizers-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/organizers-list/index.js
@@ -60,6 +60,6 @@ registerBlockVariation( 'core/query', {
 		],
 		[ 'core/query-pagination' ],
 	],
-	allowedControls: [ 'inherit', 'order', 'taxQuery', 'search' ],
+	allowedControls: [ 'inherit', 'order', 'taxQuery', 'search', 'postCount', 'offset', 'pages' ],
 	scope: [ 'inserter' ],
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sessions-list/index.js
@@ -70,7 +70,7 @@ registerBlockVariation( 'core/query', {
 		[ 'core/query-pagination' ],
 	],
 	// Omit `order` in favor of our custom OrderControl.
-	allowedControls: [ 'inherit', 'taxQuery', 'search' ],
+	allowedControls: [ 'inherit', 'taxQuery', 'search', 'postCount', 'offset', 'pages' ],
 	scope: [ 'inserter' ],
 } );
 

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/speakers-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/speakers-list/index.js
@@ -53,6 +53,6 @@ registerBlockVariation( 'core/query', {
 		],
 		[ 'core/query-pagination' ],
 	],
-	allowedControls: [ 'inherit', 'order', 'taxQuery', 'search' ],
+	allowedControls: [ 'inherit', 'order', 'taxQuery', 'search', 'postCount', 'offset', 'pages' ],
 	scope: [ 'inserter' ],
 } );

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/sponsors-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/sponsors-list/index.js
@@ -46,6 +46,6 @@ registerBlockVariation( 'core/query', {
 		],
 		[ 'core/query-pagination' ],
 	],
-	allowedControls: [ 'inherit', 'order', 'taxQuery', 'search' ],
+	allowedControls: [ 'inherit', 'order', 'taxQuery', 'search', 'postCount', 'offset', 'pages' ],
 	scope: [ 'inserter' ],
 } );


### PR DESCRIPTION
As of Gutenberg 19.0, the pagination settings for the Query block were moved from always-visible in the toolbar, to controlled by the variation in the inspector. Since we set `allowedControls` on the blocks to filter out post type controls on our CPT blocks, this also had the effect of preventing these settings. This PR brings them back to the sidebar by 

Fixes #1388
Props ryelle, limecanvas.

### Screenshots

| Before | After |
|---|---|
| ![display-before](https://github.com/user-attachments/assets/821df265-0d7e-466a-9673-08f9bba2d023) | ![display-after](https://github.com/user-attachments/assets/8478c85c-204d-411f-ba16-11561c0ce0ac) |

### How to test the changes in this Pull Request:

1. Build the blocks  `yarn workspace wordcamp-blocks run build`
2. Add any post type loop to a page: Organizers List, Sessions List, Speakers List, Sponsors List
3. See that it's limited to 10 items
4. You can now change that - show more than 10, offset some number, etc

