### PR TITLE
Fix organizer reminder emails failing with empty team email

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -127,7 +127,7 @@ class WCOR_Mailer {
 	 */
 	protected function mail( $to, $subject, $body, $headers, $email, $wordcamp ) {
 		if ( ! $this->validate_email_addresses( $to ) ) {
-			log( 'Message not sent because of invalid recipients.', compact( 'email', 'wordcamp' ) );
+			log( 'Message not sent because of invalid recipients.', compact( 'to', 'email', 'wordcamp' ) );
 			return false;
 		}
 
@@ -620,9 +620,12 @@ class WCOR_Mailer {
 			} else {
 				$recipients[] = sanitize_email( get_post_meta( $wordcamp_id, 'E-mail Address', true ) ); // Team address.
 			}
+
+			// Also send to the lead organizer's personal email address ("Email" = Lead organizer email, "E-mail" = team email).
+			$recipients[] = get_post_meta( $wordcamp_id, 'Email Address', true );
 		}
 
-		$recipients = array_unique( $recipients );
+		$recipients = array_unique( array_filter( $recipients ) );
 		return $recipients;
 	}
 


### PR DESCRIPTION
## Summary
- Adds `array_filter()` to `get_recipients()` to strip empty strings before returning, preventing `validate_email_addresses()` from rejecting the entire send.
- Adds the lead organizer's personal email (`Email Address` meta) to `wcor_send_organizers` recipients, so organizers get emails even when no team address (`E-mail Address` meta) is set — which is the case for Campus Connect events.
- Logs the intended `$to` recipients on send failure for easier debugging.

## Test plan
- [ ] Create/find a WordCamp post with no "E-mail Address" (team address) set
- [ ] Trigger a reminder email configured with `wcor_send_organizers`
- [ ] Verify the email is sent to the lead organizer's personal email address
- [ ] Verify no "invalid recipients" error is logged
- [ ] Verify that events with both a team address and lead organizer address receive emails at both addresses (deduplicated)

Fixes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)