### PR TITLE
Add a Feed of the Upcoming Events page

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -123,6 +123,8 @@
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 
 		<!-- Exclude short array syntax as it is consistently already in the codebase :) -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>

--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -358,7 +358,7 @@ function feed_parse_query( $wp_query ) {
 	// Body should be prefixed with Location & Time. RSS Dates can't be in the future.
 	add_filter( 'the_content_feed', function ( $content ) {
 		$event = get_post();
-		$time  = date( 'F j, Y g:ia', strtotime( $event->post_date ) );
+		$time  = gmdate( 'F j, Y g:ia', strtotime( $event->post_date ) ); // This is not in UTC, but the timestamps is.
 
 		$prefix = sprintf(
 			'<p><strong>Location:</strong> %s<br/><strong>Time:</strong> %s</p>',

--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -10,6 +10,7 @@ defined( 'WPINC' ) || die();
 // This intentionally doesn't have the starting/ending delimiters and flags, so that it can be used with
 // `add_rewrite_rule()`.
 const FILTERED_URL_PATTERN       = '([\w-]+)/filtered/(.+)';
+const FILTERED_URL_PATTERN_FEED  = FILTERED_URL_PATTERN . '/feed/?';
 const PRETTY_URL_VALUE_DELIMITER = '-';
 
 // Misc.
@@ -206,7 +207,7 @@ function add_rewrite_rules(): void {
 	// predictable. Instead, this just matches all the facets into a single var, and they'll be parsed out of that
 	// into individual facets later.
 	// @see set_query_vars_from_pretty_url().
-	add_rewrite_rule( FILTERED_URL_PATTERN . '/feed/?', 'index.php?pagename=$matches[1]&event_facets=$matches[2]&feed=feed', 'top' );
+	add_rewrite_rule( FILTERED_URL_PATTERN_FEED, 'index.php?pagename=$matches[1]&event_facets=$matches[2]&feed=feed', 'top' );
 	add_rewrite_rule( FILTERED_URL_PATTERN, 'index.php?pagename=$matches[1]&event_facets=$matches[2]', 'top' );
 }
 

--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -21,6 +21,7 @@ add_action( 'init', __NAMESPACE__ . '\add_rewrite_rules' );
 add_filter( 'query_vars', __NAMESPACE__ . '\add_query_vars' );
 add_action( 'parse_request', __NAMESPACE__ . '\set_query_vars_from_pretty_url' );
 add_action( 'wp', __NAMESPACE__ . '\redirect_to_pretty_query_vars' );
+add_action( 'parse_query', __NAMESPACE__ . '\feed_parse_query' );
 add_action( 'wporg_query_filter_in_form', __NAMESPACE__ . '\inject_other_filters' );
 add_filter( 'document_title_parts', __NAMESPACE__ . '\add_filters_to_page_title' );
 add_filter( 'wporg_query_total_label', __NAMESPACE__ . '\update_query_total_label', 10, 3 );
@@ -62,8 +63,13 @@ function inject_events_into_query( $posts, WP_Query $query ) {
 
 	global $wp;
 
-	$posts  = array();
-	$facets = get_query_var_facets();
+	$posts           = array();
+	$facets          = get_query_var_facets();
+	$facets['limit'] = $query->get( 'posts_per_page' );
+	if ( is_feed() ) {
+		$facets['include_description'] = true;
+	}
+
 	$events = Google_Map\get_events( 'all-upcoming', 0, 0, $facets );
 
 	// Simulate an ID that won't collide with a real post.
@@ -87,6 +93,13 @@ function inject_events_into_query( $posts, WP_Query $query ) {
 			'post_name'      => 'wporg-event-' . $event->id,
 			'guid'           => $event->url,
 			'post_type'      => 'wporg_event',
+
+			// For feeds.
+			'post_date'         => gmdate( 'Y-m-d H:i:s', $event->timestamp + $event->tz_offset ),
+			'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $event->timestamp ),
+			'post_content'      => wp_kses_post( $event->description ?? '' ),
+			'comment_status'    => 'closed',
+			'comment_count'     => 0,
 
 			// This makes Core create a new post object, rather than trying to get an instance.
 			// See https://github.com/WordPress/WordPress/blob/7926dbb4d5392c870ccbc3ec6019c002feed904c/wp-includes/post.php#L1030-L1033.
@@ -193,6 +206,7 @@ function add_rewrite_rules(): void {
 	// predictable. Instead, this just matches all the facets into a single var, and they'll be parsed out of that
 	// into individual facets later.
 	// @see set_query_vars_from_pretty_url().
+	add_rewrite_rule( FILTERED_URL_PATTERN . '/feed/?', 'index.php?pagename=$matches[1]&event_facets=$matches[2]&feed=feed', 'top' );
 	add_rewrite_rule( FILTERED_URL_PATTERN, 'index.php?pagename=$matches[1]&event_facets=$matches[2]', 'top' );
 }
 
@@ -220,7 +234,7 @@ function add_query_vars( array $query_vars ): array {
  * @see add_rewrite_rules()
  * @see add_query_vars()
  */
-function set_query_vars_from_pretty_url( WP $wp ): void {
+function set_query_vars_from_pretty_url( WP|WP_Query $wp ): void {
 	$facets = get_query_var_facets();
 
 	foreach ( $facets as $key => $value ) {
@@ -291,6 +305,72 @@ function sort_facets( array $facets ): array {
 	);
 
 	return $facets;
+}
+
+/**
+ * Adjust the query for feeds on the upcoming-events page.
+ *
+ * @param WP_Query $wp_query The WP_Query instance.
+ */
+function feed_parse_query( $wp_query ) {
+	global $wp;
+
+	if (
+		'upcoming-events' !== $wp_query->get( 'pagename' ) ||
+		! $wp_query->is_feed()
+	) {
+		return;
+	}
+
+	// Fix the feed link to use the correct URL.
+	$pagelink = home_url( preg_replace( '#/feed/?$#i', '/', $wp->request ) );
+	add_filter( 'bloginfo_rss', function( $value, $show ) use ( $pagelink ) {
+		if ( 'url' === $show ) {
+			return $pagelink;
+		}
+
+		return $value;
+	}, 10, 2 );
+
+	// The feed is built now.
+	add_filter( 'get_feed_build_date', function() {
+		return gmdate( 'r' );
+	} );
+
+	// Query for events.
+	$wp_query->parse_query( [
+		'post_type'      => 'wporg_events',
+		'feed'           => $wp_query->get( 'feed' ),
+		'posts_per_page' => 50,
+		'posts_per_rss'  => 50,
+	] );
+
+	// Permalinks should use the Guid.
+	add_filter( 'the_permalink_rss', function () {
+		return get_post()->guid;
+	} );
+
+	// Set the author to the meetup group.
+	add_filter( 'the_author', function () {
+		return get_post()->meetup;
+	} );
+
+	// Body should be prefixed with Location & Time. RSS Dates can't be in the future.
+	add_filter( 'the_content_feed', function ( $content ) {
+		$event = get_post();
+		$time  = date( 'F j, Y g:ia', strtotime( $event->post_date ) );
+
+		$prefix = sprintf(
+			'<p><strong>Location:</strong> %s<br/><strong>Time:</strong> %s</p>',
+			$event->location,
+			$time
+		);
+
+		return $prefix . $content;
+	} );
+
+	// Body doesn't need to staticize the emojis.
+	remove_filter( 'the_content_feed', 'wp_staticize_emoji' );
 }
 
 /**


### PR DESCRIPTION
Spurred by #1559 and a desire to have Events notifications in other places, it got me thinking about using RSS feeds.

This PR implements RSS feeds for urls such as:
- https://events.wordpress.org/upcoming-events/
- https://events.wordpress.org/upcoming-events/filtered/country/AU/
The feed url is suffixing `/feed/` to those URLs.

Some shortcomings were encountered:
 - The current event query code doesn't return the description, and always queries for 500 elements. https://github.com/WordPress/wporg-mu-plugins/pull/713 (This is a precursor to this feed PR)
 - RSS doesn't seem to handle future-dated content very well.. if at all.. as this is explicitly not allowed by the spec really
 - As the date isn't deemed valid by some clients, the order of the items in the feed is somewhat not predictable

Not implemented:
 - Page headers and links to the RSS feed to make it visible.
 - Feed Title is `<title>Posts filtered by: Australia &#8211; WordPress Events</title>` which could do with changing to `Upcoming Events filtered by: `

### Screenshots

Example of a RSS reader, as you can see, the event order is `December 2025, Jan 2026, Dec 2025, Nov 2025` despite the feed being ordered as `Nov, Dec, Dec, Jan`.

<img width="1115" height="448" alt="Screenshot 2025-11-13 at 4 59 37 pm" src="https://github.com/user-attachments/assets/35d56dff-7a5d-44d7-9796-698278824b97" />
