### PR TITLE
Fix media library pagination for non-admin users

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -9,7 +9,7 @@ use WCP_Payment_Request;
 defined( 'WPINC' ) || die();
 
 
-add_filter( 'the_posts',                          __NAMESPACE__ . '\hide_others_payment_files', 10, 2 );
+add_filter( 'posts_clauses',                      __NAMESPACE__ . '\exclude_others_payment_files_from_query', 10, 2 );
 add_filter( 'wp_unique_filename',                 __NAMESPACE__ . '\obscure_payment_file_names', 10, 2 );
 add_filter( 'wp_privacy_personal_data_exporters', __NAMESPACE__ . '\register_personal_data_exporters' );
 add_filter( 'wp_privacy_personal_data_erasers',   __NAMESPACE__ . '\register_personal_data_erasers'   );
@@ -18,83 +18,65 @@ add_filter( 'wp_privacy_personal_data_erasers',   __NAMESPACE__ . '\register_per
 /**
  * Prevent non-admins from viewing payment files uploaded by other users.
  *
- * The files sometimes have sensitive information, like account numbers etc. `the_posts` was chosen over
- * `ajax_query_attachments_args`, `pre_get_posts`, and other techniques, because it is the most comprehensive
- * and flexible solution. It will remove things from the Media Library, but also REST API endpoints, XML-RPC,
- * RSS, etc. It also allows the chance the to only apply the conditions to certain post types, whereas setting
- * query vars is much more limited.
+ * The files sometimes have sensitive information, like account numbers etc.
  *
- * SECURITY WARNING: When querying attachments `get_posts()`, make sure you pass `suppress_filters => false`,
- * otherwise this will not run.
+ * This uses `posts_clauses` to filter at the SQL level, so that `found_posts` and the actual results are
+ * consistent. The previous approach using `the_posts` caused the media library grid view to break for
+ * non-admin users, because removing posts after the query meant fewer results were returned than
+ * `posts_per_page`, which made the JavaScript conclude there were no more items to load.
  *
- * @param WP_Post[] $attachments
- * @param WP_Query  $wp_query
+ * See https://github.com/WordPress/wordcamp.org/issues/1316
  *
- * @return array
+ * SECURITY WARNING: When querying attachments with `get_posts()`, make sure you pass
+ * `suppress_filters => false`, otherwise this will not run.
+ *
+ * @param array    $clauses  SQL clauses for the query.
+ * @param WP_Query $wp_query The WP_Query instance.
+ *
+ * @return array Modified SQL clauses.
  */
-function hide_others_payment_files( $attachments, $wp_query ) {
-	$user = wp_get_current_user();
+function exclude_others_payment_files_from_query( $clauses, $wp_query ) {
+	global $wpdb;
 
 	if ( 'attachment' !== $wp_query->get( 'post_type' ) || current_user_can( 'manage_options' ) ) {
-		return $attachments;
+		return $clauses;
 	}
 
-	$payment_posts_ids = get_payment_file_parent_ids( $attachments );
+	$user_id = get_current_user_id();
 
-	foreach ( $attachments as $index => $attachment ) {
-		if ( ! in_array( $attachment->post_parent, $payment_posts_ids, true ) ) {
-			continue;
-		}
-
-		if ( $attachment->post_author === $user->ID ) {
-			continue;
-		}
-
-		/*
-		 * The post is already cached from the request in `get_payment_file_parent_ids()`, so this doesn't create
-		 * a new database query, it's just a way to access the individual post directly instead of iterating through
-		 * `$payment_posts_with_attachments`.
-		 */
-		$parent_author = (int) get_post( $attachment->post_parent )->post_author;
-
-		if ( $parent_author === $user->ID ) {
-			continue;
-		}
-
-		unset( $attachments[ $index ] );
+	if ( ! $user_id ) {
+		return $clauses;
 	}
 
-	// Re-index the array, because WP_Query functions will assume there are no gaps.
-	return array_values( $attachments );
-}
+	$reimbursement_type = Reimbursement_Requests\POST_TYPE;
+	$payment_type       = WCP_Payment_Request::POST_TYPE;
 
-/**
- * Get the Reimbursement/Vendor Payment posts that are attached to the given media items.
- *
- * @param WP_Post[] $attachments
- *
- * @return int[]
- */
-function get_payment_file_parent_ids( $attachments ) {
-	$parent_ids     = array_unique( wp_list_pluck( $attachments, 'post_parent' ) );
-	$orphaned_index = array_search( 0, $parent_ids, true );
+	// Exclude attachments whose parent is a payment post, unless the current user is the attachment author
+	// or the parent post author.
+	// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+	$clauses['where'] .= $wpdb->prepare(
+		" AND NOT (
+			{$wpdb->posts}.post_parent IN (
+				SELECT ID FROM {$wpdb->posts} parent_post
+				WHERE parent_post.post_type IN (%s, %s)
+			)
+			AND {$wpdb->posts}.post_author != %d
+			AND {$wpdb->posts}.post_parent NOT IN (
+				SELECT ID FROM {$wpdb->posts} parent_post2
+				WHERE parent_post2.post_type IN (%s, %s)
+				AND parent_post2.post_author = %d
+			)
+		)",
+		$reimbursement_type,
+		$payment_type,
+		$user_id,
+		$reimbursement_type,
+		$payment_type,
+		$user_id
+	);
+	// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
-	// All payment files should be attached to a post, so unattached files can be removed.
-	if ( false !== $orphaned_index ) {
-		unset( $parent_ids[ $orphaned_index ] );
-	}
-
-	$payment_posts_with_attachments = get_posts( array(
-		'post__in'    => $parent_ids,
-		'post_status' => 'any',
-		'numberposts' => 1000,
-		'post_type'   => array(
-			Reimbursement_Requests\POST_TYPE,
-			WCP_Payment_Request::POST_TYPE,
-		),
-	) );
-
-	return wp_list_pluck( $payment_posts_with_attachments, 'ID' );
+	return $clauses;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Non-admin users (editors) could not load more than the first page of media items in the media library grid view (fixes #1316)
- Root cause: the `the_posts` filter in `wordcamp-payments/includes/privacy.php` removed payment attachments from query results *after* the query ran, returning fewer items than `posts_per_page`, which made the media library JavaScript conclude there were no more items to load
- Fix: switch from `the_posts` to `posts_clauses` to exclude other users'  payment attachments at the SQL level, so `found_posts` and actual results stay consistent

## Test plan

- [ ] Log in as an editor (non-admin) user on a WordCamp site that has payment attachments
- [ ] Go to Media > Library and switch to grid view
- [ ] Verify that scrolling down loads more media items (infinite scroll / load more works)
- [ ] Verify that the "Showing X of Y media items" count is accurate
- [ ] Log in as an admin and verify payment attachments are still fully visible
- [ ] Verify that non-admin users still cannot see other users' payment file attachments

Generated with [Claude Code](https://claude.com/claude-code)