### PR TITLE
Automatically stop existing action runs for PRs with multiple commits.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,6 +11,10 @@ on:
     paths:
     - public_html/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: All

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,10 @@ on:
     - .github/workflows/**
     - phpunit.*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-js:
     name: JavaScript


### PR DESCRIPTION
When multiple commits are made, allowing the actions for the previous commit to run are often not needed.

This enables the concurrency option which aborts in-progress actions for the same branch.