### PR TITLE
Add a Student Club type to the WordCamp tracker.

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1154,6 +1154,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'wordcamp'      => __( 'WordCamp', 'wordcamporg' ),
 				'doaction'      => __( 'DoAction', 'wordcamporg' ),
 				'campusconnect' => __( 'Campus Connect', 'wordcamporg' ),
+				'student-club'  => __( 'Student Club', 'wordcamporg' ),
 				'other'         => __( 'Other Event', 'wordcamporg' ),
 			);
 		}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -54,6 +54,8 @@ class WordCamp_New_Site {
 				$placeholder = 'https://events.wordpress.org/city/' . wp_date( 'Y' ) . '/type/';
 			} elseif ( 'campusconnect' === $event_subtype ) {
 				$placeholder = 'https://events.wordpress.org/campusconnect/' . wp_date( 'Y' ) . '/' . $city . '/';
+			} elseif ( 'student-club' === $event_subtype ) {
+				$placeholder = 'https://campus.wordpress.org/' . $city . '/';
 			}
 		} else {
 			$placeholder = 'https://' . $city . '.wordcamp.org/' . wp_date( 'Y' ) . '-locale/';


### PR DESCRIPTION
Ideally this would be a Meetup subtype, but for now this is a WordCamp subtype due to being hosted on the WordCamp network.

See https://wordpress.slack.com/archives/C08QK4V94AF/p1759460787933679?thread_ts=1758637313.150119&cid=C08QK4V94AF