### PR TITLE
Fix media library grid pagination for non-admin users

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -46,6 +46,7 @@ require_once( $core_tests_directory . '/includes/functions.php' );
  * bootstrap for a particular suite before the suite loads (see https://stackoverflow.com/a/30170762/450127). It's
  * not clear if that would properly isolate them from each other, and allow multiple independent contexts, though.
  */
+require_once WP_PLUGIN_DIR . '/wordcamp-payments/tests/bootstrap.php';
 require_once( WP_PLUGIN_DIR . '/wordcamp-organizer-reminders/tests/bootstrap.php' );
 require_once WP_PLUGIN_DIR . '/wcpt/tests/bootstrap.php';
 require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,6 +38,12 @@
 			</directory>
 		</testsuite>
 
+		<testsuite name="WordCamp Budgets">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/wordcamp-payments/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="WordCamp Post Types">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/plugins/wc-post-types/tests/

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -51,30 +51,19 @@ function exclude_others_payment_files_from_query( $clauses, $wp_query ) {
 	$reimbursement_type = Reimbursement_Requests\POST_TYPE;
 	$payment_type       = WCP_Payment_Request::POST_TYPE;
 
-	// Exclude attachments whose parent is a payment post, unless the current user is the attachment author
-	// or the parent post author.
-	// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+	// Join only payment-type parent posts so we can check authorship.
+	$clauses['join'] .= $wpdb->prepare(
+		" LEFT JOIN {$wpdb->posts} AS payment_parent ON {$wpdb->posts}.post_parent = payment_parent.ID AND payment_parent.post_type IN (%s, %s)",
+		$reimbursement_type,
+		$payment_type
+	);
+
+	// Allow the attachment if: no payment parent (NULL), or current user is the attachment/parent author.
 	$clauses['where'] .= $wpdb->prepare(
-		" AND NOT (
-			{$wpdb->posts}.post_parent IN (
-				SELECT ID FROM {$wpdb->posts} parent_post
-				WHERE parent_post.post_type IN (%s, %s)
-			)
-			AND {$wpdb->posts}.post_author != %d
-			AND {$wpdb->posts}.post_parent NOT IN (
-				SELECT ID FROM {$wpdb->posts} parent_post2
-				WHERE parent_post2.post_type IN (%s, %s)
-				AND parent_post2.post_author = %d
-			)
-		)",
-		$reimbursement_type,
-		$payment_type,
+		" AND ( payment_parent.ID IS NULL OR {$wpdb->posts}.post_author = %d OR payment_parent.post_author = %d )",
 		$user_id,
-		$reimbursement_type,
-		$payment_type,
 		$user_id
 	);
-	// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 	return $clauses;
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -9,7 +9,7 @@ use WCP_Payment_Request;
 defined( 'WPINC' ) || die();
 
 
-add_filter( 'the_posts',                          __NAMESPACE__ . '\hide_others_payment_files', 10, 2 );
+add_filter( 'posts_clauses',                      __NAMESPACE__ . '\exclude_others_payment_files_from_query', 10, 2 );
 add_filter( 'wp_unique_filename',                 __NAMESPACE__ . '\obscure_payment_file_names', 10, 2 );
 add_filter( 'wp_privacy_personal_data_exporters', __NAMESPACE__ . '\register_personal_data_exporters' );
 add_filter( 'wp_privacy_personal_data_erasers',   __NAMESPACE__ . '\register_personal_data_erasers'   );
@@ -18,83 +18,65 @@ add_filter( 'wp_privacy_personal_data_erasers',   __NAMESPACE__ . '\register_per
 /**
  * Prevent non-admins from viewing payment files uploaded by other users.
  *
- * The files sometimes have sensitive information, like account numbers etc. `the_posts` was chosen over
- * `ajax_query_attachments_args`, `pre_get_posts`, and other techniques, because it is the most comprehensive
- * and flexible solution. It will remove things from the Media Library, but also REST API endpoints, XML-RPC,
- * RSS, etc. It also allows the chance the to only apply the conditions to certain post types, whereas setting
- * query vars is much more limited.
+ * The files sometimes have sensitive information, like account numbers etc.
  *
- * SECURITY WARNING: When querying attachments `get_posts()`, make sure you pass `suppress_filters => false`,
- * otherwise this will not run.
+ * This uses `posts_clauses` to filter at the SQL level, so that `found_posts` and the actual results are
+ * consistent. The previous approach using `the_posts` caused the media library grid view to break for
+ * non-admin users, because removing posts after the query meant fewer results were returned than
+ * `posts_per_page`, which made the JavaScript conclude there were no more items to load.
  *
- * @param WP_Post[] $attachments
- * @param WP_Query  $wp_query
+ * See https://github.com/WordPress/wordcamp.org/issues/1316
  *
- * @return array
+ * SECURITY WARNING: When querying attachments with `get_posts()`, make sure you pass
+ * `suppress_filters => false`, otherwise this will not run.
+ *
+ * @param array    $clauses  SQL clauses for the query.
+ * @param WP_Query $wp_query The WP_Query instance.
+ *
+ * @return array Modified SQL clauses.
  */
-function hide_others_payment_files( $attachments, $wp_query ) {
-	$user = wp_get_current_user();
+function exclude_others_payment_files_from_query( $clauses, $wp_query ) {
+	global $wpdb;
 
 	if ( 'attachment' !== $wp_query->get( 'post_type' ) || current_user_can( 'manage_options' ) ) {
-		return $attachments;
+		return $clauses;
 	}
 
-	$payment_posts_ids = get_payment_file_parent_ids( $attachments );
+	$user_id = get_current_user_id();
 
-	foreach ( $attachments as $index => $attachment ) {
-		if ( ! in_array( $attachment->post_parent, $payment_posts_ids, true ) ) {
-			continue;
-		}
-
-		if ( $attachment->post_author === $user->ID ) {
-			continue;
-		}
-
-		/*
-		 * The post is already cached from the request in `get_payment_file_parent_ids()`, so this doesn't create
-		 * a new database query, it's just a way to access the individual post directly instead of iterating through
-		 * `$payment_posts_with_attachments`.
-		 */
-		$parent_author = (int) get_post( $attachment->post_parent )->post_author;
-
-		if ( $parent_author === $user->ID ) {
-			continue;
-		}
-
-		unset( $attachments[ $index ] );
+	if ( ! $user_id ) {
+		return $clauses;
 	}
 
-	// Re-index the array, because WP_Query functions will assume there are no gaps.
-	return array_values( $attachments );
-}
+	$reimbursement_type = Reimbursement_Requests\POST_TYPE;
+	$payment_type       = WCP_Payment_Request::POST_TYPE;
 
-/**
- * Get the Reimbursement/Vendor Payment posts that are attached to the given media items.
- *
- * @param WP_Post[] $attachments
- *
- * @return int[]
- */
-function get_payment_file_parent_ids( $attachments ) {
-	$parent_ids     = array_unique( wp_list_pluck( $attachments, 'post_parent' ) );
-	$orphaned_index = array_search( 0, $parent_ids, true );
+	// Exclude attachments whose parent is a payment post, unless the current user is the attachment author
+	// or the parent post author.
+	// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+	$clauses['where'] .= $wpdb->prepare(
+		" AND NOT (
+			{$wpdb->posts}.post_parent IN (
+				SELECT ID FROM {$wpdb->posts} parent_post
+				WHERE parent_post.post_type IN (%s, %s)
+			)
+			AND {$wpdb->posts}.post_author != %d
+			AND {$wpdb->posts}.post_parent NOT IN (
+				SELECT ID FROM {$wpdb->posts} parent_post2
+				WHERE parent_post2.post_type IN (%s, %s)
+				AND parent_post2.post_author = %d
+			)
+		)",
+		$reimbursement_type,
+		$payment_type,
+		$user_id,
+		$reimbursement_type,
+		$payment_type,
+		$user_id
+	);
+	// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
-	// All payment files should be attached to a post, so unattached files can be removed.
-	if ( false !== $orphaned_index ) {
-		unset( $parent_ids[ $orphaned_index ] );
-	}
-
-	$payment_posts_with_attachments = get_posts( array(
-		'post__in'    => $parent_ids,
-		'post_status' => 'any',
-		'numberposts' => 1000,
-		'post_type'   => array(
-			Reimbursement_Requests\POST_TYPE,
-			WCP_Payment_Request::POST_TYPE,
-		),
-	) );
-
-	return wp_list_pluck( $payment_posts_with_attachments, 'ID' );
+	return $clauses;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WordCamp\Budgets\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugin for testing.
+ */
+function manually_load_plugin() {
+	// Register the post types needed for tests.
+	register_post_type( 'wcp_payment_request' );
+	register_post_type( 'wcb_reimbursement' );
+
+	require_once dirname( __DIR__ ) . '/includes/payment-request.php';
+	require_once dirname( __DIR__ ) . '/includes/reimbursement-request.php';
+	require_once dirname( __DIR__ ) . '/includes/privacy.php';
+}
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -107,6 +107,9 @@ class Test_Privacy extends WP_UnitTestCase {
 		return $query->posts;
 	}
 
+	/**
+	 * Admins (super admins in multisite) should see all attachments, including payment files.
+	 */
 	public function test_admin_sees_all_attachments() {
 		$ids = $this->query_attachments_as( self::$admin_id );
 
@@ -115,12 +118,18 @@ class Test_Privacy extends WP_UnitTestCase {
 		$this->assertContains( self::$regular_attachment_id, $ids );
 	}
 
+	/**
+	 * Editors should see payment attachments they uploaded.
+	 */
 	public function test_editor_sees_own_payment_attachment() {
 		$ids = $this->query_attachments_as( self::$editor_id );
 
 		$this->assertContains( self::$own_attachment_id, $ids, 'Editor should see their own attachment on their payment post.' );
 	}
 
+	/**
+	 * Editors should see all attachments on their own payment posts, even if uploaded by others.
+	 */
 	public function test_editor_sees_attachment_on_own_payment_post() {
 		// other_editor uploaded an attachment to editor's payment post.
 		// editor (the payment post author) should still see it.
@@ -129,6 +138,9 @@ class Test_Privacy extends WP_UnitTestCase {
 		$this->assertContains( self::$other_attachment_id, $ids, 'Editor should see attachments on their own payment post, even if uploaded by someone else.' );
 	}
 
+	/**
+	 * Editors unrelated to a payment post should not see its attachments.
+	 */
 	public function test_other_editor_cannot_see_payment_attachments() {
 		// A third editor who is neither the attachment author nor the payment post author.
 		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
@@ -139,6 +151,9 @@ class Test_Privacy extends WP_UnitTestCase {
 		$this->assertNotContains( self::$other_attachment_id, $ids, 'Unrelated editor should not see payment attachments from other users.' );
 	}
 
+	/**
+	 * Non-payment attachments should remain visible to all users.
+	 */
 	public function test_regular_attachments_visible_to_all() {
 		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 
@@ -147,6 +162,9 @@ class Test_Privacy extends WP_UnitTestCase {
 		$this->assertContains( self::$regular_attachment_id, $ids, 'Regular attachments should be visible to all users.' );
 	}
 
+	/**
+	 * Verify found_posts matches the actual result count, preventing the original pagination bug.
+	 */
 	public function test_found_posts_matches_returned_count() {
 		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -52,9 +52,8 @@ class Test_Privacy extends WP_UnitTestCase {
 		self::$editor_id      = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$other_editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 
-		// Grant manage_options to admin so current_user_can check passes.
-		$admin_user = get_user_by( 'id', self::$admin_id );
-		$admin_user->add_cap( 'manage_options' );
+		// In multisite, manage_options requires super admin.
+		grant_super_admin( self::$admin_id );
 
 		// Create a payment request post owned by editor.
 		self::$payment_post_id = $factory->post->create( array(

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -47,6 +47,11 @@ class Test_Privacy extends WP_UnitTestCase {
 	 */
 	private static $regular_attachment_id;
 
+	/**
+	 * Create test users, a payment post, and attachments for all tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$admin_id       = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$editor_id      = $factory->user->create( array( 'role' => 'editor' ) );
@@ -163,7 +168,10 @@ class Test_Privacy extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify found_posts matches the actual result count, preventing the original pagination bug.
+	 * Verify found_posts matches the actual result count.
+	 *
+	 * When filtering happens after the query (e.g. via the_posts), found_posts can be higher than
+	 * the actual number of returned posts, which breaks media library grid pagination.
 	 */
 	public function test_found_posts_matches_returned_count() {
 		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace WordCamp\Budgets\Tests;
+
+use WP_Query;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the payment file privacy filter.
+ *
+ * @see \WordCamp\Budgets\Privacy\exclude_others_payment_files_from_query()
+ */
+class Test_Privacy extends WP_UnitTestCase {
+
+	/**
+	 * @var int Admin user ID.
+	 */
+	private static $admin_id;
+
+	/**
+	 * @var int Editor user ID (non-admin).
+	 */
+	private static $editor_id;
+
+	/**
+	 * @var int Another editor user ID.
+	 */
+	private static $other_editor_id;
+
+	/**
+	 * @var int A payment request post owned by $editor_id.
+	 */
+	private static $payment_post_id;
+
+	/**
+	 * @var int Attachment on the payment post, uploaded by $editor_id.
+	 */
+	private static $own_attachment_id;
+
+	/**
+	 * @var int Attachment on the payment post, uploaded by $other_editor_id.
+	 */
+	private static $other_attachment_id;
+
+	/**
+	 * @var int A regular (non-payment) attachment.
+	 */
+	private static $regular_attachment_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id      = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$other_editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+
+		// Grant manage_options to admin so current_user_can check passes.
+		$admin_user = get_user_by( 'id', self::$admin_id );
+		$admin_user->add_cap( 'manage_options' );
+
+		// Create a payment request post owned by editor.
+		self::$payment_post_id = $factory->post->create( array(
+			'post_type'   => 'wcp_payment_request',
+			'post_status' => 'draft',
+			'post_author' => self::$editor_id,
+		) );
+
+		// Attachment uploaded by the editor (owner), attached to the payment post.
+		self::$own_attachment_id = $factory->post->create( array(
+			'post_type'   => 'attachment',
+			'post_parent' => self::$payment_post_id,
+			'post_author' => self::$editor_id,
+			'post_status' => 'inherit',
+		) );
+
+		// Attachment uploaded by another editor, attached to the same payment post.
+		self::$other_attachment_id = $factory->post->create( array(
+			'post_type'   => 'attachment',
+			'post_parent' => self::$payment_post_id,
+			'post_author' => self::$other_editor_id,
+			'post_status' => 'inherit',
+		) );
+
+		// A regular attachment not attached to any payment post.
+		self::$regular_attachment_id = $factory->post->create( array(
+			'post_type'   => 'attachment',
+			'post_parent' => 0,
+			'post_author' => self::$other_editor_id,
+			'post_status' => 'inherit',
+		) );
+	}
+
+	/**
+	 * Helper to query attachments as a specific user.
+	 *
+	 * @param int $user_id The user to run the query as.
+	 *
+	 * @return int[] Attachment IDs returned by the query.
+	 */
+	private function query_attachments_as( $user_id ) {
+		wp_set_current_user( $user_id );
+
+		$query = new WP_Query( array(
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'posts_per_page' => 100,
+			'fields'         => 'ids',
+		) );
+
+		return $query->posts;
+	}
+
+	public function test_admin_sees_all_attachments() {
+		$ids = $this->query_attachments_as( self::$admin_id );
+
+		$this->assertContains( self::$own_attachment_id, $ids );
+		$this->assertContains( self::$other_attachment_id, $ids );
+		$this->assertContains( self::$regular_attachment_id, $ids );
+	}
+
+	public function test_editor_sees_own_payment_attachment() {
+		$ids = $this->query_attachments_as( self::$editor_id );
+
+		$this->assertContains( self::$own_attachment_id, $ids, 'Editor should see their own attachment on their payment post.' );
+	}
+
+	public function test_editor_sees_attachment_on_own_payment_post() {
+		// other_editor uploaded an attachment to editor's payment post.
+		// editor (the payment post author) should still see it.
+		$ids = $this->query_attachments_as( self::$editor_id );
+
+		$this->assertContains( self::$other_attachment_id, $ids, 'Editor should see attachments on their own payment post, even if uploaded by someone else.' );
+	}
+
+	public function test_other_editor_cannot_see_payment_attachments() {
+		// A third editor who is neither the attachment author nor the payment post author.
+		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$ids = $this->query_attachments_as( $third_editor_id );
+
+		$this->assertNotContains( self::$own_attachment_id, $ids, 'Unrelated editor should not see payment attachments from other users.' );
+		$this->assertNotContains( self::$other_attachment_id, $ids, 'Unrelated editor should not see payment attachments from other users.' );
+	}
+
+	public function test_regular_attachments_visible_to_all() {
+		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$ids = $this->query_attachments_as( $third_editor_id );
+
+		$this->assertContains( self::$regular_attachment_id, $ids, 'Regular attachments should be visible to all users.' );
+	}
+
+	public function test_found_posts_matches_returned_count() {
+		$third_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $third_editor_id );
+
+		$query = new WP_Query( array(
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'posts_per_page' => 100,
+		) );
+
+		$this->assertSame(
+			count( $query->posts ),
+			(int) $query->found_posts,
+			'found_posts should match the actual number of returned posts (the original bug).'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes media library "load more" button not working for non-admin users
- Root cause: the `the_posts` filter in `privacy.php` removed payment file attachments AFTER the query, causing fewer results than `posts_per_page`. The JavaScript then concluded there were no more items to load.
- Solution: moves the filtering from `the_posts` to `posts_clauses`, so the exclusion happens at the SQL level and `found_posts` matches the actual results
- Non-admins still cannot see payment files uploaded by other users (security preserved)

Fixes #1316

## Test plan
- [ ] Log in as an Editor (non-admin) user
- [ ] Go to Media Library in grid view
- [ ] Scroll down and verify the "Load more" button works
- [ ] Verify payment files from other users are still hidden
- [ ] Log in as an admin and verify all files are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)