### PR TITLE
Config: Add the missing "CAMPUS_NETWORK_ID" to prevent PHP warning on docker

### DIFF
--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -42,7 +42,7 @@ const WORDCAMP_NETWORK_ID   = 1;
 const WORDCAMP_ROOT_BLOG_ID = 5;
 const EVENTS_NETWORK_ID     = 2;
 const EVENTS_ROOT_BLOG_ID   = 47;
-const CAMPUS_NETWORK_ID     = 9999;
+const CAMPUS_NETWORK_ID     = 3;
 
 switch ( strtolower( $_SERVER['HTTP_HOST'] ) ) {
 	case 'events.wordpress.test':

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -42,6 +42,7 @@ const WORDCAMP_NETWORK_ID   = 1;
 const WORDCAMP_ROOT_BLOG_ID = 5;
 const EVENTS_NETWORK_ID     = 2;
 const EVENTS_ROOT_BLOG_ID   = 47;
+const CAMPUS_NETWORK_ID     = 9999;
 
 switch ( strtolower( $_SERVER['HTTP_HOST'] ) ) {
 	case 'events.wordpress.test':


### PR DESCRIPTION
On the production branch, it currently throws a warning:

> Warning: Use of undefined constant CAMPUS_NETWORK_ID - assumed 'CAMPUS_NETWORK_ID' (this will throw an Error in a future version of PHP) in /usr/src/public_html/wp-content/sunrise.php on line 91

So I've added the const to `wp-config.php` near the other network consts. 

### How to test the changes in this Pull Request:

1. Spin up the docker env
2. Visit a test site
3. It works, there is no PHP warning

