### PR TITLE
Fix comment textarea cut off on mobile

### DIFF
--- a/public_html/wp-content/themes/wordcamp-central-2012/style.css
+++ b/public_html/wp-content/themes/wordcamp-central-2012/style.css
@@ -2747,8 +2747,9 @@ h3#comments-title {
 }
 
 #content #respond textarea {
-	width: 98.8% !important;
-	height: 185px
+	width: 100% !important;
+	height: 185px;
+	box-sizing: border-box;
 }
 
 #content .comment #respond textarea {


### PR DESCRIPTION
## Summary
- The comment textarea on central.wordcamp.org news posts used `width: 98.8%` which caused overflow on mobile viewports, cutting off the right border
- Changes to `width: 100%` with `box-sizing: border-box` so padding is included in the width calculation
- This ensures the textarea fits properly within its container at all screen sizes

## Test plan
- [ ] Visit a news post on central.wordcamp.org (e.g. any post with comments enabled)
- [ ] View in mobile viewport and verify the comment textarea border is fully visible on all sides
- [ ] Verify the textarea still looks correct on desktop

Fixes https://github.com/WordPress/wordcamp.org/issues/1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)