### PR TITLE
Post Types: Fix term conflict on "teams" for Organizers, Volunteers

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1763,44 +1763,20 @@ class WordCamp_Post_Types_Plugin {
 			'wcb_organizer_team',
 			'wcb_organizer',
 			array(
-				'labels'       => $labels,
-				'rewrite'      => array( 'slug' => 'team' ),
-				'query_var'    => 'team',
-				'hierarchical' => true,
-				'public'       => true,
-				'show_ui'      => true,
-				'show_in_rest' => true,
-				'rest_base'    => 'organizer_team',
+				'labels'            => $labels,
+				'rewrite'           => array( 'slug' => 'team' ),
+				'query_var'         => 'team',
+				'hierarchical'      => true,
+				'public'            => true,
+				'show_ui'           => true,
+				'show_in_rest'      => true,
+				'show_admin_column' => true,
+				'rest_base'         => 'organizer_team',
 			)
 		);
 
-		// Labels for volunteer teams.
-		$labels = array(
-			'name'          => __( 'Teams',         'wordcamporg' ),
-			'singular_name' => __( 'Team',          'wordcamporg' ),
-			'search_items'  => __( 'Search Teams',  'wordcamporg' ),
-			'popular_items' => __( 'Popular Teams', 'wordcamporg' ),
-			'all_items'     => __( 'All Teams',     'wordcamporg' ),
-			'edit_item'     => __( 'Edit Team',     'wordcamporg' ),
-			'update_item'   => __( 'Update Team',   'wordcamporg' ),
-			'add_new_item'  => __( 'Add Team',      'wordcamporg' ),
-			'new_item_name' => __( 'New Team',      'wordcamporg' ),
-		);
-
-		// Register volunteer teams taxonomy.
-		register_taxonomy(
-			'wcb_volunteer_team',
-			'wcb_volunteer',
-			array(
-				'labels'       => $labels,
-				'rewrite'      => array( 'slug' => 'team' ),
-				'query_var'    => 'team',
-				'hierarchical' => true,
-				'public'       => true,
-				'show_ui'      => true,
-				'show_in_rest' => true,
-			)
-		);
+		// Register organizer teams on Volunteers too.
+		register_taxonomy_for_object_type( 'wcb_organizer_team', 'wcb_volunteer' );
 
 		// Labels for speaker groups.
 		$labels = array(

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1775,8 +1775,34 @@ class WordCamp_Post_Types_Plugin {
 			)
 		);
 
-		// Register organizer teams on Volunteers too.
-		register_taxonomy_for_object_type( 'wcb_organizer_team', 'wcb_volunteer' );
+		// Labels for volunteer teams.
+		$labels = array(
+			'name'          => __( 'Teams',         'wordcamporg' ),
+			'singular_name' => __( 'Team',          'wordcamporg' ),
+			'search_items'  => __( 'Search Teams',  'wordcamporg' ),
+			'popular_items' => __( 'Popular Teams', 'wordcamporg' ),
+			'all_items'     => __( 'All Teams',     'wordcamporg' ),
+			'edit_item'     => __( 'Edit Team',     'wordcamporg' ),
+			'update_item'   => __( 'Update Team',   'wordcamporg' ),
+			'add_new_item'  => __( 'Add Team',      'wordcamporg' ),
+			'new_item_name' => __( 'New Team',      'wordcamporg' ),
+		);
+
+		// Register volunteer teams taxonomy.
+		register_taxonomy(
+			'wcb_volunteer_team',
+			'wcb_volunteer',
+			array(
+				'labels'            => $labels,
+				'rewrite'           => array( 'slug' => 'volunteer_team' ),
+				'query_var'         => 'volunteer_team',
+				'hierarchical'      => true,
+				'public'            => true,
+				'show_ui'           => true,
+				'show_in_rest'      => true,
+				'show_admin_column' => true,
+			)
+		);
 
 		// Labels for speaker groups.
 		$labels = array(


### PR DESCRIPTION
Currently, the "team" taxonomy is broken on Organizers. For example, we have organizers published on the "Programming" team, but https://us.wordcamp.org/2025/team/programming/ does not work. The same is true if you [try to view in wp-admin](https://us.wordcamp.org/2025/wp-admin/edit.php?team=programming&post_type=wcb_organizer). The issue is that both `wcb_organizer_team` and `wcb_volunteer_team` use the same `query_var=team`, so it's trying to find a volunteer term for "programming" and an organizer term for "programming" and a post with both… which is nothing.

To fix this, I first thought to combine the teams into one taxonomy, but Volunteers & Organizers are split up differently (volunteers might be room monitors, reg desk, etc, while organizers are on programming, web, sponsors…). This also has the benefit of not removing any existing content, because the taxonomy names stay the same. Now Volunteer teams will be `volunteer_team=whatever` and Organizers can stay with `team=whatever`.

Props ryelle

### Screenshots

I also added the team to the CPT list table, so it's easy to see who's on what team.

<img width="742" alt="Screenshot 2025-06-19 at 12 00 16 PM" src="https://github.com/user-attachments/assets/0198a763-1f2b-4b95-b13b-413231f7bf35" />

### How to test the changes in this Pull Request:

1. Set up some organizers, volunteers, and teams for each
2. You should see the team on the CPT list table for the Organizer or Volunteer
3. You can filter by team in wp-admin
4. The URLs for team archives should work
