### PR TITLE
Add Other payment method option for vendor payments and reimbursements

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -288,6 +288,8 @@ class WordCamp_Budgets {
 			$methods['Credit Card'] = __( 'Credit Card', 'wordcamporg' );
 		}
 
+		$methods['Other'] = __( 'Other', 'wordcamporg' );
+
 		return $methods;
 	}
 
@@ -366,6 +368,10 @@ class WordCamp_Budgets {
 				case 'sepa_bic':
 				case 'sepa_iban':
 					$safe_value = sanitize_text_field( $unsafe_value );
+					break;
+
+				case 'other_payment_method_note':
+					$safe_value = sanitize_textarea_field( $unsafe_value );
 					break;
 
 				case 'ach_account_type':

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -114,6 +114,18 @@
 				<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Country',           'wordcamporg' ), 'beneficiary_country_iso3166' ); ?>
 			</table>
 		</div>
+
+		<div id="payment_method_other_fields" class="form-table payment_method_fields <?php echo 'Other' == $selected_payment_method ? 'active' : 'hidden'; ?>">
+			<table>
+				<?php $this->render_textarea_input(
+					$post,
+					esc_html__( 'Payment Details', 'wordcamporg' ),
+					'other_payment_method_note',
+					esc_html__( 'Describe the preferred payment method and any relevant details (e.g., PayPal address, credit card portal URL, etc.)', 'wordcamporg' ),
+					true
+				); ?>
+			</table>
+		</div>
 	</fieldset>
 
 	<p class="wcb-form-required">


### PR DESCRIPTION
## Summary
- Adds "Other" as a payment method option for both vendor payments and reimbursements
- Includes a free-form textarea for describing the alternative payment method details (e.g., PayPal, credit card portal URL)
- The note field is sanitized via sanitize_textarea_field()

Closes #1608

## Test plan
- [ ] Create a vendor payment and verify "Other" appears as a payment method option
- [ ] Select "Other" and verify the Payment Details textarea appears
- [ ] Fill in the details, save, and verify they persist
- [ ] Create a reimbursement request and verify "Other" also appears there
- [ ] Verify existing payment methods (Direct Deposit, Check, Wire, Credit Card) still work normally

Generated with [Claude Code](https://claude.com/claude-code)