### PR TITLE
Instamojo: Handle IPN notifications of timedout / failed payments as part of transaction.

### DIFF
--- a/public_html/wp-content/plugins/campt-indian-payment-gateway/inc/instamojo/class-camptix-payment-method-instamojo.php
+++ b/public_html/wp-content/plugins/campt-indian-payment-gateway/inc/instamojo/class-camptix-payment-method-instamojo.php
@@ -205,7 +205,7 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 			// Else, fall back to the status of the transaction in the webhook.
 			if ( $data['status'] == "Credit" ) {
 				// Payment was successful, mark it as successful in your database.
-				return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );	
+				return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );
 			} else {
 				// Payment was unsuccessful, mark it as failed in your database.
 				return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_FAILED, $payment_data );
@@ -213,7 +213,6 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 		} else {
 			return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
 		}
-		
 	}
 
 	public function payment_checkout( $payment_token ) {
@@ -356,7 +355,7 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 	 * Runs when the user cancels their payment during checkout at Instamojo.
 	 * his will simply tell CampTix to put the created attendee drafts into to Cancelled state.
 	 */
-	function payment_cancel() {
+	public function payment_cancel() {
 		global $camptix;
 
 		$this->log( sprintf( 'Running payment_cancel. Request data attached.' ), null, $_REQUEST );
@@ -376,7 +375,7 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 	 * @param string $payment_request_id Payment Request ID.
 	 * @return object|false
 	 */
-	function get_payment_request( $payment_request_id ) {
+	public function get_payment_request( $payment_request_id ) {
 		$url = 'https://' . ( $this->options['sandbox'] ? 'test' : 'www' ) . '.instamojo.com/api/1.1/payment-requests/' . $payment_request_id . '/';
 		$response = wp_remote_get(
 			$url,

--- a/public_html/wp-content/plugins/campt-indian-payment-gateway/inc/instamojo/class-camptix-payment-method-instamojo.php
+++ b/public_html/wp-content/plugins/campt-indian-payment-gateway/inc/instamojo/class-camptix-payment-method-instamojo.php
@@ -177,15 +177,38 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 		// Pass the 'salt' without <>
 		$mac_calculated = hash_hmac( "sha1", implode( "|", $data ), $instamojo_salt );
 		if ( $mac_provided == $mac_calculated ) {
+
+			// Request is valid, but this might be a webhook for a timed out payment / failed payment, where one has actually passed.
+			// Check the payment request to see what other statuses are.
+			$request = get_payment_request( $data['payment_request_id'] );
+			if ( $request && 'Completed' === $request->status ) {
+				// Look for a Credit transaction, and just succeed on that.
+				foreach ( $request->payments as $payment ) {
+					if ( 'Credit' === $payment->status ) {
+						return $this->payment_result(
+							$_REQUEST['tix_payment_token'],
+							CampTix_Plugin::PAYMENT_STATUS_COMPLETED,
+							array(
+								'transaction_id'      => $payment->payment_id,
+								'transaction_details' => $payment,
+								'payment_request'     => $request,
+							)
+						);
+					}
+				}
+			}
+
+			// Else, fall back to the status of the transaction in the webhook.
+
 			if ( $data['status'] == "Credit" ) {
 				// Payment was successful, mark it as successful in your database.
-				$this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );	
+				return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );	
 			} else {
 				// Payment was unsuccessful, mark it as failed in your database.
-				$this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_FAILED, $payment_data );
+				return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_FAILED, $payment_data );
 			}
 		} else {
-			$this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
+			return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
 		}
 		
 	}
@@ -342,5 +365,29 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 		}
 		// Set the associated attendees to cancelled.
 		return $this->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_CANCELLED );
+	}
+
+	/**
+	 * Get payment request details from Instamojo.
+	 *
+	 * @param string $payment_request_id Payment Request ID.
+	 * @return object|false
+	 */
+	function get_payment_request( $payment_request_id ) {
+		$url = 'https://' . ( $this->options['sandbox'] ? 'test' : 'www' ) . '.instamojo.com/api/1.1/payment-requests/' . $payment_request_id . '/';
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 60,
+				'headers' => array(
+					'Accept'       => 'application/json',
+					'Content-Type' => 'application/json;charset=UTF-8',
+					'X-Api-Key'    => $this->options['Instamojo-Api-Key'],
+					'X-Auth-Token' => $this->options['Instamojo-Auth-Token'],
+				),
+			)
+		);
+
+		return json_decode( wp_remote_retrieve_body( $response ) )->payment_request ?? false;
 	}
 }

--- a/public_html/wp-content/plugins/campt-indian-payment-gateway/inc/instamojo/class-camptix-payment-method-instamojo.php
+++ b/public_html/wp-content/plugins/campt-indian-payment-gateway/inc/instamojo/class-camptix-payment-method-instamojo.php
@@ -181,6 +181,10 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 			// Request is valid, but this might be a webhook for a timed out payment / failed payment, where one has actually passed.
 			// Check the payment request to see what other statuses are.
 			$request = get_payment_request( $data['payment_request_id'] );
+			if ( $request ) {
+				$payment_data['payment_request'] = $request;
+			}
+
 			if ( $request && 'Completed' === $request->status ) {
 				// Look for a Credit transaction, and just succeed on that.
 				foreach ( $request->payments as $payment ) {
@@ -199,7 +203,6 @@ class CampTix_Payment_Method_Instamojo extends CampTix_Payment_Method {
 			}
 
 			// Else, fall back to the status of the transaction in the webhook.
-
 			if ( $data['status'] == "Credit" ) {
 				// Payment was successful, mark it as successful in your database.
 				return $this->payment_result( $_REQUEST['tix_payment_token'], CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );	


### PR DESCRIPTION
The Instamojo class has long known had to have problems marking attendees as failed, when they've actually paid.

It turns out that this is caused by having multiple payment methods enabled within Instamojo and one of them timing out.

For example, a log of an attendee:
<img width="643" height="721" alt="Screenshot 2025-10-28 at 4 24 26 pm" src="https://github.com/user-attachments/assets/e564801d-83e9-4020-a3bc-d02fa55ca1e3" />

You can see that a successful transaction occurred at 9am, and a failed one came in at 11am.
What you don't see, is that the 9am one was made with `UPI` and the 11am one was a `QR Checkout` which timed out after 2 hours.

This PR simply accepts the webhook notification of the payment, but fetches the checkout session of the payment to verify what the overall checkout sessions state is, instead of the individual transaction (of which there are multiple of for each session)