### PR TITLE
Update Meetup tracker sync

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-functions.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-functions.php
@@ -80,7 +80,7 @@ function wcpt_get_log_entries( $event_id ) {
 function process_raw_entries( $raw_entries, $entry_type ) {
 	$entries = array();
 	foreach ( $raw_entries as $entry ) {
-		$user = get_user_by( 'id', $entry['user_id'] );
+		$user = get_user_by( 'id', $entry['user_id'] ?? 0 );
 
 		if ( $user ) {
 			$entry['user_display_name'] = $user->display_name;

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -371,8 +371,8 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 			$event_hosts = array();
 			if ( isset( $group_leads ) && is_array( $group_leads ) ) {
 				foreach ( $group_leads as $event_host ) {
-					if ( WCPT_WORDPRESS_MEETUP_ID === $event_host['id'] ) {
-						// Skip WordPress admin user.
+					// Skip WordPress admin user.
+					if ( WCPT_WORDPRESS_MEETUP_ID === (int) $event_host['id'] ) {
 						continue;
 					}
 					$event_hosts[] = array(
@@ -423,8 +423,8 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 			);
 
 			$original_organizers_list = $this->get_organizer_list(
-				$original_data['Primary organizer WordPress.org username'][0],
-				$original_data['Co-Organizers usernames (seperated by comma)'][0]
+				$original_data['Primary organizer WordPress.org username'][0] ?? '',
+				$original_data['Co-Organizers usernames (seperated by comma)'][0] ?? ''
 			);
 
 			$new_organizers = array_diff( $organizers_list, $original_organizers_list );

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -786,7 +786,11 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 			$query = new WP_Query(
 				array(
 					'post_type'      => self::get_event_type(),
-					'post_status'    => 'wcpt-mtp-active',
+					'post_status'    => [
+						'wcpt-mtp-active',
+						'wcpt-mtp-dormant',
+						'wcpt-mtp-nds-nw-ow',
+					],
 					'fields'         => 'ids',
 					'posts_per_page' => - 1,
 				)

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -416,6 +416,25 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				}
 			}
 
+			// Update the meetup URL if it has changed, ignore case and trailing slash changes.
+			if ( $group_details['link'] && strtolower( trailingslashit( $group_details['link'] ) ) !== strtolower( trailingslashit( $meetup_url ) ) ) {
+				update_post_meta( $post_id, 'Meetup URL', $group_details['link'] );
+
+				add_post_meta(
+					$post_id,
+					'_note',
+					array(
+						'timestamp' => time(),
+						'user_id'   => 0,
+						'message'   => sprintf(
+							'Meetup URL updated from %s to %s via Meetup.com API sync.',
+							$meetup_url,
+							$group_details['link']
+						),
+					)
+				);
+			}
+
 			update_post_meta( $post_id, 'Meetup Co-organizer names', $event_hosts );
 			update_post_meta( $post_id, 'Meetup Location (From meetup.com)', $group_details['localized_location'] );
 			update_post_meta( $post_id, 'Meetup Coordinates', "{$group_details['lat']},{$group_details['lon']}" );

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -110,6 +110,7 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				// These fields are updated by Meetup API and will be overwritten even if manually changed.
 				'Meetup Co-organizer names',
 				'Meetup Location (From meetup.com)',
+				'Meetup Coordinates',
 				'Meetup members count',
 				'Meetup group created on',
 				'Number of past meetups',
@@ -383,6 +384,9 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 
 			update_post_meta( $post_id, 'Meetup Co-organizer names', $event_hosts );
 			update_post_meta( $post_id, 'Meetup Location (From meetup.com)', $group_details['localized_location'] );
+			update_post_meta( $post_id, 'Meetup Coordinates', "{$group_details['lat']},{$group_details['lon']}" );
+			update_post_meta( $post_id, '_lat', $group_details['lat'] );
+			update_post_meta( $post_id, '_lon', $group_details['lon'] );
 			update_post_meta( $post_id, 'Meetup members count', $group_details['members'] );
 			update_post_meta( $post_id, 'Meetup group created on', $group_details['created'] );
 
@@ -624,6 +628,8 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				'Primary organizer WordPress.org username'     => 'text',
 				'Co-Organizers usernames (seperated by comma)' => 'text',
 				'Meetup Location (From meetup.com)'            => 'text',
+				'Meetup Coordinates'                           => 'text',
+				'Meetup members count'                         => 'text',
 				'Meetup group created on'                      => 'date',
 				'Number of past meetups'                       => 'text',
 				'Last meetup on'                               => 'date',

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -331,6 +331,11 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 		 * @return array|WP_Error
 		 */
 		public static function update_meetup_data( $post_id ) {
+			// Used to prevent a self loop when updating post status to canceled.
+			static $self_loop_prevent = false;
+			if ( $self_loop_prevent ) {
+				return;
+			}
 
 			$meetup_url = get_post_meta( $post_id, 'Meetup URL', true );
 			$meetup_path = wp_parse_url( $meetup_url, PHP_URL_PATH );
@@ -353,8 +358,37 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				return new WP_Error( 'invalid-response', __( 'Received invalid response from Meetup API.', 'wordcamporg' ) );
 			}
 
+			// If the group doesn't exist, mark it as canceled. Note: This is different from removed-from-chapter.
+			if ( false === $group_details ) {
+				// Only mark active groups as removed.
+				if ( ! in_array( get_post( $post_id )->post_status, [ 'wcpt-mtp-active', 'wcpt-mtp-dormant', 'wcpt-mtp-nds-nw-ow' ] ) ) {
+					return;
+				}
+
+				add_post_meta(
+					$post_id,
+					'_note',
+					array(
+						'timestamp' => time(),
+						'user_id'   => 0,
+						'message'   => 'Meetup no longer exists per Meetup.com API sync.',
+					)
+				);
+
+				$self_loop_prevent = true;
+
+				wp_update_post( array(
+					'ID'          => $post_id,
+					'post_status' => 'wcpt-mtp-canceled',
+				) );
+
+				$self_loop_prevent = false;
+
+				return;
+			}
+
 			$group_leads = $mtp_client->get_group_members(
-				$slug,
+				$group_details['urlname'],
 				array(
 					'role' => 'leads',
 				)

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -333,13 +333,13 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 		public static function update_meetup_data( $post_id ) {
 
 			$meetup_url = get_post_meta( $post_id, 'Meetup URL', true );
+			$meetup_path = wp_parse_url( $meetup_url, PHP_URL_PATH );
 
-			$parsed_url = wp_parse_url( $meetup_url, -1 );
-
-			if ( ! $parsed_url ) {
+			if ( ! $meetup_path ) {
 				return new WP_Error( 'invalid-url', __('Provided Meetup URL is not a valid URL.', 'wordcamporg' ) );
 			}
-			$url_path_segments = explode( '/', rtrim( $parsed_url['path'], '/' ) );
+
+			$url_path_segments = explode( '/', rtrim( $meetup_path, '/' ) );
 			$slug              = array_pop( $url_path_segments );
 			$mtp_client        = new WordPressdotorg\MU_Plugins\Utilities\Meetup_Client();
 


### PR DESCRIPTION
This updates the Meetup listings to:
 - Include Lat / Lon coords for groups
 - ~Include the Member count on the overview~
 - Automatically remove a group from the chapter-post_status when it's no longer in existence
 - ~Properly exclude the WordPress organizer from the listings~

Split some items into #1573 
