### PR TITLE
Redirect old event site URLs to the latest year after rename

### DIFF
--- a/phpunit-database-testcase.php
+++ b/phpunit-database-testcase.php
@@ -23,6 +23,7 @@ class Database_TestCase extends WP_UnitTestCase {
 	protected static $slash_year_2020_site_id;
 	protected static $yearless_site_id;
 	protected static $slash_year_with_yearless_site_id;
+	protected static $events_rome_training_site_id;
 
 	/**
 	 * Create sites we'll need for the tests.
@@ -113,11 +114,15 @@ class Database_TestCase extends WP_UnitTestCase {
 			'network_id' => WORDCAMP_NETWORK_ID,
 		) );
 
-		self::$slash_year_with_yearless_site_id = $factory->blog->create( array(
+		self::$events_rome_training_site_id = $factory->blog->create( array(
 			'domain'     => 'events.wordpress.test',
 			'path'       => '/rome/2024/training/',
 			'network_id' => EVENTS_NETWORK_ID,
 		) );
+
+		// Simulate renamed sites by adding old_home_url blogmeta.
+		add_site_meta( self::$slash_year_2020_site_id, 'old_home_url', 'https://vancouver.wordcamp.test/2019/' );
+		add_site_meta( self::$events_rome_training_site_id, 'old_home_url', 'https://events.wordpress.test/rome/2023/training/' );
 	}
 
 	/**
@@ -134,6 +139,7 @@ class Database_TestCase extends WP_UnitTestCase {
 		wp_delete_site( self::$slash_year_2016_site_id );
 		wp_delete_site( self::$slash_year_2018_dev_site_id );
 		wp_delete_site( self::$slash_year_2020_site_id );
+		wp_delete_site( self::$events_rome_training_site_id );
 
 		foreach ( [ WORDCAMP_NETWORK_ID, EVENTS_NETWORK_ID ] as $network_id ) {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE site_id = %d", $network_id ) );

--- a/public_html/wp-content/mu-plugins/site-url-history.php
+++ b/public_html/wp-content/mu-plugins/site-url-history.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WordCamp\Site_URL_History;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'wp_update_site', __NAMESPACE__ . '\store_old_url_on_rename', 10, 2 );
+
+/**
+ * Store the old home URL in blogmeta when a site's domain or path changes.
+ *
+ * This allows sunrise.php to redirect requests for old URLs to the new location.
+ *
+ * @param WP_Site $new_site The site object after the update.
+ * @param WP_Site $old_site The site object before the update.
+ */
+function store_old_url_on_rename( $new_site, $old_site ) {
+	if ( $new_site->domain === $old_site->domain && $new_site->path === $old_site->path ) {
+		return;
+	}
+
+	$old_home_url = 'https://' . $old_site->domain . $old_site->path;
+
+	// Store the old URL. Multiple renames accumulate multiple entries.
+	$old_urls = get_site_meta( $new_site->id, 'old_home_url' );
+
+	if ( ! in_array( $old_home_url, $old_urls, true ) ) {
+		add_site_meta( $new_site->id, 'old_home_url', $old_home_url );
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -27,6 +27,7 @@ function manually_load_plugins() {
 	require_once dirname( dirname( __DIR__ ) ) . '/sunrise.php';
 	require_once dirname( dirname( __DIR__ ) ) . '/sunrise-events.php';
 
+	require_once dirname( __DIR__ ) . '/site-url-history.php';
 	require_once dirname( __DIR__ ) . '/0-error-handling.php';
 	require_once dirname( __DIR__ ) . '/wordcamp/lets-encrypt-helper.php';
 	require_once dirname( __DIR__ ) . '/latest-site-hints.php';

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise.php
@@ -18,6 +18,7 @@ use WordCamp\Tests\Database_TestCase;
 use function WordCamp\Sunrise\{
 	get_canonical_year_url, get_post_slug_url_without_duplicate_dates, guess_requested_domain_path,
 	get_corrected_root_relative_url, get_city_slash_year_url, domain_redirects, root_redirects,
+	get_renamed_site_url,
 };
 
 defined( 'WPINC' ) || die();
@@ -668,6 +669,44 @@ class Test_Sunrise extends Database_TestCase {
 				'/',
 				'/2020/2019/save-the-date-for-wordcamp-vancouver-2020/',
 				false,
+			),
+		);
+	}
+
+	/**
+	 * @covers WordCamp\Sunrise\get_renamed_site_url
+	 *
+	 * @dataProvider data_get_renamed_site_url
+	 */
+	public function test_get_renamed_site_url( $domain, $path, $expected ) {
+		$actual = get_renamed_site_url( $domain, $path );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Test cases for test_get_renamed_site_url().
+	 *
+	 * @return array
+	 */
+	public function data_get_renamed_site_url() {
+		return array(
+			'old WordCamp URL redirects to current site' => array(
+				'vancouver.wordcamp.test',
+				'/2019/',
+				'https://vancouver.wordcamp.test/2020/',
+			),
+
+			'unknown URL returns false' => array(
+				'narnia.wordcamp.test',
+				'/2025/',
+				false,
+			),
+
+			'old Events URL redirects to current site' => array(
+				'events.wordpress.test',
+				'/rome/2023/training/',
+				'https://events.wordpress.test/rome/2024/training/',
 			),
 		);
 	}

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -98,15 +98,6 @@ function set_network_and_site() {
 	}
 
 	if ( ! $current_blog ) {
-		// If the request doesn't match a site, try to redirect to the latest year for the same city/type.
-		$latest_url = get_latest_event_url( $path );
-
-		if ( $latest_url ) {
-			header( 'X-Redirect-By: Events/Sunrise::set_network_and_site (latest year)' );
-			header( 'Location: ' . $latest_url, true, 301 );
-			exit;
-		}
-
 		// Check if this URL was previously used by a site that has since been renamed.
 		$renamed_url = get_renamed_site_url( DOMAIN_CURRENT_SITE, $path );
 
@@ -125,53 +116,6 @@ function set_network_and_site() {
 	$blog_id = $current_blog->id;
 	$domain  = $current_blog->domain;
 	$public  = $current_blog->public;
-}
-
-/**
- * Get the URL of the latest event site matching the same city and type.
- *
- * When an event site is renamed (e.g., year changed from 2025 to 2026),
- * the old URL should redirect to the latest year's site for the same city/type.
- *
- * @param string $request_path The request URI path.
- *
- * @return string|false The URL to redirect to, or false if no match found.
- */
-function get_latest_event_url( string $request_path ) {
-	global $wpdb;
-
-	if ( ! preg_match( PATTERN_CITY_YEAR_TYPE_PATH, $request_path, $matches ) ) {
-		return false;
-	}
-
-	$city = $matches[1];
-	$type = $matches[3];
-
-	$latest_site = $wpdb->get_row( $wpdb->prepare(
-		"SELECT `domain`, `path`
-		FROM `$wpdb->blogs`
-		WHERE
-			`domain` = %s AND
-			`path` LIKE %s AND
-			`public` = 1 AND
-			`deleted` = 0
-		ORDER BY `path` DESC
-		LIMIT 1",
-		DOMAIN_CURRENT_SITE,
-		"/$city/%/$type/"
-	) );
-
-	if ( ! $latest_site ) {
-		return false;
-	}
-
-	// Don't redirect to the exact same path that was requested.
-	$requested_path = rtrim( $request_path, '/' ) . '/';
-	if ( $latest_site->path === $requested_path ) {
-		return false;
-	}
-
-	return 'https://' . $latest_site->domain . $latest_site->path;
 }
 
 /**

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -685,43 +685,6 @@ function get_latest_site( string $domain ) {
 }
 
 /**
- * Check if this URL was previously used by a site that has since been renamed.
- *
- * When a site's domain or path is changed (e.g., narnia.wordcamp.org/2026 to
- * somewhere.wordcamp.org/2026), the old URL is stored in blogmeta. This function
- * queries that data to redirect old URLs to the current location.
- *
- * @param string $domain The requested domain.
- * @param string $path   The requested path.
- *
- * @return string|false The new URL to redirect to, or false if no match.
- */
-function get_renamed_site_url( string $domain, string $path ): string|false {
-	global $wpdb;
-
-	$old_home_url = 'https://' . $domain . trailingslashit( $path );
-
-	$blog_id = $wpdb->get_var( $wpdb->prepare(
-		"SELECT blog_id FROM {$wpdb->blogmeta}
-		WHERE meta_key = 'old_home_url' AND meta_value = %s
-		LIMIT 1",
-		$old_home_url
-	) );
-
-	if ( ! $blog_id ) {
-		return false;
-	}
-
-	$site = get_site( $blog_id );
-
-	if ( ! $site || $site->deleted || ! $site->public ) {
-		return false;
-	}
-
-	return 'https://' . $site->domain . $site->path;
-}
-
-/**
  * Redirect `/year-foo/%year%/%monthnum%/%day%/%postname%/` permalinks to `/%postname%/`.
  *
  * `year-foo` is the _site_ slug, while `%year%` is part of the _post_ slug. This makes sure that URLs on old sites

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -202,6 +202,11 @@ function redirect_to_site( string $domain, string $path ): void {
 		}
 	}
 
+	// Check if this URL was previously used by a site that has since been renamed.
+	if ( ! $redirect ) {
+		$redirect = get_renamed_site_url( $domain, $path );
+	}
+
 	if ( ! $redirect ) {
 		return;
 	}
@@ -677,6 +682,43 @@ function get_latest_site( string $domain ) {
 	) );
 
 	return $latest;
+}
+
+/**
+ * Check if this URL was previously used by a site that has since been renamed.
+ *
+ * When a site's domain or path is changed (e.g., narnia.wordcamp.org/2026 to
+ * somewhere.wordcamp.org/2026), the old URL is stored in blogmeta. This function
+ * queries that data to redirect old URLs to the current location.
+ *
+ * @param string $domain The requested domain.
+ * @param string $path   The requested path.
+ *
+ * @return string|false The new URL to redirect to, or false if no match.
+ */
+function get_renamed_site_url( string $domain, string $path ): string|false {
+	global $wpdb;
+
+	$old_home_url = 'https://' . $domain . trailingslashit( $path );
+
+	$blog_id = $wpdb->get_var( $wpdb->prepare(
+		"SELECT blog_id FROM {$wpdb->blogmeta}
+		WHERE meta_key = 'old_home_url' AND meta_value = %s
+		LIMIT 1",
+		$old_home_url
+	) );
+
+	if ( ! $blog_id ) {
+		return false;
+	}
+
+	$site = get_site( $blog_id );
+
+	if ( ! $site || $site->deleted || ! $site->public ) {
+		return false;
+	}
+
+	return 'https://' . $site->domain . $site->path;
 }
 
 /**

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -131,4 +131,48 @@ function get_domain_network_id( string $domain ): int {
 	}
 }
 
+/**
+ * Look up the current URL for a site that was previously at the given domain/path.
+ *
+ * When a site's domain or path is changed, the old URL is stored in `blogmeta`
+ * by the `site-url-history` mu-plugin. This queries that data so the caller can
+ * redirect old URLs to the current location.
+ *
+ * @param string $domain The requested domain.
+ * @param string $path   The requested path.
+ *
+ * @return string|false The new URL to redirect to, or false if no match.
+ */
+function get_renamed_site_url( string $domain, string $path ) {
+	global $wpdb;
+
+	$old_home_url = 'https://' . $domain . trailingslashit( $path );
+
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Sunrise runs before caching is available.
+	$blog_id = $wpdb->get_var( $wpdb->prepare(
+		"SELECT blog_id FROM {$wpdb->blogmeta}
+		WHERE meta_key = 'old_home_url' AND meta_value = %s
+		LIMIT 1",
+		$old_home_url
+	) );
+
+	if ( ! $blog_id ) {
+		return false;
+	}
+
+	$site = $wpdb->get_row( $wpdb->prepare(
+		"SELECT domain, path FROM {$wpdb->blogs}
+		WHERE blog_id = %d AND public = 1 AND deleted = 0
+		LIMIT 1",
+		$blog_id
+	) );
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	if ( ! $site ) {
+		return false;
+	}
+
+	return 'https://' . $site->domain . $site->path;
+}
+
 load_network_sunrise();

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -148,25 +148,18 @@ function get_renamed_site_url( string $domain, string $path ) {
 
 	$old_home_url = 'https://' . $domain . trailingslashit( $path );
 
-	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Sunrise runs before caching is available.
-	$blog_id = $wpdb->get_var( $wpdb->prepare(
-		"SELECT blog_id FROM {$wpdb->blogmeta}
-		WHERE meta_key = 'old_home_url' AND meta_value = %s
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Sunrise runs before caching is available.
+	$site = $wpdb->get_row( $wpdb->prepare(
+		"SELECT b.domain, b.path
+		FROM {$wpdb->blogmeta} bm
+		JOIN {$wpdb->blogs} b ON b.blog_id = bm.blog_id
+		WHERE bm.meta_key = 'old_home_url'
+			AND bm.meta_value = %s
+			AND b.public = 1
+			AND b.deleted = 0
 		LIMIT 1",
 		$old_home_url
 	) );
-
-	if ( ! $blog_id ) {
-		return false;
-	}
-
-	$site = $wpdb->get_row( $wpdb->prepare(
-		"SELECT domain, path FROM {$wpdb->blogs}
-		WHERE blog_id = %d AND public = 1 AND deleted = 0
-		LIMIT 1",
-		$blog_id
-	) );
-	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	if ( ! $site ) {
 		return false;


### PR DESCRIPTION
## Summary
- **Renamed site redirect** (both networks): When a site's domain or path is changed, store the old `home_url` in `wp_blogmeta`. On future requests, check blogmeta for matching old URLs and 301 redirect to the current location
- New `site-url-history.php` mu-plugin hooks into `wp_update_site` to track URL renames

This PR only handles redirects for renamed sites. A follow-up PR will add redirecting old event URLs to the latest year for the same city/type.

### How it works

1. **Renamed site redirect**: `get_renamed_site_url()` queries `wp_blogmeta` joined with `wp_blogs` for `old_home_url` entries matching the requested URL, then redirects to the current site URL
2. **URL history storage**: The `wp_update_site` action fires when a site's domain or path changes — the old `home_url` is stored in blogmeta, accumulating across multiple renames

## Test plan
- [ ] Rename a WordCamp site (e.g., change `narnia.wordcamp.org/2026` path) — verify old URL 301 redirects to new location
- [ ] Rename an Events site path — verify old URL 301 redirects to new location
- [ ] Visit a URL that was never a site — verify it falls through to NOBLOGREDIRECT

Part of #1588

🤖 Generated with [Claude Code](https://claude.com/claude-code)