### PR TITLE
Add scssphp as a required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
 	],
 	"require": {
 		"adhocore/jwt": "^1.0",
+		"scssphp/scssphp": "^2.1.0",
 		"wporg/wporg-parent-2021": "dev-build"
 	},
 	"require-dev": {


### PR DESCRIPTION
This is used for the Custom CSS / Additional CSS functionality.

Fixes #1583
