### PR TITLE
Optimize Camptix log for report queries

### DIFF
--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -12,7 +12,7 @@
 
 class CampTix_Network_Tools {
 	private $options;
-	private $db_version = 20260119;
+	private $db_version = 20260121;
 	const PLUGIN_URL    = 'http://wordpress.org/plugins/camptix-network-tools';
 
 	function __construct() {
@@ -56,6 +56,7 @@ class CampTix_Network_Tools {
 			PRIMARY KEY (`id`),
 			KEY `timestamp` (`timestamp`)
   			KEY `blog_object` (`blog_id`,`object_id`)
+			KEY `message_prefix` (`message`(8))
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -12,7 +12,7 @@
 
 class CampTix_Network_Tools {
 	private $options;
-	private $db_version = 20240226;
+	private $db_version = 20260119;
 	const PLUGIN_URL    = 'http://wordpress.org/plugins/camptix-network-tools';
 
 	function __construct() {
@@ -54,6 +54,7 @@ class CampTix_Network_Tools {
 			section varchar(32) DEFAULT 'general',
 			data mediumtext NOT NULL,
 			PRIMARY KEY (`id`),
+			KEY `timestamp` (`timestamp`)
   			KEY `blog_object` (`blog_id`,`object_id`)
 		) $charset_collate;";
 

--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -153,11 +153,12 @@ class CampTix_Network_Tools {
 
 		$table_name = $wpdb->base_prefix . 'camptix_log';
 		$wpdb->insert( $table_name, array(
-			'blog_id' => $blog_id,
+			'timestamp' => current_time( 'mysql' ),
+			'blog_id'   => $blog_id,
 			'object_id' => $post_id,
-			'message' => $message,
-			'data' => $data,
-			'section' => $section,
+			'message'   => $message,
+			'section'   => $section,
+			'data'      => $data,
 		) );
 		$camptix->tmp( 'last_log_id', $wpdb->insert_id );
 

--- a/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
+++ b/public_html/wp-content/plugins/camptix-network-tools/camptix-network-tools.php
@@ -54,8 +54,8 @@ class CampTix_Network_Tools {
 			section varchar(32) DEFAULT 'general',
 			data mediumtext NOT NULL,
 			PRIMARY KEY (`id`),
-			KEY `timestamp` (`timestamp`)
-  			KEY `blog_object` (`blog_id`,`object_id`)
+			KEY `timestamp` (`timestamp`),
+			KEY `blog_object` (`blog_id`,`object_id`),
 			KEY `message_prefix` (`message`(8))
 		) $charset_collate;";
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -2820,7 +2820,6 @@ class CampTix_Plugin {
 			'run_time'     => number_format( microtime( true ) - $start_time, 3 ),
 		);
 
-		$this->log( sprintf( 'Revenue report data generated in %s seconds', $results['run_time'] ) );
 		return $results;
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-ticket-revenue.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-ticket-revenue.php
@@ -248,10 +248,9 @@ class Ticket_Revenue extends Date_Range {
 		$where_values = array();
 		$where        = '';
 
-		$where_clause[] = 'UNIX_TIMESTAMP( timestamp ) BETWEEN ' .
-						  $this->start_date->getTimestamp() .
-						  ' AND ' .
-						  $this->end_date->getTimestamp();
+		$where_clause[] = '`timestamp` BETWEEN %s AND %s';
+		$where_values[] = gmdate( 'Y-m-d H:i:s', $this->start_date->getTimestamp() );
+		$where_values[] = gmdate( 'Y-m-d H:i:s', $this->end_date->getTimestamp() );
 
 		if ( ! empty( $message_filter ) ) {
 			$like_clause = array();

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-ticket-revenue.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-ticket-revenue.php
@@ -256,8 +256,8 @@ class Ticket_Revenue extends Date_Range {
 			$like_clause = array();
 
 			foreach ( $message_filter as $string ) {
-				$like_clause[]  = 'message LIKE \'%%%s%%\'';
-				$where_values[] = $string;
+				$like_clause[]  = 'message LIKE %s';
+				$where_values[] = $string . '%';
 			}
 
 			$where_clause[] = '( ' . implode( ' OR ', $like_clause ) . ' )';


### PR DESCRIPTION
See #1578

This PR:
 - Adjusts the table to have an index on the timestamp column
 - Uses a query syntax that can make use of that index

This resolves #1578 for small data sets, but still runs into limits on larger time frames.

The main issue is that the query is filtering by `message LIKE *X* OR message LIKE *Y*` which results in it needing to perform a full table scan of the matched rows.
A further index on the `message` field to group by the first X characters may help here, The first 10 char should be fairly non-unique set of data points. However, the query isn't anchored to the prefix so would be unable to use it at present.