### PR TITLE
Rate limit form submissions that create draft posts

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Host region'                 => 'textarea',
 
 						// In-person
-						'Venue Name'                 => 'text',
+						'Venue Name'                 => 'textarea',
 						'Physical Address'           => 'textarea',
 						'Maximum Capacity'           => 'text',
 						'Available Rooms'            => 'text',
@@ -590,7 +590,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 							'Virtual event only'               => 'checkbox',
 							'Streaming account to use'         => 'select-streaming',
 							'Host region'                      => 'textarea',
-							'Venue Name'                       => 'text',
+							'Venue Name'                       => 'textarea',
 							'Physical Address'                 => 'textarea',
 							'Maximum Capacity'                 => 'text',
 							'Available Rooms'                  => 'text',


### PR DESCRIPTION
## Summary

- Adds IP-based rate limiting (3 submissions per hour) for non-logged-in users on forms that create draft posts (call-for-speakers, call-for-sponsors, call-for-volunteers).
- Submissions exceeding the limit are silently marked as spam via the existing `jetpack_contact_form_is_spam` filter, preventing draft post creation.
- Logged-in users bypass the rate limit entirely.

This addresses the issue where pentesters and spammers submit forms in bulk, creating thousands of unwanted draft session/speaker/sponsor/volunteer posts.

Fixes #1269

## Test plan

- [ ] Submit a call-for-sponsors or call-for-volunteers form 3 times as a logged-out user -- all 3 should succeed and create drafts.
- [ ] Submit a 4th time within the same hour -- should be silently treated as spam, no draft created.
- [ ] Wait for the transient to expire (1 hour) or delete it manually, then verify submissions work again.
- [ ] Log in and submit a form more than 3 times -- all should succeed (logged-in users bypass the rate limit).
- [ ] Verify the call-for-speakers login requirement still works correctly for logged-out users.