### PR TITLE
Add EUR SEPA Transfer payment method

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-list-table.php
@@ -225,7 +225,7 @@ class Payment_Requests_List_Table extends WP_List_Table {
 	public function column_method( $request ) {
 		$method = get_post_meta( $request->ID, '_camppayments_payment_method', true );
 
-		return esc_html( $method );
+		return esc_html( \WordCamp_Budgets::get_payment_method_label( $method ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/reimbursement-requests-list-table.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/reimbursement-requests-list-table.php
@@ -268,7 +268,7 @@ class Reimbursement_Requests_List_Table extends WP_List_Table {
 	public function column_method( $request ) {
 		$method = get_post_meta( $request->ID, '_wcbrr_payment_method', true );
 
-		return esc_html( $method );
+		return esc_html( \WordCamp_Budgets::get_payment_method_label( $method ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -650,9 +650,9 @@ function _generate_payment_report_sepa( $args ) {
 		)
 	);
 
-	if ( $args['post_type'] == 'wcp_payment_request' ) {
+	if ( 'wcp_payment_request' === $args['post_type'] ) {
 		return WCP_Payment_Request::_generate_payment_report_sepa( $args );
-	} elseif ( $args['post_type'] == 'wcb_reimbursement' ) {
+	} elseif ( 'wcb_reimbursement' === $args['post_type'] ) {
 		return Reimbursement_Requests\_generate_payment_report_sepa( $args );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -164,6 +164,13 @@ function get_export_types() {
 			'callback'  => __NAMESPACE__ . '\_generate_payment_report_jpm_checks',
 			'filename'  => 'wordcamp-payments-%s-%s-jpm-checks.csv',
 		),
+
+		'sepa' => array(
+			'label'     => 'SEPA Credit Transfer (ISO 20022 XML)',
+			'mime_type' => 'application/xml',
+			'callback'  => __NAMESPACE__ . '\_generate_payment_report_sepa',
+			'filename'  => 'wordcamp-payments-%s-%s-sepa.xml',
+		),
 	);
 }
 
@@ -623,6 +630,30 @@ function _generate_payment_report_jpm_wires( $args ) {
 		return WCP_Payment_Request::_generate_payment_report_jpm_wires( $args );
 	} elseif ( $args['post_type'] == 'wcb_reimbursement' ) {
 		return Reimbursement_Requests\_generate_payment_report_jpm_wires( $args );
+	}
+}
+
+/**
+ * SEPA Credit Transfer – ISO 20022 XML
+ *
+ * @param array $args
+ *
+ * @return string
+ */
+function _generate_payment_report_sepa( $args ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'data'      => array(),
+			'status'    => '',
+			'post_type' => '',
+		)
+	);
+
+	if ( $args['post_type'] == 'wcp_payment_request' ) {
+		return WCP_Payment_Request::_generate_payment_report_sepa( $args );
+	} elseif ( $args['post_type'] == 'wcb_reimbursement' ) {
+		return Reimbursement_Requests\_generate_payment_report_sepa( $args );
 	}
 }
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -71,7 +71,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 				'_camppayments_invoice_number'   => 'SEPA-INV-001',
 				'_camppayments_payment_category' => 'venue',
 
-				'_camppayments_sepa_account_name' => WCP_Encryption::encrypt( 'Hans Muster' ),
+				'_camppayments_sepa_account_name' => WCP_Encryption::encrypt( 'Account Name Here' ),
 				'_camppayments_sepa_bic'          => WCP_Encryption::encrypt( 'DEUTDEDBFRA' ),
 				'_camppayments_sepa_iban'         => WCP_Encryption::encrypt( 'DE89370400440532013000' ),
 			),
@@ -212,7 +212,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<ChrgBr>SLEV</ChrgBr>', $actual );
 
 		// Verify payment data.
-		$this->assertStringContainsString( '<Nm>Hans Muster</Nm>', $actual );
+		$this->assertStringContainsString( '<Nm>Account Name Here</Nm>', $actual );
 		$this->assertStringContainsString( '<IBAN>DE89370400440532013000</IBAN>', $actual );
 		$this->assertStringContainsString( '<BIC>DEUTDEDBFRA</BIC>', $actual );
 		$this->assertStringContainsString( '<InstdAmt Ccy="EUR">250.00</InstdAmt>', $actual );

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -67,7 +67,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 				'_camppayments_due_by'           => strtotime( 'Next Tuesday' ),
 				'_camppayments_payment_amount'   => '250',
 				'_camppayments_currency'         => 'EUR',
-				'_camppayments_payment_method'   => 'EUR SEPA Transfer',
+				'_camppayments_payment_method'   => 'sepa_transfer',
 				'_camppayments_invoice_number'   => 'SEPA-INV-001',
 				'_camppayments_payment_category' => 'venue',
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -4,6 +4,7 @@ namespace WordCamp\Budgets_Dashboard\Tests;
 
 use Payment_Requests_Dashboard;
 use WCP_Encryption;
+use WordCamp_Budgets;
 use WP_UnitTestCase;
 use function WordCamp\Budgets_Dashboard\{ generate_payment_report };
 
@@ -53,6 +54,26 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 				'_camppayments_beneficiary_zip_code'        => WCP_Encryption::encrypt( '98765' ),
 				'_camppayments_beneficiary_country_iso3166' => WCP_Encryption::encrypt( 'Test' ),
 				'_camppayments_beneficiary_account_number'  => WCP_Encryption::encrypt( '987654' ),
+			),
+		) );
+
+		$factory->post->create( array(
+			'post_type'   => 'wcp_payment_request',
+			'post_status' => 'wcb-approved',
+
+			'meta_input' => array(
+				'_wcb_updated_timestamp'         => strtotime( 'Yesterday 10am' ),
+				'_camppayments_description'      => 'SEPA Test Request',
+				'_camppayments_due_by'           => strtotime( 'Next Tuesday' ),
+				'_camppayments_payment_amount'   => '250',
+				'_camppayments_currency'         => 'EUR',
+				'_camppayments_payment_method'   => 'EUR SEPA Transfer',
+				'_camppayments_invoice_number'   => 'SEPA-INV-001',
+				'_camppayments_payment_category' => 'venue',
+
+				'_camppayments_sepa_account_name' => WCP_Encryption::encrypt( 'Hans Muster' ),
+				'_camppayments_sepa_bic'          => WCP_Encryption::encrypt( 'DEUTDEDBFRA' ),
+				'_camppayments_sepa_iban'         => WCP_Encryption::encrypt( 'DE89370400440532013000' ),
 			),
 		) );
 
@@ -157,5 +178,158 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		);
 
 		return $cases;
