### PR TITLE
Prevent Stripe non-card payments from timing out prematurely

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -425,7 +425,6 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_FAILED, $payment_data );
 		}
 
-		// Success! (status can only be open, or completed)
 		// Technically there can be multiple charges (ie. partial payments / installments) but we don't have that enabled.
 		$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
 
@@ -440,6 +439,13 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			),
 		);
 
+		// Delayed payment methods (boleto, OXXO, etc.) complete the session but payment is still pending.
+		if ( 'complete' === $session['status'] && 'unpaid' === $session['payment_status'] ) {
+			$camptix->log( 'Stripe checkout complete, payment pending (delayed payment method).', $order['attendee_id'], $session );
+			return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
+		}
+
+		// Success! Payment is confirmed.
 		return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );
 	}
 
@@ -641,14 +647,19 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	}
 
 	/**
-	 * Check if a stripe session timed out.
+	 * Check if a Stripe session should be timed out, or if the timeout should be delayed.
+	 *
+	 * Handles three scenarios:
+	 * 1. The payment completed successfully -- mark the attendee as paid.
+	 * 2. The payment is still pending (delayed payment methods like boleto) -- delay the timeout.
+	 * 3. The session is still open and not expired -- delay the timeout.
 	 */
 	public function pre_attendee_timeout( $attendee_id ) {
 		/** @var CampTix_Plugin $camptix */
 		global $camptix;
 
-		// precheck the attendee is in draft.
-		if ( 'draft' !== get_post_field( 'post_status', $attendee_id ) ) {
+		// Only process attendees that are still awaiting payment.
+		if ( ! in_array( get_post_field( 'post_status', $attendee_id ), array( 'draft', 'pending' ), true ) ) {
 			return;
 		}
 
@@ -665,7 +676,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			return;
 		}
 
-		// Uh oh, we've hit timeout on a ticket, but the linked checkout session succeeded.
+		// Scenario 1: The checkout session completed and payment is confirmed.
 		if ( 'complete' === $session['status'] && 'paid' === $session['payment_status'] ) {
 			$camptix->log( 'Stripe checkout timed out, but order succeeded.', $attendee_id, $session );
 
@@ -678,7 +689,70 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			);
 
 			$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data, false /* non-interactive */ );
+			return;
 		}
