### PR TITLE
Allow selection of the Event Subtype for Organizer Reminders

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -113,7 +113,6 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 
 		update_post_meta( self::$other_event_post_id, 'E-mail Address', 'other@wordcamp.org' );
 		update_post_meta( self::$other_event_post_id, 'event_subtype',  'other'              );
-
 	}
 
 	/**
@@ -323,5 +322,4 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			$result
 		);
 	}
-
 }

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -25,9 +25,19 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 	protected static $timed_reminder_post_id;
 
 	/**
+	 * @var int $not_for_wordcamp_post_id The ID of an Organizer Reminder post which is not configured to be sent for WordCamps.
+	 */
+	protected static $not_for_wordcamp_post_id;
+
+	/**
 	 * @var int $wordcamp_dayton_post_id The ID of a WordCamp post for Dayton, Ohio, USA.
 	 */
 	protected static $wordcamp_dayton_post_id;
+
+	/**
+	 * @var int $other_event_post_id The ID of a non-WordCamp event post.
+	 */
+	protected static $other_event_post_id;
 
 	/**
 	 * Set up the mocked PHPMailer instance before each test method.
@@ -69,6 +79,16 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 
 		update_post_meta( self::$timed_reminder_post_id, 'wcor_send_where', 'wcor_send_budget_wrangler' );
 
+		self::$not_for_wordcamp_post_id = $factory->post->create(
+			array(
+				'post_type'    => WCOR_Reminder::AUTOMATED_POST_TYPE_SLUG,
+				'post_title'   => 'This reminder is not for WordCamps',
+				'post_content' => 'So it should not be sent to WordCamp.',
+			)
+		);
+
+		update_post_meta( self::$not_for_wordcamp_post_id, 'wcor_event_subtypes', [ 'other' ] );
+
 		self::$wordcamp_dayton_post_id = $factory->post->create(
 			array(
 				'post_type'  => WCPT_POST_TYPE_ID,
@@ -83,6 +103,17 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 		update_post_meta( self::$wordcamp_dayton_post_id, 'Physical Address',               '3640 Colonel Glenn Hwy, Dayton, OH, US' );
 		update_post_meta( self::$wordcamp_dayton_post_id, 'Budget Wrangler Name',           'Sally Smith'                            );
 		update_post_meta( self::$wordcamp_dayton_post_id, 'Budget Wrangler E-mail Address', 'sally.smith+trez@gmail.com'             );
+
+		self::$other_event_post_id = $factory->post->create(
+			array(
+				'post_type'  => WCPT_POST_TYPE_ID,
+				'post_title' => 'Some Other Event',
+			)
+		);
+
+		update_post_meta( self::$other_event_post_id, 'E-mail Address', 'other@wordcamp.org' );
+		update_post_meta( self::$other_event_post_id, 'event_subtype',  'other'              );
+
 	}
 
 	/**
@@ -258,4 +289,39 @@ class Test_WCOR_Mailer extends WP_UnitTestCase {
 			$result
 		);
 	}
+
+	/**
+	 * Test that event subtype is respected when sending reminders.
+	 *
+	 * @covers WCOR_Mailer::applies_to_wordcamp
+	 */
+	public function test_not_sent_to_non_wordcamp() {
+		/** @var WCOR_Mailer $WCOR_Mailer */
+		global $WCOR_Mailer;
+
+		$message  = get_post( self::$not_for_wordcamp_post_id );
+		$wordcamp = get_post( self::$wordcamp_dayton_post_id );
+		$other    = get_post( self::$other_event_post_id );
+
+		// Test that WordCamp doesn't send.
+		$result = $WCOR_Mailer->send_manual_email( $message, $wordcamp );
+
+		// Verify the email wasn't sent.
+		$this->assertFalse( $result );
+		$this->assertSame( 0, did_action( 'wp_mail_failed' ) );
+		$this->assertSame( 0, did_action( 'wp_mail_succeeded' ) );
+
+		// Test that it sends to Other event.
+		$result = $WCOR_Mailer->send_manual_email( $message, $other );
+
+		$this->assertTrue( $result );
+
+		$this->assert_mail_succeeded(
+			'other@wordcamp.org',
+			'This reminder is not for WordCamps',
+			'So it should not be sent to WordCamp.',
+			$result
+		);
+	}
+
 }

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
@@ -15,6 +15,7 @@
 	<li>[wordcamp_hashtag]</li>
 	<li>[wordcamp_anticipated_attendees]</li>
 	<li>[multi_event_sponsor_region]</li>
