### PR TITLE
Add 'Actual Attendees' and 'Series Event' to event post types

### DIFF
--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -44,6 +44,8 @@ class CampTix_Attendance extends CampTix_Addon {
 			return;
 		}
 
+		add_action( 'tix_scheduled_daily', array( $this, 'cron_stats_update_attended_count' ) );
+
 		add_filter( 'wp_ajax_camptix-attendance', array( $this, 'ajax_callback' ) );
 		add_filter( 'wp_ajax_nopriv_camptix-attendance', array( $this, 'ajax_callback' ) );
 
@@ -94,6 +96,7 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * Sets are removes the attended flag for a given camptix_id.
 	 */
 	public function _ajax_sync_model() {
+		global $camptix;
 		if ( empty( $_REQUEST['camptix_id'] ) )
 			return;
 
@@ -105,9 +108,11 @@ class CampTix_Attendance extends CampTix_Addon {
 
 		if ( isset( $_REQUEST['camptix_set_attendance'] ) ) {
 			if ( 'true' == $_REQUEST['camptix_set_attendance'] ) {
+				$camptix->increment_stats( 'attended', 1 );
 				$this->log( 'Marked attendee as attended.', $attendee->ID );
 				update_post_meta( $attendee->ID, 'tix_attended', true );
 			} else {
+				$camptix->increment_stats( 'attended', -1 );
 				$this->log( 'Marked attendee as did not attended.', $attendee->ID );
 				delete_post_meta( $attendee->ID, 'tix_attended' );
 			}
@@ -438,6 +443,40 @@ class CampTix_Attendance extends CampTix_Addon {
 		) );
 
 		return $this->tickets;
+	}
+
+	/**
+	 * Get attended count.
+	 *
+	 * @return int Number of attendees marked as attended.
+	 */
+	public function get_attended_count() {
+		$attended_query = new WP_Query( array(
+			'post_type'      => 'tix_attendee',
+			'post_status'    => 'publish',
+			'meta_key'       => 'tix_attended',
+			'meta_value'     => '1',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		) );
+
+		return $attended_query->found_posts;
+	}
+
+	/**
+	 * Cron job to update attended count in stats.
+	 */
+	public function cron_stats_update_attended_count() {
+		global $camptix;
+
+		$attended_count = $this->get_attended_count();
+		if ( ! $attended_count ) {
+			$attended_count = 0;
+		}
+
+		$camptix->update_stats( array(
+			'attended' => $attended_count,
+		) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -93,7 +93,7 @@ class CampTix_Attendance extends CampTix_Addon {
 	/**
 	 * Synchronize a single attendee model.
 	 *
-	 * Sets are removes the attended flag for a given camptix_id.
+	 * Sets or removes the attended flag for a given camptix_id.
 	 */
 	public function _ajax_sync_model() {
 		global $camptix;

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -496,7 +496,7 @@ abstract class Event_Admin {
 				if ( is_array( $_POST[ $post_value ] ) ) {
 					$values[ $key ] = array_filter(
 						array_map( 'esc_attr', wp_unslash( $_POST[ $post_value ] ) ),
-						static function( $value ) {
+						static function ( $value ) {
 							return ! is_null( $value ) && '' !== $value;
 						}
 					);

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -491,7 +491,19 @@ abstract class Event_Admin {
 
 		foreach ( $meta_keys as $key => $value ) {
 			$post_value     = wcpt_key_to_str( $key, 'wcpt_' );
-			$values[ $key ] = isset( $_POST[ $post_value ] ) ? esc_attr( $_POST[ $post_value ] ) : '';
+			$values[ $key ] = '';
+			if ( isset( $_POST[ $post_value ] ) ) {
+				if ( is_array( $_POST[ $post_value ] ) ) {
+					$values[ $key ] = array_filter(
+						array_map( 'esc_attr', wp_unslash( $_POST[ $post_value ] ) ),
+						static function( $value ) {
+							return ! is_null( $value ) && '' !== $value;
+						}
+					);
+				} else {
+					$values[ $key ] = esc_attr( wp_unslash( $_POST[ $post_value ] ) );
+				}
+			}
 
 			// Don't update protected fields.
 			if ( $this->is_protected_field( $key ) ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1368,7 +1368,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					if ( $site_id ) {
 						// Use attendees checked in, falling back to tickets sold.
 						$camptix_stats      = get_blog_option( $site_id, 'camptix_stats', array() );
-						$attendees_attended = $camptix_stats['attended'] ?? ( $camptix_stats['sold'] ?? 0 );
+						$attendees_attended = ( $camptix_stats['attended'] ?? 0 ) ?: ( $camptix_stats['sold'] ?? 0 );
 
 						// Assume sales were not through Camptix if less than 10 tickets total.
 						if ( $attendees_attended >= 10 ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1360,6 +1360,22 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'post_status' => 'wcpt-closed',
 					)
 				);
+
+				// If the 'Actual Attendees' field isn't yet set, set it to the camptix sales.
+				$actual_attendees = get_post_meta( $wordcamp->ID, 'Actual Attendees', true );
+				if ( empty( $actual_attendees ) ) {
+					$site_id = get_wordcamp_site_id( $wordcamp );
+					if ( $site_id ) {
+						// Use attendees checked in, falling back to tickets sold.
+						$camptix_stats      = get_blog_option( $site_id, 'camptix_stats', array() );
+						$attendees_attended = $camptix_stats['attended'] ?? ( $camptix_stats['sold'] ?? 0 );
+
+						// Assume sales were not through Camptix if less than 10 tickets total.
+						if ( $attendees_attended >= 10 ) {
+							update_post_meta( $wordcamp->ID, 'Actual Attendees', $attendees_attended );
+						}
+					}
+				}
 			}
 		}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -425,6 +425,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Twitter'                           => 'text',
 						'WordCamp Hashtag'                  => 'text',
 						'Number of Anticipated Attendees'   => 'text',
+						'Actual Attendees'                  => 'text',
 						'Multi-Event Sponsor Region'        => 'mes-dropdown',
 						'Global Sponsorship Grant Currency' => 'select-currency',
 						'Global Sponsorship Grant Amount'   => 'number',
@@ -432,14 +433,27 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Running money through WPCS PBC'    => 'checkbox',
 						'Transparency Report Received'      => 'checkbox',
 						'Hide from Event Feeds'             => 'checkbox-delete-on-unset',
+						'Series Event'                      => 'checkbox', // Campus Connect.
 					);
 
 					/*
 					 * The "Transparency Report Received" checkbox can only be checked or unchecked when the current user is admin or super admin.
 					 * See https://github.com/WordPress/wordcamp.org/issues/1280#issuecomment-2058571557.
+					 *
+					 * Same for 'Series Event'.
 					 */
 					if ( ! current_user_can( 'manage_options' ) ) {
 						unset( $retval['Transparency Report Received'] );
+						unset( $retval['Series Event'] );
+					}
+
+					/*
+					 * The "Actual Attendees" field is only able to be set after the event is concluded.
+					 *
+					 * get_post() allows this to target the editor, allowing for report export.
+					 */
+					if ( get_post() && get_post_status() !== 'wcpt-closed' ) {
+						unset( $retval['Actual Attendees'] );
 					}
 
 					break;
@@ -457,6 +471,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Twitter'                           => 'text',
 						'WordCamp Hashtag'                  => 'text',
 						'Number of Anticipated Attendees'   => 'text',
+						'Actual Attendees'                  => 'text',
 						'Multi-Event Sponsor Region'        => 'mes-dropdown',
 						'Global Sponsorship Grant Currency' => 'select-currency',
 						'Global Sponsorship Grant Amount'   => 'number',
@@ -464,14 +479,27 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Running money through WPCS PBC'    => 'checkbox',
 						'Transparency Report Received'      => 'checkbox',
 						'Hide from Event Feeds'             => 'checkbox-delete-on-unset',
+						'Series Event'                      => 'checkbox', // Campus Connect.
 					);
 
 					/*
 					 * The "Transparency Report Received" checkbox can only be checked or unchecked when the current user is admin or super admin.
 					 * See https://github.com/WordPress/wordcamp.org/issues/1280#issuecomment-2058571557.
+					 *
+					 * Same for 'Series Event'.
 					 */
 					if ( ! current_user_can( 'manage_options' ) ) {
 						unset( $retval['Transparency Report Received'] );
+						unset( $retval['Series Event'] );
+					}
+
+					/*
+					 * The "Actual Attendees" field is only able to be set after the event is concluded.
+					 *
+					 * get_post() allows this to target the editor, allowing for report export.
+					 */
+					if ( get_post() && get_post_status() !== 'wcpt-closed' ) {
+						unset( $retval['Actual Attendees'] );
 					}
 
 					$retval = array_merge(
@@ -1157,6 +1185,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					$protected_fields,
 					array(
 						'Multi-Event Sponsor Region',
+						'Series Event',
 					)
 				);
 			}
@@ -1504,9 +1533,11 @@ function wcpt_metabox( $meta_keys, $metabox ) {
 		'Mailing Address'                 => 'Shipping address.',
 		'Twitter'                         => 'Should begin with @. Ex. @wordpress',
 		'WordCamp Hashtag'                => 'Should begin with #. Ex. #wcus',
+		'Actual Attendees'                => 'Number of attendees who actually attended the event.',
 		'Global Sponsorship Grant Amount' => 'No commas, thousands separators or currency symbols. Ex. 1234.56',
 		'Global Sponsorship Grant'        => 'Deprecated.',
 		'Hide from Event Feeds'           => 'Do not show in the public schedule and dashboard feeds, the site is still publicly accessible.',
+		'Series Event'                    => '(Campus Connect only) Event is part of a multi-venue or multi-session series (e.g., workshops held across several campuses)',
 	);
 
 	if ( 'wcpt_venue_info' === $metabox ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #1558

Some magic sugar is added, in that the number is automatically calculated at event close based on either a) tickets sold, or b) if the attendee checkin app has used, how many have checked in.

I'm not 100% that setting this automatically is wanted, as this may cause organisers to not fill it in.. however, I make an assumption that it's more likely that it's going to be WordCamp Admins who are setting this field, so perhaps filling this in with the best estimate would be useful for reporting purposes? I might split that into a new PR.