### PR TITLE
Fix access to campus network admin

### DIFF
--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -43,8 +43,18 @@ const WORDCAMP_ROOT_BLOG_ID = 5;
 const EVENTS_NETWORK_ID     = 2;
 const EVENTS_ROOT_BLOG_ID   = 47;
 const CAMPUS_NETWORK_ID     = 3;
+const CAMPUS_ROOT_BLOG_ID   = 47;
 
 switch ( strtolower( $_SERVER['HTTP_HOST'] ) ) {
+	case 'campus.wordpress.test':
+		define( 'SITE_ID_CURRENT_SITE',  CAMPUS_NETWORK_ID );
+		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID );
+		define( 'DOMAIN_CURRENT_SITE',   'events.wordpress.test' );
+		define( 'SUBDOMAIN_INSTALL',     false );
+		define( 'NOBLOGREDIRECT',        'https://events.wordpress.test/campusconnect/' );
+		define( 'CLI_HOSTNAME_OVERRIDE', 'events.wordpress.test' );
+		break;
+
 	case 'events.wordpress.test':
 		define( 'SITE_ID_CURRENT_SITE',  EVENTS_NETWORK_ID );
 		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID );

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -49,7 +49,7 @@ switch ( strtolower( $_SERVER['HTTP_HOST'] ) ) {
 	case 'campus.wordpress.test':
 		define( 'SITE_ID_CURRENT_SITE',  CAMPUS_NETWORK_ID );
 		define( 'BLOG_ID_CURRENT_SITE',  EVENTS_ROOT_BLOG_ID );
-		define( 'DOMAIN_CURRENT_SITE',   'events.wordpress.test' );
+		define( 'DOMAIN_CURRENT_SITE',   'campus.wordpress.test' );
 		define( 'SUBDOMAIN_INSTALL',     false );
 		define( 'NOBLOGREDIRECT',        'https://events.wordpress.test/campusconnect/' );
 		define( 'CLI_HOSTNAME_OVERRIDE', 'campus.wordpress.test' );

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -52,7 +52,7 @@ switch ( strtolower( $_SERVER['HTTP_HOST'] ) ) {
 		define( 'DOMAIN_CURRENT_SITE',   'events.wordpress.test' );
 		define( 'SUBDOMAIN_INSTALL',     false );
 		define( 'NOBLOGREDIRECT',        'https://events.wordpress.test/campusconnect/' );
-		define( 'CLI_HOSTNAME_OVERRIDE', 'events.wordpress.test' );
+		define( 'CLI_HOSTNAME_OVERRIDE', 'campus.wordpress.test' );
 		break;
 
 	case 'events.wordpress.test':

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -70,6 +70,7 @@ function set_network_and_site() {
 
 	// Originally WP referred to networks as "sites" and sites as "blogs".
 	$current_site = WP_Network::get_instance( SITE_ID_CURRENT_SITE );
+	$current_blog = false;
 	$site_id      = $current_site->id;
 	$path         = stripslashes( $_SERVER['REQUEST_URI'] );
 
@@ -82,29 +83,25 @@ function set_network_and_site() {
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 3 );
 
-	} elseif (
-		CAMPUS_NETWORK_ID === $site_id &&
-		1 === preg_match( PATTERN_CITY_PATH, $path )
-	) {
+	} elseif ( CAMPUS_NETWORK_ID === $site_id ) {
 		if ( is_admin() ) {
 			$path = preg_replace( '#(.*)/wp-admin/.*#', '$1/', $path );
 		}
 
 		list( $path ) = explode( '?', $path );
 
-		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
-		if ( ! $current_blog ) {
-			// If the request doesn't match a site, redirect to the campus connect page.
-			header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
-			exit;
+		if ( 1 === preg_match( PATTERN_CITY_PATH, $path ) ) {
+			$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
 		}
-	} elseif ( CAMPUS_NETWORK_ID === $site_id ) {
+	} else {
+		$current_blog = WP_Site::get_instance( BLOG_ID_CURRENT_SITE ); // The Root site constant defined in wp-config.php
+	}
+
+	if ( ! $current_blog ) {
 		// If the request doesn't match a site, redirect to the campus connect page.
+		header( 'X-Redirect-By: Events/Sunrise::set_network_and_site' );
 		header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
 		exit;
-
-	} else {
-		$current_blog = WP_Site::get_instance( EVENTS_ROOT_BLOG_ID );
 	}
 
 	$blog_id = $current_blog->id;

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -96,7 +96,7 @@ function set_network_and_site() {
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
 	} else {
-		$current_blog = WP_Site::get_instance( BLOG_ID_CURRENT_SITE ); // The Root site constant defined in wp-config.php
+		$current_blog = WP_Site::get_instance( BLOG_ID_CURRENT_SITE ); // The Root site constant defined in wp-config.php.
 	}
 
 	if ( ! $current_blog ) {

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -111,6 +111,9 @@ function set_network_and_site() {
 	$public  = $current_blog->public;
 }
 
+/**
+ * Handle any redirects needed on the Events & Campus networks.
+ */
 function do_redirects() {
 	global $blog_id, $site_id;
 

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -25,6 +25,8 @@ function main() {
 	}
 
 	set_network_and_site();
+
+	do_redirects();
 }
 
 /**
@@ -70,7 +72,6 @@ function set_network_and_site() {
 
 	// Originally WP referred to networks as "sites" and sites as "blogs".
 	$current_site = WP_Network::get_instance( SITE_ID_CURRENT_SITE );
-	$current_blog = false;
 	$site_id      = $current_site->id;
 	$path         = stripslashes( $_SERVER['REQUEST_URI'] );
 
@@ -83,16 +84,17 @@ function set_network_and_site() {
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 3 );
 
-	} elseif ( CAMPUS_NETWORK_ID === $site_id ) {
+	} elseif (
+		CAMPUS_NETWORK_ID === $site_id &&
+		1 === preg_match( PATTERN_CITY_PATH, $path )
+	) {
 		if ( is_admin() ) {
 			$path = preg_replace( '#(.*)/wp-admin/.*#', '$1/', $path );
 		}
 
 		list( $path ) = explode( '?', $path );
 
-		if ( 1 === preg_match( PATTERN_CITY_PATH, $path ) ) {
-			$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
-		}
+		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 2 );
 	} else {
 		$current_blog = WP_Site::get_instance( BLOG_ID_CURRENT_SITE ); // The Root site constant defined in wp-config.php
 	}
@@ -107,4 +109,15 @@ function set_network_and_site() {
 	$blog_id = $current_blog->id;
 	$domain  = $current_blog->domain;
 	$public  = $current_blog->public;
+}
+
+function do_redirects() {
+	global $blog_id, $site_id;
+
+	// campus.wordpress.org should redirect to the landing page.
+	if ( CAMPUS_NETWORK_ID === $site_id && CAMPUS_ROOT_BLOG_ID === $blog_id && ! is_admin() && ! is_network_admin() ) {
+		header( 'X-Redirect-By: Events/Sunrise::do_redirects' );
+		header( 'Location: https://events.wordpress.org/campusconnect/', true, 302 );
+		exit;
+	}
 }


### PR DESCRIPTION
Currently the campus redirects render campus.wordpress.org/wp-admin/network/ inaccessible, this fixes that.

A new site was added at campus.wordpress.org/ which remains inaccessible, but is needed for a placeholder to allow access.

Some minimal changes were made to the local docker config to hopefully avoid fatals for those users, but i haven't tested it.