### PR TITLE
Add All option to Format dropdown on events page

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
+++ b/public_html/wp-content/themes/wporg-events-2023/inc/events-query.php
@@ -462,10 +462,11 @@ function get_format_type_options( array $options ): array {
 		'key' => 'format_type',
 		'action' => build_form_action_url(),
 		'options' => array(
+			''          => 'All',
 			'online'    => 'Online',
 			'in-person' => 'In Person',
 		),
-		'selected' => $selected,
+		'selected' => $count > 0 ? $selected : array( '' ),
 	);
 }
 


### PR DESCRIPTION
## Summary
- The Format filter on the events page is a single-select dropdown (radio buttons) with no way to reset back to showing all formats
- Adds an "All" option as the default selection, consistent with how the Patterns directory handles its single-select filters
- When no format is actively filtered, "All" is pre-selected; selecting "Online" or "In Person" filters as before

## Test plan
- [ ] Visit the events listing page and open the Format dropdown
- [ ] Verify "All" is listed as the first option and is selected by default
- [ ] Select "Online", apply - verify only online events show
- [ ] Re-open Format, select "All", apply - verify all events show again
- [ ] Select "In Person", apply - verify only in-person events show

Fixes #1292

Generated with [Claude Code](https://claude.com/claude-code)