### PR TITLE
Sort the Past Events by date DESC rather than ASC.

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
@@ -20,6 +20,10 @@
 		"limit": {
 			"type": "number",
 			"default": 100
+		},
+		"order": {
+			"enum": [ "asc", "desc" ],
+			"default": "asc"
 		}
 	},
 	"supports": {

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -45,18 +45,26 @@ function render( $attributes, $content, $block ) {
 	$events = Google_Map\get_events( $attributes['events'], 0, 0, $facets );
 
 	// Get all the filters that are currently applied.
-	$filtered_events = array_slice( filter_events( $events ), 0, (int) $attributes['limit'] );
-
-	// The results are not guaranteed to be in order, so sort them.
-	usort( $filtered_events,
-		function ( $a, $b ) {
-			return $a->timestamp - $b->timestamp;
-		}
-	);
+	$filtered_events = filter_events( $events );
 
 	if ( count( $filtered_events ) < 1 ) {
 		return get_no_result_view();
 	}
+
+	// The results are not guaranteed to be in order, so sort them.
+	$order = strtoupper( $attributes['order'] ?? 'ASC' );
+	usort( $filtered_events,
+		function ( $a, $b ) use( $order ) {
+			if ( 'ASC' === $order ) {
+				return $a->timestamp - $b->timestamp;
+			} else {
+				return $b->timestamp - $a->timestamp;
+			}
+		}
+	);
+
+	// Limit the length of the results, as requested.
+	$filtered_events = array_slice( $filtered_events, 0, (int) $attributes['limit'] );
 
 	// Prune to only the used properties, to reduce the size of the payload.
 	$filtered_events = array_map(

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
@@ -12,7 +12,7 @@
 		<!-- /wp:group -->
 
 		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters-with-count"} /-->
-		<!-- wp:wporg/event-list {"events":"all-past","groupByMonth":"true","limit":"500"} /-->
+		<!-- wp:wporg/event-list {"events":"all-past","groupByMonth":"true","limit":"500","order":"desc"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>

--- a/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
+++ b/public_html/wp-content/themes/wporg-events-2023/templates/page-past-events.html
@@ -11,7 +11,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters-with-count"} /-->
+		<!-- wp:pattern {"slug":"wporg-events-2023/event-list-filters"} /-->
 		<!-- wp:wporg/event-list {"events":"all-past","groupByMonth":"true","limit":"500","order":"desc"} /-->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
When viewing https://events.wordpress.org/past-events/filtered/country/AU/ the events should be sorted from most recent to oldest.

This differs from https://events.wordpress.org/upcoming-events/ which should list the events from soonest to furthest in the future.


### Screenshots

| Before | After
| --- | --- |
| <img width="1468" alt="Screenshot 2025-06-26 at 10 22 24 am" src="https://github.com/user-attachments/assets/c7abb8c0-a430-4a67-8a0e-f1186e02e91d" /> | <img width="1459" alt="Screenshot 2025-06-26 at 10 22 05 am" src="https://github.com/user-attachments/assets/db0f2e0e-c6f4-4700-8308-c8c00c709ec9" /> |

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
