### PR TITLE
Allow for Events to be hidden from event feeds

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -523,6 +523,15 @@ abstract class Event_Admin {
 					update_post_meta( $post_id, $key, floatval( $values[ $key ] ) );
 					break;
 
+				case 'checkbox-delete-on-unset':
+					// If the checkbox is not set, delete the meta.
+					if ( empty( $values[ $key ] ) || 'on' !== $values[ $key ] ) {
+						delete_post_meta( $post_id, $key );
+					} else {
+						update_post_meta( $post_id, $key, true );
+					}
+					break;
+
 				case 'checkbox':
 					if ( ! empty( $values[ $key ] ) && 'on' == $values[ $key ] ) {
 						update_post_meta( $post_id, $key, true );
@@ -751,7 +760,7 @@ abstract class Event_Admin {
 			?>
 
 			<div class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
-				<?php if ( 'checkbox' == $value ) : ?>
+				<?php if ( 'checkbox' == $value || 'checkbox-delete-on-unset' == $value ) : ?>
 
 					<p>
 						<label>

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -764,6 +764,9 @@ abstract class Event_Admin {
 								<?php echo esc_attr( $readonly ); ?>
 							/>
 						</label>
+						<?php if ( ! empty( $messages[ $key ] ) ) : ?>
+							<span class="description"><?php echo esc_html( $messages[ $key ] ); ?></span>
+						<?php endif; ?>
 					</p>
 
 				<?php else : ?>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -423,14 +423,16 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Global Sponsorship Grant Amount'   => 'number',
 						'Global Sponsorship Grant'          => 'text',
 						'Running money through WPCS PBC'    => 'checkbox',
+						'Transparency Report Received'      => 'checkbox',
+						'Hide from Event Feeds'             => 'checkbox',
 					);
 
 					/*
 					 * The "Transparency Report Received" checkbox can only be checked or unchecked when the current user is admin or super admin.
 					 * See https://github.com/WordPress/wordcamp.org/issues/1280#issuecomment-2058571557.
 					 */
-					if ( current_user_can( 'manage_options' ) ) {
-						$retval['Transparency Report Received'] = 'checkbox';
+					if ( ! current_user_can( 'manage_options' ) ) {
+						unset( $retval['Transparency Report Received'] );
 					}
 
 					break;
@@ -453,14 +455,16 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Global Sponsorship Grant Amount'   => 'number',
 						'Global Sponsorship Grant'          => 'text',
 						'Running money through WPCS PBC'    => 'checkbox',
+						'Transparency Report Received'      => 'checkbox',
+						'Hide from Event Feeds'             => 'checkbox',
 					);
 
 					/*
 					 * The "Transparency Report Received" checkbox can only be checked or unchecked when the current user is admin or super admin.
 					 * See https://github.com/WordPress/wordcamp.org/issues/1280#issuecomment-2058571557.
 					 */
-					if ( current_user_can( 'manage_options' ) ) {
-						$retval['Transparency Report Received'] = 'checkbox';
+					if ( ! current_user_can( 'manage_options' ) ) {
+						unset( $retval['Transparency Report Received'] );
 					}
 
 					$retval = array_merge(
@@ -1258,6 +1262,7 @@ function wcpt_metabox( $meta_keys, $metabox ) {
 		'WordCamp Hashtag'                => 'Should begin with #. Ex. #wcus',
 		'Global Sponsorship Grant Amount' => 'No commas, thousands separators or currency symbols. Ex. 1234.56',
 		'Global Sponsorship Grant'        => 'Deprecated.',
+		'Hide from Event Feeds'           => 'Do not show in the public schedule and dashboard feeds, the site is still publicly accessible.',
 	);
 
 	if ( 'wcpt_venue_info' === $metabox ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -424,7 +424,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Global Sponsorship Grant'          => 'text',
 						'Running money through WPCS PBC'    => 'checkbox',
 						'Transparency Report Received'      => 'checkbox',
-						'Hide from Event Feeds'             => 'checkbox',
+						'Hide from Event Feeds'             => 'checkbox-delete-on-unset',
 					);
 
 					/*
@@ -456,7 +456,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Global Sponsorship Grant'          => 'text',
 						'Running money through WPCS PBC'    => 'checkbox',
 						'Transparency Report Received'      => 'checkbox',
-						'Hide from Event Feeds'             => 'checkbox',
+						'Hide from Event Feeds'             => 'checkbox-delete-on-unset',
 					);
 
 					/*

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -383,6 +383,7 @@ class WordCamp_Loader extends Event_Loader {
 			'Available Rooms',
 			'Website URL',
 			'Exhibition Space Available',
+			'Hide from Event Feeds',
 		);
 
 		return array_merge(

--- a/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
+++ b/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
@@ -66,8 +66,7 @@ class WordCamp_API_ICS {
 				),
 				array(
 					'key'        => 'Hide from Event Feeds',
-					'compare'    => '!=',
-					'value'      => '1',
+					'compare'    => 'NOT EXISTS',
 				),
 			)
 		) );

--- a/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
+++ b/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
@@ -58,11 +58,18 @@ class WordCamp_API_ICS {
 			'meta_key'       => 'Start Date (YYYY-mm-dd)',
 			'orderby'        => 'meta_value',
 			'order'          => 'ASC',
-			'meta_query'     => array( array(
-				'key'        => 'Start Date (YYYY-mm-dd)',
-				'value'      => strtotime( '-15 days' ),
-				'compare'    => '>'
-			) )
+			'meta_query'     => array(
+				array(
+					'key'        => 'Start Date (YYYY-mm-dd)',
+					'value'      => strtotime( '-15 days' ),
+					'compare'    => '>',
+				),
+				array(
+					'key'        => 'Hide from Event Feeds',
+					'compare'    => '!=',
+					'value'      => '1',
+				),
+			)
 		) );
 
 		while ( $query->have_posts() ) {

--- a/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
+++ b/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
@@ -68,7 +68,7 @@ class WordCamp_API_ICS {
 					'key'        => 'Hide from Event Feeds',
 					'compare'    => 'NOT EXISTS',
 				),
-			)
+			),
 		) );
 
 		while ( $query->have_posts() ) {

--- a/public_html/wp-content/themes/wordcamp-central-2012/sidebar-schedule.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/sidebar-schedule.php
@@ -17,11 +17,18 @@
 					'meta_key'       => 'Start Date (YYYY-mm-dd)',
 					'orderby'        => 'meta_value',
 					'order'          => 'ASC',
-					'meta_query'     => array( array(
-						'key'        => 'Start Date (YYYY-mm-dd)',
-						'value'      => 1,
-						'compare'    => '>' // Only with dates
-					) )
+					'meta_query'     => array(
+						array(
+							'key'        => 'Start Date (YYYY-mm-dd)',
+							'value'      => 1,
+							'compare'    => '>', // Only with dates
+						),
+						'relation' => 'AND',
+						array(
+							'key'     => 'Hide from Event Feeds',
+							'compare' => 'NOT EXISTS',
+						),
+					),
 				);
 			?>
 

--- a/public_html/wp-content/themes/wordcamp-central-2012/sidebar-schedule.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/sidebar-schedule.php
@@ -21,7 +21,7 @@
 						array(
 							'key'        => 'Start Date (YYYY-mm-dd)',
 							'value'      => 1,
-							'compare'    => '>', // Only with dates
+							'compare'    => '>', // Only with dates.
 						),
 						'relation' => 'AND',
 						array(

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
@@ -35,11 +35,18 @@ get_header(); ?>
 							'meta_key'       => 'Start Date (YYYY-mm-dd)',
 							'orderby'        => 'meta_value',
 							'order'          => 'DESC',
-							'meta_query'     => array( array(
-								'key'        => 'Start Date (YYYY-mm-dd)',
-								'value'      => strtotime( '-2 days' ),
-								'compare'    => '<'
-							) )
+							'meta_query'     => array(
+								array(
+									'key'        => 'Start Date (YYYY-mm-dd)',
+									'value'      => strtotime( '-2 days' ),
+									'compare'    => '<'
+								),
+								'relation' => 'AND',
+								array(
+									'key'     => 'Hide from Event Feeds',
+									'compare' => 'NOT EXISTS',
+								),
+							)
 						) )
 					) :
 						global $wcpt_template;

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
@@ -39,14 +39,14 @@ get_header(); ?>
 								array(
 									'key'        => 'Start Date (YYYY-mm-dd)',
 									'value'      => strtotime( '-2 days' ),
-									'compare'    => '<'
+									'compare'    => '<',
 								),
 								'relation' => 'AND',
 								array(
 									'key'     => 'Hide from Event Feeds',
 									'compare' => 'NOT EXISTS',
 								),
-							)
+							),
 						) )
 					) :
 						global $wcpt_template;

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
@@ -31,16 +31,23 @@ get_header(); ?>
 							'orderby'        => 'meta_value',
 							'order'          => 'ASC',
 							'meta_query'     => array(
-								'relation' => 'OR',
 								array(
-									'key'     => 'Start Date (YYYY-mm-dd)',
-									'value'   => strtotime( '-2 days' ),
-									'compare' => '>',
+									'relation' => 'OR',
+									array(
+										'key'     => 'Start Date (YYYY-mm-dd)',
+										'value'   => strtotime( '-2 days' ),
+										'compare' => '>',
+									),
+									array(
+										'key'     => 'End Date (YYYY-mm-dd)',
+										'value'   => strtotime( 'today' ),
+										'compare' => '>',
+									),
 								),
+								'relation' => 'AND',
 								array(
-									'key'     => 'End Date (YYYY-mm-dd)',
-									'value'   => strtotime( 'today' ),
-									'compare' => '>',
+									'key'     => 'Hide from Event Feeds',
+									'compare' => 'NOT EXISTS',
 								),
 							)
 						) )


### PR DESCRIPTION
There are sometimes a need to have an event scheduled, but excluded from being displayed in the list of upcoming events.

This implements a checkbox that allows hiding the event from the Schedule and ICS feed.

A change to the events plugin that runs the dashboard feed is included below.