### PR TITLE
Improve SEPA transfer form fields and IBAN handling

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -451,7 +451,7 @@ class WCP_Payment_Request {
 	 * @param bool    $readonly
 	 * @param bool    $required
 	 */
-	protected function render_text_input( $post, $label, $name, $description = '', $variant = 'text', $row_classes = array(), $readonly = false, $required = true ) {
+	protected function render_text_input( $post, $label, $name, $description = '', $variant = 'text', $row_classes = array(), $readonly = false, $required = true, $placeholder = '' ) {
 		$value = $this->get_field_value( $name, $post );
 		array_walk( $row_classes, 'sanitize_html_class' );
 		$row_classes = implode( ' ', $row_classes );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -1028,6 +1028,9 @@ class WordCamp_Budgets {
 
 		// Individual transactions.
 		foreach ( $payments as $payment ) {
+			$iban = preg_replace( '/\s/', '', $payment['iban'] );
+			$bic  = preg_replace( '/\s/', '', $payment['bic'] ?? '' );
+
 			$tx = $dom->createElement( 'CdtTrfTxInf' );
 
 			$pmt_id   = $dom->createElement( 'PmtId' );
@@ -1041,10 +1044,10 @@ class WordCamp_Budgets {
 			$amt->appendChild( $instd );
 			$tx->appendChild( $amt );
 
-			if ( ! empty( $payment['bic'] ) ) {
+			if ( ! empty( $bic ) ) {
 				$cdtr_agt     = $dom->createElement( 'CdtrAgt' );
 				$cdtr_fin_id  = $dom->createElement( 'FinInstnId' );
-				$cdtr_fin_id->appendChild( $dom->createElement( 'BIC', $payment['bic'] ) );
+				$cdtr_fin_id->appendChild( $dom->createElement( 'BIC', $bic ) );
 				$cdtr_agt->appendChild( $cdtr_fin_id );
 				$tx->appendChild( $cdtr_agt );
 			}
@@ -1055,7 +1058,7 @@ class WordCamp_Budgets {
 
 			$cdtr_acct = $dom->createElement( 'CdtrAcct' );
 			$cdtr_id   = $dom->createElement( 'Id' );
-			$cdtr_id->appendChild( $dom->createElement( 'IBAN', $payment['iban'] ) );
+			$cdtr_id->appendChild( $dom->createElement( 'IBAN', $iban ) );
 			$cdtr_acct->appendChild( $cdtr_id );
 			$tx->appendChild( $cdtr_acct );
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/wordcamp-budgets.js
@@ -163,7 +163,8 @@ jQuery( document ).ready( function( $ ) {
 		isValidIban : function( iban ) {
 			iban = iban.replace( /\s/g, '' ).toUpperCase();
 
-			if ( ! /^[A-Z]{2}\d{2}[A-Z0-9]{4,30}$/.test( iban ) ) {
+			// Minimum IBAN length is 15 (Norway), maximum is 34.
+			if ( ! /^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test( iban ) ) {
 				return false;
 			}
 
@@ -208,11 +209,13 @@ jQuery( document ).ready( function( $ ) {
 		 * Attach blur validation to SEPA IBAN and BIC fields.
 		 */
 		setupSepaValidation : function() {
+			$( '#sepa_iban' ).attr( 'minlength', 15 );
+
 			$( '#sepa_iban' ).on( 'blur', function() {
 				var val = $( this ).val().trim();
 
 				if ( val && ! app.isValidIban( val ) ) {
-					this.setCustomValidity( 'Please enter a valid IBAN.' );
+					this.setCustomValidity( 'Please enter a valid IBAN (minimum 15 characters).' );
 					this.reportValidity();
 				} else {
 					this.setCustomValidity( '' );

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-text.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/input-text.php
@@ -14,6 +14,8 @@
 			<?php if ( $readonly ) {
 				echo 'readonly="readonly"'; } ?>
 			<?php __checked_selected_helper( $required, true, true, 'required' ); ?>
+			<?php if ( ! empty( $placeholder ) ) {
+				echo 'placeholder="' . esc_attr( $placeholder ) . '"'; } ?>
 			class="regular-text"
 			/>
 

--- a/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/views/payment-request/metabox-payment.php
@@ -54,9 +54,9 @@
 
 		<div id="payment_method_sepa_transfer_fields" class="form-table payment_method_fields <?php echo 'sepa_transfer' == $selected_payment_method ? 'active' : 'hidden'; ?>">
 			<table>
-				<?php $this->render_text_input( $post, esc_html__( 'Account Name', 'wordcamporg' ), 'sepa_account_name' ); ?>
-				<?php $this->render_text_input( $post, esc_html__( 'BIC',          'wordcamporg' ), 'sepa_bic'          ); ?>
-				<?php $this->render_text_input( $post, esc_html__( 'IBAN',         'wordcamporg' ), 'sepa_iban'         ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'Account Holder Name', 'wordcamporg' ), 'sepa_account_name', '', 'text', array(), false, true, esc_attr__( 'Jane Doe or XYZ Company', 'wordcamporg' ) ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'BIC', 'wordcamporg' ), 'sepa_bic', '', 'text', array(), false, true, esc_attr__( 'XXXXGB00', 'wordcamporg' ) ); ?>
+				<?php $this->render_text_input( $post, esc_html__( 'IBAN', 'wordcamporg' ), 'sepa_iban', '', 'text', array(), false, true, esc_attr__( 'GB00 XXXX 0000 0000 0000 00', 'wordcamporg' ) ); ?>
 			</table>
 		</div>
 


### PR DESCRIPTION
## Summary
- Renames "Account Name" to "Account Holder Name" for clarity
- Adds placeholder text to all SEPA fields (Account Holder Name, BIC, IBAN) to guide users on expected format
- Enforces IBAN minimum length of 15 characters (Norway has the shortest IBAN) via both HTML `minlength` and JS regex validation
- Strips whitespace from IBAN and BIC values in `generate_sepa_xml()` as a safety net, ensuring IBANs entered with spaces are properly structured in the XML export

Fixes #1609

## Test plan
- [ ] Select Euro SEPA Transfer as payment method and verify the field is now labeled "Account Holder Name"
- [ ] Verify placeholder text appears in all three SEPA fields
- [ ] Enter an IBAN shorter than 15 characters and verify validation rejects it
- [ ] Enter an IBAN with spaces (e.g. `GB29 NWBK 6016 1331 9268 19`) and verify the SEPA XML export contains the IBAN without spaces
- [ ] Verify the same form improvements appear on reimbursement requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)