+	}
+
+	/**
+	 * @covers WordCamp\Budgets_Dashboard\generate_payment_report
+	 * @covers WordCamp\Budgets_Dashboard\_generate_payment_report_sepa
+	 * @covers WCP_Payment_Request::_generate_payment_report_sepa
+	 * @covers WordCamp_Budgets::generate_sepa_xml
+	 */
+	public function test_generate_sepa_payment_report() : void {
+		$args = array(
+			'status'     => 'wcb-approved',
+			'start_date' => strtotime( '3 days ago' ),
+			'end_date'   => time(),
+			'post_type'  => 'wcp_payment_request',
+
+			'export_type' => array(
+				'label'     => 'SEPA Credit Transfer (ISO 20022 XML)',
+				'mime_type' => 'application/xml',
+				'callback'  => 'WordCamp\Budgets_Dashboard\_generate_payment_report_sepa',
+				'filename'  => 'wordcamp-payments-%s-%s-sepa.xml',
+			),
+		);
+
+		$actual = generate_payment_report( $args );
+
+		$this->assertIsString( $actual, 'SEPA report should return a string.' );
+		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $actual );
+		$this->assertStringContainsString( 'pain.001.003.03', $actual );
+		$this->assertStringContainsString( '<CstmrCdtTrfInitn>', $actual );
+		$this->assertStringContainsString( '<PmtMtd>TRF</PmtMtd>', $actual );
+		$this->assertStringContainsString( '<Cd>SEPA</Cd>', $actual );
+		$this->assertStringContainsString( '<ChrgBr>SLEV</ChrgBr>', $actual );
+
+		// Verify payment data.
+		$this->assertStringContainsString( '<Nm>Hans Muster</Nm>', $actual );
+		$this->assertStringContainsString( '<IBAN>DE89370400440532013000</IBAN>', $actual );
+		$this->assertStringContainsString( '<BIC>DEUTDEDBFRA</BIC>', $actual );
+		$this->assertStringContainsString( '<InstdAmt Ccy="EUR">250.00</InstdAmt>', $actual );
+		$this->assertStringContainsString( '<Ustrd>SEPA-INV-001</Ustrd>', $actual );
+
+		// Verify counts.
+		$this->assertStringContainsString( '<NbOfTxs>1</NbOfTxs>', $actual );
+		$this->assertStringContainsString( '<CtrlSum>250.00</CtrlSum>', $actual );
+	}
+
+	/**
+	 * SEPA export with no matching posts should return an empty string.
+	 *
+	 * @covers WordCamp\Budgets_Dashboard\generate_payment_report
+	 * @covers WordCamp\Budgets_Dashboard\_generate_payment_report_sepa
+	 */
+	public function test_generate_sepa_report_no_matching_posts() : void {
+		$args = array(
+			'status'     => 'wcb-approved',
+			'start_date' => strtotime( '8 days ago' ),
+			'end_date'   => strtotime( '5 days ago' ),
+			'post_type'  => 'wcp_payment_request',
+
+			'export_type' => array(
+				'label'     => 'SEPA Credit Transfer (ISO 20022 XML)',
+				'mime_type' => 'application/xml',
+				'callback'  => 'WordCamp\Budgets_Dashboard\_generate_payment_report_sepa',
+				'filename'  => 'wordcamp-payments-%s-%s-sepa.xml',
+			),
+		);
+
+		$actual = generate_payment_report( $args );
+
+		$this->assertSame( '', $actual, 'SEPA report with no matching posts should return an empty string.' );
+	}
+
+	/**
+	 * Test generate_sepa_xml() output format directly.
+	 *
+	 * @covers WordCamp_Budgets::generate_sepa_xml
+	 */
+	public function test_generate_sepa_xml_format() : void {
+		add_filter( 'wcb_sepa_debtor_bic', function () {
+			return 'TESTBIC123';
+		} );
+		add_filter( 'wcb_sepa_debtor_iban', function () {
+			return 'DE00000000000000000000';
+		} );
+
+		$payments = array(
+			array(
+				'amount'       => 100.50,
+				'account_name' => 'Alice',
+				'bic'          => 'ALICEBIC',
+				'iban'         => 'DE11111111111111111111',
+				'reference'    => 'wcb-1-100',
+				'invoice'      => 'INV-100',
+			),
+			array(
+				'amount'       => 200.00,
+				'account_name' => 'Bob',
+				'bic'          => '',
+				'iban'         => 'DE22222222222222222222',
+				'reference'    => 'wcb-1-200',
+				'invoice'      => '',
+			),
+		);
+
+		$xml = WordCamp_Budgets::generate_sepa_xml( $payments );
+
+		// Validate XML structure.
+		$dom = new \DOMDocument();
+		$this->assertTrue( $dom->loadXML( $xml ), 'Output should be valid XML.' );
+
+		$root = $dom->documentElement;
+		$this->assertSame( 'Document', $root->localName );
+		$this->assertSame( 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03', $root->namespaceURI );
+
+		// Verify header counts.
+		$this->assertStringContainsString( '<NbOfTxs>2</NbOfTxs>', $xml );
+		$this->assertStringContainsString( '<CtrlSum>300.50</CtrlSum>', $xml );
+
+		// Verify debtor info from filters.
+		$this->assertStringContainsString( '<Nm>WordPress Community Support PBC</Nm>', $xml );
+		$this->assertStringContainsString( '<IBAN>DE00000000000000000000</IBAN>', $xml );
+		$this->assertStringContainsString( '<BIC>TESTBIC123</BIC>', $xml );
+
+		// Verify first payment.
+		$this->assertStringContainsString( '<Nm>Alice</Nm>', $xml );
+		$this->assertStringContainsString( '<IBAN>DE11111111111111111111</IBAN>', $xml );
+		$this->assertStringContainsString( '<BIC>ALICEBIC</BIC>', $xml );
+		$this->assertStringContainsString( '<InstdAmt Ccy="EUR">100.50</InstdAmt>', $xml );
+		$this->assertStringContainsString( '<Ustrd>INV-100</Ustrd>', $xml );
+		$this->assertStringContainsString( '<EndToEndId>wcb-1-100</EndToEndId>', $xml );
+
+		// Verify second payment (no BIC, no invoice).
+		$this->assertStringContainsString( '<Nm>Bob</Nm>', $xml );
+		$this->assertStringContainsString( '<IBAN>DE22222222222222222222</IBAN>', $xml );
+		$this->assertStringContainsString( '<InstdAmt Ccy="EUR">200.00</InstdAmt>', $xml );
+		$this->assertStringContainsString( '<EndToEndId>wcb-1-200</EndToEndId>', $xml );
+
+		// Bob has no BIC, so CdtrAgt should not appear for that transaction.
+		// Bob has no invoice, so RmtInf should not appear for that transaction.
+		// Count occurrences: Alice has BIC, Bob doesn't - so only 1 CdtrAgt (besides the debtor).
+		$this->assertSame( 1, substr_count( $xml, '<BIC>ALICEBIC</BIC>' ) );
+
+		// Clean up filters.
+		remove_all_filters( 'wcb_sepa_debtor_bic' );
+		remove_all_filters( 'wcb_sepa_debtor_iban' );
+	}
+
+	/**
+	 * Test generate_sepa_xml() with empty payments returns empty string.
+	 *
+	 * @covers WordCamp_Budgets::generate_sepa_xml
+	 */
+	public function test_generate_sepa_xml_empty_payments() : void {
+		$this->assertSame( '', WordCamp_Budgets::generate_sepa_xml( array() ) );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -186,7 +186,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	 * @covers WCP_Payment_Request::_generate_payment_report_sepa
 	 * @covers WordCamp_Budgets::generate_sepa_xml
 	 */
-	public function test_generate_sepa_payment_report() : void {
+	public function test_generate_sepa_payment_report(): void {
 		$args = array(
 			'status'     => 'wcb-approved',
 			'start_date' => strtotime( '3 days ago' ),
@@ -229,7 +229,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	 * @covers WordCamp\Budgets_Dashboard\generate_payment_report
 	 * @covers WordCamp\Budgets_Dashboard\_generate_payment_report_sepa
 	 */
-	public function test_generate_sepa_report_no_matching_posts() : void {
+	public function test_generate_sepa_report_no_matching_posts(): void {
 		$args = array(
 			'status'     => 'wcb-approved',
 			'start_date' => strtotime( '8 days ago' ),
@@ -254,13 +254,19 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	 *
 	 * @covers WordCamp_Budgets::generate_sepa_xml
 	 */
-	public function test_generate_sepa_xml_format() : void {
-		add_filter( 'wcb_sepa_debtor_bic', function () {
-			return 'TESTBIC123';
-		} );
-		add_filter( 'wcb_sepa_debtor_iban', function () {
-			return 'DE00000000000000000000';
-		} );
+	public function test_generate_sepa_xml_format(): void {
+		add_filter(
+			'wcb_sepa_debtor_bic',
+			function () {
+				return 'TESTBIC123';
+			}
+		);
+		add_filter(
+			'wcb_sepa_debtor_iban',
+			function () {
+				return 'DE00000000000000000000';
+			}
+		);
 
 		$payments = array(
 			array(
@@ -287,8 +293,11 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		$dom = new \DOMDocument();
 		$this->assertTrue( $dom->loadXML( $xml ), 'Output should be valid XML.' );
 
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOMDocument native properties.
 		$root = $dom->documentElement;
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertSame( 'Document', $root->localName );
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertSame( 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03', $root->namespaceURI );
 
 		// Verify header counts.
@@ -329,7 +338,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	 *
 	 * @covers WordCamp_Budgets::generate_sepa_xml
 	 */
-	public function test_generate_sepa_xml_empty_payments() : void {
+	public function test_generate_sepa_xml_empty_payments(): void {
 		$this->assertSame( '', WordCamp_Budgets::generate_sepa_xml( array() ) );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -1658,4 +1658,52 @@ Thanks for helping us with these details!",
 		$results = remove_accents( $results );
 		return $results;
 	}
+
+	/**
+	 * SEPA Credit Transfer – ISO 20022 XML (pain.001.003.03)
+	 *
+	 * @param array $args
+	 *
+	 * @return string
+	 */
+	public static function _generate_payment_report_sepa( $args ) {
+		$args = wp_parse_args( $args, array(
+			'data'      => array(),
+			'status'    => '',
+			'post_type' => '',
+		) );
+
+		$payments = array();
+
+		foreach ( $args['data'] as $entry ) {
+			switch_to_blog( $entry->blog_id );
+			$post = get_post( $entry->post_id );
+
+			if ( $args['status'] && $post->post_status != $args['status'] ) {
+				restore_current_blog();
+				continue;
+			} elseif ( $post->post_type != self::POST_TYPE ) {
+				restore_current_blog();
+				continue;
+			} elseif ( get_post_meta( $post->ID, '_camppayments_payment_method', true ) != 'EUR SEPA Transfer' ) {
+				restore_current_blog();
+				continue;
+			}
+
+			$amount = round( floatval( get_post_meta( $post->ID, '_camppayments_payment_amount', true ) ), 2 );
+
+			$payments[] = array(
+				'amount'       => $amount,
+				'account_name' => WCP_Encryption::maybe_decrypt( get_post_meta( $post->ID, '_camppayments_sepa_account_name', true ) ),
+				'bic'          => WCP_Encryption::maybe_decrypt( get_post_meta( $post->ID, '_camppayments_sepa_bic', true ) ),
+				'iban'         => preg_replace( '#\s#', '', WCP_Encryption::maybe_decrypt( get_post_meta( $post->ID, '_camppayments_sepa_iban', true ) ) ),
+				'reference'    => sprintf( 'wcb-%d-%d', $entry->blog_id, $entry->post_id ),
+				'invoice'      => get_post_meta( $post->ID, '_camppayments_invoice_number', true ),
+			);
+
+			restore_current_blog();
+		}
+
+		return WordCamp_Budgets::generate_sepa_xml( $payments );
+	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -510,7 +510,7 @@ class WCP_Payment_Request {
 				break;
 
 			case 'payment_method':
-				$value = WordCamp_Budgets::get_valid_payment_methods( $post->post_type );
+				$value = WordCamp_Budgets::get_payment_methods( $post->post_type );
 				break;
 
 			case 'general_notes':
@@ -528,7 +528,10 @@ class WCP_Payment_Request {
 				break;
 
 			case 'ach_account_type':
-				$value = array( 'Personal', 'Company' );
+				$value = array(
+					'Personal' => __( 'Personal', 'wordcamporg' ),
+					'Company'  => __( 'Company', 'wordcamporg' ),
+				);
 				break;
 
 			default:
@@ -1688,7 +1691,7 @@ Thanks for helping us with these details!",
 			} elseif ( self::POST_TYPE !== $post->post_type ) {
 				restore_current_blog();
 				continue;
-			} elseif ( 'EUR SEPA Transfer' !== get_post_meta( $post->ID, '_camppayments_payment_method', true ) ) {
+			} elseif ( 'sepa_transfer' !== get_post_meta( $post->ID, '_camppayments_payment_method', true ) ) {
 				restore_current_blog();
 				continue;
 			}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -1667,11 +1667,14 @@ Thanks for helping us with these details!",
 	 * @return string
 	 */
 	public static function _generate_payment_report_sepa( $args ) {
-		$args = wp_parse_args( $args, array(
-			'data'      => array(),
-			'status'    => '',
-			'post_type' => '',
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'data'      => array(),
+				'status'    => '',
+				'post_type' => '',
+			)
+		);
 
 		$payments = array();
 
@@ -1679,13 +1682,13 @@ Thanks for helping us with these details!",
 			switch_to_blog( $entry->blog_id );
 			$post = get_post( $entry->post_id );
 
-			if ( $args['status'] && $post->post_status != $args['status'] ) {
+			if ( $args['status'] && $args['status'] !== $post->post_status ) {
 				restore_current_blog();
 				continue;
-			} elseif ( $post->post_type != self::POST_TYPE ) {
+			} elseif ( self::POST_TYPE !== $post->post_type ) {
 				restore_current_blog();
 				continue;
-			} elseif ( get_post_meta( $post->ID, '_camppayments_payment_method', true ) != 'EUR SEPA Transfer' ) {
+			} elseif ( 'EUR SEPA Transfer' !== get_post_meta( $post->ID, '_camppayments_payment_method', true ) ) {
 				restore_current_blog();
 				continue;
 			}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -1668,3 +1668,58 @@ function _generate_payment_report_jpm_wires( $args ) {
 	$results = remove_accents( $results );
 	return $results;
 }
+
+/**
+ * SEPA Credit Transfer – ISO 20022 XML (pain.001.003.03)
+ *
+ * @param array $args
+ *
+ * @return string
+ */
+function _generate_payment_report_sepa( $args ) {
+	$args = wp_parse_args( $args, array(
+		'data'      => array(),
+		'status'    => '',
+		'post_type' => '',
+	) );
+
+	$payments = array();
+
+	foreach ( $args['data'] as $entry ) {
+		switch_to_blog( $entry->blog_id );
+		$post = get_post( $entry->request_id );
+
+		if ( $args['status'] && $post->post_status != $args['status'] ) {
+			restore_current_blog();
+			continue;
+		} elseif ( $post->post_type != POST_TYPE ) {
+			restore_current_blog();
+			continue;
+		} elseif ( get_post_meta( $post->ID, '_wcbrr_payment_method', true ) != 'EUR SEPA Transfer' ) {
+			restore_current_blog();
+			continue;
+		}
+
+		$amount   = 0;
+		$expenses = get_post_meta( $post->ID, '_wcbrr_expenses', true );
+		foreach ( $expenses as $expense ) {
+			if ( ! empty( $expense['_wcbrr_amount'] ) ) {
+				$amount += floatval( $expense['_wcbrr_amount'] );
+			}
+		}
+		$amount = round( $amount, 2 );
+
+		$payments[] = array(
+			'amount'       => $amount,
+			'account_name' => \WCP_Encryption::maybe_decrypt( get_post_meta( $post->ID, '_wcbrr_sepa_account_name', true ) ),
+			'bic'          => \WCP_Encryption::maybe_decrypt( get_post_meta( $post->ID, '_wcbrr_sepa_bic', true ) ),
+			'iban'         => preg_replace( '#\s#', '', \WCP_Encryption::maybe_decrypt( get_post_meta( $post->ID, '_wcbrr_sepa_iban', true ) ) ),
+			'reference'    => sprintf( 'wcb-%d-%d', $entry->blog_id, $entry->request_id ),
+			'invoice'      => '',
+		);
+
+		restore_current_blog();
+	}
+
+	return \WordCamp_Budgets::generate_sepa_xml( $payments );
+}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -1677,11 +1677,14 @@ function _generate_payment_report_jpm_wires( $args ) {
  * @return string
  */
 function _generate_payment_report_sepa( $args ) {
-	$args = wp_parse_args( $args, array(
-		'data'      => array(),
-		'status'    => '',
-		'post_type' => '',
-	) );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'data'      => array(),
+			'status'    => '',
+			'post_type' => '',
+		)
+	);
 
 	$payments = array();
 
@@ -1689,13 +1692,13 @@ function _generate_payment_report_sepa( $args ) {
 		switch_to_blog( $entry->blog_id );
 		$post = get_post( $entry->request_id );
 
-		if ( $args['status'] && $post->post_status != $args['status'] ) {
+		if ( $args['status'] && $args['status'] !== $post->post_status ) {
 			restore_current_blog();
 			continue;
-		} elseif ( $post->post_type != POST_TYPE ) {
+		} elseif ( POST_TYPE !== $post->post_type ) {
 			restore_current_blog();
 			continue;
-		} elseif ( get_post_meta( $post->ID, '_wcbrr_payment_method', true ) != 'EUR SEPA Transfer' ) {
+		} elseif ( 'EUR SEPA Transfer' !== get_post_meta( $post->ID, '_wcbrr_payment_method', true ) ) {
 			restore_current_blog();
 			continue;
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -1698,7 +1698,7 @@ function _generate_payment_report_sepa( $args ) {
 		} elseif ( POST_TYPE !== $post->post_type ) {
 			restore_current_blog();
 			continue;
-		} elseif ( 'EUR SEPA Transfer' !== get_post_meta( $post->ID, '_wcbrr_payment_method', true ) ) {
+		} elseif ( 'sepa_transfer' !== get_post_meta( $post->ID, '_wcbrr_payment_method', true ) ) {
 			restore_current_blog();
 			continue;
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -280,7 +280,7 @@ class WordCamp_Budgets {
 		$methods = array(
 			'Direct Deposit' => __( 'Direct Deposit', 'wordcamporg' ),
 			'Check'          => __( 'Check', 'wordcamporg' ),
-			'sepa_transfer'  => __( 'EUR SEPA Transfer', 'wordcamporg' ),
+			'sepa_transfer'  => __( 'Euro SEPA Transfer', 'wordcamporg' ),
 			'Wire'           => __( 'Wire', 'wordcamporg' ),
 		);
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -267,20 +267,52 @@ class WordCamp_Budgets {
 	}
 
 	/**
-	 * Get a list of valid payment methods
+	 * Get payment methods as slug => label pairs.
 	 *
-	 * @param $post_type
+	 * Existing payment method slugs retain their original string values
+	 * for backward compatibility with stored post meta.
 	 *
-	 * @return array
+	 * @param string $post_type
+	 *
+	 * @return array Associative array of slug => translated label.
 	 */
-	public static function get_valid_payment_methods( $post_type ) {
-		$methods = array( 'Direct Deposit', 'Check', 'Wire', 'EUR SEPA Transfer' );
+	public static function get_payment_methods( $post_type ) {
+		$methods = array(
+			'Direct Deposit' => __( 'Direct Deposit', 'wordcamporg' ),
+			'Check'          => __( 'Check', 'wordcamporg' ),
+			'Wire'           => __( 'Wire', 'wordcamporg' ),
+			'sepa_transfer'  => __( 'EUR SEPA Transfer', 'wordcamporg' ),
+		);
 
 		if ( WCP_Payment_Request::POST_TYPE === $post_type ) {
-			$methods[] = 'Credit Card';
+			$methods['Credit Card'] = __( 'Credit Card', 'wordcamporg' );
 		}
 
 		return $methods;
+	}
+
+	/**
+	 * Get the translated label for a payment method slug.
+	 *
+	 * @param string $slug Payment method slug.
+	 *
+	 * @return string Translated label, or the slug itself if not found.
+	 */
+	public static function get_payment_method_label( $slug ) {
+		$methods = self::get_payment_methods( WCP_Payment_Request::POST_TYPE );
+
+		return isset( $methods[ $slug ] ) ? $methods[ $slug ] : $slug;
+	}
+
+	/**
+	 * Get a list of valid payment method slugs.
+	 *
+	 * @param string $post_type
+	 *
+	 * @return array List of payment method slugs.
+	 */
+	public static function get_valid_payment_methods( $post_type ) {
+		return array_keys( self::get_payment_methods( $post_type ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -274,7 +274,7 @@ class WordCamp_Budgets {
 	 * @return array
 	 */
 	public static function get_valid_payment_methods( $post_type ) {
-		$methods = array( 'Direct Deposit', 'Check', 'Wire' );
+		$methods = array( 'Direct Deposit', 'Check', 'Wire', 'EUR SEPA Transfer' );
 
 		if ( WCP_Payment_Request::POST_TYPE === $post_type ) {
 			$methods[] = 'Credit Card';
@@ -330,6 +330,10 @@ class WordCamp_Budgets {
 				case 'ach_routing_number':
 				case 'ach_account_number':
 				case 'ach_account_holder_name':
+
+				case 'sepa_account_name':
+				case 'sepa_bic':
+				case 'sepa_iban':
 					$safe_value = sanitize_text_field( $unsafe_value );
 					break;
 
@@ -434,6 +438,9 @@ class WordCamp_Budgets {
 			'ach_routing_number',
 			'ach_account_number',
 			'ach_account_holder_name',
+			'sepa_account_name',
+			'sepa_bic',
+			'sepa_iban',
 		);
 	}
 
@@ -897,5 +904,132 @@ class WordCamp_Budgets {
 		$log   = json_encode( $log );
 
 		update_post_meta( $post_id, '_wcp_log', wp_slash( $log ) );
+	}
+
+	/**
+	 * Generate a SEPA Credit Transfer XML file (pain.001.003.03).
+	 *
+	 * @param array $payments Array of payment arrays with keys: amount, account_name, bic, iban, reference, invoice.
+	 *
+	 * @return string XML content.
+	 */
+	public static function generate_sepa_xml( $payments ) {
+		if ( empty( $payments ) ) {
+			return '';
+		}
+
+		$message_id    = 'WCORG-' . gmdate( 'YmdHis' ) . '-' . wp_rand( 1000, 9999 );
+		$total_amount  = 0;
+		$payment_count = count( $payments );
+
+		foreach ( $payments as $payment ) {
+			$total_amount += $payment['amount'];
+		}
+
+		$initiator_name = 'WordPress Community Support PBC';
+		$debtor_name    = $initiator_name;
+		$debtor_bic     = apply_filters( 'wcb_sepa_debtor_bic', '' );
+		$debtor_iban    = apply_filters( 'wcb_sepa_debtor_iban', '' );
+
+		$dom = new DOMDocument( '1.0', 'UTF-8' );
+		$dom->formatOutput = true;
+
+		$root = $dom->createElementNS( 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03', 'Document' );
+		$dom->appendChild( $root );
+
+		$cst_trf_init = $dom->createElement( 'CstmrCdtTrfInitn' );
+		$root->appendChild( $cst_trf_init );
+
+		// Group Header.
+		$grp_hdr = $dom->createElement( 'GrpHdr' );
+		$cst_trf_init->appendChild( $grp_hdr );
+
+		$grp_hdr->appendChild( $dom->createElement( 'MsgId', $message_id ) );
+		$grp_hdr->appendChild( $dom->createElement( 'CreDtTm', gmdate( 'Y-m-d\TH:i:s\Z' ) ) );
+		$grp_hdr->appendChild( $dom->createElement( 'NbOfTxs', $payment_count ) );
+		$grp_hdr->appendChild( $dom->createElement( 'CtrlSum', number_format( $total_amount, 2, '.', '' ) ) );
+
+		$init_pty = $dom->createElement( 'InitgPty' );
+		$init_pty->appendChild( $dom->createElement( 'Nm', $initiator_name ) );
+		$grp_hdr->appendChild( $init_pty );
+
+		// Payment Information.
+		$pmt_inf = $dom->createElement( 'PmtInf' );
+		$cst_trf_init->appendChild( $pmt_inf );
+
+		$pmt_inf->appendChild( $dom->createElement( 'PmtInfId', $message_id . '-1' ) );
+		$pmt_inf->appendChild( $dom->createElement( 'PmtMtd', 'TRF' ) );
+		$pmt_inf->appendChild( $dom->createElement( 'NbOfTxs', $payment_count ) );
+		$pmt_inf->appendChild( $dom->createElement( 'CtrlSum', number_format( $total_amount, 2, '.', '' ) ) );
+
+		$pmt_tp_inf = $dom->createElement( 'PmtTpInf' );
+		$svc_lvl    = $dom->createElement( 'SvcLvl' );
+		$svc_lvl->appendChild( $dom->createElement( 'Cd', 'SEPA' ) );
+		$pmt_tp_inf->appendChild( $svc_lvl );
+		$pmt_inf->appendChild( $pmt_tp_inf );
+
+		$pmt_inf->appendChild( $dom->createElement( 'ReqdExctnDt', gmdate( 'Y-m-d' ) ) );
+
+		$dbtr = $dom->createElement( 'Dbtr' );
+		$dbtr->appendChild( $dom->createElement( 'Nm', $debtor_name ) );
+		$pmt_inf->appendChild( $dbtr );
+
+		$dbtr_acct = $dom->createElement( 'DbtrAcct' );
+		$dbtr_id   = $dom->createElement( 'Id' );
+		$dbtr_id->appendChild( $dom->createElement( 'IBAN', $debtor_iban ) );
+		$dbtr_acct->appendChild( $dbtr_id );
+		$pmt_inf->appendChild( $dbtr_acct );
+
+		$dbtr_agt     = $dom->createElement( 'DbtrAgt' );
+		$fin_instn_id = $dom->createElement( 'FinInstnId' );
+		$fin_instn_id->appendChild( $dom->createElement( 'BIC', $debtor_bic ) );
+		$dbtr_agt->appendChild( $fin_instn_id );
+		$pmt_inf->appendChild( $dbtr_agt );
+
+		$pmt_inf->appendChild( $dom->createElement( 'ChrgBr', 'SLEV' ) );
+
+		// Individual transactions.
+		foreach ( $payments as $payment ) {
+			$tx = $dom->createElement( 'CdtTrfTxInf' );
+
+			$pmt_id   = $dom->createElement( 'PmtId' );
+			$end_to_end = substr( $payment['reference'], 0, 35 );
+			$pmt_id->appendChild( $dom->createElement( 'EndToEndId', $end_to_end ) );
+			$tx->appendChild( $pmt_id );
+
+			$amt     = $dom->createElement( 'Amt' );
+			$instd   = $dom->createElement( 'InstdAmt', number_format( $payment['amount'], 2, '.', '' ) );
+			$instd->setAttribute( 'Ccy', 'EUR' );
+			$amt->appendChild( $instd );
+			$tx->appendChild( $amt );
+
+			if ( ! empty( $payment['bic'] ) ) {
+				$cdtr_agt     = $dom->createElement( 'CdtrAgt' );
+				$cdtr_fin_id  = $dom->createElement( 'FinInstnId' );
+				$cdtr_fin_id->appendChild( $dom->createElement( 'BIC', $payment['bic'] ) );
+				$cdtr_agt->appendChild( $cdtr_fin_id );
+				$tx->appendChild( $cdtr_agt );
+			}
+
+			$cdtr = $dom->createElement( 'Cdtr' );
+			$cdtr->appendChild( $dom->createElement( 'Nm', substr( $payment['account_name'], 0, 70 ) ) );
+			$tx->appendChild( $cdtr );
+
+			$cdtr_acct = $dom->createElement( 'CdtrAcct' );
+			$cdtr_id   = $dom->createElement( 'Id' );
+			$cdtr_id->appendChild( $dom->createElement( 'IBAN', $payment['iban'] ) );
+			$cdtr_acct->appendChild( $cdtr_id );
+			$tx->appendChild( $cdtr_acct );
+
+			if ( ! empty( $payment['invoice'] ) ) {
+				$rmt_inf = $dom->createElement( 'RmtInf' );
+				$rmt_inf->appendChild( $dom->createElement( 'Ustrd', substr( $payment['invoice'], 0, 140 ) ) );
+				$tx->appendChild( $rmt_inf );
+			}
+
+			$pmt_inf->appendChild( $tx );
+		}
+
+		return $dom->saveXML();
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -330,7 +330,6 @@ class WordCamp_Budgets {
 				case 'ach_routing_number':
 				case 'ach_account_number':
 				case 'ach_account_holder_name':
-
 				case 'sepa_account_name':
 				case 'sepa_bic':
 				case 'sepa_iban':
@@ -932,6 +931,7 @@ class WordCamp_Budgets {
 		$debtor_iban    = apply_filters( 'wcb_sepa_debtor_iban', '' );
 
 		$dom = new DOMDocument( '1.0', 'UTF-8' );
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOMDocument native property.
 		$dom->formatOutput = true;
 
 		$root = $dom->createElementNS( 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03', 'Document' );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -280,8 +280,8 @@ class WordCamp_Budgets {
 		$methods = array(
 			'Direct Deposit' => __( 'Direct Deposit', 'wordcamporg' ),
 			'Check'          => __( 'Check', 'wordcamporg' ),
-			'Wire'           => __( 'Wire', 'wordcamporg' ),
 			'sepa_transfer'  => __( 'EUR SEPA Transfer', 'wordcamporg' ),
+			'Wire'           => __( 'Wire', 'wordcamporg' ),
 		);
 
 		if ( WCP_Payment_Request::POST_TYPE === $post_type ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -3,6 +3,15 @@ jQuery( document ).ready( function( $ ) {
 	'use strict';
 
 	var wcb = window.WordCampBudgets;
+
+	// SEPA zone country codes (ISO 3166-1 alpha-2).
+	var sepaCountries = [
+		'AT', 'BE', 'BG', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES',
+		'FI', 'FR', 'GB', 'GI', 'GR', 'HR', 'HU', 'IE', 'IS', 'IT',
+		'LI', 'LT', 'LU', 'LV', 'MC', 'MT', 'NL', 'NO', 'PL', 'PT',
+		'RO', 'SE', 'SI', 'SK', 'SM', 'VA'
+	];
+
 	var app = wcb.PaymentRequests = {
 
 		/**
@@ -56,7 +65,12 @@ jQuery( document ).ready( function( $ ) {
 				}
 
 				$('#row-payment-method').show();
+				app.toggleSepaAvailability();
 			}).trigger('change');
+
+			$('#currency').on('change', function() {
+				app.toggleSepaAvailability();
+			});
 		},
 
 		/**
@@ -79,6 +93,27 @@ jQuery( document ).ready( function( $ ) {
 				// todo make the transition smoother
 			} catch ( exception ) {
 				wcb.log( exception );
+			}
+		},
+
+		/**
+		 * Show/hide the EUR SEPA Transfer option based on currency and country
+		 */
+		toggleSepaAvailability : function() {
+			var currency = $( '#currency' ).val(),
+				country  = $( '#payment_receipt_country_iso3166' ).val(),
+				sepaContainer = $( '#payment_method_eur-sepa-transfer_container' );
+
+			if ( 'EUR' === currency && sepaCountries.indexOf( country ) !== -1 ) {
+				sepaContainer.show();
+			} else {
+				sepaContainer.hide();
+
+				// If SEPA was selected, deselect it.
+				if ( $( '#payment_method_eur-sepa-transfer' ).prop( 'checked' ) ) {
+					$( '#payment_method_eur-sepa-transfer' ).prop( 'checked', false );
+					$( '#payment_method_eur-sepa-transfer_fields' ).removeClass( 'active' ).addClass( 'hidden' );
+				}
 			}
 		}
 	};

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -102,7 +102,7 @@ jQuery( document ).ready( function( $ ) {
 		toggleSepaAvailability : function() {
 			var currency = $( '#currency' ).val(),
 				country  = $( '#payment_receipt_country_iso3166' ).val(),
-				sepaContainer = $( '#payment_method_eur-sepa-transfer_container' );
+				sepaContainer = $( '#payment_method_sepa_transfer_container' );
 
 			if ( 'EUR' === currency && sepaCountries.indexOf( country ) !== -1 ) {
 				sepaContainer.show();
@@ -110,9 +110,9 @@ jQuery( document ).ready( function( $ ) {
 				sepaContainer.hide();
 
 				// If SEPA was selected, deselect it.
-				if ( $( '#payment_method_eur-sepa-transfer' ).prop( 'checked' ) ) {
-					$( '#payment_method_eur-sepa-transfer' ).prop( 'checked', false );
-					$( '#payment_method_eur-sepa-transfer_fields' ).removeClass( 'active' ).addClass( 'hidden' );
+				if ( $( '#payment_method_sepa_transfer' ).prop( 'checked' ) ) {
+					$( '#payment_method_sepa_transfer' ).prop( 'checked', false );
+					$( '#payment_method_sepa_transfer_fields' ).removeClass( 'active' ).addClass( 'hidden' );
 				}
 			}
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -97,7 +97,7 @@ jQuery( document ).ready( function( $ ) {
 		},
 
 		/**
-		 * Show/hide the EUR SEPA Transfer option based on currency and country
+		 * Show/hide the Euro SEPA Transfer option based on currency and country
 		 */
 		toggleSepaAvailability : function() {
 			var currency = $( '#currency' ).val(),

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/payment-requests.js
@@ -104,7 +104,7 @@ jQuery( document ).ready( function( $ ) {
 				country  = $( '#payment_receipt_country_iso3166' ).val(),
 				sepaContainer = $( '#payment_method_sepa_transfer_container' );
 
-			if ( 'EUR' === currency && sepaCountries.indexOf( country ) !== -1 ) {
+			if ( 'EUR' === currency && ( ! country || sepaCountries.indexOf( country ) !== -1 ) ) {
 				sepaContainer.show();
 			} else {
 				sepaContainer.hide();

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -129,7 +129,7 @@ jQuery( document ).ready( function( $ ) {
 		toggleSepaAvailability : function() {
 			var currency = $( '#_wcbrr_currency' ).val(),
 				country  = $( '#payment_receipt_country_iso3166' ).val(),
-				sepaContainer = $( '#payment_method_eur-sepa-transfer_container' );
+				sepaContainer = $( '#payment_method_sepa_transfer_container' );
 
 			if ( 'EUR' === currency && sepaCountries.indexOf( country ) !== -1 ) {
 				sepaContainer.show();
@@ -137,9 +137,9 @@ jQuery( document ).ready( function( $ ) {
 				sepaContainer.hide();
 
 				// If SEPA was selected, deselect it.
-				if ( $( '#payment_method_eur-sepa-transfer' ).prop( 'checked' ) ) {
-					$( '#payment_method_eur-sepa-transfer' ).prop( 'checked', false );
-					$( '#payment_method_eur-sepa-transfer_fields' ).removeClass( 'active' ).addClass( 'hidden' );
+				if ( $( '#payment_method_sepa_transfer' ).prop( 'checked' ) ) {
+					$( '#payment_method_sepa_transfer' ).prop( 'checked', false );
+					$( '#payment_method_sepa_transfer_fields' ).removeClass( 'active' ).addClass( 'hidden' );
 				}
 			}
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -131,7 +131,7 @@ jQuery( document ).ready( function( $ ) {
 				country  = $( '#payment_receipt_country_iso3166' ).val(),
 				sepaContainer = $( '#payment_method_sepa_transfer_container' );
 
-			if ( 'EUR' === currency && sepaCountries.indexOf( country ) !== -1 ) {
+			if ( 'EUR' === currency && ( ! country || sepaCountries.indexOf( country ) !== -1 ) ) {
 				sepaContainer.show();
 			} else {
 				sepaContainer.hide();

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -124,7 +124,7 @@ jQuery( document ).ready( function( $ ) {
 		},
 
 		/**
-		 * Show/hide the EUR SEPA Transfer option based on currency and country
+		 * Show/hide the Euro SEPA Transfer option based on currency and country
 		 */
 		toggleSepaAvailability : function() {
 			var currency = $( '#_wcbrr_currency' ).val(),

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/reimbursement-requests.js
@@ -3,6 +3,15 @@ jQuery( document ).ready( function( $ ) {
 	'use strict';
 
 	var wcb = window.WordCampBudgets;
+
+	// SEPA zone country codes (ISO 3166-1 alpha-2).
+	var sepaCountries = [
+		'AT', 'BE', 'BG', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES',
+		'FI', 'FR', 'GB', 'GI', 'GR', 'HR', 'HU', 'IE', 'IS', 'IT',
+		'LI', 'LT', 'LU', 'LV', 'MC', 'MT', 'NL', 'NO', 'PL', 'PT',
+		'RO', 'SE', 'SI', 'SK', 'SM', 'VA'
+	];
+
 	var app = wcb.ReimbursementRequests = {
 
 		/**
@@ -68,7 +77,12 @@ jQuery( document ).ready( function( $ ) {
 				}
 
 				$('#row-payment-method').show();
+				app.toggleSepaAvailability();
 			}).trigger('change');
+
+			$('#_wcbrr_currency').on('change', function() {
+				app.toggleSepaAvailability();
+			});
 		},
 
 		/**
@@ -106,6 +120,27 @@ jQuery( document ).ready( function( $ ) {
 				app.expenses.add( {} );
 			} catch ( exception ) {
 				wcb.log( exception );
+			}
+		},
+
+		/**
+		 * Show/hide the EUR SEPA Transfer option based on currency and country
+		 */
+		toggleSepaAvailability : function() {
+			var currency = $( '#_wcbrr_currency' ).val(),
+				country  = $( '#payment_receipt_country_iso3166' ).val(),
+				sepaContainer = $( '#payment_method_eur-sepa-transfer_container' );
+
+			if ( 'EUR' === currency && sepaCountries.indexOf( country ) !== -1 ) {
+				sepaContainer.show();
+			} else {
+				sepaContainer.hide();
+
+				// If SEPA was selected, deselect it.
+				if ( $( '#payment_method_eur-sepa-transfer' ).prop( 'checked' ) ) {
+					$( '#payment_method_eur-sepa-transfer' ).prop( 'checked', false );
+					$( '#payment_method_eur-sepa-transfer_fields' ).removeClass( 'active' ).addClass( 'hidden' );
+				}
 			}
 		}
 	};

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-radio.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-radio.php
@@ -4,21 +4,21 @@
 	</th>
 
 	<td>
-		<?php foreach ( $options as $option ) : ?>
-			<?php $option_name = $name . '_' . sanitize_title_with_dashes( str_replace( ' ', '_', $option ) ); ?>
+		<?php foreach ( $options as $slug => $label ) : ?>
+			<?php $option_name = $name . '_' . sanitize_title_with_dashes( str_replace( ' ', '_', $slug ) ); ?>
 
 			<span id="<?php echo esc_attr( $option_name ) . '_container'; ?>">
 				<input
 					type="radio"
 					id="<?php echo esc_attr( $option_name ); ?>"
 					name="<?php echo esc_attr( $name ); ?>"
-					value="<?php echo esc_attr( $option ); ?>"
-					<?php checked( $option, $selected ); ?>
+					value="<?php echo esc_attr( $slug ); ?>"
+					<?php checked( $slug, $selected ); ?>
 					<?php __checked_selected_helper( $required, true, true, 'required' ); ?>
 					/>
 
 				<label for="<?php echo esc_attr( $option_name ); ?>">
-					<?php echo esc_html( $option ); ?>:
+					<?php echo esc_html( $label ); ?>:
 				</label>
 			</span>
 		<?php endforeach; ?>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -107,7 +107,7 @@
 			</table>
 		</div>
 
-		<div id="payment_method_eur-sepa-transfer_fields" class="form-table payment_method_fields <?php echo 'EUR SEPA Transfer' == $selected_payment_method ? 'active' : 'hidden'; ?>">
+		<div id="payment_method_sepa_transfer_fields" class="form-table payment_method_fields <?php echo 'sepa_transfer' == $selected_payment_method ? 'active' : 'hidden'; ?>">
 			<table>
 				<?php $this->render_text_input( $post, esc_html__( 'Account Name', 'wordcamporg' ), 'sepa_account_name' ); ?>
 				<?php $this->render_text_input( $post, esc_html__( 'BIC',          'wordcamporg' ), 'sepa_bic'          ); ?>

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -106,6 +106,14 @@
 				<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Country',           'wordcamporg' ), 'beneficiary_country_iso3166' ); ?>
 			</table>
 		</div>
+
+		<div id="payment_method_eur-sepa-transfer_fields" class="form-table payment_method_fields <?php echo 'EUR SEPA Transfer' == $selected_payment_method ? 'active' : 'hidden'; ?>">
+			<table>
+				<?php $this->render_text_input( $post, esc_html__( 'Account Name', 'wordcamporg' ), 'sepa_account_name' ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'BIC',          'wordcamporg' ), 'sepa_bic'          ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'IBAN',         'wordcamporg' ), 'sepa_iban'         ); ?>
+			</table>
+		</div>
 	</fieldset>
 
 	<p class="wcb-form-required">

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -52,6 +52,14 @@
 			<?php esc_html_e( 'Please make sure that you upload an authorization form above, if one is required by the vendor.', 'wordcamporg' ); ?>
 		</p>
 
+		<div id="payment_method_sepa_transfer_fields" class="form-table payment_method_fields <?php echo 'sepa_transfer' == $selected_payment_method ? 'active' : 'hidden'; ?>">
+			<table>
+				<?php $this->render_text_input( $post, esc_html__( 'Account Name', 'wordcamporg' ), 'sepa_account_name' ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'BIC',          'wordcamporg' ), 'sepa_bic'          ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'IBAN',         'wordcamporg' ), 'sepa_iban'         ); ?>
+			</table>
+		</div>
+
 		<div id="payment_method_wire_fields" class="form-table payment_method_fields <?php echo 'Wire' == $selected_payment_method ? 'active' : 'hidden'; ?>">
 			<h3>
 				<?php esc_html_e( 'Beneficiary’s Bank', 'wordcamporg' ); ?>
@@ -104,14 +112,6 @@
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s State / Province',  'wordcamporg' ), 'beneficiary_state'           ); ?>
 				<?php $this->render_text_input(    $post, esc_html__( 'Beneficiary’s ZIP / Postal Code', 'wordcamporg' ), 'beneficiary_zip_code'        ); ?>
 				<?php $this->render_country_input( $post, esc_html__( 'Beneficiary’s Country',           'wordcamporg' ), 'beneficiary_country_iso3166' ); ?>
-			</table>
-		</div>
-
-		<div id="payment_method_sepa_transfer_fields" class="form-table payment_method_fields <?php echo 'sepa_transfer' == $selected_payment_method ? 'active' : 'hidden'; ?>">
-			<table>
-				<?php $this->render_text_input( $post, esc_html__( 'Account Name', 'wordcamporg' ), 'sepa_account_name' ); ?>
-				<?php $this->render_text_input( $post, esc_html__( 'BIC',          'wordcamporg' ), 'sepa_bic'          ); ?>
-				<?php $this->render_text_input( $post, esc_html__( 'IBAN',         'wordcamporg' ), 'sepa_iban'         ); ?>
 			</table>
 		</div>
 	</fieldset>


### PR DESCRIPTION
## Summary
- Adds a new **EUR SEPA Transfer** payment method for Vendor Payments and Reimbursement Requests
- Conditionally shown only when currency is EUR and country is in the SEPA zone (36 countries)
- Collects Account Name, BIC, and IBAN (all encrypted at rest)
- Adds SEPA Credit Transfer ISO 20022 XML export (pain.001.003.03 format) for the network dashboard
- Debtor bank details are configurable via `wcb_sepa_debtor_bic` and `wcb_sepa_debtor_iban` filters
- SEPA payments are automatically excluded from Wire exports (different payment method value)

### Note on Wire rename
The issue proposes renaming "Wire" to "Wire (SWIFT / IBAN)". This was intentionally deferred because the payment method value is used as both the stored value and the display label throughout the codebase. Renaming it would require a data migration for existing Wire payments. This could be addressed in a follow-up with a proper migration strategy.

## Test plan
- [ ] Create a Vendor Payment, select EUR currency and a SEPA country (e.g., DE) — verify "EUR SEPA Transfer" radio option appears
- [ ] Select a non-EUR currency — verify SEPA option is hidden
- [ ] Select EUR with a non-SEPA country — verify SEPA option is hidden
- [ ] Select EUR SEPA Transfer, fill in Account Name, BIC, IBAN — verify fields save and are encrypted
- [ ] Repeat the above for Reimbursement Requests
- [ ] Export SEPA payments from the network dashboard — verify valid pain.001.003.03 XML output
- [ ] Export Wire payments — verify SEPA entries are not included

Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)