### PR TITLE
Preserve invoice fields after failed server validation

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-form.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-form.php
@@ -7,10 +7,10 @@ defined( 'WPINC' ) || die();
 // Preserve field values after failed server-side validation.
 // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce is verified by CampTix core before rendering.
 $need_invoice    = ! empty( $_POST['camptix-need-invoice'] );
-$saved_email     = isset( $_POST['invoice-email'] ) ? sanitize_email( wp_unslash( $_POST['invoice-email'] ) ) : '';
-$saved_name      = isset( $_POST['invoice-name'] ) ? sanitize_text_field( wp_unslash( $_POST['invoice-name'] ) ) : '';
-$saved_address   = isset( $_POST['invoice-address'] ) ? sanitize_textarea_field( wp_unslash( $_POST['invoice-address'] ) ) : '';
-$saved_vat       = isset( $_POST['invoice-vat-number'] ) ? sanitize_text_field( wp_unslash( $_POST['invoice-vat-number'] ) ) : '';
+$saved_email     = sanitize_email( wp_unslash( $_POST['invoice-email'] ?? '' ) );
+$saved_name      = sanitize_text_field( wp_unslash( $_POST['invoice-name'] ?? '' ) );
+$saved_address   = sanitize_textarea_field( wp_unslash( $_POST['invoice-address'] ?? '' ) );
+$saved_vat       = sanitize_text_field( wp_unslash( $_POST['invoice-vat-number'] ?? '' ) );
 // phpcs:enable WordPress.Security.NonceVerification.Missing
 
 ?>

--- a/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-form.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/views/invoice-form.php
@@ -4,11 +4,20 @@ defined( 'WPINC' ) || die();
 
 /** @var string $invoice_vat_number */
 
+// Preserve field values after failed server-side validation.
+// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce is verified by CampTix core before rendering.
+$need_invoice    = ! empty( $_POST['camptix-need-invoice'] );
+$saved_email     = isset( $_POST['invoice-email'] ) ? sanitize_email( wp_unslash( $_POST['invoice-email'] ) ) : '';
+$saved_name      = isset( $_POST['invoice-name'] ) ? sanitize_text_field( wp_unslash( $_POST['invoice-name'] ) ) : '';
+$saved_address   = isset( $_POST['invoice-address'] ) ? sanitize_textarea_field( wp_unslash( $_POST['invoice-address'] ) ) : '';
+$saved_vat       = isset( $_POST['invoice-vat-number'] ) ? sanitize_text_field( wp_unslash( $_POST['invoice-vat-number'] ) ) : '';
+// phpcs:enable WordPress.Security.NonceVerification.Missing
+
 ?>
 
 <div class="camptix-invoice-toggle-wrapper">
 
-	<input type="checkbox" value="1" name="camptix-need-invoice" id="camptix-need-invoice"/>
+	<input type="checkbox" value="1" name="camptix-need-invoice" id="camptix-need-invoice" <?php checked( $need_invoice ); ?> />
 	<label for="camptix-need-invoice">
 		<?php echo esc_html__( 'I need an invoice', 'wordcamporg' ); ?>
 	</label>
@@ -23,7 +32,7 @@ defined( 'WPINC' ) || die();
 					</label>
 				</td>
 				<td class="tix-right">
-					<input type="text" name="invoice-email" id="invoice-email" pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$" />
+					<input type="text" name="invoice-email" id="invoice-email" value="<?php echo esc_attr( $saved_email ); ?>" pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$" />
 				</td>
 			</tr>
 
@@ -34,7 +43,7 @@ defined( 'WPINC' ) || die();
 					</label>
 				</td>
 				<td class="tix-right">
-					<input type="text" name="invoice-name" id="invoice-name" />
+					<input type="text" name="invoice-name" id="invoice-name" value="<?php echo esc_attr( $saved_name ); ?>" />
 				</td>
 			</tr>
 
@@ -45,7 +54,7 @@ defined( 'WPINC' ) || die();
 					</label>
 				</td>
 				<td class="tix-right">
-					<textarea name="invoice-address" id="invoice-address" rows="2"></textarea>
+					<textarea name="invoice-address" id="invoice-address" rows="2"><?php echo esc_textarea( $saved_address ); ?></textarea>
 				</td>
 			</tr>
 
@@ -57,7 +66,7 @@ defined( 'WPINC' ) || die();
 						</label>
 					</td>
 					<td class="tix-right">
-						<input type="text" name="invoice-vat-number" id="invoice-vat-number" />
+						<input type="text" name="invoice-vat-number" id="invoice-vat-number" value="<?php echo esc_attr( $saved_vat ); ?>" />
 					</td>
 				</tr>
 			<?php endif; ?>


### PR DESCRIPTION
## Summary
- Invoice form fields (checkbox, email, name, address, VAT number) are now preserved after a failed server-side checkout validation
- Previously, all invoice fields were cleared on validation failure because the form template did not read from `$_POST` data
- This matches how CampTix core preserves attendee info fields (first_name, last_name, email) via `$this->form_data`

## Changes
- `invoice-form.php`: Read submitted values from `$_POST` and populate form fields with `value` attributes. The "I need an invoice" checkbox is also restored via `checked()`. All values are properly sanitized.

## Root Cause
The invoice form template rendered all inputs with empty values and no checked state. When CampTix validation fails, the form re-renders with `$_POST` data available, but the invoice form was not using it - unlike the core attendee fields which do.

## Test plan
- [ ] Enable invoices in CampTix settings
- [ ] Fill in ticket form with invalid email (e.g. `a@b.c`) and complete invoice fields
- [ ] Submit - verify validation fails and invoice checkbox remains checked, fields visible, and values preserved
- [ ] Submit with valid data - verify normal checkout flow still works

Closes WordPress/wordcamp.org#1354

Generated with [Claude Code](https://claude.com/claude-code)