+
+		// Scenario 2: The checkout session completed but payment is still pending.
+		// This happens with delayed payment methods like boleto, OXXO, etc.
+		if ( 'complete' === $session['status'] && 'unpaid' === $session['payment_status'] ) {
+			$payment_intent_status = $session['payment_intent']['status'] ?? '';
+
+			// Only delay timeout if the payment is still in a pending state.
+			if ( in_array( $payment_intent_status, array( 'requires_action', 'processing' ), true ) ) {
+				$camptix->log( 'Stripe payment still pending, delaying timeout.', $attendee_id, array(
+					'payment_intent_status' => $payment_intent_status,
+					'payment_status'        => $session['payment_status'],
+				) );
+
+				$this->delay_attendee_timeout( $attendee_id );
+				return;
+			}
+		}
+
+		// Scenario 3: The checkout session is still open and has not expired per Stripe.
+		if ( 'open' === $session['status'] ) {
+			$expires_at = $session['expires_at'] ?? 0;
+
+			if ( $expires_at > time() ) {
+				$camptix->log( 'Stripe session still open, delaying timeout.', $attendee_id, array(
+					'expires_at' => $expires_at,
+				) );
+
+				$this->delay_attendee_timeout( $attendee_id );
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Delay an attendee's timeout by resetting its timestamp.
+	 *
+	 * This pushes the attendee's timestamp forward so that the timeout review
+	 * will not pick it up again until the next cycle. A maximum age limit of
+	 * 7 days from the original purchase prevents indefinite delays.
+	 *
+	 * @param int $attendee_id The attendee post ID.
+	 */
+	protected function delay_attendee_timeout( $attendee_id ) {
+		$original_timestamp = get_post_meta( $attendee_id, 'tix_timestamp_original', true );
+
+		// Store the original timestamp if not already saved.
+		if ( ! $original_timestamp ) {
+			$original_timestamp = get_post_meta( $attendee_id, 'tix_timestamp', true );
+			update_post_meta( $attendee_id, 'tix_timestamp_original', $original_timestamp );
+		}
+
+		// Do not delay beyond 7 days from the original purchase.
+		$max_age = 7 * DAY_IN_SECONDS;
+		if ( ( time() - $original_timestamp ) >= $max_age ) {
+			/** @var CampTix_Plugin $camptix */
+			global $camptix;
+			$camptix->log( 'Stripe payment pending too long, allowing timeout.', $attendee_id );
+			return;
+		}
+
+		// Push the timestamp forward to now, so the 24-hour timeout resets.
+		update_post_meta( $attendee_id, 'tix_timestamp', time() );
 	}
 }
 

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -699,10 +699,11 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 			// Only delay timeout if the payment is still in a pending state.
 			if ( in_array( $payment_intent_status, array( 'requires_action', 'processing' ), true ) ) {
-				$camptix->log( 'Stripe payment still pending, delaying timeout.', $attendee_id, array(
+				$log_data = array(
 					'payment_intent_status' => $payment_intent_status,
 					'payment_status'        => $session['payment_status'],
-				) );
+				);
+				$camptix->log( 'Stripe payment still pending, delaying timeout.', $attendee_id, $log_data );
 
 				$this->delay_attendee_timeout( $attendee_id );
 				return;
@@ -714,9 +715,8 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			$expires_at = $session['expires_at'] ?? 0;
 
 			if ( $expires_at > time() ) {
-				$camptix->log( 'Stripe session still open, delaying timeout.', $attendee_id, array(
-					'expires_at' => $expires_at,
-				) );
+				$log_data = array( 'expires_at' => $expires_at );
+				$camptix->log( 'Stripe session still open, delaying timeout.', $attendee_id, $log_data );
 
 				$this->delay_attendee_timeout( $attendee_id );
 				return;

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -712,11 +712,15 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		if ( empty( $session['status'] ) ) {
+			$camptix->log( 'Stripe session lookup did not return a status during timeout review, delaying timeout.', $attendee_id, $session );
+			$this->delay_attendee_timeout( $attendee_id );
 			return;
 		}
 
+		$payment_status = $session['payment_status'] ?? '';
+
 		// Scenario 1: The checkout session completed and payment is confirmed.
-		if ( 'complete' === $session['status'] && 'paid' === $session['payment_status'] ) {
+		if ( 'complete' === $session['status'] && 'paid' === $payment_status ) {
 			$camptix->log( 'Stripe checkout timed out, but order succeeded.', $attendee_id, $session );
 
 			$payment_data = $this->get_payment_data_for_session( $session );
@@ -727,14 +731,15 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		// Scenario 2: The checkout session completed but payment is still pending.
 		// This happens with delayed payment methods like boleto, OXXO, etc.
-		if ( 'complete' === $session['status'] && 'unpaid' === $session['payment_status'] ) {
-			$payment_intent_status = $session['payment_intent']['status'] ?? '';
+		if ( 'complete' === $session['status'] && 'unpaid' === $payment_status ) {
+			$payment_intent        = $session['payment_intent'] ?? array();
+			$payment_intent_status = is_array( $payment_intent ) ? ( $payment_intent['status'] ?? '' ) : '';
 
 			// Only delay timeout if the payment is still in a pending state.
 			if ( in_array( $payment_intent_status, array( 'requires_action', 'processing' ), true ) ) {
 				$log_data = array(
 					'payment_intent_status' => $payment_intent_status,
-					'payment_status'        => $session['payment_status'],
+					'payment_status'        => $payment_status,
 				);
 				$camptix->log( 'Stripe payment still pending, delaying timeout.', $attendee_id, $log_data );
 
@@ -767,11 +772,11 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	 * @param int $attendee_id The attendee post ID.
 	 */
 	protected function delay_attendee_timeout( $attendee_id ) {
-		$original_timestamp = get_post_meta( $attendee_id, 'tix_timestamp_original', true );
+		$original_timestamp = absint( get_post_meta( $attendee_id, 'tix_timestamp_original', true ) );
 
 		// Store the original timestamp if not already saved.
 		if ( ! $original_timestamp ) {
-			$original_timestamp = get_post_meta( $attendee_id, 'tix_timestamp', true );
+			$original_timestamp = absint( get_post_meta( $attendee_id, 'tix_timestamp', true ) );
 			update_post_meta( $attendee_id, 'tix_timestamp_original', $original_timestamp );
 		}
 

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -379,17 +379,28 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 			if ( $stripe_session ) {
 				$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
-				$session = $stripe->get_session( $stripe_session );
+				$session = $this->get_session_with_retry( $stripe, $stripe_session );
 
-				if ( ! is_wp_error( $session ) && ! empty( $session['status'] ) && 'complete' === $session['status'] ) {
+				if ( is_wp_error( $session ) ) {
+					$camptix->log( 'Error during Stripe payment_cancel, failed to fetch session twice.', $order['attendee_id'], $session );
+					wp_die( 'A temporary issue has occurred with the payment gateway. The order was not cancelled; please try again in a few minutes.' );
+				}
+
+				if ( empty( $session['status'] ) ) {
+					$camptix->log( "Dying because couldn't get Payment status during Stripe payment_cancel", $order['attendee_id'], compact( 'payment_token', 'stripe_session' ) );
+					wp_die( 'could not find payment details' );
+				}
+
+				if ( 'complete' === $session['status'] ) {
 					$payment_data = $this->get_payment_data_for_session( $session );
+					$payment_status = $session['payment_status'] ?? '';
 
-					if ( 'unpaid' === $session['payment_status'] ) {
+					if ( 'unpaid' === $payment_status ) {
 						$camptix->log( 'False alarm on Stripe payment_cancel. Payment is pending.', $order['attendee_id'], $session );
 						return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
 					}
 
-					if ( 'paid' === $session['payment_status'] ) {
+					if ( 'paid' === $payment_status ) {
 						$camptix->log( 'False alarm on Stripe payment_cancel. Payment is complete.', $order['attendee_id'], $session );
 						return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );
 					}
@@ -435,7 +446,12 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		// Fetch the Payment details.
 		$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
-		$session = $stripe->get_session( $stripe_session );
+		$session = $this->get_session_with_retry( $stripe, $stripe_session );
+
+		if ( is_wp_error( $session ) ) {
+			$camptix->log( 'Error during post-stripe return, failed to fetch session twice.', $order['attendee_id'], $session );
+			wp_die( 'A temporary issue has occurred with the payment gateway. Your purchase may have been processed; please try again in a few minutes.' );
+		}
 
 		if ( empty( $session['status'] ) ) {
 			$camptix->log( "Dying because couldn't get Payment status", $order['attendee_id'], compact( 'payment_token', 'payment_session' ) );
@@ -453,9 +469,10 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		$payment_data = $this->get_payment_data_for_session( $session );
+		$payment_status = $session['payment_status'] ?? '';
 
 		// Delayed payment methods (boleto, OXXO, etc.) complete the session but payment is still pending.
-		if ( 'complete' === $session['status'] && 'unpaid' === $session['payment_status'] ) {
+		if ( 'complete' === $session['status'] && 'unpaid' === $payment_status ) {
 			$camptix->log( 'Stripe checkout complete, payment pending (delayed payment method).', $order['attendee_id'], $session );
 			return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
 		}
@@ -547,7 +564,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 				'Got Stripe checkout session.',
 				$order['attendee_id'],
 				array(
-					'stripe_payment_logs'   => esc_url( 'https://dashboard.stripe.com/payments/' . urlencode( $session['payment_intent'] ) ),
+					'stripe_payment_logs'   => esc_url( 'https://dashboard.stripe.com/payments/' . urlencode( $session['payment_intent'] ?? '' ) ),
 					'camptix_payment_token' => $payment_token,
 					'request_payload'       => compact( 'order_items', 'receipt_email' ),
 					'response'              => $session,
@@ -686,9 +703,15 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
-		$session = $stripe->get_session( $stripe_session_id );
+		$session = $this->get_session_with_retry( $stripe, $stripe_session_id );
 
-		if ( is_wp_error( $session ) || empty( $session['status'] ) ) {
+		if ( is_wp_error( $session ) ) {
+			$camptix->log( 'Stripe session lookup failed during timeout review, delaying timeout.', $attendee_id, $session );
+			$this->delay_attendee_timeout( $attendee_id );
+			return;
+		}
+
+		if ( empty( $session['status'] ) ) {
 			return;
 		}
 
@@ -766,6 +789,24 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	}
 
 	/**
+	 * Retrieve a Stripe checkout session, retrying once on transient API errors.
+	 *
+	 * @param CampTix_Stripe_API_Client $stripe         The Stripe API client.
+	 * @param string                    $stripe_session The Stripe checkout session ID.
+	 *
+	 * @return array|WP_Error
+	 */
+	protected function get_session_with_retry( $stripe, $stripe_session ) {
+		$session = $stripe->get_session( $stripe_session );
+
+		if ( is_wp_error( $session ) ) {
+			$session = $stripe->get_session( $stripe_session );
+		}
+
+		return $session;
+	}
+
+	/**
 	 * Get the payment data CampTix stores for a Stripe checkout session.
 	 *
 	 * @param array $session The Stripe checkout session.
@@ -774,7 +815,8 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	 */
 	protected function get_payment_data_for_session( $session ) {
 		// Technically there can be multiple charges (ie. partial payments / installments) but we don't have that enabled.
-		$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
+		$payment_intent = $session['payment_intent'] ?? array();
+		$transaction_id = is_array( $payment_intent ) ? ( $payment_intent['latest_charge'] ?? '' ) : '';
 
 		/**
 		 * Note that when returning a successful payment, CampTix will be

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -364,10 +364,37 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		$camptix->log( sprintf( 'Running payment_cancel. Request data attached.' ), null, $_REQUEST );
 
-		$payment_token = $_REQUEST['tix_payment_token'] ?? '';
+		$payment_token  = wp_unslash( $_REQUEST['tix_payment_token'] ?? '' );
+		$stripe_session = wp_unslash( $_REQUEST['tix_stripe_session'] ?? '' );
 
 		if ( ! $payment_token ) {
 			wp_die( 'empty token' );
+		}
+
+		$order = $this->get_order( $payment_token );
+		if ( $order ) {
+			if ( ! $stripe_session || '{CHECKOUT_SESSION_ID}' === $stripe_session ) {
+				$stripe_session = get_post_meta( $order['attendee_id'], '_stripe_checkout_session_id', true );
+			}
+
+			if ( $stripe_session ) {
+				$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
+				$session = $stripe->get_session( $stripe_session );
+
+				if ( ! is_wp_error( $session ) && ! empty( $session['status'] ) && 'complete' === $session['status'] ) {
+					$payment_data = $this->get_payment_data_for_session( $session );
+
+					if ( 'unpaid' === $session['payment_status'] ) {
+						$camptix->log( 'False alarm on Stripe payment_cancel. Payment is pending.', $order['attendee_id'], $session );
+						return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_PENDING, $payment_data );
+					}
+
+					if ( 'paid' === $session['payment_status'] ) {
+						$camptix->log( 'False alarm on Stripe payment_cancel. Payment is complete.', $order['attendee_id'], $session );
+						return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );
+					}
+				}
+			}
 		}
 
 		// Set the associated attendees to cancelled.
@@ -425,19 +452,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_FAILED, $payment_data );
 		}
 
-		// Technically there can be multiple charges (ie. partial payments / installments) but we don't have that enabled.
-		$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
-
-		/**
-		 * Note that when returning a successful payment, CampTix will be
-		 * expecting the transaction_id and transaction_details array keys.
-		 */
-		$payment_data = array(
-			'transaction_id'      => $transaction_id,
-			'transaction_details' => array(
-				'raw' => $session,
-			),
-		);
+		$payment_data = $this->get_payment_data_for_session( $session );
 
 		// Delayed payment methods (boleto, OXXO, etc.) complete the session but payment is still pending.
 		if ( 'complete' === $session['status'] && 'unpaid' === $session['payment_status'] ) {
@@ -514,6 +529,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 				'tix_action'         => 'payment_cancel',
 				'tix_payment_token'  => $payment_token,
 				'tix_payment_method' => 'stripe',
+				'tix_stripe_session' => '{CHECKOUT_SESSION_ID}',
 			),
 			$camptix->get_tickets_url()
 		);
@@ -680,13 +696,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		if ( 'complete' === $session['status'] && 'paid' === $session['payment_status'] ) {
 			$camptix->log( 'Stripe checkout timed out, but order succeeded.', $attendee_id, $session );
 
-			$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
-			$payment_data   = array(
-				'transaction_id'      => $transaction_id,
-				'transaction_details' => array(
-					'raw' => $session,
-				),
-			);
+			$payment_data = $this->get_payment_data_for_session( $session );
 
 			$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data, false /* non-interactive */ );
 			return;
@@ -753,6 +763,29 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		// Push the timestamp forward to now, so the 24-hour timeout resets.
 		update_post_meta( $attendee_id, 'tix_timestamp', time() );
+	}
+
+	/**
+	 * Get the payment data CampTix stores for a Stripe checkout session.
+	 *
+	 * @param array $session The Stripe checkout session.
+	 *
+	 * @return array
+	 */
+	protected function get_payment_data_for_session( $session ) {
+		// Technically there can be multiple charges (ie. partial payments / installments) but we don't have that enabled.
+		$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
+
+		/**
+		 * Note that when returning a successful payment, CampTix will be
+		 * expecting the transaction_id and transaction_details array keys.
+		 */
+		return array(
+			'transaction_id'      => $transaction_id,
+			'transaction_details' => array(
+				'raw' => $session,
+			),
+		);
 	}
 }
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7297,7 +7297,7 @@ class CampTix_Plugin {
 		while ( $attendees = get_posts( array(
 			'fields' => 'ids',
 			'post_type' => 'tix_attendee',
-			'post_status' => 'draft',
+			'post_status' => array( 'draft', 'pending' ),
 			'posts_per_page' => 100,
 			'cache_results' => false,
 			'meta_query' => array(
@@ -7319,8 +7319,8 @@ class CampTix_Plugin {
 			foreach ( $attendees as $attendee_id ) {
 				do_action( 'camptix_pre_attendee_timeout', $attendee_id );
 
-				// Check the post_status again, incase a filter has caused the post to change.
-				if ( 'draft' !== get_post_field( 'post_status', $attendee_id ) ) {
+				// Check the post_status again, in case a hook has caused the post to change.
+				if ( ! in_array( get_post_field( 'post_status', $attendee_id ), array( 'draft', 'pending' ), true ) ) {
 					continue;
 				}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7293,50 +7293,83 @@ class CampTix_Plugin {
 		$processed = 0;
 		$current_loop = 1;
 		$max_loops = 500;
-
-		while ( $attendees = get_posts( array(
-			'fields' => 'ids',
-			'post_type' => 'tix_attendee',
-			'post_status' => array( 'draft', 'pending' ),
-			'posts_per_page' => 100,
-			'cache_results' => false,
-			'meta_query' => array(
-				array(
-					'key' => 'tix_timestamp',
-					'compare' => '<',
-					'value' => time() - 60 * 60 * 24, // 24 hours ago
-					'type' => 'NUMERIC',
-				),
-				array(
-					'key' => 'tix_timestamp',
-					'compare' => '>',
-					'value' => 0,
-					'type' => 'NUMERIC',
+		$timeout_timestamp = time() - 60 * 60 * 24; // 24 hours ago.
+		$timestamp_meta_query = array(
+			array(
+				'key' => 'tix_timestamp',
+				'compare' => '<',
+				'value' => $timeout_timestamp,
+				'type' => 'NUMERIC',
+			),
+			array(
+				'key' => 'tix_timestamp',
+				'compare' => '>',
+				'value' => 0,
+				'type' => 'NUMERIC',
+			),
+		);
+		$timeout_queries = array(
+			array(
+				'post_status' => 'draft',
+				'meta_query'  => $timestamp_meta_query,
+			),
+			array(
+				'post_status' => 'pending',
+				'meta_query'  => array_merge(
+					$timestamp_meta_query,
+					array(
+						array(
+							'key'     => 'tix_payment_method',
+							'compare' => '=',
+							'value'   => 'stripe',
+							'type'    => 'CHAR',
+						),
+					)
 				),
 			),
-		) ) ) {
+		);
 
-			foreach ( $attendees as $attendee_id ) {
-				do_action( 'camptix_pre_attendee_timeout', $attendee_id );
+		foreach ( $timeout_queries as $timeout_query ) {
+			$query_args = array_merge(
+				array(
+					'fields'         => 'ids',
+					'post_type'      => 'tix_attendee',
+					'posts_per_page' => 100,
+					'cache_results'  => false,
+				),
+				$timeout_query
+			);
 
-				// Check the post_status again, in case a hook has caused the post to change.
-				if ( ! in_array( get_post_field( 'post_status', $attendee_id ), array( 'draft', 'pending' ), true ) ) {
-					continue;
+			while ( $attendees = get_posts( $query_args ) ) {
+
+				foreach ( $attendees as $attendee_id ) {
+					do_action( 'camptix_pre_attendee_timeout', $attendee_id );
+
+					// Check the post_status again, in case a hook has caused the post to change.
+					if ( ! in_array( get_post_field( 'post_status', $attendee_id ), array( 'draft', 'pending' ), true ) ) {
+						continue;
+					}
+
+					// Check the timestamp again, in case a hook has delayed the timeout.
+					$attendee_timestamp = absint( get_post_meta( $attendee_id, 'tix_timestamp', true ) );
+					if ( ! $attendee_timestamp || $attendee_timestamp >= $timeout_timestamp ) {
+						continue;
+					}
+
+					wp_update_post( [
+						'ID'          => $attendee_id,
+						'post_status' => 'timeout',
+					] );
+
+					$this->log( 'Attendee timeout', $attendee_id );
+
+					$processed++;
 				}
 
-				wp_update_post( [
-					'ID'          => $attendee_id,
-					'post_status' => 'timeout',
-				] );
-
-				$this->log( 'Attendee timeout', $attendee_id );
-
-				$processed++;
+				// Just in case we get stuck in here
+				if ( $current_loop++ >= $max_loops )
+					break 2;
 			}
-
-			// Just in case we get stuck in here
-			if ( $current_loop++ >= $max_loops )
-				break;
 		}
 		// Only log action message if we did something.
 		if ( $processed > 0 ) {

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -1062,14 +1062,17 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	 */
 	public function test_review_timeout_payments_respects_delayed_timestamp_after_hook() {
 		$ticket_id   = $this->create_ticket();
-		$attendee_id = $this->create_attendee( $ticket_id, array(
-			'status'         => 'draft',
-			'payment_method' => 'stripe',
-		) );
+		$attendee_id = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'         => 'draft',
+				'payment_method' => 'stripe',
+			)
+		);
 
 		update_post_meta( $attendee_id, 'tix_timestamp', time() - 2 * DAY_IN_SECONDS );
 
-		$delay_timeout = static function( $timeout_attendee_id ) use ( $attendee_id ) {
+		$delay_timeout = static function ( $timeout_attendee_id ) use ( $attendee_id ) {
 			if ( $attendee_id === $timeout_attendee_id ) {
 				update_post_meta( $attendee_id, 'tix_timestamp', time() );
 			}
@@ -1088,14 +1091,20 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	public function test_review_timeout_payments_only_sweeps_pending_stripe_attendees() {
 		$ticket_id = $this->create_ticket();
 
-		$paypal_attendee_id = $this->create_attendee( $ticket_id, array(
-			'status'         => 'pending',
-			'payment_method' => 'paypal',
-		) );
-		$stripe_attendee_id = $this->create_attendee( $ticket_id, array(
-			'status'         => 'pending',
-			'payment_method' => 'stripe',
-		) );
+		$paypal_attendee_id = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'         => 'pending',
+				'payment_method' => 'paypal',
+			)
+		);
+		$stripe_attendee_id = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'         => 'pending',
+				'payment_method' => 'stripe',
+			)
+		);
 
 		update_post_meta( $paypal_attendee_id, 'tix_timestamp', time() - 2 * DAY_IN_SECONDS );
 		update_post_meta( $stripe_attendee_id, 'tix_timestamp', time() - 2 * DAY_IN_SECONDS );

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -1058,6 +1058,55 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify timeout review respects hooks that delay an attendee timestamp.
+	 */
+	public function test_review_timeout_payments_respects_delayed_timestamp_after_hook() {
+		$ticket_id   = $this->create_ticket();
+		$attendee_id = $this->create_attendee( $ticket_id, array(
+			'status'         => 'draft',
+			'payment_method' => 'stripe',
+		) );
+
+		update_post_meta( $attendee_id, 'tix_timestamp', time() - 2 * DAY_IN_SECONDS );
+
+		$delay_timeout = static function( $timeout_attendee_id ) use ( $attendee_id ) {
+			if ( $attendee_id === $timeout_attendee_id ) {
+				update_post_meta( $attendee_id, 'tix_timestamp', time() );
+			}
+		};
+
+		add_action( 'camptix_pre_attendee_timeout', $delay_timeout );
+		self::$camptix->review_timeout_payments();
+		remove_action( 'camptix_pre_attendee_timeout', $delay_timeout );
+
+		$this->assertSame( 'draft', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * Verify timeout review only includes Stripe attendees when sweeping pending payments.
+	 */
+	public function test_review_timeout_payments_only_sweeps_pending_stripe_attendees() {
+		$ticket_id = $this->create_ticket();
+
+		$paypal_attendee_id = $this->create_attendee( $ticket_id, array(
+			'status'         => 'pending',
+			'payment_method' => 'paypal',
+		) );
+		$stripe_attendee_id = $this->create_attendee( $ticket_id, array(
+			'status'         => 'pending',
+			'payment_method' => 'stripe',
+		) );
+
+		update_post_meta( $paypal_attendee_id, 'tix_timestamp', time() - 2 * DAY_IN_SECONDS );
+		update_post_meta( $stripe_attendee_id, 'tix_timestamp', time() - 2 * DAY_IN_SECONDS );
+
+		self::$camptix->review_timeout_payments();
+
+		$this->assertSame( 'pending', get_post_status( $paypal_attendee_id ) );
+		$this->assertSame( 'timeout', get_post_status( $stripe_attendee_id ) );
+	}
+
+	/**
 	 * Verify is_wordcamp_closed returns false when no WordCamp post exists.
 	 */
 	public function test_is_wordcamp_closed_returns_false_when_no_wordcamp_post() {


### PR DESCRIPTION
## Summary

- Delayed payment methods (boleto, OXXO, etc.) complete the Stripe checkout session but payment settlement takes days. Previously the 24-hour CampTix timeout would expire these attendees before payment could complete, causing attendees to lose their tickets.
- When returning from Stripe with an unpaid delayed payment session, attendees are now marked as `pending` instead of `completed`, so tickets are not issued until payment actually settles.
- The timeout review now checks both `draft` and `pending` attendees. For pending Stripe payments, the timeout is delayed by resetting the attendee timestamp (up to a 7-day maximum safety limit).
- Open Stripe sessions that have not expired according to Stripe are also given extra time before timing out.

Fixes #1532

## Test plan

- [ ] Purchase a ticket using a delayed payment method (e.g., boleto in test mode)
- [ ] Verify the attendee is marked as `pending` (not `published`) after returning from Stripe
- [ ] Wait for the daily timeout cron to run and verify the attendee is NOT timed out while payment is still pending
- [ ] Complete the payment and verify the attendee is correctly marked as `published` on the next timeout review cycle
- [ ] Verify that after 7 days of pending status, the attendee is allowed to time out
- [ ] Verify standard card payments still work as before (immediate completion)

Generated with [Claude Code](https://claude.com/claude-code)