### PR TITLE
Organisers should be able to refund regardless of the refund window settings

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6625,18 +6625,20 @@ class CampTix_Plugin {
 			die();
 		}
 
-		if ( ! $this->options['refunds_enabled'] && ! current_user_can( $this->caps['manage_attendees'] ) ) {
-			$this->error_flags['invalid_access_token'] = true;
-			$this->redirect_with_error_flags();
-			die();
-		}
+		// If the user can't manage attendees, then we'll check that refunds are enabled, and they're within the refund window.
+		if ( ! current_user_can( $this->caps['manage_attendees'] ) ) {
+			if ( ! $this->options['refunds_enabled'] ) {
+				$this->error_flags['invalid_access_token'] = true;
+				$this->redirect_with_error_flags();
+				die();
+			}
 
-		$today = date( 'Y-m-d' );
-		$refunds_until = $this->options['refunds_date_end'];
-		if ( ! strtotime( $refunds_until ) || strtotime( $refunds_until ) < strtotime( $today ) ) {
-			$this->error_flags['cannot_refund'] = true;
-			$this->redirect_with_error_flags();
-			die();
+			$refunds_until = $this->options['refunds_date_end'];
+			if ( ! strtotime( $refunds_until ) || strtotime( $refunds_until ) < time() ) {
+				$this->error_flags['cannot_refund'] = true;
+				$this->redirect_with_error_flags();
+				die();
+			}
 		}
 
 		$access_token = $_REQUEST['tix_access_token'];


### PR DESCRIPTION
See https://wordpress.slack.com/archives/C08M59V3P/p1771842194561359

The Event didn't have refunds enabled ever, so didn't have the `refunds_date_end` value set.

The existing code bypassed the `Refunds enabled?` checks, but didn't bypass the `refunds_date_end` check.

This simply refactors it to bypass both. 