### PR TITLE
Implement subtype filtering for WordCamp events overview

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1236,32 +1236,34 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				}
 				$filtering = true;
 
-				// Filter wp_count_posts()
-				add_filter( 'wp_count_posts', $cb = function( $counts ) use( $current_subtype ) {
-					global $wpdb;
+				add_filter(
+					'wp_count_posts',
+					$cb = function ( $counts ) use( $current_subtype ) {
+						global $wpdb;
 
-					// NOTE: This skips the $permission checks, as these are not sensitive statii
+						// NOTE: This skips the $permission checks, as these are not sensitive statii.
 
-					$results = (array) $wpdb->get_results(
-						$wpdb->prepare(
-							"SELECT post_status, COUNT( * ) AS num_posts
-							FROM {$wpdb->posts}
-								JOIN {$wpdb->postmeta} ON ( {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id AND {$wpdb->postmeta}.meta_key = 'event_subtype' AND {$wpdb->postmeta}.meta_value = %s )
-							WHERE post_type = %s
-							GROUP BY post_status",
-							$current_subtype,
-							WCPT_POST_TYPE_ID
-						)
-					);
+						$results = (array) $wpdb->get_results(
+							$wpdb->prepare(
+								"SELECT post_status, COUNT( * ) AS num_posts
+								FROM {$wpdb->posts}
+									JOIN {$wpdb->postmeta} ON ( {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id AND {$wpdb->postmeta}.meta_key = 'event_subtype' AND {$wpdb->postmeta}.meta_value = %s )
+								WHERE post_type = %s
+								GROUP BY post_status",
+								$current_subtype,
+								WCPT_POST_TYPE_ID
+							)
+						);
 
-					$counts = array_fill_keys( array_keys( (array) $counts ), 0 );
+						$counts = array_fill_keys( array_keys( (array) $counts ), 0 );
 
-					foreach ( $results as $row ) {
-						$counts[ $row->post_status ] = $row->num_posts;
+						foreach ( $results as $row ) {
+							$counts[ $row->post_status ] = $row->num_posts;
+						}
+
+						return (object) $counts;
 					}
-
-					return (object) $counts;
-				} );
+				);
 
 				$views = $wp_list_table->get_views();
 
@@ -1277,11 +1279,11 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			?>
 			<ul class="subsubsub" style="float: none">
 				<li class="all">
-					<a href="<?php echo esc_url( $base_url ); ?>" <?php if ( ! $current_subtype ) { echo 'class="current"'; } ?>>All Events</a>
+					<a href="<?php echo esc_url( $base_url ); ?>" <?php if ( ! $current_subtype ) echo 'class="current"'; ?>>All Events</a>
 				</li>
 				<?php foreach ( $this->get_event_subtypes() as $subtype_key => $subtype_label ) : ?>
 					<li class="<?php echo esc_attr( $subtype_key ); ?>">
-						| <a href="<?php echo esc_url( add_query_arg( 'type', $subtype_key, $base_url ) ); ?>"  <?php if ( $current_subtype === $subtype_key ) { echo 'class="current"'; } ?>>
+						| <a href="<?php echo esc_url( add_query_arg( 'type', $subtype_key, $base_url ) ); ?>"  <?php if ( $current_subtype === $subtype_key ) echo 'class="current"'; ?>>
 							<?php echo esc_html( $subtype_label ); ?>
 						</a>
 					</li>
@@ -1292,6 +1294,9 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			if ( $current_subtype ) {
 				foreach ( $views as $key => &$html ) {
 					$html = str_replace( 'post_type=wordcamp', 'post_type=wordcamp&#038;type=' . $current_subtype, $html );
+
+					// Replace the Label too, e.g., "WordCamp (10)" becomes "DoAction (10)". Only applies to the views list.
+					$html = str_replace( 'WordCamp', $this->get_event_subtypes()[ $current_subtype ], $html );
 				}
 
 				// Remove the "Mine" filter, as this isn't compatible with subtype filtering.. and isn't relevant usually for wranglers.
@@ -1304,7 +1309,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		/**
 		 * Filter the WordCamp list by Event Subtype.
 		 */
-		function filter_by_subtype( $query ) {
+		public function filter_by_subtype( $query ) {
 			if (
 				! $query->is_main_query() ||
 				WCPT_POST_TYPE_ID !== $query->get( 'post_type' ) ||
@@ -1315,7 +1320,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 
 			$type = sanitize_text_field( wp_unslash( $_REQUEST['type'] ) );
 
-			$meta_query = $query->get( 'meta_query' ) ?: []; 
+			$meta_query = $query->get( 'meta_query' ) ?: [];
 
 			$meta_query[] = array(
 				'key'     => 'event_subtype',

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -49,6 +49,10 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				2
 			); // after enforce_post_status.
 
+			// Filters - Subtype filtering on the WordCamp list table.
+			add_filter( 'views_edit-wordcamp', array( $this, 'alter_views' ) );
+			add_action( 'parse_query', array( $this, 'filter_by_subtype' ) );
+
 			// Cron jobs.
 			add_action( 'plugins_loaded', array( $this, 'schedule_cron_jobs' ), 11 );
 			add_action( 'wcpt_close_wordcamps_after_event', array( $this, 'close_wordcamps_after_event' ) );
@@ -1207,6 +1211,119 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					)
 				);
 			}
+		}
+
+		/**
+		 * Add a dropdown to filter by Event Subtype.
+		 *
+		 * This is hacked in by abusing the `views` filter for the wordcamp PT.
+		 */
+		public function alter_views( $views ) {
+			global $wp_list_table;
+
+			// For low-privilege users, just return the unmodified views.
+			if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
+				return $views;
+			}
+
+			$current_subtype = sanitize_text_field( wp_unslash( $_GET['type'] ?? '' ) );
+
+			// If we're currently filtering to a type, regenerate the Views, as the counts and available statii need updating.
+			if ( $current_subtype ) {
+				static $filtering = false;
+				if ( $filtering ) {
+					return $views;
+				}
+				$filtering = true;
+
+				// Filter wp_count_posts()
+				add_filter( 'wp_count_posts', $cb = function( $counts ) use( $current_subtype ) {
+					global $wpdb;
+
+					// NOTE: This skips the $permission checks, as these are not sensitive statii
+
+					$results = (array) $wpdb->get_results(
+						$wpdb->prepare(
+							"SELECT post_status, COUNT( * ) AS num_posts
+							FROM {$wpdb->posts}
+								JOIN {$wpdb->postmeta} ON ( {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id AND {$wpdb->postmeta}.meta_key = 'event_subtype' AND {$wpdb->postmeta}.meta_value = %s )
+							WHERE post_type = %s
+							GROUP BY post_status",
+							$current_subtype,
+							WCPT_POST_TYPE_ID
+						)
+					);
+
+					$counts = array_fill_keys( array_keys( (array) $counts ), 0 );
+
+					foreach ( $results as $row ) {
+						$counts[ $row->post_status ] = $row->num_posts;
+					}
+
+					return (object) $counts;
+				} );
+
+				$views = $wp_list_table->get_views();
+
+				remove_filter( 'wp_count_posts', $cb );
+
+				$filtering = false;
+			}
+
+			$base_url = admin_url( 'edit.php?post_type=' . WCPT_POST_TYPE_ID );
+			if ( isset( $_GET['post_status'] ) ) {
+				$base_url = add_query_arg( 'post_status', sanitize_text_field( wp_unslash( $_GET['post_status'] ) ), $base_url );
+			}
+			?>
+			<ul class="subsubsub" style="float: none">
+				<li class="all">
+					<a href="<?php echo esc_url( $base_url ); ?>" <?php if ( ! $current_subtype ) { echo 'class="current"'; } ?>>All Events</a>
+				</li>
+				<?php foreach ( $this->get_event_subtypes() as $subtype_key => $subtype_label ) : ?>
+					<li class="<?php echo esc_attr( $subtype_key ); ?>">
+						| <a href="<?php echo esc_url( add_query_arg( 'type', $subtype_key, $base_url ) ); ?>"  <?php if ( $current_subtype === $subtype_key ) { echo 'class="current"'; } ?>>
+							<?php echo esc_html( $subtype_label ); ?>
+						</a>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+			<?php
+
+			if ( $current_subtype ) {
+				foreach ( $views as $key => &$html ) {
+					$html = str_replace( 'post_type=wordcamp', 'post_type=wordcamp&#038;type=' . $current_subtype, $html );
+				}
+
+				// Remove the "Mine" filter, as this isn't compatible with subtype filtering.. and isn't relevant usually for wranglers.
+				unset( $views['mine'] );
+			}
+
+			return $views;
+		}
+
+		/**
+		 * Filter the WordCamp list by Event Subtype.
+		 */
+		function filter_by_subtype( $query ) {
+			if (
+				! $query->is_main_query() ||
+				WCPT_POST_TYPE_ID !== $query->get( 'post_type' ) ||
+				empty( $_REQUEST['type'] )
+			) {
+				return;
+			}
+
+			$type = sanitize_text_field( wp_unslash( $_REQUEST['type'] ) );
+
+			$meta_query = $query->get( 'meta_query' ) ?: []; 
+
+			$meta_query[] = array(
+				'key'     => 'event_subtype',
+				'value'   => $type,
+				'compare' => '=',
+			);
+
+			$query->set( 'meta_query', $meta_query );
 		}
 	}
 endif; // class_exists check.


### PR DESCRIPTION
Currently we have `WordCamp`, `DoAction`, `Campus Connect`, `Student Clubs` and `Other events` all in a single mixed table.

This is causing a headache for people whom are only managing CampusConnect/StudentClubs as they're forced to see all of the WordCamps/etc as part of their admin in WordCamp Central.

While ideally these other types would be moved to their own Post Type, I've been avoiding that due to it being unknown on how much work that's actually going to involve.

As a temporary stop-gap, this adds some filters to the WordCamp listing page that allows selection of the Event Type.

### Screenshots

Before
<img width="1525" height="163" alt="Screenshot 2025-10-20 at 2 26 08 pm" src="https://github.com/user-attachments/assets/b91a9c43-0e9a-4f0e-a1e2-a2ea0239868f" />

After
<img width="1536" height="203" alt="Screenshot 2025-10-20 at 2 26 21 pm" src="https://github.com/user-attachments/assets/63ce769c-1090-4df1-8bb8-1f1f85c34444" />

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