+	<li>[event_type]</li>
 </ul>
 
 <h5>The organizing team:</h5>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -170,3 +170,36 @@ defined( 'WPINC' ) || die();
 		</tr>
 	</tbody>
 </table>
+
+<h4>For which type of events?</h4>
+<table>
+	<tbody>
+		<tr>
+			<?php
+			$selected_subtypes = get_post_meta( $post->ID, 'wcor_event_subtypes', true ) ?: [ 'all' ];
+			$subtypes = $GLOBALS['wordcamp_admin']->get_event_subtypes();
+			?>
+			<td><label>
+				<input type="checkbox" name="wcor_event_subtypes[]" value="all" <?php checked( in_array( 'all', $selected_subtypes ) ); ?> />
+				All
+			</label></td>
+			<?php
+			foreach ( $subtypes as $subtype_id => $subtype_name ) :
+			?>
+				<td><label>
+					<input type="checkbox" name="wcor_event_subtypes[]" value="<?php echo esc_attr( $subtype_id ); ?>" <?php checked( in_array( $subtype_id, $selected_subtypes ) ); ?> />
+					<?php echo esc_html( $subtype_name ); ?>
+				</label></td>
+			<?php endforeach; ?>
+			<script>
+				( function( $ ) {
+					/* Enforce 'All for no selections. */
+					$( 'input[name="wcor_event_subtypes[]"]' ).on( 'change', function() {
+						const multipleChecked = $( 'input[name="wcor_event_subtypes[]"]:not([value="all"]):checked' ).length > 0;
+						$( 'input[name="wcor_event_subtypes[]"][value="all"]' ).prop( 'checked', ! multipleChecked );
+					} ).change();
+				} )( jQuery );
+			</script>
+		</tr>
+	</tbody>
+</table>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -185,7 +185,7 @@ defined( 'WPINC' ) || die();
 			</label></td>
 			<?php
 			foreach ( $subtypes as $subtype_id => $subtype_name ) :
-			?>
+				?>
 				<td><label>
 					<input type="checkbox" name="wcor_event_subtypes[]" value="<?php echo esc_attr( $subtype_id ); ?>" <?php checked( in_array( $subtype_id, $selected_subtypes ) ); ?> />
 					<?php echo esc_html( $subtype_name ); ?>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -172,7 +172,7 @@ defined( 'WPINC' ) || die();
 </table>
 
 <h4>For which type of events?</h4>
-<table>
+<table id="event-type-selection">
 	<tbody>
 		<tr>
 			<?php
