### PR TITLE
Disable attachment pages on legacy WordCamp sites

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-misc.php
+++ b/public_html/wp-content/mu-plugins/wcorg-misc.php
@@ -69,6 +69,18 @@ add_filter( 'pre_option_blog_public', 'wcorg_enforce_public_blog_option' );
 add_filter( 'pre_update_option_blog_public', 'wcorg_enforce_public_blog_option' );
 
 /**
+ * Disable attachment pages on all sites.
+ *
+ * WordPress 6.4+ disables attachment pages on new installs, but legacy sites still have them enabled.
+ * This forces them off for all sites, which causes WordPress core to 301 redirect attachment page
+ * requests to the attachment file URL.
+ *
+ * See https://github.com/WordPress/wordcamp.org/issues/1333
+ * See https://make.wordpress.org/core/2023/10/16/changes-to-attachment-pages/
+ */
+add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_zero' );
+
+/**
  * We want to let organizers use shortcodes inside Text widgets.
  */
 add_filter( 'widget_text', 'do_shortcode' );


### PR DESCRIPTION
## Summary
- Forces `wp_attachment_pages_enabled` to `0` via `pre_option` filter in `wcorg-misc.php`
- WordPress 6.4+ disables attachment pages on new installs, but legacy sites still have them enabled
- When disabled, WordPress core automatically 301 redirects attachment page requests to the attachment file URL

## Details
The fix is a single line: `add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_zero' );`

This follows the same pattern already used for `blog_public` in the same file.

Reference: https://make.wordpress.org/core/2023/10/16/changes-to-attachment-pages/

## Test plan
- [ ] Verify attachment page URLs return 301 redirects to the media file URL
- [ ] Verify normal pages and posts are unaffected

Fixes #1333

Generated with [Claude Code](https://claude.com/claude-code)