### PR TITLE
Fix: hide contact form field warnings after successful submission on Coming Soon pages.

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -365,6 +365,15 @@ class WordCamp_Coming_Soon_Page {
 			}
 
 			if ( $contact_form_content ) {
+				// If the form was successfully submitted, wrap it so
+				// Coming Soon styles can suppress post-submit warnings.
+				if ( false !== strpos( $contact_form_content, 'Your message has been sent' ) ) {
+					$contact_form_content = sprintf(
+						'<div class="wccsp-contact-form-success">%s</div>',
+						$contact_form_content
+					);
+				}
+
 				break;
 			}
 		}

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/css/template-coming-soon.css
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/css/template-coming-soon.css
@@ -248,3 +248,10 @@ label {
 	width: auto;
 	text-shadow: none;
 }
+
+/* Hide Jetpack contact form field warnings after successful submission */
+.wccsp-contact-form-success .warning,
+.wccsp-contact-form-success .is-error,
+.wccsp-contact-form-success .contact-form__warning {
+	display: none;
+}


### PR DESCRIPTION
## Problem
On Coming Soon pages, Jetpack contact forms display field-level warnings
even after a successful submission message ("Your message has been sent")
is shown.

This can be reproduced on:
- https://us.wordcamp.org/2026/
- https://testing.wordcamp.org/2022/

The issue occurs only on Coming Soon pages and does not appear on
standard WordPress pages using the same Jetpack contact form.

## Root cause
The Coming Soon plugin renders Jetpack contact forms via shortcode or
block output, but does not provide a post-submission success state.
As a result, Jetpack’s field-level warning styles remain visible even
after a successful submission.

## Solution
This PR adds a Coming Soon–specific success wrapper around the rendered
contact form output when a successful submission is detected.

### Code changes
- Updated `get_contact_form_shortcode()` in  
  `wordcamp-coming-soon-page.php`
- Detects successful submissions by checking for Jetpack’s success
  message in the rendered form output
- Wraps successful form output in a `.wccsp-contact-form-success` container
- Adds scoped CSS to suppress field-level warning styles only when the
  success wrapper is present

This approach:
- Avoids modifying Jetpack core behavior
- Limits the change strictly to Coming Soon pages
- Preserves normal validation behavior before submission

## How to test
1. Visit a Coming Soon site with a contact form
2. Submit the form with valid data
3. Confirm the success message is displayed
4. Verify that no field-level warnings appear after submission

## Testing notes
I wasn’t able to run a full WordCamp.org environment locally.
The change is scoped to the Coming Soon plugin and was verified through
code inspection and by matching the behavior observed on the affected
production and testing URLs.

Fixes #1566
