### PR TITLE
Add ability to notify mentors via Organizer Reminders (#1634)

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			add_action( 'plugins_loaded', array( $this, 'schedule_cron_jobs' ), 11 );
 			add_action( 'wcpt_close_wordcamps_after_event', array( $this, 'close_wordcamps_after_event' ) );
 			add_action( 'wcpt_metabox_save_done', array( $this, 'update_venue_address' ), 10, 2 );
-			add_action( 'wcpt_metabox_save_done', array( $this, 'update_mentor' ) );
+			add_action( 'wcpt_metabox_save_done', array( $this, 'update_mentor' ), 10, 2 );
 
 			add_action( 'parse_query', array( $this, 'default_sortby' ), 9 );
 			add_action( 'parse_query', array( $this, 'sort_by_event_date' ) );
@@ -169,11 +169,12 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		}
 
 		/**
-		 * Update mentor username.
+		 * Update mentor username, and fire the mentor assigned/changed trigger if the mentor has changed.
 		 *
-		 * @param int $post_id
+		 * @param int   $post_id
+		 * @param array $original_meta_values Original meta values before save.
 		 */
-		public function update_mentor( $post_id ) {
+		public function update_mentor( $post_id, $original_meta_values = array() ) {
 			if ( $this->get_event_type() !== get_post_type() ) {
 				return;
 			}
@@ -182,6 +183,12 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			$username = $_POST[ wcpt_key_to_str( 'Mentor WordPress.org User Name', 'wcpt_' ) ];
 
 			$this->add_mentor( get_post( $post_id ), $username );
+
+			$old_username = $original_meta_values['Mentor WordPress.org User Name'][0] ?? '';
+
+			if ( ! empty( $username ) && $username !== $old_username ) {
+				do_action( 'wcor_mentor_assigned_or_changed', get_post( $post_id ) );
+			}
 		}
 
 		/**

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -108,6 +108,9 @@ class Test_WCOR_Mailer extends Database_TestCase {
 		update_post_meta( self::$wordcamp_dayton_post_id, 'Start Date (YYYY-mm-dd)',        strtotime( 'Jan 1st, 2019' )             );
 		update_post_meta( self::$wordcamp_dayton_post_id, 'Budget Wrangler Name',           'Sally Smith'                            );
 		update_post_meta( self::$wordcamp_dayton_post_id, 'Budget Wrangler E-mail Address', 'sally.smith+trez@gmail.com'             );
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor WordPress.org User Name', 'mentorjane'                             );
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor Name',                    'Jane Mentor'                            );
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor E-mail Address',          'jane.mentor@example.com'                );
 
 		self::$other_event_post_id = $factory->post->create(
 			array(
@@ -329,6 +332,38 @@ class Test_WCOR_Mailer extends Database_TestCase {
 			'This reminder is not for WordCamps',
 			"<p>So it should not be sent to WordCamp.</p>\n",
 			$result
+		);
+	}
+
+	/**
+	 * Test that mentor-triggered reminders are sent to the mentor.
+	 *
+	 * @covers WCOR_Mailer::send_trigger_mentor_assigned_or_changed
+	 */
+	public function test_mentor_trigger_sends_to_mentor() {
+		/** @var WCOR_Mailer $WCOR_Mailer */
+		global $WCOR_Mailer;
+
+		$mentor_reminder_id = self::factory()->post->create(
+			array(
+				'post_type'    => WCOR_Reminder::AUTOMATED_POST_TYPE_SLUG,
+				'post_title'   => 'You have been assigned as mentor for [wordcamp_name]',
+				'post_content' => 'Hi [mentor_name], you have been assigned as mentor. Your email on file is [mentor_email].',
+			)
+		);
+
+		update_post_meta( $mentor_reminder_id, 'wcor_send_when',      'wcor_send_trigger'                );
+		update_post_meta( $mentor_reminder_id, 'wcor_which_trigger',  'wcor_mentor_assigned_or_changed'  );
+		update_post_meta( $mentor_reminder_id, 'wcor_send_where',     'wcor_send_mentor'                 );
+
+		$wordcamp = get_post( self::$wordcamp_dayton_post_id );
+
+		do_action( 'wcor_mentor_assigned_or_changed', $wordcamp );
+
+		$this->assert_mail_succeeded(
+			'jane.mentor@example.com',
+			'You have been assigned as mentor for WordCamp Dayton',
+			'Hi Jane Mentor, you have been assigned as mentor. Your email on file is jane.mentor@example.com.'
 		);
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -341,7 +341,7 @@ class Test_WCOR_Mailer extends Database_TestCase {
 	 * @covers WCOR_Mailer::send_trigger_mentor_assigned_or_changed
 	 */
 	public function test_mentor_trigger_sends_to_mentor() {
-		/** @var WCOR_Mailer $WCOR_Mailer */
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		global $WCOR_Mailer;
 
 		$mentor_reminder_id = self::factory()->post->create(

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -363,7 +363,7 @@ class Test_WCOR_Mailer extends Database_TestCase {
 		$this->assert_mail_succeeded(
 			'jane.mentor@example.com',
 			'You have been assigned as mentor for WordCamp Dayton',
-			'Hi Jane Mentor, you have been assigned as mentor. Your email on file is jane.mentor@example.com.'
+			'Hi Jane Mentor, you have been assigned as mentor. Your email on file is <a href="mailto:jane.mentor@example.com">jane.mentor@example.com</a>.'
 		);
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-placeholders.php
@@ -58,6 +58,13 @@
 	<li>[safety_wrangler_email]</li>
 </ul>
 
+<h5>Mentor:</h5>
+
+<ul class="ul-disc">
+	<li>[mentor_name]</li>
+	<li>[mentor_email]</li>
+</ul>
+
 <h5>Venue</h5>
 
 <ul class="ul-disc">

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/views/metabox-reminder-details.php
@@ -101,6 +101,11 @@ defined( 'WPINC' ) || die();
 		</tr>
 
 		<tr>
+			<th><input id="wcor_send_mentor" name="wcor_send_where[]" type="checkbox" value="wcor_send_mentor" <?php checked( in_array( 'wcor_send_mentor', $send_where ) ); ?>></th>
+			<td colspan="2"><label for="wcor_send_mentor">The Assigned Mentor</label></td>
+		</tr>
+
+		<tr>
 			<th><input id="wcor_send_mes" name="wcor_send_where[]" type="checkbox" value="wcor_send_mes" <?php checked( in_array( 'wcor_send_mes', $send_where ) ); ?>></th>
 			<td colspan="2"><label for="wcor_send_mes">The WordCamp's Multi-Event Sponsors</label></td>
 		</tr>

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -364,7 +364,7 @@ class WCOR_Mailer {
 			'[venue_contact_info]',
 			'[venue_exhibition_space_message]',
 
-			// Mentor
+			// Mentor.
 			'[mentor_name]',
 			'[mentor_email]',
 
@@ -437,7 +437,7 @@ class WCOR_Mailer {
 			empty( $wordcamp_meta['Contact Information'][0] ) ? 'N/A' : $wordcamp_meta['Contact Information'][0],
 			empty( $wordcamp_meta['Exhibition Space Available'][0] ) ? 'This event has no exhibition space.' : 'This event might have exhibition space available, please check with the organizers for more information.',
 
-			// Mentor
+			// Mentor.
 			$wordcamp_meta['Mentor Name'][0] ?? '',
 			$wordcamp_meta['Mentor E-mail Address'][0] ?? '',
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -61,6 +61,18 @@ class WCOR_Mailer {
 					),
 				),
 			),
+
+			'wcor_mentor_assigned_or_changed' => array(
+				'name'     => 'When Mentor is assigned / changed',
+				'actions'  => array(
+					array(
+						'name'       => 'wcor_mentor_assigned_or_changed',
+						'callback'   => 'send_trigger_mentor_assigned_or_changed',
+						'priority'   => 10,
+						'parameters' => 1,
+					),
+				),
+			),
 		);
 
 		add_action( 'wcor_send_timed_emails', array( $this, 'send_timed_emails' ) );
@@ -352,6 +364,10 @@ class WCOR_Mailer {
 			'[venue_contact_info]',
 			'[venue_exhibition_space_message]',
 
+			// Mentor
+			'[mentor_name]',
+			'[mentor_email]',
+
 			// Miscellaneous
 			'[multi_event_sponsor_info]',
 			'[session_feedback_list_url]',
@@ -420,6 +436,10 @@ class WCOR_Mailer {
 			empty( $wordcamp_meta['Website URL'][0] )         ? 'N/A' : $wordcamp_meta['Website URL'][0],
 			empty( $wordcamp_meta['Contact Information'][0] ) ? 'N/A' : $wordcamp_meta['Contact Information'][0],
 			empty( $wordcamp_meta['Exhibition Space Available'][0] ) ? 'This event has no exhibition space.' : 'This event might have exhibition space available, please check with the organizers for more information.',
+
+			// Mentor
+			$wordcamp_meta['Mentor Name'][0] ?? '',
+			$wordcamp_meta['Mentor E-mail Address'][0] ?? '',
 
 			// Miscellaneous
 			$this->get_mes_info( $wordcamp->ID ),
@@ -570,6 +590,21 @@ class WCOR_Mailer {
 		if ( in_array( 'wcor_send_camera_wrangler', $send_where ) ) {
 			$region_id = get_post_meta( $wordcamp_id, 'Multi-Event Sponsor Region', true );
 			$recipients[] = MES_Region::get_camera_wranger_from_region( $region_id );
+		}
+
+		if ( in_array( 'wcor_send_mentor', $send_where ) ) {
+			$mentor_email = get_post_meta( $wordcamp_id, 'Mentor E-mail Address', true );
+
+			if ( is_email( $mentor_email ) ) {
+				$recipients[] = $mentor_email;
+			} else {
+				$mentor_username = get_post_meta( $wordcamp_id, 'Mentor WordPress.org User Name', true );
+				$mentor_user     = wcorg_get_user_by_canonical_names( $mentor_username );
+
+				if ( $mentor_user && is_email( $mentor_user->user_email ) ) {
+					$recipients[] = $mentor_user->user_email;
+				}
+			}
 		}
 
 		if ( in_array( 'wcor_send_organizers', $send_where ) ) {
@@ -911,6 +946,17 @@ class WCOR_Mailer {
 	 */
 	public function send_trigger_wordcamp_site_created( $wordcamp_id ) {
 		$this->send_triggered_emails( get_post( $wordcamp_id ), 'wcor_wordcamp_site_created' );
+	}
+
+	/**
+	 * Sends e-mails hooked to the wcor_mentor_assigned_or_changed trigger.
+	 *
+	 * This fires when a mentor is assigned or changed on a WordCamp.
+	 *
+	 * @param WP_Post $wordcamp
+	 */
+	public function send_trigger_mentor_assigned_or_changed( $wordcamp ) {
+		$this->send_triggered_emails( $wordcamp, 'wcor_mentor_assigned_or_changed' );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-reminder.php
@@ -204,7 +204,7 @@ class WCOR_Reminder {
 	 * @param array $new_meta
 	 */
 	protected function save_post_meta( $post, $new_meta ) {
-		$send_where_whitelist = array( 'wcor_send_organizers', 'wcor_send_sponsor_wrangler', 'wcor_send_budget_wrangler', 'wcor_send_venue_wrangler', 'wcor_send_speaker_wrangler', 'wcor_send_food_wrangler', 'wcor_send_swag_wrangler', 'wcor_send_volunteer_wrangler', 'wcor_send_printing_wrangler', 'wcor_send_design_wrangler', 'wcor_send_website_wrangler', 'wcor_send_social_wrangler', 'wcor_send_a_v_wrangler', 'wcor_send_party_wrangler', 'wcor_send_travel_wrangler', 'wcor_send_safety_wrangler', 'wcor_send_mes', 'wcor_send_camera_wrangler', 'wcor_send_custom' );
+		$send_where_whitelist = array( 'wcor_send_organizers', 'wcor_send_sponsor_wrangler', 'wcor_send_budget_wrangler', 'wcor_send_venue_wrangler', 'wcor_send_speaker_wrangler', 'wcor_send_food_wrangler', 'wcor_send_swag_wrangler', 'wcor_send_volunteer_wrangler', 'wcor_send_printing_wrangler', 'wcor_send_design_wrangler', 'wcor_send_website_wrangler', 'wcor_send_social_wrangler', 'wcor_send_a_v_wrangler', 'wcor_send_party_wrangler', 'wcor_send_travel_wrangler', 'wcor_send_safety_wrangler', 'wcor_send_mes', 'wcor_send_camera_wrangler', 'wcor_send_mentor', 'wcor_send_custom' );
 
 		delete_post_meta( $post->ID, 'wcor_send_where' );
 		if ( isset( $new_meta['wcor_send_where'] ) ) {


### PR DESCRIPTION
## Summary

- Adds a new **trigger**: "When Mentor is assigned / changed" (`wcor_mentor_assigned_or_changed`) — fires when a mentor is first assigned or the assigned mentor is changed on a WordCamp.
- Adds a new **recipient**: "The Assigned Mentor" (`wcor_send_mentor`) — sends to the mentor email address stored in the WordCamp tracker, falling back to the WordPress.org account email if no explicit mentor email is set.
- Adds new **placeholders**: `[mentor_name]` and `[mentor_email]` for use in email subject/body.
- Includes integration test for the new trigger and recipient.

Fixes #1634

## Changes

| File | Change |
|------|--------|
| `wcor-mailer.php` | New trigger definition, trigger callback, mentor recipient in `get_recipients()`, mentor placeholders in `replace_placeholders()` |
| `wcor-reminder.php` | Added `wcor_send_mentor` to the `send_where` whitelist |
| `views/metabox-reminder-details.php` | Added "The Assigned Mentor" checkbox |
| `views/metabox-placeholders.php` | Added mentor placeholder section |
| `wordcamp-admin.php` | Fire `wcor_mentor_assigned_or_changed` action when mentor username changes |
| `tests/test-wcor-mailer.php` | Integration test for mentor trigger + recipient + placeholders |

## Screenshots

Screenshots taken from local Docker environment.

**New recipient option:** "The Assigned Mentor" checkbox added to the "Who should this e-mail be sent to?" section, between the Safety Wrangler and Multi-Event Sponsors options.

**New trigger option:** "When Mentor is assigned / changed" added to the "on a trigger:" dropdown, after "WordCamp website created".

**New placeholders:** A "Mentor:" section added to the Available Placeholders sidebar with `[mentor_name]` and `[mentor_email]`.

## Test plan

- [ ] Create a new Organizer Reminder with trigger "When Mentor is assigned / changed" and recipient "The Assigned Mentor"
- [ ] Use `[mentor_name]` and `[mentor_email]` placeholders in the email body
- [ ] Assign a mentor to a WordCamp and verify the email is sent to the mentor
- [ ] Change the mentor to a different user and verify a new email is sent
- [ ] Verify that setting the same mentor again does not re-trigger the email
- [ ] Verify existing triggers and recipients still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)