@@ -194,12 +194,22 @@ defined( 'WPINC' ) || die();
 			<script>
 				( function( $ ) {
 					/* Enforce 'All for no selections. */
-					$( 'input[name="wcor_event_subtypes[]"]' ).on( 'change', function() {
+					$( '#event-type-selection input[name="wcor_event_subtypes[]"]' ).on( 'change', function() {
+						if ( this.value == 'all' && this.checked ) {
+							$( 'input[name="wcor_event_subtypes[]"]:not([value="all"])' ).prop( 'checked', false );
+							return;
+						}
+
 						const multipleChecked = $( 'input[name="wcor_event_subtypes[]"]:not([value="all"]):checked' ).length > 0;
 						$( 'input[name="wcor_event_subtypes[]"][value="all"]' ).prop( 'checked', ! multipleChecked );
 					} ).change();
 				} )( jQuery );
 			</script>
+			<style>
+				#event-type-selection td > label {
+					padding-right: 1em;
+				}
+			</style>
 		</tr>
 	</tbody>
 </table>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -507,6 +507,10 @@ class WCOR_Mailer {
 	public function send_manual_email( $email, $wordcamp ) {
 		$recipient = $this->get_recipients( $wordcamp->ID, $email->ID );
 
+		if ( ! $this->applies_to_wordcamp( $wordcamp, $email ) ) {
+			return false;
+		}
+
 		return $this->mail( $recipient, $email->post_title, $email->post_content, array(), $email, $wordcamp );
 	}
 
@@ -555,6 +559,10 @@ class WCOR_Mailer {
 
 			foreach ( $reminder_emails as $email ) {
 				if ( ! $this->timed_email_is_ready_to_send( $wordcamp, $email, $sent_email_ids ) ) {
+					continue;
+				}
+
+				if ( ! $this->applies_to_wordcamp( $wordcamp, $email ) ) {
 					continue;
 				}
 
@@ -670,6 +678,32 @@ class WCOR_Mailer {
 		}
 
 		return $ready;
+	}
+
+
+	/**
+	 * Determines if an email applies to a given WordCamp.
+	 *
+	 * @param WP_Post $wordcamp
+	 * @param WP_Post $email
+	 * @return bool
+	 */
+	protected function applies_to_wordcamp( $wordcamp, $email ) {
+		$restricted_event_types = get_post_meta( $email->ID, 'wcor_event_subtypes', true ) ?: [];
+
+		// If the email has no restrictions, it applies to all WordCamps.
+		if ( ! $restricted_event_types || in_array( 'all', $restricted_event_types ) ) {
+			return true;
+		}
+
+		// Get the WordCamp subtype, and see if it applies.
+		$wordcamp_event_subtype = get_post_meta( $wordcamp->ID, 'event_subtype', true ) ?: 'none';
+
+		if ( in_array( $wordcamp_event_subtype, $restricted_event_types ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -190,6 +190,7 @@ class WCOR_Mailer {
 			'[wordcamp_hashtag]',
 			'[wordcamp_anticipated_attendees]',
 			'[multi_event_sponsor_region]',
+			'[event_type]',
 
 			// The organizing team
 			'[organizer_name]',
@@ -242,6 +243,10 @@ class WCOR_Mailer {
 			'[session_feedback_list_url]',
 		);
 
+		// Extract the Event Type name.
+		$event_subtype_name = empty( $wordcamp_meta['event_subtype'] ) ? 'N/A' : $wordcamp_meta['event_subtype'][0];
+		$event_subtype_name = $wordcamp_admin->get_event_subtypes()[ $event_subtype_name ] ?? $event_subtype_name;
+
 		$replace = array(
 			// The WordCamp
 			$wordcamp->post_title,
@@ -254,6 +259,7 @@ class WCOR_Mailer {
 			empty( $wordcamp_meta['WordCamp Hashtag'][0] ) ? 'N/A' : esc_url( 'https://twitter.com/hashtag/' . $wordcamp_meta['WordCamp Hashtag'][0] ),
 			empty( $wordcamp_meta['Number of Anticipated Attendees'][0] ) ? '' : absint( $wordcamp_meta['Number of Anticipated Attendees'][0] ),
 			empty( $wordcamp_meta['Multi-Event Sponsor Region'][0] ) ? '' : get_term( $wordcamp_meta['Multi-Event Sponsor Region'][0], MES_Region::TAXONOMY_SLUG )->name,
+			$event_subtype_name,
 
 			// The organizing team
 			$wordcamp_meta['Organizer Name'][0] ?? '',

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -102,13 +102,13 @@ class WCOR_Reminder {
 			if ( $sent ) {
 				?>
 				<div class="updated">
-					<p><?php printf( __( 'The e-mail was sent successfully to the recipient(s) for %s.', 'wordcamporg' ), esc_html( $wordcamp->post_title ) ); ?></p>
+					<p><?php printf( esc_html__( 'The e-mail was sent successfully to the recipient(s) for %s.', 'wordcamporg' ), esc_html( $wordcamp->post_title ) ); ?></p>
 				</div>
 				<?php
 			} else {
 				?>
 				<div class="error">
-					<p><?php printf( __( 'There was an error sending the e-mail for %s.', 'wordcamporg' ), esc_html( $wordcamp->post_title ) ); ?></p>
+					<p><?php printf( esc_html__( 'There was an error sending the e-mail for %s.', 'wordcamporg' ), esc_html( $wordcamp->post_title ) ); ?></p>
 				</div>
 				<?php
 			}
@@ -250,8 +250,9 @@ class WCOR_Reminder {
 
 		if ( isset( $new_meta['wcor_event_subtypes'] ) ) {
 			// Remove 'all', we it's the default.
-			if ( ( $key = array_search( 'all', $new_meta['wcor_event_subtypes'] ) ) !== false ) {
-				unset( $new_meta['wcor_event_subtypes'][ $key ] );
+			$all_key = array_search( 'all', $new_meta['wcor_event_subtypes'] );
+			if ( $all_key !== false ) {
+				unset( $new_meta['wcor_event_subtypes'][ $all_key ] );
 			}
 
 			$new_meta['wcor_event_subtypes'] = array_filter( $new_meta['wcor_event_subtypes'] );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -16,6 +16,7 @@ class WCOR_Reminder {
 		add_action( 'init',                              array( $this, 'register_post_type' ) );
 		add_action( 'admin_init',                        array( $this, 'add_meta_boxes' ) );
 		add_action( 'admin_menu',                        array( $this, 'register_menu_pages' ) );
+		add_action( 'admin_notices',                     array( $this, 'admin_notices' ) );
 		add_action( 'save_post_' . self::AUTOMATED_POST_TYPE_SLUG, array( $this, 'save_post' ), 10, 2 );
 	}
 
@@ -87,6 +88,31 @@ class WCOR_Reminder {
 			self::AUTOMATED_POST_TYPE_SLUG,
 			'side'
 		);
+	}
+
+	/**
+	 * Renders admin notices
+	 */
+	public function admin_notices() {
+		if ( isset( $_COOKIE['wcor_manual_email_sent'] ) ) {
+			list( $sent, $event ) = explode( ':', $_COOKIE['wcor_manual_email_sent'] );
+			setcookie( 'wcor_manual_email_sent', '', time() - HOUR_IN_SECONDS );
+
+			$wordcamp = get_post( $event );
+			if ( $sent ) {
+				?>
+				<div class="updated">
+					<p><?php printf( __( 'The e-mail was sent successfully to the recipient(s) for %s.', 'wordcamporg' ), esc_html( $wordcamp->post_title ) ); ?></p>
+				</div>
+				<?php
+			} else {
+				?>
+				<div class="error">
+					<p><?php printf( __( 'There was an error sending the e-mail for %s.', 'wordcamporg' ), esc_html( $wordcamp->post_title ) ); ?></p>
+				</div>
+				<?php
+			}
+		}
 	}
 
 	/**
@@ -244,6 +270,8 @@ class WCOR_Reminder {
 		}
 
 		$wordcamp = get_post( $form_values['wcor_manually_send_wordcamp'] );
-		$WCOR_Mailer->send_manual_email( $email, $wordcamp );
+		$sent = $WCOR_Mailer->send_manual_email( $email, $wordcamp );
+
+		setcookie( 'wcor_manual_email_sent', "{$sent}:{$wordcamp->ID}", time() + MINUTE_IN_SECONDS );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -247,6 +247,17 @@ class WCOR_Reminder {
 				update_post_meta( $post->ID, 'wcor_which_trigger', $new_meta['wcor_which_trigger'] );
 			}
 		}
+
+		if ( isset( $new_meta['wcor_event_subtypes'] ) ) {
+			// Remove 'all', we it's the default.
+			if ( ( $key = array_search( 'all', $new_meta['wcor_event_subtypes'] ) ) !== false ) {
+				unset( $new_meta['wcor_event_subtypes'][ $key ] );
+			}
+
+			$new_meta['wcor_event_subtypes'] = array_filter( $new_meta['wcor_event_subtypes'] );
+
+			update_post_meta( $post->ID, 'wcor_event_subtypes', $new_meta['wcor_event_subtypes'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1512

As part of this I've backfilled the `subtype` for older events as appropriate.

I've made it so that you can't manually send the email to an event if it doesn't meet the criteria.

### Screenshots

| Default | All events except WPCC/Student Clubs |
| --- | --- |
| <img width="965" height="323" alt="Screenshot 2025-10-16 at 2 10 59 pm" src="https://github.com/user-attachments/assets/d2d613c2-d4f8-46f5-a493-3df06ab594e4" /> | <img width="957" height="319" alt="Screenshot 2025-10-16 at 2 11 12 pm" src="https://github.com/user-attachments/assets/c35f0cbf-01b6-4b58-86ff-13feb04fa125" /> |


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Good
2. Luck
3. Little Pademelon!
