### PR TITLE
Simplify Docker DB setup (Remove HyperDB)

### DIFF
--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -26,7 +26,7 @@ define( 'DB_USER',     'root'         );
 define( 'DB_PASSWORD', 'mysql'        );
 define( 'DB_HOST',     'wordcamp.db'  );
 
-// Force utf8mb4
+// Force utf8mb4.
 define( 'DB_CHARSET', 'utf8mb4' );
 define( 'DB_COLLATE', 'utf8mb4_general_ci' );
 

--- a/.docker/wp-config.php
+++ b/.docker/wp-config.php
@@ -26,7 +26,7 @@ define( 'DB_USER',     'root'         );
 define( 'DB_PASSWORD', 'mysql'        );
 define( 'DB_HOST',     'wordcamp.db'  );
 
-// Force utf8mb4 since HyperDB won't admit it supports it.
+// Force utf8mb4
 define( 'DB_CHARSET', 'utf8mb4' );
 define( 'DB_COLLATE', 'utf8mb4_general_ci' );
 

--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,6 @@
 		"wpackagist-plugin/edit-flow": "*",
 		"wpackagist-plugin/email-post-changes": "dev-trunk",
 		"wpackagist-plugin/gutenberg": "*",
-		"wpackagist-plugin/hyperdb": "dev-trunk",
 		"wpackagist-plugin/jetpack": "*",
 		"wpackagist-plugin/liveblog": "*",
 		"wpackagist-plugin/public-post-preview": "*",

--- a/public_html/wp-content/db.php
+++ b/public_html/wp-content/db.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once( dirname( __FILE__ ) . '/plugins/hyperdb/db.php' );

--- a/public_html/wp-content/mu-plugins/0-error-handling.php
+++ b/public_html/wp-content/mu-plugins/0-error-handling.php
@@ -166,7 +166,6 @@ function is_third_party_file( $file ) {
 		WP_PLUGIN_DIR . '/edit-flow/',
 		WP_PLUGIN_DIR . '/email-post-changes/',
 		// Gutenberg isn't included here, because `send_error_to_slack()` will pipe it to a separate channel.
-		WP_PLUGIN_DIR . '/hyperdb/',
 		// Jetpack isn't included here, because `send_error_to_slack()` will pipe it to a separate channel.
 		WP_PLUGIN_DIR . '/liveblog/',
 		WP_PLUGIN_DIR . '/public-post-preview/',

--- a/public_html/wp-content/mu-plugins/tests/test-0-error-handler.php
+++ b/public_html/wp-content/mu-plugins/tests/test-0-error-handler.php
@@ -59,11 +59,6 @@ class Test_Error_Handling extends WP_UnitTestCase {
 				true,
 			),
 
-			'hyperdb' => array(
-				WP_PLUGIN_DIR . '/hyperdb/db.php',
-				true,
-			),
-
 			'camptix-paystack' => array(
 				WP_PLUGIN_DIR . '/camptix-paystack/includes/class-paystack.php',
 				true,

--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -42,13 +42,7 @@ class CampTix_Network_Tools {
 	function upgrade() {
 		global $wpdb;
 
-		$charset_collate = '';
-		if ( ! empty( $wpdb->charset ) ) {
-			$charset_collate = "DEFAULT CHARACTER SET $wpdb->charset";
-		}
-		if ( ! empty( $wpdb->collate ) ) {
-			$charset_collate .= " COLLATE $wpdb->collate";
-		}
+		$charset_collate = $wpdb->get_charset_collate();
 
 		$table_name = $wpdb->base_prefix . 'camptix_log';
 		$sql        = "CREATE TABLE $table_name (

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -60,7 +60,7 @@ class Payment_Requests_Dashboard {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
 		$charset_collate = $wpdb->get_charset_collate();
-		$sql             = sprintf( "CREATE TABLE %i (
+		$sql             = sprintf( "CREATE TABLE %s (
 			id int(11) unsigned NOT NULL auto_increment,
 			blog_id int(11) unsigned NOT NULL default '0',
 			post_id int(11) unsigned NOT NULL default '0',
@@ -76,7 +76,7 @@ class Payment_Requests_Dashboard {
 			KEY blog_post_id (blog_id, post_id),
 			KEY due (due),
 			KEY status (status)
-		) $charset_collate;", self::get_table_name() );
+		) %s;", self::get_table_name(), $charset_collate );
 
 		dbDelta( $sql );
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -59,8 +59,8 @@ class Payment_Requests_Dashboard {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-		$charset_collate = "DEFAULT CHARACTER SET {$wpdb->charset} COLLATE {$wpdb->collate}";
-		$sql             = sprintf( "CREATE TABLE %s (
+		$charset_collate = $wpdb->get_charset_collate();
+		$sql             = sprintf( "CREATE TABLE %i (
 			id int(11) unsigned NOT NULL auto_increment,
 			blog_id int(11) unsigned NOT NULL default '0',
 			post_id int(11) unsigned NOT NULL default '0',
@@ -76,7 +76,7 @@ class Payment_Requests_Dashboard {
 			KEY blog_post_id (blog_id, post_id),
 			KEY due (due),
 			KEY status (status)
-		) %s;", self::get_table_name(), $charset_collate );
+		) $charset_collate;", self::get_table_name() );
 
 		dbDelta( $sql );
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/reimbursement-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/reimbursement-requests-dashboard.php
@@ -151,6 +151,8 @@ function upgrade_database() {
 	$table_name = get_index_table_name();
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
+	$charset_collate = $wpdb->get_charset_collate();
+
 	$schema = "
 		CREATE TABLE $table_name (
 			blog_id        int( 11 )        unsigned NOT NULL default '0',
@@ -168,8 +170,7 @@ function upgrade_database() {
 			PRIMARY KEY  (blog_id, request_id),
 			KEY status (status)
 		)
-		DEFAULT CHARACTER SET {$wpdb->charset}
-		COLLATE {$wpdb->collate};
+		$charset_collate
 	";
 
 	dbDelta( $schema );

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -182,6 +182,8 @@ function upgrade_database() {
 	$table_name = get_index_table_name();
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
+	$charset_collate = $wpdb->get_charset_collate();
+
 	$schema = "
 		CREATE TABLE $table_name (
 			blog_id        int( 11 )        unsigned NOT NULL default '0',
@@ -202,8 +204,7 @@ function upgrade_database() {
 			KEY status (status)
 			KEY last_modified (last_modified)
 		)
-		DEFAULT CHARACTER SET {$wpdb->charset}
-		COLLATE {$wpdb->collate};
+		$charset_collate
 	";
 
 	dbDelta( $schema );


### PR DESCRIPTION
As part of attempting to stream line WordCamp to use the WordPress.org HyperDB I've run into a case where it's probably easier to remove the HyperDB handling from the github codebase, than it is to workaround having part of it open-source verses the closed-source (DB configuration).

As HyperDB is not actually needed by WordCamp.org in local environments (There's only a singular Database/server) it might as well just be removed.

This might have some unexpected edgecases, as WordPress may upgrade the local-dev DB tables collation from `utf8mb4_general_ci` to `utf8mb4_unicode_520_ci` which we're not presently using on WordCamp.org (AFAIK), but this isn't likely to cause any compatibility issues between the two environments.