### PR TITLE
Skip cancelled events in city redirect and latest-site hints

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -168,6 +168,18 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		return false;
 	}
 
+	$central_prefix   = $wpdb->base_prefix . ( 1 === WORDCAMP_ROOT_BLOG_ID ? '' : WORDCAMP_ROOT_BLOG_ID . '_' );
+	$not_cancelled_sq = "
+		AND NOT EXISTS (
+			SELECT 1
+			FROM {$central_prefix}postmeta pm
+			JOIN {$central_prefix}posts p ON p.ID = pm.post_id
+			WHERE pm.meta_key = '_site_id'
+			AND pm.meta_value = $wpdb->blogs.blog_id
+			AND p.post_type = 'wordcamp'
+			AND p.post_status = 'wcpt-cancelled'
+		)";
+
 	if ( preg_match( PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		// Remove the year prefix.
 		$city_domain = substr(
@@ -181,6 +193,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 			WHERE
 				`domain` LIKE %s AND
 				SUBSTR( domain, 1, 4 ) REGEXP '^-?[0-9]+$' -- exclude secondary language domains like 2013-fr.ottawa.wordcamp.org
+				$not_cancelled_sq
 			ORDER BY `domain` DESC
 			LIMIT 1",
 			'%.' . $city_domain
@@ -191,6 +204,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 			SELECT `domain`, `path`
 			FROM `$wpdb->blogs`
 			WHERE `domain` = %s
+				$not_cancelled_sq
 			ORDER BY `domain`, `path` DESC
 			LIMIT 1",
 			$current_domain
@@ -207,6 +221,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 			WHERE
 				`domain` = %s AND
 				`path` LIKE %s
+				$not_cancelled_sq
 			ORDER BY `path` DESC
 			LIMIT 1",
 			$current_domain,

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -180,6 +180,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 			AND p.post_status = 'wcpt-cancelled'
 		)";
 
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $not_cancelled_sq is a subquery built from trusted $wpdb table names.
 	if ( preg_match( PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		// Remove the year prefix.
 		$city_domain = substr(
@@ -227,6 +228,7 @@ function get_latest_home_url( $current_domain, $current_path ) {
 			$current_domain,
 			$latest_path
 		);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	} else {
 		return false;

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -664,6 +664,7 @@ function get_latest_site( string $domain ) {
 
 	$central_prefix = $wpdb->base_prefix . ( 1 === WORDCAMP_ROOT_BLOG_ID ? '' : WORDCAMP_ROOT_BLOG_ID . '_' );
 
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names from trusted $wpdb properties and prefixes.
 	$latest = $wpdb->get_row( $wpdb->prepare( "
 		SELECT `blog_id`, `domain`, `path`
 		FROM $wpdb->blogs
@@ -688,6 +689,7 @@ function get_latest_site( string $domain ) {
 		$domain,
 		"%.{$domain}"
 	) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	return $latest;
 }

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -656,9 +656,13 @@ function get_canonical_year_url( $domain, $path ) {
 
 /**
  * Get the latest site for a given city.
+ *
+ * Skips sites whose corresponding WordCamp tracker entry is cancelled.
  */
 function get_latest_site( string $domain ) {
 	global $wpdb;
+
+	$central_prefix = $wpdb->base_prefix . ( 1 === WORDCAMP_ROOT_BLOG_ID ? '' : WORDCAMP_ROOT_BLOG_ID . '_' );
 
 	$latest = $wpdb->get_row( $wpdb->prepare( "
 		SELECT `blog_id`, `domain`, `path`
@@ -669,6 +673,15 @@ function get_latest_site( string $domain ) {
 			(
    				( domain =    %s AND path != '/' ) OR -- Match city/year format.
 				( domain LIKE %s AND path  = '/' )    -- Match year.city format.
+			)
+			AND NOT EXISTS (                          -- Cancelled events should be skipped.
+				SELECT 1
+				FROM {$central_prefix}postmeta pm
+				JOIN {$central_prefix}posts p ON p.ID = pm.post_id
+				WHERE pm.meta_key = '_site_id'
+				AND pm.meta_value = $wpdb->blogs.blog_id
+				AND p.post_type = 'wordcamp'
+				AND p.post_status = 'wcpt-cancelled'
 			)
 		ORDER BY path DESC, domain DESC
 		LIMIT 1;",


### PR DESCRIPTION
## Summary
- Modifies get_latest_site() in sunrise-wordcamp.php to exclude sites whose WordCamp tracker post has wcpt-cancelled status
- Updates all three query paths in get_latest_home_url() in latest-site-hints.php with the same exclusion
- Cancelled event sites remain accessible at their direct URLs (e.g., city.wordcamp.org/2025/) - only the automatic redirect is affected

Closes #1600

## Test plan
- [ ] Verify that city.wordcamp.org redirects to the most recent non-cancelled event
- [ ] Verify that the "See the next edition" banner on older events does not link to a cancelled event
- [ ] Verify that a cancelled event site is still directly accessible at its full URL
- [ ] Verify the redirect still works correctly for cities with no cancelled events

Generated with [Claude Code](https://claude.com/claude-code)