### PR TITLE
Fix sponsor invoice prefill and invoice title display

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-invoice-sponsor.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-invoice-sponsor.php
@@ -17,7 +17,10 @@
 
 				<li>
 					<a href="<?php echo esc_url( get_edit_post_link( $invoice->ID ) ); ?>">
-						<?php echo _draft_or_post_title( $invoice ); ?>
+						<?php
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _draft_or_post_title() returns esc_html().
+						echo _draft_or_post_title( $invoice );
+						?>
 					</a>
 				</li>
 

--- a/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-invoice-sponsor.php
+++ b/public_html/wp-content/plugins/wc-post-types/views/sponsors/metabox-invoice-sponsor.php
@@ -17,7 +17,7 @@
 
 				<li>
 					<a href="<?php echo esc_url( get_edit_post_link( $invoice->ID ) ); ?>">
-						<?php echo _draft_or_post_title( $invoice->post_title ); ?>
+						<?php echo _draft_or_post_title( $invoice ); ?>
 					</a>
 				</li>
 

--- a/public_html/wp-content/plugins/wordcamp-payments/javascript/sponsor-invoices.js
+++ b/public_html/wp-content/plugins/wordcamp-payments/javascript/sponsor-invoices.js
@@ -43,11 +43,11 @@ jQuery( document ).ready( function( $ ) {
 					return;
 				}
 
-				if ( info.amount ) {
+				if ( info.amount && ! $( '#_wcbsi_amount' ).val() ) {
 					$( '#_wcbsi_amount' ).val( info.amount );
 				}
 
-				if ( info.currency ) {
+				if ( info.currency && ! $( '#_wcbsi_currency' ).val() ) {
 					$( '#_wcbsi_currency' ).val( info.currency ).trigger( 'change' );
 				}
 


### PR DESCRIPTION
## Summary
- Fix sponsor data prefill (amount/currency from e1088c0) overwriting customized post_meta values on page load. Now only prefills when fields are empty, so secondary invoices with custom amounts are preserved.
- Fix invoice titles showing "(no title)" in the sponsor Invoice metabox by passing the post object to `_draft_or_post_title()` instead of the title string.

## Test plan
- [ ] Create a sponsor invoice, customize the amount, save. Reload the page and verify the custom amount persists.
- [ ] Create a second invoice for the same sponsor with a different amount, verify it saves correctly.
- [ ] On a new invoice, verify the sponsor amount/currency still prefills from sponsor data.
- [ ] Check the "Invoice Sponsor" metabox on a sponsor post — existing invoices should show their titles, not "(no title)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)