### PR TITLE
Switch the Camptix sender from 'wordpress@' to 'noreply@'

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -8368,6 +8368,7 @@ class CampTix_Plugin {
 			return;
 		}
 
+		add_filter( 'wp_mail_from', array( $this, 'set_mail_from' ) );
 		add_filter( 'wp_mail_from_name', array( $this, 'set_mail_from_name' ) );
 
 		if ( is_email( get_option( 'admin_email' ) ) ) {
@@ -8380,6 +8381,9 @@ class CampTix_Plugin {
 		remove_action( 'phpmailer_init', array( $this, 'maybe_send_html_email' ) );
 		$log_message = $results ? sprintf( 'Sent e-mail to %s.', $to ) : sprintf( 'E-mail to %s failed to send.', $to );
 		$this->log( $log_message, null, $message_data, 'email' );
+
+		remove_filter( 'wp_mail_from', array( $this, 'set_mail_from' ) );
+		remove_filter( 'wp_mail_from_name', array( $this, 'set_mail_from_name' ) );
 
 		do_action( 'camptix_wp_mail_finish' );
 		return $results;
@@ -8397,6 +8401,18 @@ class CampTix_Plugin {
 	 */
 	public function set_mail_from_name( $name ) {
 		return $this->options['event_name'];
+	}
+
+	/**
+	 * Change the default email sender address from wordpress@ to noreply@.
+	 *
+	 * This is mainly to avoid some rogue spam filters that are overeager.
+	 *
+	 * @param string $email
+	 * @return string
+	 */
+	public function set_mail_from( $email ) {
+		return preg_replace( '/^wordpress@/', 'noreply@', $email );
 	}
 
 	/**


### PR DESCRIPTION
As reported on Slack by @harishankerr gmail marked some WCAsia ticket emails as suspicious:

<img width="2392" height="1115" alt="image" src="https://github.com/user-attachments/assets/aefd35f6-5423-43c6-8235-fee12f670e78" />

Personally I feel that this may have been caused by the wordpress@wordcamp.org email address, which has caused similar problems in the past elsewhere. 
Previous history has also suggest that the PHPMailer X-Sender header may also trigger this situation.

On WordPress.org we've customised this to `noreply@` which is also a much better user-experience, so let's do that for WordCamp as well.

This might have no effect upon the email deliverability (at worst).

This specifically targets `Camptix::wp_mail()` but these should possibly should be migrated to affecting all outgoing emails. Review of all the places that call `wp_mail()` in the codebase should be reviewed first though: https://github.com/search?q=repo%3AWordPress%2Fwordcamp.org%20wp_mail&type=code

_(Note: This has already been deployed to WordCamp manually before this PR was submitted)_