### PR TITLE
Fix dynamic property deprecation in WordCamp_Post_Types_Plugin_Back_Compat

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
@@ -8,6 +8,7 @@
 class WordCamp_Post_Types_Plugin_Back_Compat {
 	protected $stylesheet = '';
 	protected $template   = '';
+	protected $wcpt;
 
 	function __construct() {
 		// This must run before `WordCamp_Post_Types_Plugin::init()` so that `wcpt_back_compat_init` is registered
@@ -58,7 +59,7 @@ class WordCamp_Post_Types_Plugin_Back_Compat {
 		global $wcpt_plugin;
 
 		// Keep a link to the main plugin object.
-		$this->wcpt =& $wcpt_plugin;
+		$this->wcpt = $wcpt_plugin;
 
 		add_filter( 'wcb_entry_meta', array( $this, 'wcb_session_entry_meta' ) );
 


### PR DESCRIPTION
## Summary
- PHP 8.2+ deprecates creation of dynamic properties. `WordCamp_Post_Types_Plugin_Back_Compat::$wcpt` was being created on the fly in `wcpt_back_compat_init()`, triggering: *Deprecated: Creation of dynamic property WordCamp_Post_Types_Plugin_Back_Compat::\$wcpt is deprecated in .../wc-post-types/inc/back-compat.php on line 61*.
- Declares `$wcpt` explicitly on the class alongside the existing `$stylesheet` / `$template`.
- Also drops the unnecessary `=&` reference assignment when capturing `$wcpt_plugin` — it's a PHP 4-ism. Since PHP 5, objects are handled by reference, so plain `=` already binds both names to the same instance.

## Test plan
- [ ] Load a wordcamp using the `wordcamp-base` or `wordcamp-base-v2` theme on a "back-compat" site (blog ID ≤ 528, excluding the listed exceptions). Confirm the deprecation no longer fires in the error log.
- [ ] Confirm the `[speakers]`, `[sessions]`, and `[sponsors]` shortcodes still render on those sites (they pull data via `$this->wcpt->get_sponsor_levels()` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)