### PR TITLE
Rename venue Contact Information field and require for Scheduled status

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -809,6 +809,9 @@ abstract class Event_Admin {
 						<?php if ( in_array( $key, $required_fields, true ) ) : ?>
 							<span class="description"><?php esc_html_e( '(required)', 'wordcamporg' ); ?></span>
 						<?php endif; ?>
+						<?php if ( ! empty( $messages[ $key ] ) ) : ?>
+							<span class="description"><?php echo esc_html( $messages[ $key ] ); ?></span>
+						<?php endif; ?>
 					</p>
 
 					<p>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -431,7 +431,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Maximum Capacity'           => 'text',
 						'Available Rooms'            => 'text',
 						'Website URL'                => 'text',
-						'Contact Email Address'      => 'text',
+						'Contact Information'        => 'textarea',
 						'Exhibition Space Available' => 'checkbox',
 					);
 					break;
@@ -588,7 +588,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 							'Maximum Capacity'                 => 'text',
 							'Available Rooms'                  => 'text',
 							'Website URL'                      => 'text',
-							'Contact Email Address'            => 'text',
+							'Contact Information'              => 'textarea',
 							'Exhibition Space Available'       => 'checkbox',
 
 							'Contributor Day'                  => 'checkbox',
@@ -1144,8 +1144,10 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'Budget Wrangler E-mail Address',
 			);
 
-			// Venue.
-			$scheduled[] = 'Contact Email Address';
+			// Venue Contact Information is required for Campus Connect events.
+			if ( 'campusconnect' === get_post_meta( $post_id, 'event_subtype', true ) ) {
+				$scheduled[] = 'Contact Information';
+			}
 
 			// Required because the Events Widget needs a physical address in order to show events.
 			$scheduled[] = self::get_address_key( $post_id );
@@ -1670,6 +1672,7 @@ function wcpt_metabox( $meta_keys, $metabox ) {
 		'Global Sponsorship Grant'        => 'Deprecated.',
 		'Hide from Event Feeds'           => 'Do not show in the public schedule and dashboard feeds, the site is still publicly accessible.',
 		'Series Event'                    => '(Campus Connect only) Event is part of a multi-venue or multi-session series (e.g., workshops held across several campuses)',
+		'Contact Information'             => 'Please provide a contact email address for the venue.',
 	);
 
 	if ( 'wcpt_venue_info' === $metabox ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -431,7 +431,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Maximum Capacity'           => 'text',
 						'Available Rooms'            => 'text',
 						'Website URL'                => 'text',
-						'Contact Information'        => 'textarea',
+						'Contact Email Address'      => 'text',
 						'Exhibition Space Available' => 'checkbox',
 					);
 					break;
@@ -588,7 +588,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 							'Maximum Capacity'                 => 'text',
 							'Available Rooms'                  => 'text',
 							'Website URL'                      => 'text',
-							'Contact Information'              => 'textarea',
+							'Contact Email Address'            => 'text',
 							'Exhibition Space Available'       => 'checkbox',
 
 							'Contributor Day'                  => 'checkbox',
@@ -1143,6 +1143,9 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				'Budget Wrangler Name',
 				'Budget Wrangler E-mail Address',
 			);
+
+			// Venue.
+			$scheduled[] = 'Contact Email Address';
 
 			// Required because the Events Widget needs a physical address in order to show events.
 			$scheduled[] = self::get_address_key( $post_id );

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -418,7 +418,7 @@ class WCOR_Mailer {
 			empty( $wordcamp_meta['Maximum Capacity'][0] )    ? 'N/A' : $wordcamp_meta['Maximum Capacity'][0],
 			empty( $wordcamp_meta['Available Rooms'][0] )     ? 'N/A' : $wordcamp_meta['Available Rooms'][0],
 			empty( $wordcamp_meta['Website URL'][0] )         ? 'N/A' : $wordcamp_meta['Website URL'][0],
-			empty( $wordcamp_meta['Contact Information'][0] ) ? 'N/A' : $wordcamp_meta['Contact Information'][0],
+			empty( $wordcamp_meta['Contact Email Address'][0] ) ? 'N/A' : $wordcamp_meta['Contact Email Address'][0],
 			empty( $wordcamp_meta['Exhibition Space Available'][0] ) ? 'This event has no exhibition space.' : 'This event might have exhibition space available, please check with the organizers for more information.',
 
 			// Miscellaneous

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -418,7 +418,7 @@ class WCOR_Mailer {
 			empty( $wordcamp_meta['Maximum Capacity'][0] )    ? 'N/A' : $wordcamp_meta['Maximum Capacity'][0],
 			empty( $wordcamp_meta['Available Rooms'][0] )     ? 'N/A' : $wordcamp_meta['Available Rooms'][0],
 			empty( $wordcamp_meta['Website URL'][0] )         ? 'N/A' : $wordcamp_meta['Website URL'][0],
-			empty( $wordcamp_meta['Contact Email Address'][0] ) ? 'N/A' : $wordcamp_meta['Contact Email Address'][0],
+			empty( $wordcamp_meta['Contact Information'][0] ) ? 'N/A' : $wordcamp_meta['Contact Information'][0],
 			empty( $wordcamp_meta['Exhibition Space Available'][0] ) ? 'This event has no exhibition space.' : 'This event might have exhibition space available, please check with the organizers for more information.',
 
 			// Miscellaneous


### PR DESCRIPTION
## Summary
- Renames "Contact Information" to "Contact Email Address" in the venue fields, and changes it from a textarea to a text input
- Adds "Contact Email Address" as a required field for the "Scheduled" status
- Updates the organizer reminder email template to use the new meta key

Closes #1598

## Test plan
- [ ] Edit a Campus Connect tracker entry and verify the field now reads "Contact Email Address"
- [ ] Verify the field is a single-line text input instead of a textarea
- [ ] Attempt to move a Campus Connect entry to "Scheduled" status without filling in the Contact Email Address - verify it is blocked
- [ ] Fill in the Contact Email Address and verify the status transition to Scheduled succeeds

Generated with [Claude Code](https://claude.com/claude-code)