### PR TITLE
Fix session editor crash with UTC offset timezones

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/js/src/components/date-control/index.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/src/components/date-control/index.js
@@ -9,7 +9,6 @@ import { TZDate } from '@date-fns/tz';
  */
 import { getSettings } from '@wordpress/date';
 import { BaseControl, TimePicker } from '@wordpress/components';
-import { sprintf } from '@wordpress/i18n';
 
 const TIMEZONELESS_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
@@ -23,12 +22,11 @@ const TIMEZONELESS_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
  * @return {string}
  */
 function getTimezoneOffset( { offset = 0 } ) {
-	return sprintf(
-		'%1$s%2$02d:%3$02d',
-		Number( offset ) < 0 ? '-' : '+',
-		Math.floor( Math.abs( offset ) ),
-		( Math.abs( offset ) % 1 ) * 60
-	);
+	const num = Number( offset );
+	const sign = num < 0 ? '-' : '+';
+	const hours = String( Math.floor( Math.abs( num ) ) ).padStart( 2, '0' );
+	const minutes = String( ( Math.abs( num ) % 1 ) * 60 ).padStart( 2, '0' );
+	return `${ sign }${ hours }:${ minutes }`;
 }
 
 export default function( { date, label, onChange } ) {


### PR DESCRIPTION
## Summary
- Fixes the block editor crash when editing sessions on sites using UTC offset timezones (e.g. UTC+6)
- Root cause: `@wordpress/i18n` `sprintf` does not support zero-padding flags like `%02d`, so `getTimezoneOffset()` produced `"+6:0"` instead of `"+06:00"`
- `TZDate` from `@date-fns/tz` rejects malformed offset strings, throwing `Invalid time value` which crashes the editor

## Root Cause Analysis
The `getTimezoneOffset()` function used `sprintf('%1$s%2$02d:%3$02d', ...)` expecting C-style zero-padded formatting. However, WordPress JS `sprintf` (from `sprintf-js`) does not handle `%02d` — it outputs `6` instead of `06`, producing `"+6:0"` which is not a valid ISO 8601 timezone offset.

**Verified with test:**
```js
// @wordpress/i18n sprintf
sprintf('%1$s%2$02d:%3$02d', '+', 6, 0) // => "+6:0" (WRONG)

// TZDate behavior
new TZDate(date, '+6:0')   // => throws "Invalid time value"
new TZDate(date, '+06:00') // => works correctly
```

## Fix
Replaced `sprintf` with native JS `String.padStart()` for reliable zero-padding.

## Test plan
- [ ] Set a WordCamp site timezone to UTC+6 (or any UTC offset)
- [ ] Create/edit a Session post
- [ ] Open the Session Info panel — verify no crash
- [ ] Verify the date/time picker shows the correct time
- [ ] Repeat with fractional offsets like UTC+5:30 (India) and UTC+5:45 (Nepal)
- [ ] Verify sites with IANA timezones (America/New_York) still work correctly

Fixes https://github.com/WordPress/wordcamp.org/issues/1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)