### PR TITLE
Allow the wporg/event-list block to have multiple instances on a page

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/block.json
@@ -22,6 +22,7 @@
 			"default": 100
 		},
 		"order": {
+			"type": "string",
 			"enum": [ "asc", "desc" ],
 			"default": "asc"
 		}

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -41,6 +41,8 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
+	$attributes['id'] ??= wp_unique_id('events');
+
 	$facets = Events_2023\get_query_var_facets();
 	$events = Google_Map\get_events( $attributes['events'], 0, 0, $facets );
 
@@ -88,7 +90,12 @@ function render( $attributes, $content, $block ) {
 		// `generate_block_asset_handle()` includes the index if `viewScript` is an array, so this is fragile.
 		// There isn't a way to get it programmatically, though, so it just has to manually be kept in sync.
 		'wporg-event-list-view-script-2',
-		'globalEventsPayload = ' . wp_json_encode( $payload ) . ';',
+		sprintf(
+			'var globalEventsPayload = globalEventsPayload || {};
+			globalEventsPayload["%s"] = %s;',
+			$attributes['id'],
+			wp_json_encode( $payload )
+		),
 		'before'
 	);
 
@@ -97,7 +104,7 @@ function render( $attributes, $content, $block ) {
 	?>
 
 	<p class="wporg-marker-list__loading">
-		Loading global events...
+		Loading events...
 		<img
 			src="<?php echo esc_url( includes_url( 'images/spinner-2x.gif' ) ); ?>"
 			width="20"
@@ -110,7 +117,9 @@ function render( $attributes, $content, $block ) {
 
 	$content = ob_get_clean();
 
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$wrapper_attributes = get_block_wrapper_attributes( array(
+		'id' => 'wp-block-wporg-event-list-' . $attributes['id'],
+	) );
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
@@ -17,7 +17,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			const listContainer = document.querySelector( `#wp-block-wporg-event-list-${ id }` );
 			if ( ! listContainer ) {
 				// eslint-disable-next-line no-console
-				console.error( 'Missing container for global events with id ' + id );
+				console.error( `Missing container for global events with id ${ id }` );
 				continue;
 			}
 

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
@@ -13,7 +13,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			return;
 		}
 
-		for ( var id in globalEventsPayload ) {
+		for ( let id in globalEventsPayload ) {
 			const listContainer = document.querySelector( `#wp-block-wporg-event-list-${ id }` );
 			if ( ! listContainer ) {
 				// eslint-disable-next-line no-console
@@ -23,8 +23,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			renderGlobalEvents(
 				listContainer,
-				globalEventsPayload[id].events,
-				globalEventsPayload[id].groupByMonth
+				globalEventsPayload[ id ].events,
+				globalEventsPayload[ id ].groupByMonth
 			);
 		}
 	}

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
@@ -2,7 +2,6 @@
 
 document.addEventListener( 'DOMContentLoaded', function() {
 	const speak = wp.a11y.speak;
-	const globalEventList = document.querySelector( '.wp-block-wporg-event-list' );
 
 	/**
 	 * Initialize the component.
@@ -14,17 +13,31 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			return;
 		}
 
-		renderGlobalEvents( globalEventsPayload.events, globalEventsPayload.groupByMonth );
+		for ( var id in globalEventsPayload ) {
+			const listContainer = document.querySelector( `#wp-block-wporg-event-list-${ id }` );
+			if ( ! listContainer ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Missing container for global events with id ' + id );
+				continue;
+			}
+
+			renderGlobalEvents(
+				listContainer,
+				globalEventsPayload[id].events,
+				globalEventsPayload[id].groupByMonth
+			);
+		}
 	}
 
 	/**
 	 * Render global events
 	 *
+	 * @param {Object}  container
 	 * @param {Array}   events
 	 * @param {boolean} groupByMonth
 	 */
-	function renderGlobalEvents( events, groupByMonth ) {
-		const loadingElement = globalEventList.querySelector( '.wporg-marker-list__loading' );
+	function renderGlobalEvents( container, events, groupByMonth ) {
+		const loadingElement = container.querySelector( '.wporg-marker-list__loading' );
 		const groupedEvents = {};
 		let markup = '';
 
@@ -46,7 +59,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			markup = renderEventList( events );
 		}
 
-		globalEventList.innerHTML = markup;
+		container.innerHTML = markup;
 
 		loadingElement.classList.add( 'wporg-events__hidden' );
 		speak( 'Global events loaded.' );

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
@@ -13,7 +13,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			return;
 		}
 
-		for ( let id in globalEventsPayload ) {
+		for ( const id in globalEventsPayload ) {
 			const listContainer = document.querySelector( `#wp-block-wporg-event-list-${ id }` );
 			if ( ! listContainer ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
Very simple, allows the `wporg/event-list` block to have multiple instances on a page.

