### PR TITLE
Latest Site: Make the notice text translatable

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -126,11 +126,12 @@ function show_notification_about_latest_site() {
 	}
 
 	echo '<div class="wordcamp-latest-site-notify"><p>' .
-		wp_sprintf( 
-			// translators: %s is the name of the WordCamp, %s is the URL of the next edition.
-			__( '%s is over. Check out <a href="%s">the next edition</a>!', 'wordcamporg' ), 
-			esc_html( get_blog_details( $current_blog->blog_id )->blogname ), esc_url( $latest_domain ) 
-		) .
+		wp_kses_post( wp_sprintf(
+			// translators: %1$s is the name of the WordCamp, %2$s is the URL of the next edition.
+			__( '%1$s is over. Check out <a href="%2$s">the next edition</a>!', 'wordcamporg' ),
+			esc_html( get_blog_details( $current_blog->blog_id )->blogname ),
+			esc_url( $latest_domain )
+		) ) .
 	'</p></div>';
 }
 

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -126,7 +126,11 @@ function show_notification_about_latest_site() {
 	}
 
 	echo '<div class="wordcamp-latest-site-notify"><p>' .
-		wp_sprintf( '%s is over. Check out <a href="%s">the next edition</a>!', esc_html( get_blog_details( $current_blog->blog_id )->blogname ), esc_url( $latest_domain ) ) .
+		wp_sprintf( 
+			// translators: %s is the name of the WordCamp, %s is the URL of the next edition.
+			__( '%s is over. Check out <a href="%s">the next edition</a>!', 'wordcamporg' ), 
+			esc_html( get_blog_details( $current_blog->blog_id )->blogname ), esc_url( $latest_domain ) 
+		) .
 	'</p></div>';
 }
 


### PR DESCRIPTION
This PR wraps the "latest site/upcoming edition" notice in internationalization functions so that it can be translated into different languages. Previously, the message was hard-coded in English, making it inaccessible for non-English WordCamp sites.

Fixes #1526