### PR TITLE
Fix mentor notification to send on each mentor change

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -368,6 +368,49 @@ class Test_WCOR_Mailer extends Database_TestCase {
 	}
 
 	/**
+	 * Test that repeatable triggers can send emails multiple times.
+	 *
+	 * @covers WCOR_Mailer::send_triggered_emails
+	 */
+	public function test_repeatable_trigger_sends_multiple_times() {
+		$mentor_reminder_id = self::factory()->post->create(
+			array(
+				'post_type'    => WCOR_Reminder::AUTOMATED_POST_TYPE_SLUG,
+				'post_title'   => 'Mentor changed for [wordcamp_name]',
+				'post_content' => 'Hi [mentor_name], you are now the mentor.',
+			)
+		);
+
+		update_post_meta( $mentor_reminder_id, 'wcor_send_when',      'wcor_send_trigger'               );
+		update_post_meta( $mentor_reminder_id, 'wcor_which_trigger',  'wcor_mentor_assigned_or_changed' );
+		update_post_meta( $mentor_reminder_id, 'wcor_send_where',     'wcor_send_mentor'                );
+
+		$wordcamp = get_post( self::$wordcamp_dayton_post_id );
+
+		// First send.
+		do_action( 'wcor_mentor_assigned_or_changed', $wordcamp );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertNotFalse( $mailer->get_sent(), 'First email was not sent.' );
+
+		// Reset mailer and change mentor.
+		reset_phpmailer_instance();
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor Name',          'New Mentor'              );
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor E-mail Address', 'new.mentor@example.com' );
+
+		// Second send — should still work despite the email ID being in wcor_sent_email_ids.
+		do_action( 'wcor_mentor_assigned_or_changed', $wordcamp );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertNotFalse( $mailer->get_sent(), 'Second email was not sent — repeatable trigger blocked.' );
+		$this->assertSame( 'new.mentor@example.com', $mailer->get_recipient( 'to' )->address );
+
+		// Restore original mentor data.
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor Name',           'Jane Mentor'             );
+		update_post_meta( self::$wordcamp_dayton_post_id, 'Mentor E-mail Address', 'jane.mentor@example.com' );
+	}
+
+	/**
 	 * Test that HTML content is preserved in emails.
 	 *
 	 * @covers WCOR_Mailer::mail

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -63,8 +63,9 @@ class WCOR_Mailer {
 			),
 
 			'wcor_mentor_assigned_or_changed' => array(
-				'name'     => 'When Mentor is assigned / changed',
-				'actions'  => array(
+				'name'       => 'When Mentor is assigned / changed',
+				'repeatable' => true,
+				'actions'    => array(
 					array(
 						'name'       => 'wcor_mentor_assigned_or_changed',
 						'callback'   => 'send_trigger_mentor_assigned_or_changed',
@@ -970,13 +971,14 @@ class WCOR_Mailer {
 	protected function send_triggered_emails( $wordcamp, $trigger ) {
 		$sent_email_ids = (array) get_post_meta( $wordcamp->ID, 'wcor_sent_email_ids', true );
 		$emails         = $this->get_triggered_posts( $trigger );
+		$is_repeatable  = ! empty( $this->triggers[ $trigger ]['repeatable'] );
 
 		foreach( $emails as $email ) {
 			if ( ! $this->applies_to_wordcamp( $wordcamp, $email ) ) {
 				continue;
 			}
 
-			if ( in_array( $email->ID, $sent_email_ids ) ) {
+			if ( ! $is_repeatable && in_array( $email->ID, $sent_email_ids ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

- The mentor notification trigger from #1635 only fired once per WordCamp because `send_triggered_emails()` tracks sent email IDs in `wcor_sent_email_ids` post meta and skips duplicates.
- Added a `repeatable` flag to trigger definitions. When a trigger is marked as repeatable, the duplicate check is skipped so the email sends each time the trigger fires.
- The `wcor_mentor_assigned_or_changed` trigger is marked as repeatable since it should fire every time the mentor changes.

Fixes #1634

## Changes

| File | Change |
|------|--------|
| `wcor-mailer.php` | Added `'repeatable' => true` to mentor trigger definition; skip duplicate check for repeatable triggers in `send_triggered_emails()` |
| `tests/test-wcor-mailer.php` | Added `test_repeatable_trigger_sends_multiple_times()` to verify the mentor trigger can fire twice for the same WordCamp |

## Test plan

- [ ] Create an automated reminder with trigger "When Mentor is assigned / changed" and recipient "The Assigned Mentor"
- [ ] Assign a mentor to a WordCamp — verify the email is sent
- [ ] Change the mentor to a different person — verify the email is sent again to the new mentor
- [ ] Verify non-repeatable triggers (e.g., "Added to final schedule") still only send once per WordCamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)