### PR TITLE
Fixed Deprecated Code

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -9,6 +9,8 @@
  */
 
 class CampTix_Addon_Shortcodes extends CampTix_Addon {
+	private $did_shortcode_private_template_redirect;
+
 	/**
 	 * Runs during camptix_init, @see CampTix_Addon
 	 */

--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -9,7 +9,7 @@
  */
 
 class CampTix_Addon_Shortcodes extends CampTix_Addon {
-	private $did_shortcode_private_template_redirect;
+	protected bool $did_shortcode_private_template_redirect = false;
 
 	/**
 	 * Runs during camptix_init, @see CampTix_Addon
@@ -429,7 +429,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 		global $camptix;
 
 		// Indicates this function did run, nothing more.
-		$this->did_shortcode_private_template_redirect = 1;
+		$this->did_shortcode_private_template_redirect = true;
 
 		if ( isset( $_POST['tix_private_shortcode_submit'] ) ) {
 			$email = isset( $_POST['tix_email'] ) ? trim( stripslashes( $_POST['tix_email'] ) ) : '';
@@ -496,7 +496,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 	public function shortcode_private( $atts, $content ) {
 		global $camptix;
 
-		if ( ! isset( $this->did_shortcode_private_template_redirect ) ) {
+		if ( ! $this->did_shortcode_private_template_redirect ) {
 			return __( 'An error has occurred.', 'wordcamporg' );
 		}
 


### PR DESCRIPTION
Fixed Deprecated code

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

PHP Deprecated:  Creation of dynamic property CampTix_Addon_Shortcodes::$did_shortcode_private_template_redirect is deprecated in \wp-content\plugins\camptix\addons\shortcodes.php on line 430