### PR TITLE
Profile Activity: Don't send 'attendee registered' profile activity

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
+++ b/public_html/wp-content/plugins/wordcamp-participation-notifier/wordcamp-participation-notifier.php
@@ -307,6 +307,8 @@ class WordCamp_Participation_Notifier {
 	 * @param string  $username
 	 */
 	public function primary_attendee_registered( $attendee, $username ) {
+		return; // TODO: This is not supported by profiles.
+
 		$user_id = $this->get_saved_wporg_user_id( $attendee );
 		$payload = $this->get_post_activity_payload( $attendee, $user_id, 'attendee_registered' );
 
@@ -328,6 +330,8 @@ class WordCamp_Participation_Notifier {
 	 * @param string $username
 	 */
 	public function additional_attendee_confirmed_registration( $attendee_id, $username ) {
+		return; // TODO: This is not supported by profiles.
+
 		$attendee = get_post( $attendee_id );
 		$user_id  = $this->get_saved_wporg_user_id( $attendee );
 		$payload  = $this->get_post_activity_payload( $attendee, $user_id, 'attendee_registered' );


### PR DESCRIPTION
This is not supported by profiles.wordpress.org at present, and causes PHP Warnings to be thrown on both WordCamp and Profiles when this isn't accepted.

This should be implemented, but for now we can skip this.


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #, See #

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
