### PR TITLE
Fix REST API fatals when array passed to string params

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -400,7 +400,11 @@ function register_user_validation_route() {
 			'permission_callback' => '__return_true',
 			'args'                => array(
 				'username' => array(
+					'type'              => 'string',
 					'validate_callback' => function ( $value ) {
+						if ( ! is_string( $value ) ) {
+							return false;
+						}
 						$wporg_user = wcorg_get_user_by_canonical_names( $value );
 						return (bool) $wporg_user;
 					},
@@ -710,7 +714,11 @@ function register_fav_sessions_email() {
 			'args'                => array(
 				'email-address' => array(
 					'required'          => true,
+					'type'              => 'string',
 					'validate_callback' => function ( $value, $request, $param ) {
+						if ( ! is_string( $value ) ) {
+							return false;
+						}
 						return is_email( trim( $value ) );
 					},
 					'sanitize_callback' => function ( $value, $request, $param ) {
@@ -720,7 +728,11 @@ function register_fav_sessions_email() {
 
 				'session-list'  => array(
 					'required'          => true,
+					'type'              => 'string',
 					'validate_callback' => function ( $value, $request, $param ) {
+						if ( ! is_string( $value ) ) {
+							return false;
+						}
 						$session_ids = explode( ',', $value );
 						$session_count = count( $session_ids );
 						for ( $i = 0; $i < $session_count; $i++ ) {
@@ -738,7 +750,11 @@ function register_fav_sessions_email() {
 
 				'page-slug'     => array(
 					'required'          => true,
+					'type'              => 'string',
 					'validate_callback' => function ( $value, $request, $param ) {
+						if ( ! is_string( $value ) ) {
+							return false;
+						}
 						$pages = get_posts( array(
 							'name'        => $value,
 							'post_type'   => 'page',


### PR DESCRIPTION
## Summary
- The `/wc-post-types/v1/validation` and `/wc-post-types/v1/email-fav-sessions` endpoints define custom `validate_callback`s that call `trim()` / `explode()` on the input, assuming it's a string.
- When a custom `validate_callback` is set, WP does not run the default type-based validation, so requests like `?username[0]=admin` reach `trim()`/`explode()` and trigger a fatal `TypeError` under PHP 8.
- Adds `'type' => 'string'` for documentation and an explicit `is_string()` guard in each `validate_callback` so array inputs are rejected cleanly with a 400 instead of a 500.

Observed in production logs from bots/scanners hitting:
- `/wp-json/wc-post-types/v1/validation?username[0]=admin`
- `/wp-json/wc-post-types/v1/email-fav-sessions` (with an array `session-list`)

## Test plan
- [ ] `curl 'https://<site>/wp-json/wc-post-types/v1/validation?username[0]=admin'` returns a 400, not a 500
- [ ] `curl 'https://<site>/wp-json/wc-post-types/v1/validation?username=somerealuser'` still validates correctly
- [ ] POST to `/wp-json/wc-post-types/v1/email-fav-sessions` with `email-address[]=foo` returns 400, not 500
- [ ] Normal favourite-sessions email submission flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)