### PR TITLE
Correct Stripe payments for UGX.

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -111,7 +111,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		$currency_multipliers = array(
 			// Zero-decimal currencies
 			1    => array(
-				'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF',
+				'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'VND', 'VUV', 'XAF',
 				'XOF', 'XPF',
 			),
 			100  => array(
@@ -119,12 +119,15 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 				'BMD', 'BND', 'BOB', 'BRL', 'BSD', 'BWP', 'BZD', 'CAD', 'CDF', 'CHF', 'CNY', 'COP',
 				'CRC', 'CVE', 'CZK', 'DKK', 'DOP', 'DZD', 'EGP', 'ETB', 'EUR', 'FJD', 'FKP',
 				'GBP', 'GEL', 'GIP', 'GMD', 'GTQ', 'GYD', 'HKD', 'HNL', 'HRK', 'HTG', 'HUF', 'IDR',
-				'ILS', 'INR', 'ISK', 'JMD', 'KES', 'KGS', 'KHR', 'KYD', 'KZT',
+				'ILS', 'INR', 'JMD', 'KES', 'KGS', 'KHR', 'KYD', 'KZT',
 				'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'MAD', 'MDL', 'MKD', 'MMK', 'MNT', 'MRO', 'MOP', 'MUR', 'MVR', 'MWK',
 				'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR',
 				'PLN', 'QAR', 'RON', 'RSD', 'RUB', 'SAR', 'SBD', 'SCR', 'SEK', 'SGD', 'SHP', 'SLL',
 				'SOS', 'SRD', 'STD', 'SZL', 'THB', 'TJS', 'TOP', 'TRY', 'TTD', 'TWD',
 				'TZS', 'UAH', 'USD', 'UYU', 'UZS', 'WST', 'XCD', 'YER', 'ZAR', 'ZMW',
+				// See https://docs.stripe.com/currencies#special-cases
+				// ZERO decimal currencies which MUST be passed with a 100x multiplier
+				'ISK', 'UGX',
 			),
 		);
 

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -125,8 +125,8 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 				'PLN', 'QAR', 'RON', 'RSD', 'RUB', 'SAR', 'SBD', 'SCR', 'SEK', 'SGD', 'SHP', 'SLL',
 				'SOS', 'SRD', 'STD', 'SZL', 'THB', 'TJS', 'TOP', 'TRY', 'TTD', 'TWD',
 				'TZS', 'UAH', 'USD', 'UYU', 'UZS', 'WST', 'XCD', 'YER', 'ZAR', 'ZMW',
-				// See https://docs.stripe.com/currencies#special-cases
-				// ZERO decimal currencies which MUST be passed with a 100x multiplier
+				// Zero-decimal currencies which MUST be passed with a 100x multiplier.
+				// (See https://docs.stripe.com/currencies#special-cases).
 				'ISK', 'UGX',
 			),
 		);


### PR DESCRIPTION
UGX and ISK are both zero-decimal currencies, but for back-compat Stripe requires these to be passed with a 100x multiplier.

Previously: https://github.com/WordPress/wordcamp.org/commit/97c1d78601db10860f819b8b8ceccca6552a001c