### PR TITLE
Camptix: Add "Purchase Week" to the ticket summary options

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -2399,7 +2399,7 @@ class CampTix_Plugin {
 			'purchase_time' => __( 'Purchase time', 'wordcamporg' ),
 			'purchase_datetime' => __( 'Purchase date and time', 'wordcamporg' ),
 			'purchase_dayofweek' => __( 'Purchase day of week', 'wordcamporg' ),
-            'purchase_week' => __( 'Purchase week', 'wordcamporg' ),
+			'purchase_week' => __( 'Purchase week', 'wordcamporg' ),
 		) );
 	}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -2359,8 +2359,12 @@ class CampTix_Plugin {
 					$date = mysql2date( 'l', $attendee->post_date );
 					$this->increment_summary( $summary, $date );
                 } elseif ( $summarize_by == 'purchase_week' ) {
-					$date = mysql2date( 'W', $attendee->post_date );
-					$this->increment_summary( $summary, $date );
+					$week = mysql2date( 'W', $attendee->post_date );
+					$year = mysql2date( 'Y', $attendee->post_date );
+					$datetime = new \DateTime();
+					$datetime->setISODate( $year, $week );
+					$label = sprintf( "Week $year-$week (starting %s)", $datetime->format('M j Y') );
+					$this->increment_summary( $summary, $label );
 				} elseif ( $summarize_by == 'coupon' ) {
 					$coupon = get_post_meta( $attendee->ID, 'tix_coupon', true );
 					if ( ! $coupon )

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -2358,12 +2358,16 @@ class CampTix_Plugin {
 				} elseif ( $summarize_by == 'purchase_dayofweek' ) {
 					$date = mysql2date( 'l', $attendee->post_date );
 					$this->increment_summary( $summary, $date );
-                } elseif ( $summarize_by == 'purchase_week' ) {
-					$week = mysql2date( 'W', $attendee->post_date );
-					$year = mysql2date( 'Y', $attendee->post_date );
+				} elseif ( $summarize_by == 'purchase_week' ) {
+					$week = (int) mysql2date( 'W', $attendee->post_date );
+					$year = (int) mysql2date( 'Y', $attendee->post_date );
+					$month = (int) mysql2date( 'n', $attendee->post_date );
+					if ( 12 === $month && 1 === $week ) {
+						$year++;
+					}
 					$datetime = new \DateTime();
 					$datetime->setISODate( $year, $week );
-					$label = sprintf( "Week $year-$week (starting %s)", $datetime->format('M j Y') );
+					$label = sprintf( "Week %s-%02d (starting %s)", $year, $week, $datetime->format('M j Y') );
 					$this->increment_summary( $summary, $label );
 				} elseif ( $summarize_by == 'coupon' ) {
 					$coupon = get_post_meta( $attendee->ID, 'tix_coupon', true );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -2358,6 +2358,9 @@ class CampTix_Plugin {
 				} elseif ( $summarize_by == 'purchase_dayofweek' ) {
 					$date = mysql2date( 'l', $attendee->post_date );
 					$this->increment_summary( $summary, $date );
+                } elseif ( $summarize_by == 'purchase_week' ) {
+					$date = mysql2date( 'W', $attendee->post_date );
+					$this->increment_summary( $summary, $date );
 				} elseif ( $summarize_by == 'coupon' ) {
 					$coupon = get_post_meta( $attendee->ID, 'tix_coupon', true );
 					if ( ! $coupon )
@@ -2388,6 +2391,7 @@ class CampTix_Plugin {
 			'purchase_time' => __( 'Purchase time', 'wordcamporg' ),
 			'purchase_datetime' => __( 'Purchase date and time', 'wordcamporg' ),
 			'purchase_dayofweek' => __( 'Purchase day of week', 'wordcamporg' ),
+            'purchase_week' => __( 'Purchase week', 'wordcamporg' ),
 		) );
 	}
 


### PR DESCRIPTION
This adds a new summary option for the ticket purchase data, grouping by "purchase week". Showing purchases by date can be too detailed and hard to see trends when ticket sales are open for more than a few weeks, so showing by week can give data without requiring the organizer to download and graph the dates (which I've definitely done).

The only downside is the column title is just the week number, not very human friendly. I used this to check the weeks: https://www.epochconverter.com/weeks/2025

### Screenshots

<img width="450" alt="" src="https://github.com/user-attachments/assets/0dbd4388-5342-4194-aea9-42f909e0c85e" />

### How to test the changes in this Pull Request:

1. Go to the summarize tab in Tickets > Tools
2. Select "Purchase week" to summarize by
3. Show summary
4. You should see the tickets purchased by week numbers
