### PR TITLE
Add note to the github issue templates not to include PII information in issue screenshots

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,6 +27,8 @@ A clear and concise description of what you expected to happen.
 
 Please try to include screenshots or screencasts whenever possible to help people better understand the questions you are describing.
 
+Please ensure that you don't include any private details in your screenshot (Ticket holder names, Email addresses, transaction identifiers, etc). You can blank out any details in your editor prior to uploading it. Names that are public (organisers, public profile names) are OK.
+
 ### WordCamp
 
 If this is a problem on a specific WordCamp's site, list the site or page URL here.

--- a/.github/ISSUE_TEMPLATE/✨-feature-discussion---request---proposal.md
+++ b/.github/ISSUE_TEMPLATE/✨-feature-discussion---request---proposal.md
@@ -26,6 +26,8 @@ What opportunities do you see (rationale), and what do you propose to achieve th
 
 Add screenshots or screencasts to make your description more clear.
 
+Please ensure that you don't include any private details in your screenshot (Ticket holder names, Email addresses, transaction identifiers, etc). You can blank out any details in your editor prior to uploading it. Names that are public (organisers, public profile names) are OK.
+
 ### Stakeholders
 
 Who are the stakeholders stand to benefit from implementing the features outlined in this ticket


### PR DESCRIPTION
Our issue templates ask for screenshots, and when it comes to WordCamps these may be of administration panels.

We should add a note to suggest that no PII should be included, just to prompt submitters to double-check screenshots before posting.

This will save headaches later on if anything is submitted that contains private data.

Wording suggestions welcome.