### PR TITLE
Redirect old event URLs to the latest year for the same city/type

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
@@ -138,7 +138,7 @@ class Test_Sunrise_Events_Database extends Database_TestCase {
 	 * @dataProvider data_get_latest_event_url
 	 */
 	public function test_get_latest_event_url( $request_path, $expected ) {
-		$actual = get_latest_event_url( $request_path );
+		$actual = get_latest_event_url( $request_path, 'events.wordpress.test' );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
@@ -131,7 +131,7 @@ class Test_Sunrise_Events extends Database_TestCase {
 	 * @dataProvider data_get_latest_event_url
 	 */
 	public function test_get_latest_event_url( $request_path, $expected ) {
-		$actual = get_latest_event_url( $request_path, get_network( EVENTS_NETWORK_ID )->domain );
+		$actual = get_latest_event_url( $request_path );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
@@ -12,6 +12,7 @@
 
 namespace WordCamp\Sunrise\Events;
 use WP_UnitTestCase;
+use WordCamp\Tests\Database_TestCase;
 
 defined( 'WPINC' ) || die();
 
@@ -123,5 +124,51 @@ class Test_Sunrise_Events extends WP_UnitTestCase {
 		$this->assertSame( 1, $original_count );
 
 		wp_delete_site( $site_id );
+	}
+}
+
+/**
+ * @group sunrise
+ * @group mu-plugins
+ */
+class Test_Sunrise_Events_Database extends Database_TestCase {
+	/**
+	 * @covers WordCamp\Sunrise\Events\get_latest_event_url
+	 *
+	 * @dataProvider data_get_latest_event_url
+	 */
+	public function test_get_latest_event_url( $request_path, $expected ) {
+		$actual = get_latest_event_url( $request_path );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Test cases for test_get_latest_event_url().
+	 *
+	 * @return array
+	 */
+	public function data_get_latest_event_url() {
+		return array(
+			'old year redirects to latest year' => array(
+				'/rome/2023/training/',
+				'https://events.wordpress.test/rome/2024/training/',
+			),
+
+			'current year does not redirect' => array(
+				'/rome/2024/training/',
+				false,
+			),
+
+			'unknown city returns false' => array(
+				'/narnia/2023/meetup/',
+				false,
+			),
+
+			'non-matching path returns false' => array(
+				'/some-page/',
+				false,
+			),
+		);
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
@@ -138,7 +138,7 @@ class Test_Sunrise_Events_Database extends Database_TestCase {
 	 * @dataProvider data_get_latest_event_url
 	 */
 	public function test_get_latest_event_url( $request_path, $expected ) {
-		$actual = get_latest_event_url( $request_path, 'events.wordpress.test' );
+		$actual = get_latest_event_url( $request_path, get_network( EVENTS_NETWORK_ID )->domain );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise-events.php
@@ -11,7 +11,6 @@
 
 
 namespace WordCamp\Sunrise\Events;
-use WP_UnitTestCase;
 use WordCamp\Tests\Database_TestCase;
 
 defined( 'WPINC' ) || die();
@@ -20,7 +19,7 @@ defined( 'WPINC' ) || die();
  * @group sunrise
  * @group mu-plugins
  */
-class Test_Sunrise_Events extends WP_UnitTestCase {
+class Test_Sunrise_Events extends Database_TestCase {
 	/**
 	 * @covers WordCamp\Sunrise\get_redirect_url
 	 *
@@ -125,13 +124,7 @@ class Test_Sunrise_Events extends WP_UnitTestCase {
 
 		wp_delete_site( $site_id );
 	}
-}
 
-/**
- * @group sunrise
- * @group mu-plugins
- */
-class Test_Sunrise_Events_Database extends Database_TestCase {
 	/**
 	 * @covers WordCamp\Sunrise\Events\get_latest_event_url
 	 *

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -107,6 +107,15 @@ function set_network_and_site() {
 			exit;
 		}
 
+		// Try to redirect to the latest year for the same city/type.
+		$latest_url = get_latest_event_url( $path );
+
+		if ( $latest_url ) {
+			header( 'X-Redirect-By: Events/Sunrise::set_network_and_site (latest year)' );
+			header( 'Location: ' . $latest_url, true, 301 );
+			exit;
+		}
+
 		// Otherwise, redirect to the campus connect page.
 		header( 'X-Redirect-By: Events/Sunrise::set_network_and_site' );
 		header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
@@ -116,6 +125,54 @@ function set_network_and_site() {
 	$blog_id = $current_blog->id;
 	$domain  = $current_blog->domain;
 	$public  = $current_blog->public;
+}
+
+/**
+ * Get the URL of the latest event site matching the same city and type.
+ *
+ * For example, `/vancouver/2023/diversity-day/` redirects to `/vancouver/2025/diversity-day/`
+ * if 2025 is the latest year with that city/type combination.
+ *
+ * @param string $request_path The request URI path.
+ *
+ * @return string|false The URL to redirect to, or false if no match found.
+ */
+function get_latest_event_url( string $request_path ) {
+	global $wpdb;
+
+	if ( ! preg_match( PATTERN_CITY_YEAR_TYPE_PATH, $request_path, $matches ) ) {
+		return false;
+	}
+
+	$city = $matches[1];
+	$type = $matches[3];
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Sunrise runs before caching is available.
+	$latest_site = $wpdb->get_row( $wpdb->prepare(
+		"SELECT `domain`, `path`
+		FROM `$wpdb->blogs`
+		WHERE
+			`domain` = %s AND
+			`path` LIKE %s AND
+			`public` = 1 AND
+			`deleted` = 0
+		ORDER BY `path` DESC
+		LIMIT 1",
+		DOMAIN_CURRENT_SITE,
+		$wpdb->esc_like( "/$city/" ) . '%/' . $wpdb->esc_like( "$type/" )
+	) );
+
+	if ( ! $latest_site ) {
+		return false;
+	}
+
+	// Don't redirect to the exact same path that was requested.
+	$requested_path = rtrim( $request_path, '/' ) . '/';
+	if ( $latest_site->path === $requested_path ) {
+		return false;
+	}
+
+	return 'https://' . $latest_site->domain . $latest_site->path;
 }
 
 /**

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -120,10 +120,14 @@ function set_network_and_site() {
 			exit;
 		}
 
-		// Otherwise, redirect to the campus connect page.
-		header( 'X-Redirect-By: Events/Sunrise::set_network_and_site' );
-		header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
-		exit;
+		if ( defined( 'NOBLOGREDIRECT' ) ) {
+			header( 'X-Redirect-By: Events/Sunrise::set_network_and_site' );
+			header( 'Location: ' . NOBLOGREDIRECT, true, 302 );
+			exit;
+		}
+
+		// No redirect available; fall back to the root site and let WordPress handle the 404.
+		$current_blog = WP_Site::get_instance( BLOG_ID_CURRENT_SITE );
 	}
 
 	$blog_id = $current_blog->id;

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -82,6 +82,10 @@ function set_network_and_site() {
 
 		$current_blog = get_site_by_path( DOMAIN_CURRENT_SITE, $path, 3 );
 
+		if ( $current_blog && '/' === $current_blog->path ) {
+			// We found the root site, not a matching site.
+			$current_blog = false;
+		}
 	} elseif (
 		CAMPUS_NETWORK_ID === $site_id &&
 		1 === preg_match( PATTERN_CITY_PATH, $path )

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -108,7 +108,7 @@ function set_network_and_site() {
 		}
 
 		// Try to redirect to the latest year for the same city/type.
-		$latest_url = get_latest_event_url( $path, DOMAIN_CURRENT_SITE );
+		$latest_url = get_latest_event_url( $path );
 
 		if ( $latest_url ) {
 			header( 'X-Redirect-By: Events/Sunrise::set_network_and_site (latest year)' );
@@ -137,15 +137,16 @@ function set_network_and_site() {
  *
  * @return string|false The URL to redirect to, or false if no match found.
  */
-function get_latest_event_url( string $request_path, string $domain ) {
+function get_latest_event_url( string $request_path ) {
 	global $wpdb;
 
 	if ( ! preg_match( PATTERN_CITY_YEAR_TYPE_PATH, $request_path, $matches ) ) {
 		return false;
 	}
 
-	$city = $matches[1];
-	$type = $matches[3];
+	$city   = $matches[1];
+	$type   = $matches[3];
+	$domain = defined( 'DOMAIN_CURRENT_SITE' ) ? DOMAIN_CURRENT_SITE : get_network( EVENTS_NETWORK_ID )->domain;
 
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Sunrise runs before caching is available.
 	$latest_site = $wpdb->get_row( $wpdb->prepare(

--- a/public_html/wp-content/sunrise-events.php
+++ b/public_html/wp-content/sunrise-events.php
@@ -108,7 +108,7 @@ function set_network_and_site() {
 		}
 
 		// Try to redirect to the latest year for the same city/type.
-		$latest_url = get_latest_event_url( $path );
+		$latest_url = get_latest_event_url( $path, DOMAIN_CURRENT_SITE );
 
 		if ( $latest_url ) {
 			header( 'X-Redirect-By: Events/Sunrise::set_network_and_site (latest year)' );
@@ -137,7 +137,7 @@ function set_network_and_site() {
  *
  * @return string|false The URL to redirect to, or false if no match found.
  */
-function get_latest_event_url( string $request_path ) {
+function get_latest_event_url( string $request_path, string $domain ) {
 	global $wpdb;
 
 	if ( ! preg_match( PATTERN_CITY_YEAR_TYPE_PATH, $request_path, $matches ) ) {
@@ -158,7 +158,7 @@ function get_latest_event_url( string $request_path ) {
 			`deleted` = 0
 		ORDER BY `path` DESC
 		LIMIT 1",
-		DOMAIN_CURRENT_SITE,
+		$domain,
 		$wpdb->esc_like( "/$city/" ) . '%/' . $wpdb->esc_like( "$type/" )
 	) );
 


### PR DESCRIPTION
## Summary
- Adds `get_latest_event_url()` to `sunrise-events.php` that redirects old event URLs (e.g., `/rome/2023/training/`) to the latest year with the same city/type combination (e.g., `/rome/2025/training/`)
- Wired into `set_network_and_site()` **after** the renamed-site check, before the NOBLOGREDIRECT fallback
- Added integration tests in `test-sunrise-events.php` using `Database_TestCase`

Part of #1588

## Test plan
- [x] `get_latest_event_url()` returns redirect URL when an older year is requested and a newer year exists
- [x] `get_latest_event_url()` returns `false` when the current/latest year is requested (no redirect loop)
- [x] `get_latest_event_url()` returns `false` for unknown cities
- [x] `get_latest_event_url()` returns `false` for non-matching paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)