### PR TITLE
Fix SEPA export filename for bank compatibility

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -169,7 +169,7 @@ function get_export_types() {
 			'label'     => 'SEPA Credit Transfer (ISO 20022 XML)',
 			'mime_type' => 'application/xml',
 			'callback'  => __NAMESPACE__ . '\_generate_payment_report_sepa',
-			'filename'  => 'wordcamp-payments-%s-%s-sepa.xml',
+			'filename'  => 'WordCampPayments%s%sSEPA.xml',
 		),
 	);
 }

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -197,7 +197,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 				'label'     => 'SEPA Credit Transfer (ISO 20022 XML)',
 				'mime_type' => 'application/xml',
 				'callback'  => 'WordCamp\Budgets_Dashboard\_generate_payment_report_sepa',
-				'filename'  => 'wordcamp-payments-%s-%s-sepa.xml',
+				'filename'  => 'WordCampPayments%s%sSEPA.xml',
 			),
 		);
 
@@ -240,7 +240,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 				'label'     => 'SEPA Credit Transfer (ISO 20022 XML)',
 				'mime_type' => 'application/xml',
 				'callback'  => 'WordCamp\Budgets_Dashboard\_generate_payment_report_sepa',
-				'filename'  => 'wordcamp-payments-%s-%s-sepa.xml',
+				'filename'  => 'WordCampPayments%s%sSEPA.xml',
 			),
 		);
 


### PR DESCRIPTION
## Summary
- Removes hyphens from the SEPA XML export filename so banks can import it
- Changed from `wordcamp-payments-20260301-20260302-sepa.xml` to `WordCampPayments2026030120260302SEPA.xml`
- Bank error was: *"Invalid File Name. Please use only alphanumeric characters and no spaces when naming the file. Punctuation can only be used to identify a file extension."*

## Test plan
- [ ] Export a SEPA payment report and verify the downloaded filename is purely alphanumeric (aside from `.xml`)
- [ ] Import the file into the bank system and confirm no filename error

🤖 Generated with [Claude Code](https://claude.com/claude-code)