### PR TITLE
Refactor custom customizer is_customize_preview() to use the core method.

### DIFF
--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/html-badges.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/html-badges.php
@@ -113,7 +113,9 @@ function get_customizer_section_url() {
  * @return bool
  */
 function is_customizer_request() {
-	return isset( $GLOBALS['wp_customize'] );
+	global $wp_customize;
+
+	return ( $wp_customize instanceof WP_Customize_Manager );
 }
 
 /**
@@ -169,10 +171,7 @@ function print_customizer_styles() {
  * @return bool
  */
 function is_badges_preview() {
-	/** @global WP_Customize_Manager $wp_customize */
-	global $wp_customize;
-
-	return isset( $_GET['camptix-badges'] ) && $wp_customize->is_preview();
+	return isset( $_GET['camptix-badges'] ) && is_customize_preview();
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -40,9 +40,7 @@ class WordCamp_Coming_Soon_Page {
 	 * @return bool
 	 */
 	public function is_coming_soon_preview() {
-		global $wp_customize;
-
-		return isset( $_GET['wccsp-preview'] ) && $wp_customize->is_preview();
+		return isset( $_GET['wccsp-preview'] ) && is_customize_preview();
 	}
 
 	/**


### PR DESCRIPTION
Attempts to work around some fatal errors encountered by accessing  Customizer preview views outside of the customizer.