### PR TITLE
Specify we support UPI on the ticket purchase screen

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -56,6 +56,12 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
+
+		// Use specific name for INR as we support UPI via Stripe.
+		if ( 'INR' === $this->camptix_options['currency'] ?? '' ) {
+			$this->name = 'Credit Card or UPI (Stripe)';
+			$this->description = 'Credit card and UPI processing, powered by Stripe.';
+		}
 	}
 
 	/**


### PR DESCRIPTION
We now support UPI payments in India, this updates the name of the Stripe gateway dynamically to specify that.

### Screenshots

<img width="437" height="165" alt="Screenshot 2026-02-26 at 5 16 15 pm" src="https://github.com/user-attachments/assets/49d5ccb1-7706-4436-9bfd-5698aec3144b" />
