### PR TITLE
Invoices: Update Payment instructions for EUR payments

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -408,7 +408,7 @@ class WordCamp_QBO {
 			https://central.wordcamp.org/sponsorship-payment-options/
 			';
 		} else {
-			// Non-EUR payments
+			// Non-EUR payments.
 			$payment_instructions = '
 			Please include the invoice number in the memo field when making your payment.
 

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -404,7 +404,7 @@ class WordCamp_QBO {
 			IBAN: GB12CHAS60924276907354
 			SWIFT BIC: CHASGB2L
 
-			For other Payment options, including Credit Card, please see:
+			For other payment options, including Credit Card, please see:
 			https://central.wordcamp.org/sponsorship-payment-options/
 			';
 		} else {
@@ -429,7 +429,7 @@ class WordCamp_QBO {
 
 			Please remit checks (USD only) to: WordPress Community Support, PBC, P.O. Box 101768, Pasadena, CA 91189-1768
 
-			For other Payment options, including Credit Card and EUR Payments, please see:
+			For other payment options, including Credit Card and EUR-specific instructions, please see:
 			https://central.wordcamp.org/sponsorship-payment-options/
 			';
 		}

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -416,7 +416,7 @@ class WordCamp_QBO {
 			Beneficiary Name: WordPress Community Support, PBC
 			Mailing Address: 660 4th St #119, San Francisco, CA 94107, USA
 
-			If paying in any other currency (not EUR):
+			If paying in any currency other than EUR:
 			Bank Name: JPMorgan Chase Bank, N.A.
 			Bank Address: 270 Park Ave, New York, NY 10017, USA
 			Bank Routing and Transit Number: 021000021

--- a/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
+++ b/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php
@@ -388,17 +388,35 @@ class WordCamp_QBO {
 		$oauth_header = self::qbo_client()->get_oauth_header();
 		$realm_id     = self::qbo_client()->get_realm_id();
 
-		// Note: This has a character limit when combined with $description; see $customer_memo
-		$payment_instructions = trim( str_replace( "\t", '', '
-			Please indicate the invoice number in the memo field when making your payment.
-
-			To pay via credit card, please fill out the payment form at https://central.wordcamp.org/sponsorship-payment/
-			An additional 2.9% to cover processing fees on credit card payments is highly appreciated but not required.
+		// Note: This has a character limit when combined with $description; see $customer_memo below.
+		if ( 'EUR' === $currency_code ) {
+			$payment_instructions = '
+			Please include the invoice number in the memo field when making your payment.
 
 			For International Wire Transfers:
 			Beneficiary Name: WordPress Community Support, PBC
 			Mailing Address: 660 4th St #119, San Francisco, CA 94107, USA
 
+			If paying in EUR:
+			Bank Name: J.P. Morgan Chase Bank N.A., London
+			Bank Address: 25 Bank Street, Canary Wharf, London, E14 5JP, U.K.
+			Account Number: 0076907354
+			IBAN: GB12CHAS60924276907354
+			SWIFT BIC: CHASGB2L
+
+			For other Payment options, including Credit Card, please see:
+			https://central.wordcamp.org/sponsorship-payment-options/
+			';
+		} else {
+			// Non-EUR payments
+			$payment_instructions = '
+			Please include the invoice number in the memo field when making your payment.
+
+			For International Wire Transfers:
+			Beneficiary Name: WordPress Community Support, PBC
+			Mailing Address: 660 4th St #119, San Francisco, CA 94107, USA
+
+			If paying in any other currency (not EUR):
 			Bank Name: JPMorgan Chase Bank, N.A.
 			Bank Address: 270 Park Ave, New York, NY 10017, USA
 			Bank Routing and Transit Number: 021000021
@@ -409,8 +427,13 @@ class WordCamp_QBO {
 			Bank Routing & Transit Number: 322271627
 			Account Number: 157120285
 
-			Please remit checks (USD only) to: WordPress Community Support, PBC, P.O. Box 101768, Pasadena, CA 91189-1768'
-		) );
+			Please remit checks (USD only) to: WordPress Community Support, PBC, P.O. Box 101768, Pasadena, CA 91189-1768
+
+			For other Payment options, including Credit Card and EUR Payments, please see:
+			https://central.wordcamp.org/sponsorship-payment-options/
+			';
+		}
+		$payment_instructions = trim( str_replace( "\t", '', $payment_instructions ) );
 
 		/*
 		 * The API limits CustomerMemo to 1,000 characters. We use 995 to allow for newlines between the two


### PR DESCRIPTION
This skips including all of the USD/rest-of-world payment instructions on EUR sponsorship invoices, to ease the confusion of how to pay.

For USD and rest-of-world this also means they're less likely to pay non-EUR to our EUR bank account.

In both cases, the credit card payment option is moved to the linked page ~~**(which doesn't yet exist)**~~ to hopefully encourage less stripe sponsorship fee's for us (But still available if the sponsor prefers)

This stems from me finding out we hard-code the Invoice payment instructions, as I had to update a reaaally old address in dce05dffc361630eb39b99f75a32f83fbb274a84
This change is pending review from our Accounting guru :)  Result: 👍