### PR TITLE
Revenue Report: Use a direct comparison on the timestamp field.

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-ticket-revenue.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-ticket-revenue.php
@@ -248,10 +248,9 @@ class Ticket_Revenue extends Date_Range {
 		$where_values = array();
 		$where        = '';
 
-		$where_clause[] = 'UNIX_TIMESTAMP( timestamp ) BETWEEN ' .
-						  $this->start_date->getTimestamp() .
-						  ' AND ' .
-						  $this->end_date->getTimestamp();
+		$where_clause[] = '( timestamp >= %s AND timestamp <= %s )';
+		$where_values[] = gmdate( 'Y-m-d', $this->start_date->getTimestamp() );
+		$where_values[] = gmdate( 'Y-m-d', $this->end_date->getTimestamp() );
 
 		if ( ! empty( $message_filter ) ) {
 			$like_clause = array();


### PR DESCRIPTION
This avoids MySQL needing to run `UNIX_TIMESTAMP()` on every value in the column when querying the table.

Untested as of yet. 