### PR TITLE
Event Trackers: Change Venue Name field to multi-line textarea

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 						'Host region'                 => 'textarea',
 
 						// In-person
-						'Venue Name'                 => 'text',
+						'Venue Name'                 => 'textarea',
 						'Physical Address'           => 'textarea',
 						'Maximum Capacity'           => 'text',
 						'Available Rooms'            => 'text',
@@ -590,7 +590,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 							'Virtual event only'               => 'checkbox',
 							'Streaming account to use'         => 'select-streaming',
 							'Host region'                      => 'textarea',
-							'Venue Name'                       => 'text',
+							'Venue Name'                       => 'textarea',
 							'Physical Address'                 => 'textarea',
 							'Maximum Capacity'                 => 'text',
 							'Available Rooms'                  => 'text',


### PR DESCRIPTION
## Summary

- Changes the Venue Name field in the event tracker admin from a single-line text input to a multi-line textarea
- Allows listing multiple venues for series events (e.g., Campus Connect events held across multiple campuses)
- Both occurrences of the field definition (grouped meta keys and flattened meta keys) are updated

Fixes #1604

## Test plan

- [ ] Open any event tracker in the WordPress admin (WordCamp, Campus Connect, etc.)
- [ ] Verify the Venue Name field now renders as a textarea instead of a single-line input
- [ ] Enter multiple venue names on separate lines and save
- [ ] Confirm the multi-line data is saved and displayed correctly on reload

Generated with [Claude Code](https://claude.com/claude-code)