### PR TITLE
Fix Sponsor Levels ordering on Add/Edit Sponsor page

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -83,6 +83,7 @@ class WordCamp_Post_Types_Plugin {
 		add_filter( 'dashboard_glance_items', array( $this, 'glance_items' ) );
 		add_filter( 'option_default_comment_status', array( $this, 'default_comment_ping_status' ) );
 		add_filter( 'option_default_ping_status', array( $this, 'default_comment_ping_status' ) );
+		add_filter( 'get_terms', array( $this, 'order_sponsor_levels' ), 10, 4 );
 
 		// Needs to run before WordCamp\Blocks\register_assets.
 		add_action( 'init', array( $this, 'rest_init' ), 8 );
@@ -222,6 +223,50 @@ class WordCamp_Post_Types_Plugin {
 		}
 
 		return array_merge( $ordered_terms, array_values( $terms ) );
+	}
+
+	/**
+	 * Reorder wcb_sponsor_level terms based on the saved custom order.
+	 *
+	 * @param array         $terms      Array of found terms.
+	 * @param array|null    $taxonomies Array of taxonomy names.
+	 * @param array         $args       Term query args.
+	 * @param WP_Term_Query $term_query The WP_Term_Query instance.
+	 *
+	 * @return array
+	 */
+	public function order_sponsor_levels( $terms, $taxonomies, $args, $term_query ) {
+		if ( empty( $terms ) || ! is_array( $taxonomies ) || ! in_array( 'wcb_sponsor_level', $taxonomies, true ) ) {
+			return $terms;
+		}
+
+		// Only reorder when fetching solely wcb_sponsor_level terms.
+		if ( count( $taxonomies ) !== 1 ) {
+			return $terms;
+		}
+
+		$option = get_option( 'wcb_sponsor_level_order' );
+
+		if ( empty( $option ) || ! is_array( $option ) ) {
+			return $terms;
+		}
+
+		$order_map = array_flip( $option );
+
+		usort(
+			$terms,
+			function ( $a, $b ) use ( $order_map ) {
+				$a_id = is_object( $a ) ? $a->term_id : $a;
+				$b_id = is_object( $b ) ? $b->term_id : $b;
+
+				$a_pos = $order_map[ $a_id ] ?? PHP_INT_MAX;
+				$b_pos = $order_map[ $b_id ] ?? PHP_INT_MAX;
+
+				return $a_pos - $b_pos;
+			}
+		);
+
+		return $terms;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds a `get_terms` filter that reorders `wcb_sponsor_level` terms based on the custom order saved via **Sponsors > Order Sponsor Levels**
- The sponsor level checkboxes on the Add/Edit Sponsor page now match the configured order instead of using the default alphabetical/registration order

## Test plan
- [ ] Go to Sponsors > Order Sponsor Levels and set a custom order
- [ ] Go to Add New Sponsor - verify the Sponsor Levels checkboxes match the custom order
- [ ] Edit an existing Sponsor - verify the same ordering
- [ ] Verify the Order Sponsor Levels page itself still works correctly

Closes #1528

Generated with [Claude Code](https://claude.com/claude-code)