### PR TITLE
Add the product unit type descriptor.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -871,7 +871,8 @@ class CampTix_Stripe_API_Client {
 				'quantity'     => $item['quantity'],
 				'price_data'   => array(
 					'product_data' => array(
-						'name'        => $item['name'],
+						'name'       => $item['name'],
+						'unit_label' => 'Ticket',
 					),
 					'unit_amount' => $item['fractional_price'],
 					'currency'    => $this->currency,


### PR DESCRIPTION
As prompted by Stripe, we need to add the `unit_label` to the checkout process to ensure that Stripe receipts properly show what is being purchased, to ensure that we continue to receive the most favourable Visa/Mastercard rates.

This field does not appear to be properly documented yet, and I'm not sure what values should be present, so this needs testing.

Reading:
https://support.stripe.com/questions/understand-the-visa-commercial-enhanced-data-program-%28cedp%29?email_id=em_km8f3fl4cbstlcesjsikf63zcnuy2i

This also suggest that we should be sending some additional data such as a `product_code` and `line_item[tax]` which it doesn't appear that we're doing.


| Stripe Notification | |
| --- | --- |
| <img width="413" height="666" alt="Screenshot 2025-09-29 at 9 43 58 am" src="https://github.com/user-attachments/assets/3b70d281-abae-4769-ac46-2cb0f3aad57e" /> |  |