### PR TITLE
Custom CSS Tweaks: Don't load if Jetpack isn't enabled.

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/custom-css.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/custom-css.php
@@ -23,6 +23,11 @@ if ( ! class_exists( 'Jetpack_Custom_CSS_Enhancements' ) ) {
 		 * Set up the actions and filters needed for our compatability layer on top of core's Custom CSS implementation.
 		 */
 		public static function add_hooks() {
+			// WordCamp: return early if Jetpack isn't enabled.
+			if ( ! class_exists( 'Jetpack' ) || ! defined( 'JETPACK__VERSION' ) ) {
+				return;
+			}
+
 			add_action( 'init', array( __CLASS__, 'init' ) );
 			add_action( 'customize_controls_enqueue_scripts', array( __CLASS__, 'customize_controls_enqueue_scripts' ) );
 			add_action( 'customize_register', array( __CLASS__, 'customize_register' ) );
@@ -1329,7 +1334,7 @@ if ( ! class_exists( 'Jetpack_Custom_CSS_Enhancements' ) ) {
 	}
 }
 
-Jetpack_Custom_CSS_Enhancements::add_hooks();
+add_action( 'plugins_loaded', [ 'Jetpack_Custom_CSS_Enhancements', 'add_hooks' ] );
 
 if ( ! function_exists( 'safecss_class' ) ) :
 	/**


### PR DESCRIPTION
Currently if Jetpack isn't enabled, the custom-css jetpack tweaks fatal error in multiple ways.

This just delays loading until plugins_loaded to verify if Jetpack gets enabled or not.