### PR TITLE
Jetpack CRM: Ensure admin color schemes have at least 4 color entries

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/crm.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/crm.php
@@ -13,22 +13,28 @@ defined( 'WPINC' ) || die();
  * @see ZeroBSCRM.AdminStyling.php:264
  * @see https://github.com/Automattic/jetpack/pull/47143
  */
-add_action( 'admin_head', function () {
-	if ( ! defined( 'ZBS_PLUGIN_DIR' ) ) {
-		return;
-	}
+add_action(
+	'admin_head',
+	function () {
+		if ( ! defined( 'ZBS_PLUGIN_DIR' ) ) {
+			return;
+		}
 
-	global $_wp_admin_css_colors;
+		global $_wp_admin_css_colors;
 
-	$current_color = get_user_option( 'admin_color' );
+		$current_color = get_user_option( 'admin_color' );
 
-	if ( ! isset( $_wp_admin_css_colors[ $current_color ] ) ) {
-		return;
-	}
+		if ( ! isset( $_wp_admin_css_colors[ $current_color ] ) ) {
+			return;
+		}
 
-	$colors = &$_wp_admin_css_colors[ $current_color ]->colors;
+		$colors     = &$_wp_admin_css_colors[ $current_color ]->colors;
+		$color_count = count( $colors );
 
-	while ( count( $colors ) < 4 ) {
-		$colors[] = end( $colors );
-	}
-}, 9 );
+		while ( $color_count < 4 ) {
+			$colors[] = end( $colors );
+			$color_count++;
+		}
+	},
+	9
+);

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/crm.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/crm.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WordCamp\Jetpack_Tweaks;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Ensure admin color schemes have at least 4 color entries.
+ *
+ * Workaround for zero-bs-crm accessing index 3 of `$_wp_admin_css_colors[scheme]->colors`
+ * when some color schemes only define 3 colors.
+ *
+ * @see ZeroBSCRM.AdminStyling.php:264
+ * @see https://github.com/Automattic/jetpack/pull/47143
+ */
+add_action( 'admin_head', function () {
+	if ( ! defined( 'ZBS_PLUGIN_DIR' ) ) {
+		return;
+	}
+
+	global $_wp_admin_css_colors;
+
+	$current_color = get_user_option( 'admin_color' );
+
+	if ( ! isset( $_wp_admin_css_colors[ $current_color ] ) ) {
+		return;
+	}
+
+	$colors = &$_wp_admin_css_colors[ $current_color ]->colors;
+
+	while ( count( $colors ) < 4 ) {
+		$colors[] = end( $colors );
+	}
+}, 9 );


### PR DESCRIPTION
## Summary

- Adds a new `jetpack-tweaks/crm.php` file with a workaround for zero-bs-crm accessing index 3 of `$_wp_admin_css_colors[scheme]->colors` when some color schemes only define 3 colors.
- Only applies when CRM is active (`ZBS_PLUGIN_DIR` defined).
- Upstream fix: https://github.com/Automattic/jetpack/pull/47143

## Test plan

- [ ] Activate a color scheme with only 3 colors while CRM is active — verify no PHP notice
- [ ] Verify the fix is skipped when CRM is not active


🤖 Generated with [Claude Code](https://claude.com/claude-code)