### PR TITLE
Adjust the fields we use for Internal Refs and Refs on Wires

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -107,7 +107,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 
 				'expected' => <<<EOD
 					HEADER,date,1
-					P,WIRES,,,N,USD,500.00,,,,,,,ACCT,987654,"Jane Beneficiary","9876 Beneficiary St",,"Benficiaryville New Bennieswick ",,Test,,,SWIFT,123456,"A Bank","1234 Bank St",,"Bankersville New Bankswick 12345",US,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"Invoice 1234",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,OUR,,,wcb-site_id-blog_id
+					P,WIRES,,,N,USD,500.00,,,,,,,ACCT,987654,"Jane Beneficiary","9876 Beneficiary St",,"Benficiaryville New Bennieswick ",,Test,,,SWIFT,123456,"A Bank","1234 Bank St",,"Bankersville New Bankswick 12345",US,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,wcb-site_id-blog_id,"WordPress Community Support","Invoice 1234",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,OUR,,,wcb-site_id-blog_id
 					TRAILER,1,500
 
 					EOD

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -1568,7 +1568,7 @@ Thanks for helping us with these details!",
 				'72-blank' => '',
 				'73-blank' => '',
 
-				'74-ref-text' => '', // US Wires only
+				'74-ref-text' => '', // US Wires only.
 				'75-internal-ref' => substr( sprintf( 'wcb-%d-%d', $entry->blog_id, $entry->post_id ), 0, 16 ),
 				'76-on-behalf-of' => 'WordPress Community Support',
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -1568,13 +1568,13 @@ Thanks for helping us with these details!",
 				'72-blank' => '',
 				'73-blank' => '',
 
-				'74-ref-text' => substr( get_post_meta( $post->ID, '_camppayments_invoice_number', true ), 0, 16 ),
-				'75-internal-ref' => '',
-				'76-on-behalf-of' => '',
+				'74-ref-text' => '', // US Wires only
+				'75-internal-ref' => substr( sprintf( 'wcb-%d-%d', $entry->blog_id, $entry->post_id ), 0, 16 ),
+				'76-on-behalf-of' => 'WordPress Community Support',
 
-				'77-detial-1' => '',
-				'78-detial-2' => '',
-				'79-detial-3' => '',
+				'77-detail-1' => substr( get_post_meta( $post->ID, '_camppayments_invoice_number', true ), 0, 16 ),
+				'78-detail-2' => '',
+				'79-detail-3' => '',
 				'80-detail-4' => '',
 
 				'81-blank' => '',

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -1579,12 +1579,12 @@ function _generate_payment_report_jpm_wires( $args ) {
 			'73-blank' => '',
 
 			'74-ref-text' => 'Reimbursement',
-			'75-internal-ref' => '',
-			'76-on-behalf-of' => '',
+			'75-internal-ref' => substr( sprintf( 'wcb-%d-%d', $entry->blog_id, $entry->request_id ), 0, 16 ),
+			'76-on-behalf-of' => 'WordPress Community Support',
 
-			'77-detial-1' => '',
-			'78-detial-2' => '',
-			'79-detial-3' => '',
+			'77-detail-1' => 'Reimbursement',
+			'78-detail-2' => '',
+			'79-detail-3' => '',
 			'80-detail-4' => '',
 
 			'81-blank' => '',


### PR DESCRIPTION
After chatting with our Accounting Team* there's some issues around international payments sometimes lacking details that makes it harder for vendors to locate the payments.

It appears this was due to us using the Payment Reference field, which you'd expect would be the reference for the payment, but appears to only be  used as the reference for inside-usa-payments.

This change updates it to use a `Detail` field which appears to be what is presented within the manual payment UI in our bank.

_(Note: The typo in the field name in the code that's corrected, is irrelevant, as it's only for our own usage)_

For Vendor Payments:
 - The 'Reference Text' is now always blank, let's see if the 'Details' text works.

For Reimbursements:
 - The 'Reference Text' and the 'Details' is now always 'Reimbursement' (Differs from Vendor payments)

For Both:
 - The 'On behalf of' is set to 'WordPress Community Support' which may help some transactions be identified
 - The 'Internal Reference' is set in both the Internal Ref and the 'Note' field.

@harmonyromo The duplication and difference between the two above is intentional on my part; But with the intention that you get back to me in a week orso to see how this change affects payments, if the duplication is problematic, and if people complain about the lack of reference/etc. :) 