### PR TITLE
Payments: Provide proper context to _nx_noop() for post statii

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -83,7 +83,7 @@ class WCP_Payment_Request {
 			'paid',
 			array(
 				'label'              => esc_html_x( 'Paid', 'post', 'wordcamporg' ),
-				'label_count'        => _nx_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'wordcamporg' ),
+				'label_count'        => _n_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'wordcamporg' ),
 				'public'             => true,
 				'publicly_queryable' => false,
 			)
@@ -93,7 +93,7 @@ class WCP_Payment_Request {
 			'unpaid',
 			array(
 				'label'              => esc_html_x( 'Unpaid', 'post', 'wordcamporg' ),
-				'label_count'        => _nx_noop( 'Unpaid <span class="count">(%s)</span>', 'Unpaid <span class="count">(%s)</span>', 'wordcamporg' ),
+				'label_count'        => _n_noop( 'Unpaid <span class="count">(%s)</span>', 'Unpaid <span class="count">(%s)</span>', 'wordcamporg' ),
 				'public'             => true,
 				'publicly_queryable' => false,
 			)
@@ -103,7 +103,7 @@ class WCP_Payment_Request {
 			'incomplete',
 			array(
 				'label'              => esc_html_x( 'Incomplete', 'post', 'wordcamporg' ),
-				'label_count'        => _nx_noop( 'Incomplete <span class="count">(%s)</span>', 'Incomplete <span class="count">(%s)</span>', 'wordcamporg' ),
+				'label_count'        => _n_noop( 'Incomplete <span class="count">(%s)</span>', 'Incomplete <span class="count">(%s)</span>', 'wordcamporg' ),
 				'public'             => true,
 				'publicly_queryable' => false,
 			)

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -83,7 +83,7 @@ class WCP_Payment_Request {
 			'paid',
 			array(
 				'label'              => esc_html_x( 'Paid', 'post', 'wordcamporg' ),
-				'label_count'        => _n_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'wordcamporg' ),
+				'label_count'        => _nx_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 				'public'             => true,
 				'publicly_queryable' => false,
 			)
@@ -93,7 +93,7 @@ class WCP_Payment_Request {
 			'unpaid',
 			array(
 				'label'              => esc_html_x( 'Unpaid', 'post', 'wordcamporg' ),
-				'label_count'        => _n_noop( 'Unpaid <span class="count">(%s)</span>', 'Unpaid <span class="count">(%s)</span>', 'wordcamporg' ),
+				'label_count'        => _nx_noop( 'Unpaid <span class="count">(%s)</span>', 'Unpaid <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 				'public'             => true,
 				'publicly_queryable' => false,
 			)
@@ -103,7 +103,7 @@ class WCP_Payment_Request {
 			'incomplete',
 			array(
 				'label'              => esc_html_x( 'Incomplete', 'post', 'wordcamporg' ),
-				'label_count'        => _n_noop( 'Incomplete <span class="count">(%s)</span>', 'Incomplete <span class="count">(%s)</span>', 'wordcamporg' ),
+				'label_count'        => _nx_noop( 'Incomplete <span class="count">(%s)</span>', 'Incomplete <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 				'public'             => true,
 				'publicly_queryable' => false,
 			)

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -98,7 +98,7 @@ function register_post_statuses() {
 		'wcbrr_submitted',
 		array(
 			'label'              => esc_html_x( 'Submitted', 'post', 'wordcamporg' ),
-			'label_count'        => _n_noop( 'Submitted <span class="count">(%s)</span>', 'Submitted <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _nx_noop( 'Submitted <span class="count">(%s)</span>', 'Submitted <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -108,7 +108,7 @@ function register_post_statuses() {
 		'wcbrr_info_requested',
 		array(
 			'label'              => esc_html_x( 'Information Requested', 'post', 'wordcamporg' ),
-			'label_count'        => _n_noop( 'Information Requested <span class="count">(%s)</span>', 'Information Requested <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _nx_noop( 'Information Requested <span class="count">(%s)</span>', 'Information Requested <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -118,7 +118,7 @@ function register_post_statuses() {
 		'wcbrr_rejected',
 		array(
 			'label'              => esc_html_x( 'Rejected', 'post', 'wordcamporg' ),
-			'label_count'        => _n_noop( 'Rejected <span class="count">(%s)</span>', 'Rejected <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _nx_noop( 'Rejected <span class="count">(%s)</span>', 'Rejected <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -128,7 +128,7 @@ function register_post_statuses() {
 		'wcbrr_in_process',
 		array(
 			'label'              => esc_html_x( 'Payment in Process', 'post', 'wordcamporg' ),
-			'label_count'        => _n_noop( 'Payment in Process <span class="count">(%s)</span>', 'Payment in Process <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _nx_noop( 'Payment in Process <span class="count">(%s)</span>', 'Payment in Process <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -138,7 +138,7 @@ function register_post_statuses() {
 		'wcbrr_paid',
 		array(
 			'label'              => esc_html_x( 'Paid', 'post', 'wordcamporg' ),
-			'label_count'        => _n_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _nx_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'post', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -98,7 +98,7 @@ function register_post_statuses() {
 		'wcbrr_submitted',
 		array(
 			'label'              => esc_html_x( 'Submitted', 'post', 'wordcamporg' ),
-			'label_count'        => _nx_noop( 'Submitted <span class="count">(%s)</span>', 'Submitted <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _n_noop( 'Submitted <span class="count">(%s)</span>', 'Submitted <span class="count">(%s)</span>', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -108,7 +108,7 @@ function register_post_statuses() {
 		'wcbrr_info_requested',
 		array(
 			'label'              => esc_html_x( 'Information Requested', 'post', 'wordcamporg' ),
-			'label_count'        => _nx_noop( 'Information Requested <span class="count">(%s)</span>', 'Information Requested <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _n_noop( 'Information Requested <span class="count">(%s)</span>', 'Information Requested <span class="count">(%s)</span>', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -118,7 +118,7 @@ function register_post_statuses() {
 		'wcbrr_rejected',
 		array(
 			'label'              => esc_html_x( 'Rejected', 'post', 'wordcamporg' ),
-			'label_count'        => _nx_noop( 'Rejected <span class="count">(%s)</span>', 'Rejected <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _n_noop( 'Rejected <span class="count">(%s)</span>', 'Rejected <span class="count">(%s)</span>', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -128,7 +128,7 @@ function register_post_statuses() {
 		'wcbrr_in_process',
 		array(
 			'label'              => esc_html_x( 'Payment in Process', 'post', 'wordcamporg' ),
-			'label_count'        => _nx_noop( 'Payment in Process <span class="count">(%s)</span>', 'Payment in Process <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _n_noop( 'Payment in Process <span class="count">(%s)</span>', 'Payment in Process <span class="count">(%s)</span>', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)
@@ -138,7 +138,7 @@ function register_post_statuses() {
 		'wcbrr_paid',
 		array(
 			'label'              => esc_html_x( 'Paid', 'post', 'wordcamporg' ),
-			'label_count'        => _nx_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'wordcamporg' ),
+			'label_count'        => _n_noop( 'Paid <span class="count">(%s)</span>', 'Paid <span class="count">(%s)</span>', 'wordcamporg' ),
 			'public'             => true,
 			'publicly_queryable' => false,
 		)

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -78,11 +78,11 @@ function register_post_type() {
 function get_custom_statuses() {
 	return array(
 		'wcbsi_submitted'     => array(
-			'label'       => esc_html_x( 'Submitted', 'post', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Submitted', 'sponsor invoice status', 'wordcamporg' ),
 			'label_count' => _nx_noop(
 				'Submitted <span class="count">(%s)</span>',
 				'Submitted <span class="count">(%s)</span>',
-				'post',
+				'sponsor invoice status',
 				'wordcamporg'
 			),
 		),
@@ -91,34 +91,34 @@ function get_custom_statuses() {
 			'label_count' => _nx_noop(
 				'Sent <span class="count">(%s)</span>',
 				'Sent <span class="count">(%s)</span>',
-				'post',
+				'sponsor invoice status',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_paid'          => array(
-			'label'       => esc_html_x( 'Paid', 'post', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Paid', 'sponsor invoice status', 'wordcamporg' ),
 			'label_count' => _nx_noop(
 				'Paid <span class="count">(%s)</span>',
 				'Paid <span class="count">(%s)</span>',
-				'post',
+				'sponsor invoice status',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_uncollectible' => array(
-			'label'       => esc_html_x( 'Uncollectible', 'post', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Uncollectible', 'sponsor invoice status', 'wordcamporg' ),
 			'label_count' => _n_noop(
 				'Uncollectible <span class="count">(%s)</span>',
 				'Uncollectible <span class="count">(%s)</span>',
-				'post',
+				'sponsor invoice status',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_refunded'      => array(
-			'label'       => esc_html_x( 'Refunded', 'post', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Refunded', 'sponsor invoice status', 'wordcamporg' ),
 			'label_count' => _n_noop(
 				'Refunded <span class="count">(%s)</span>',
 				'Refunded <span class="count">(%s)</span>',
-				'post',
+				'sponsor invoice status',
 				'wordcamporg'
 			),
 		),

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -78,42 +78,47 @@ function register_post_type() {
 function get_custom_statuses() {
 	return array(
 		'wcbsi_submitted'     => array(
-			'label'       => esc_html__( 'Submitted', 'wordcamporg' ),
-			'label_count' => _n_noop(
+			'label'       => esc_html_x( 'Submitted', 'post', 'wordcamporg' ),
+			'label_count' => _nx_noop(
 				'Submitted <span class="count">(%s)</span>',
 				'Submitted <span class="count">(%s)</span>',
+				'post',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_approved'      => array(
-			'label'       => esc_html__( 'Sent', 'wordcamporg' ),
-			'label_count' => _n_noop(
+			'label'       => esc_html_x( 'Sent', 'wordcamporg' ),
+			'label_count' => _nx_noop(
 				'Sent <span class="count">(%s)</span>',
 				'Sent <span class="count">(%s)</span>',
+				'post',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_paid'          => array(
-			'label'       => esc_html__( 'Paid', 'wordcamporg' ),
-			'label_count' => _n_noop(
+			'label'       => esc_html_x( 'Paid', 'post', 'wordcamporg' ),
+			'label_count' => _nx_noop(
 				'Paid <span class="count">(%s)</span>',
 				'Paid <span class="count">(%s)</span>',
+				'post',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_uncollectible' => array(
-			'label'       => esc_html__( 'Uncollectible', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Uncollectible', 'post', 'wordcamporg' ),
 			'label_count' => _n_noop(
 				'Uncollectible <span class="count">(%s)</span>',
 				'Uncollectible <span class="count">(%s)</span>',
+				'post',
 				'wordcamporg'
 			),
 		),
 		'wcbsi_refunded'      => array(
-			'label'       => esc_html__( 'Refunded', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Refunded', 'post', 'wordcamporg' ),
 			'label_count' => _n_noop(
 				'Refunded <span class="count">(%s)</span>',
 				'Refunded <span class="count">(%s)</span>',
+				'post',
 				'wordcamporg'
 			),
 		),

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -106,7 +106,7 @@ function get_custom_statuses() {
 		),
 		'wcbsi_uncollectible' => array(
 			'label'       => esc_html_x( 'Uncollectible', 'sponsor invoice status', 'wordcamporg' ),
-			'label_count' => _n_noop(
+			'label_count' => _nx_noop(
 				'Uncollectible <span class="count">(%s)</span>',
 				'Uncollectible <span class="count">(%s)</span>',
 				'sponsor invoice status',
@@ -115,7 +115,7 @@ function get_custom_statuses() {
 		),
 		'wcbsi_refunded'      => array(
 			'label'       => esc_html_x( 'Refunded', 'sponsor invoice status', 'wordcamporg' ),
-			'label_count' => _n_noop(
+			'label_count' => _nx_noop(
 				'Refunded <span class="count">(%s)</span>',
 				'Refunded <span class="count">(%s)</span>',
 				'sponsor invoice status',

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -79,7 +79,7 @@ function get_custom_statuses() {
 	return array(
 		'wcbsi_submitted'     => array(
 			'label'       => esc_html__( 'Submitted', 'wordcamporg' ),
-			'label_count' => _nx_noop(
+			'label_count' => _n_noop(
 				'Submitted <span class="count">(%s)</span>',
 				'Submitted <span class="count">(%s)</span>',
 				'wordcamporg'
@@ -87,7 +87,7 @@ function get_custom_statuses() {
 		),
 		'wcbsi_approved'      => array(
 			'label'       => esc_html__( 'Sent', 'wordcamporg' ),
-			'label_count' => _nx_noop(
+			'label_count' => _n_noop(
 				'Sent <span class="count">(%s)</span>',
 				'Sent <span class="count">(%s)</span>',
 				'wordcamporg'
@@ -95,7 +95,7 @@ function get_custom_statuses() {
 		),
 		'wcbsi_paid'          => array(
 			'label'       => esc_html__( 'Paid', 'wordcamporg' ),
-			'label_count' => _nx_noop(
+			'label_count' => _n_noop(
 				'Paid <span class="count">(%s)</span>',
 				'Paid <span class="count">(%s)</span>',
 				'wordcamporg'
@@ -103,7 +103,7 @@ function get_custom_statuses() {
 		),
 		'wcbsi_uncollectible' => array(
 			'label'       => esc_html__( 'Uncollectible', 'wordcamporg' ),
-			'label_count' => _nx_noop(
+			'label_count' => _n_noop(
 				'Uncollectible <span class="count">(%s)</span>',
 				'Uncollectible <span class="count">(%s)</span>',
 				'wordcamporg'
@@ -111,7 +111,7 @@ function get_custom_statuses() {
 		),
 		'wcbsi_refunded'      => array(
 			'label'       => esc_html__( 'Refunded', 'wordcamporg' ),
-			'label_count' => _nx_noop(
+			'label_count' => _n_noop(
 				'Refunded <span class="count">(%s)</span>',
 				'Refunded <span class="count">(%s)</span>',
 				'wordcamporg'

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -87,7 +87,7 @@ function get_custom_statuses() {
 			),
 		),
 		'wcbsi_approved'      => array(
-			'label'       => esc_html_x( 'Sent', 'wordcamporg' ),
+			'label'       => esc_html_x( 'Sent', 'sponsor invoice status', 'wordcamporg' ),
 			'label_count' => _nx_noop(
 				'Sent <span class="count">(%s)</span>',
 				'Sent <span class="count">(%s)</span>',

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -33,7 +33,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Incomplete', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Incomplete <span class="count">(%s)</span>',
 					'Incomplete <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -47,7 +47,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Pending Approval', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Pending Approval <span class="count">(%s)</span>',
 					'Pending Approval <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -61,7 +61,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Needs Follow-up', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Needs Follow-up <span class="count">(%s)</span>',
 					'Needs Follow-up <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -75,7 +75,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Approved', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Approved <span class="count">(%s)</span>',
 					'Approved <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -89,7 +89,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Payment Sent', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Payment Sent <span class="count">(%s)</span>',
 					'Payment Sent <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -103,7 +103,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Paid', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Paid <span class="count">(%s)</span>',
 					'Paid <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -117,7 +117,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Failed', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Failed <span class="count">(%s)</span>',
 					'Failed <span class="count">(%s)</span>',
 					'wordcamporg'
@@ -131,7 +131,7 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Cancelled', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _nx_noop(
+				'label_count' => _n_noop(
 					'Cancelled <span class="count">(%s)</span>',
 					'Cancelled <span class="count">(%s)</span>',
 					'wordcamporg'

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -47,9 +47,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Pending Approval', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Pending Approval <span class="count">(%s)</span>',
 					'Pending Approval <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)
@@ -61,9 +62,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Needs Follow-up', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Needs Follow-up <span class="count">(%s)</span>',
 					'Needs Follow-up <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)
@@ -75,9 +77,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Approved', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Approved <span class="count">(%s)</span>',
 					'Approved <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)
@@ -89,9 +92,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Payment Sent', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Payment Sent <span class="count">(%s)</span>',
 					'Payment Sent <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)
@@ -103,9 +107,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Paid', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Paid <span class="count">(%s)</span>',
 					'Paid <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)
@@ -117,9 +122,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Failed', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Failed <span class="count">(%s)</span>',
 					'Failed <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)
@@ -131,9 +137,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Cancelled', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Cancelled <span class="count">(%s)</span>',
 					'Cancelled <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -33,9 +33,10 @@ class WordCamp_Budgets {
 				'label'       => esc_html_x( 'Incomplete', 'payment request', 'wordcamporg' ),
 				'public'      => false,
 				'protected'   => true,
-				'label_count' => _n_noop(
+				'label_count' => _nx_noop(
 					'Incomplete <span class="count">(%s)</span>',
 					'Incomplete <span class="count">(%s)</span>',
+					'payment request',
 					'wordcamporg'
 				),
 			)


### PR DESCRIPTION
_nx_noop() was being called with the textdomain as the context parameter, and thus was not being translated properly.

This fixes that.