### PR TITLE
Match thumbnail aspect ratio to singular view banner

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/functions.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/functions.php
@@ -54,7 +54,7 @@ class WordCamp_Central_Theme {
 
 		// Add some new image sizes, also site shot is 205x148, minimap is 130x70
 		add_image_size( 'wccentral-thumbnail-small', 82, 37, true );
-		add_image_size( 'wccentral-thumbnail-large', 926, 160, true );
+		add_image_size( 'wccentral-thumbnail-large', 926, 418, true );
 		add_image_size( 'wccentral-thumbnail-past', 130, 60, true );
 		add_image_size( 'wccentral-thumbnail-hero', 493, 315, true );
 


### PR DESCRIPTION
## Summary

- Changes the `wccentral-thumbnail-large` image size from 926x160 (5.79:1 ratio) to 926x418 (2.22:1 ratio) to match the `wccentral-thumbnail-small` thumbnail size (82x37, 2.22:1 ratio).
- This ensures the banner image on the singular WordCamp view uses the same aspect ratio as the schedule listing thumbnail, so uploaded images are not cropped differently between the two views.
- Existing images will need to be regenerated (via a thumbnails regeneration) for the new size to take effect.

## Context

The schedule listing at `central.wordcamp.org/schedule/` uses `wccentral-thumbnail-small` (82x37) while the singular view uses `wccentral-thumbnail-large` (926x160). These had very different aspect ratios (2.22:1 vs 5.79:1), causing banner images to appear cropped on the sides when shown as thumbnails.

Fixes #1617

## Test plan

- [ ] Verify the image size registration in `functions.php` uses the updated dimensions
- [ ] Upload a test featured image and confirm the generated `wccentral-thumbnail-large` crop matches the aspect ratio of `wccentral-thumbnail-small`
- [ ] Check the singular WordCamp view displays the banner image correctly at the new ratio
- [ ] Confirm the schedule listing thumbnails still display correctly


Generated with [Claude Code](https://claude.com/claude-code)