### PR TITLE
Camptix_Payment::get_order() should return the first user as the attendee_id

### DIFF
--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -304,7 +304,7 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 				),
 			),
 			'fields'         => 'ids',
-			// First attendee with this payment token
+			// First attendee with this payment token.
 			'orderby'        => 'ID',
 			'order'          => 'ASC',
 		) );

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -303,13 +303,17 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 					'type'    => 'CHAR',
 				),
 			),
+			'fields'         => 'ids',
+			// First attendee with this payment token
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
 		) );
 
 		if ( ! $attendees ) {
 			return array();
 		}
 
-		return $this->get_order_by_attendee_id( $attendees[0]->ID );
+		return $this->get_order_by_attendee_id( $attendees[0] );
 	}
 
 	/**


### PR DESCRIPTION
At present CampTix_Payment_Method::get_order() returns the LAST attendee added as part of the transaction as the attendee_id.

This is usually incorrect, as the first user is often the person purchasing the ticket, and in the case of requiring user logins, will always be the purchaser.

Partially related to #1427