### PR TITLE
Show error when attaching a file already used by another request

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -231,6 +231,7 @@ class WordCamp_Budgets {
 			array(
 				'uploadModalTitle'  => esc_html__( 'Attach Supporting Documentation', 'wordcamporg' ),
 				'uploadModalButton' => esc_html__( 'Attach Files', 'wordcamporg' ),
+				'fileAlreadyAttached' => esc_html__( 'That file is already attached to another request. Please upload a fresh copy of the file to this request instead.', 'wordcamporg' ),
 			)
 		);
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -205,10 +205,10 @@ class WordCamp_Budgets {
 
 	/**
 	 * Enqueue scripts and stylesheets common to all modules
+	 *
+	 * @todo setup grunt to concat/minify js
 	 */
 	public function enqueue_common_assets() {
-		// todo setup grunt to concat/minify js
-
 		wp_enqueue_script(
 			'wordcamp-budgets',
 			plugins_url( 'javascript/wordcamp-budgets.js', __DIR__ ),
@@ -221,7 +221,7 @@ class WordCamp_Budgets {
 			'wcb-attached-files',
 			plugins_url( 'javascript/attached-files.js', __DIR__ ),
 			array( 'wordcamp-budgets', 'backbone', 'wp-util' ),
-			1,
+			filemtime( WORDCAMP_PAYMENTS_PATH . '/javascript/attached-files.js' ),
 			true
 		);
 
@@ -248,7 +248,7 @@ class WordCamp_Budgets {
 			'wordcamp-budgets',
 			plugins_url( 'css/wordcamp-budgets.css', __DIR__ ),
 			$soft_deps,
-			7
+			filemtime( WORDCAMP_PAYMENTS_PATH . '/css/wordcamp-budgets.css' ),
 		);
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/attached-files.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/attached-files.js
@@ -82,8 +82,8 @@ jQuery( document ).ready( function( $ ) {
 		 * Sometimes users add existing files to the request, rather than uploading new ones. We need to keep track
 		 * of those so that they can be attached to the request when the form is submitted.
 		 *
-		 * Files that are already attached to other posts are ignored.
-		 * @todo add an error message if the file is already attached to other posts, see https://wordpress.slack.com/archives/meta-wordcamp/p1459185670000179
+		 * Files that are already attached to other posts are ignored, and an error is shown
+		 * prompting the user to upload a fresh copy instead.
 		 *
 		 * @param {app.AttachedFile} file
 		 */
@@ -97,7 +97,16 @@ jQuery( document ).ready( function( $ ) {
 				fileIDsToAttach = [];
 			}
 
-			if ( 0 === file.get( 'post_parent' ) && -1 === $.inArray( file.get( 'ID' ), fileIDsToAttach ) ) {
+			if ( 0 !== file.get( 'post_parent' ) && file.get( 'post_parent' ) !== parseInt( $( '#post_ID' ).val(), 10 ) ) {
+				$( '.wcb-attached-file-error' ).remove();
+				$( '.wcb_files_list' ).after(
+					$( '<div class="notice notice-error wcb-attached-file-error"><p></p></div>' )
+						.find( 'p' ).text( wcbLocalizedStrings.fileAlreadyAttached ).end()
+				);
+				return;
+			}
+
+			if ( -1 === $.inArray( file.get( 'ID' ), fileIDsToAttach ) ) {
 				fileIDsToAttach.push( file.get( 'ID' ) );
 				existingFilesToAttach.val( JSON.stringify( fileIDsToAttach ) );
 			}

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/attached-files.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/attached-files.js
@@ -66,6 +66,11 @@ jQuery( document ).ready( function( $ ) {
 		},
 
 		appendFile: function( file ) {
+			if ( ! this.isFileAttachable( file ) ) {
+				this.collection.remove( file );
+				return;
+			}
+
 			var noFilesUploaded  = $( '.wcb_no_files_uploaded' );
 			var attachedFileView = new app.AttachedFileView( { model: file } );
 
@@ -73,7 +78,28 @@ jQuery( document ).ready( function( $ ) {
 			noFilesUploaded.removeClass( 'active' );
 			noFilesUploaded.addClass( 'hidden' );
 
-			this.attachExistingFile( file );
+			this.trackExistingFile( file );
+		},
+
+		/**
+		 * Check if a file can be attached to this request.
+		 *
+		 * Files already attached to other posts are rejected with an error message.
+		 *
+		 * @param {app.AttachedFile} file
+		 * @return {boolean}
+		 */
+		isFileAttachable: function( file ) {
+			if ( 0 !== file.get( 'post_parent' ) && file.get( 'post_parent' ) !== parseInt( $( '#post_ID' ).val(), 10 ) ) {
+				$( '.wcb-attached-file-error' ).remove();
+				$( '.wcb_files_list' ).after(
+					$( '<div class="notice notice-error wcb-attached-file-error"><p></p></div>' )
+						.find( 'p' ).text( wcbLocalizedStrings.fileAlreadyAttached ).end()
+				);
+				return false;
+			}
+
+			return true;
 		},
 
 		/**
@@ -82,12 +108,9 @@ jQuery( document ).ready( function( $ ) {
 		 * Sometimes users add existing files to the request, rather than uploading new ones. We need to keep track
 		 * of those so that they can be attached to the request when the form is submitted.
 		 *
-		 * Files that are already attached to other posts are ignored, and an error is shown
-		 * prompting the user to upload a fresh copy instead.
-		 *
 		 * @param {app.AttachedFile} file
 		 */
-		attachExistingFile: function( file ) {
+		trackExistingFile: function( file ) {
 			var fileIDsToAttach,
 				existingFilesToAttach = $( '#wcb_existing_files_to_attach' );
 
@@ -95,15 +118,6 @@ jQuery( document ).ready( function( $ ) {
 				fileIDsToAttach = JSON.parse( existingFilesToAttach.val() );
 			} catch ( exception ) {
 				fileIDsToAttach = [];
-			}
-
-			if ( 0 !== file.get( 'post_parent' ) && file.get( 'post_parent' ) !== parseInt( $( '#post_ID' ).val(), 10 ) ) {
-				$( '.wcb-attached-file-error' ).remove();
-				$( '.wcb_files_list' ).after(
-					$( '<div class="notice notice-error wcb-attached-file-error"><p></p></div>' )
-						.find( 'p' ).text( wcbLocalizedStrings.fileAlreadyAttached ).end()
-				);
-				return;
 			}
 
 			if ( -1 === $.inArray( file.get( 'ID' ), fileIDsToAttach ) ) {


### PR DESCRIPTION
## Summary

- When a user selects an existing media file that is already attached to a different payment/reimbursement request, the file was silently ignored. This caused confusion as the attachment appeared to not save.
- Displays an inline error notice explaining the file belongs to another request and prompting the user to upload a fresh copy instead.
- Resolves a long-standing TODO from 2016.

## Context

- Original Slack discussion (2016): https://wordpress.slack.com/archives/meta-wordcamp/p1459185670000179
- Recent report: https://wordpress.slack.com/archives/C08M59V3P/p1774274020560509

## Test plan

- [x] Create a payment or reimbursement request and attach a file
- [x] Create a second request
- [x] On the second request, open the media modal and select the file already attached to the first request
- [x] Verify an inline error notice appears below the files list explaining the file is already attached elsewhere
- [x] Verify uploading a fresh file to the second request works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)