### PR TITLE
Fix PHP 8.2+ deprecations and enable PHPCompatibilityWP

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -88,6 +88,10 @@
 	<!-- WordCamp runs recent versions of WordPress. -->
 	<config name="minimum_wp_version" value="6.8"/>
 
+	<!-- Check for PHP cross-version compatibility. -->
+	<config name="testVersion" value="8.4-"/>
+	<rule ref="PHPCompatibilityWP"/>
+
 	<rule ref="WordPress-Core">
 		<!-- I don't see anything wrong with this :) -->
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -46,6 +46,12 @@ class lessc {
 	protected $registeredVars = array();
 	protected $preserveComments = false;
 
+	protected $env = null;
+	protected $scope = null;
+	protected $formatter = null;
+	protected $_parseFile = null;
+	protected $formatterName = null;
+
 	public $vPrefix = '@'; // prefix of abstract properties
 	public $mPrefix = '$'; // prefix of abstract blocks
 	public $parentSelector = '&';
@@ -2276,6 +2282,15 @@ class lessc {
 class lessc_parser {
 	static protected $nextBlockId = 0; // used to uniquely identify blocks
 
+	public $eatWhiteDefault = true;
+	public $lessc;
+	public $sourceName = null;
+	public $writeComments = false;
+	public $count = 0;
+	public $line = 1;
+	public $buffer = '';
+	public $seenComments = array();
+
 	static protected $precedence = array(
 		'=<' => 0,
 		'>=' => 0,
@@ -3661,6 +3676,7 @@ class lessc_parser {
 
 class lessc_formatter_classic {
 	public $indentChar = "  ";
+	public $indentLevel = 0;
 
 	public $break = "\n";
 	public $open = " {";

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-details.php
@@ -75,7 +75,7 @@ class Meetup_Details extends Base_Details {
 	 *     @type array $fields        Not implemented yet.
 	 * }
 	 */
-	public function __construct( Date_Range $date_range = null, $meetup_ids = null, array $options = array() ) {
+	public function __construct( ?Date_Range $date_range = null, $meetup_ids = null, array $options = array() ) {
 		// Report-specific options.
 		$options = wp_parse_args( $options,
 			array(

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-wordcamp-details.php
@@ -89,7 +89,7 @@ class WordCamp_Details extends Base_Details {
 	 *     @type array $fields        Not implemented yet.
 	 * }
 	 */
-	public function __construct( Date_Range $date_range = null, array $wordcamp_ids = null, $include_counts = false, array $options = array() ) {
+	public function __construct( ?Date_Range $date_range = null, ?array $wordcamp_ids = null, $include_counts = false, array $options = array() ) {
 		// Report-specific options.
 
 		parent::__construct( $date_range, $wordcamp_ids, $options );


### PR DESCRIPTION
## Summary

- Declare dynamic properties in `lessc`, `lessc_parser`, and `lessc_formatter_classic` to fix PHP 8.2+ deprecation warnings (errors in future versions)
- Add `?` prefix to implicitly nullable typed parameters in `WordCamp_Details` and `Meetup_Details` constructors (deprecated in PHP 8.4)
- Enable `PHPCompatibilityWP` rule in `phpcs.xml.dist` with `testVersion` set to `8.4-` to automatically catch future compatibility issues

## Test plan

- Verify no functional changes to LESS compilation or wordcamp-reports behavior
- Run `phpcs` and confirm PHPCompatibilityWP rules are active
- Confirm no new PHPCS errors introduced by these changes