### PR TITLE
[Codex] Add centralized Stripe webhook for CampTix

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
@@ -54,8 +54,7 @@ trait CampTix_Payment_Method_Stripe_Webhook {
 			return $error;
 		}
 
-		$tolerance = (int) apply_filters( 'camptix_stripe_webhook_signature_tolerance', 5 * MINUTE_IN_SECONDS );
-		if ( $tolerance > 0 && abs( time() - $timestamp ) > $tolerance ) {
+		if ( abs( time() - $timestamp ) > 5 * MINUTE_IN_SECONDS ) {
 			return $error;
 		}
 

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * Centralized Stripe webhook handling for the CampTix Stripe payment method.
+ */
+trait CampTix_Payment_Method_Stripe_Webhook {
+	/**
+	 * Register the centralized Stripe webhook endpoint.
+	 */
+	public function register_rest_routes() {
+		if ( ! defined( 'WORDCAMP_ROOT_BLOG_ID' ) || (int) WORDCAMP_ROOT_BLOG_ID !== get_current_blog_id() ) {
+			return;
+		}
+
+		register_rest_route(
+			'camptix/v1',
+			'/stripe-webhook',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'rest_stripe_webhook' ),
+				'permission_callback' => array( $this, 'rest_stripe_webhook_permissions_check' ),
+			)
+		);
+	}
+
+	/**
+	 * Verify the Stripe webhook signature before dispatching to the route callback.
+	 *
+	 * @param WP_REST_Request $request The incoming REST request.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function rest_stripe_webhook_permissions_check( $request ) {
+		$payload          = $request->get_body();
+		$signature_header = $request->get_header( 'stripe-signature' );
+		$webhook_secret   = defined( 'WORDCAMP_CAMPTIX_STRIPE_LIVE_WEBHOOK_SECRET' ) ? trim( WORDCAMP_CAMPTIX_STRIPE_LIVE_WEBHOOK_SECRET ) : '';
+		$error            = new WP_Error(
+			'camptix_stripe_webhook_invalid_signature',
+			'Invalid Stripe webhook signature.',
+			array( 'status' => 403 )
+		);
+
+		if ( ! $webhook_secret || ! $signature_header ) {
+			return $error;
+		}
+
+		preg_match( '/(?:^|,)\s*t=(\d+)/', $signature_header, $timestamp_match );
+		preg_match_all( '/(?:^|,)\s*v1=([^,]+)/', $signature_header, $signature_matches );
+
+		$timestamp  = absint( $timestamp_match[1] ?? 0 );
+		$signatures = $signature_matches[1] ?? array();
+
+		if ( ! $timestamp || ! $signatures ) {
+			return $error;
+		}
+
+		$tolerance = (int) apply_filters( 'camptix_stripe_webhook_signature_tolerance', 5 * MINUTE_IN_SECONDS );
+		if ( $tolerance > 0 && abs( time() - $timestamp ) > $tolerance ) {
+			return $error;
+		}
+
+		$signed_payload = $timestamp . '.' . $payload;
+		$expected_signature = hash_hmac( 'sha256', $signed_payload, $webhook_secret );
+
+		foreach ( $signatures as $signature ) {
+			if ( hash_equals( $expected_signature, $signature ) ) {
+				return true;
+			}
+		}
+
+		return $error;
+	}
+
+	/**
+	 * Handle Stripe webhook notifications.
+	 *
+	 * This is intended to be called on central.wordcamp.org, then it switches
+	 * into the site that created the Checkout Session before updating tickets.
+	 *
+	 * @param WP_REST_Request $request The incoming REST request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function rest_stripe_webhook( $request ) {
+		$payload = $request->get_body();
+		$event   = json_decode( $payload, true );
+		if ( ! is_array( $event ) ) {
+			return new WP_Error(
+				'camptix_stripe_webhook_invalid_json',
+				'The Stripe webhook payload was not valid JSON.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$event_type      = $event['type'] ?? '';
+		$supported_types = array(
+			'checkout.session.completed',
+			'checkout.session.async_payment_succeeded',
+			'checkout.session.async_payment_failed',
+			'checkout.session.expired',
+		);
+
+		// Only gate webhook noise here; the fetched Checkout Session determines
+		// the CampTix payment result.
+		if ( ! in_array( $event_type, $supported_types, true ) ) {
+			return new WP_REST_Response(
+				array(
+					'status' => 'ignored',
+					'type'   => $event_type,
+				),
+				200
+			);
+		}
+
+		$webhook_session = $event['data']['object'] ?? array();
+		if ( ! is_array( $webhook_session ) ) {
+			return new WP_Error(
+				'camptix_stripe_webhook_missing_session',
+				'The Stripe webhook payload did not contain a Checkout Session.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$stripe_session_id = sanitize_text_field( $webhook_session['id'] ?? '' );
+		$payment_token     = $this->get_payment_token_from_webhook_session( $webhook_session );
+		$site_id           = $this->get_site_id_from_webhook_session( $webhook_session );
+
+		if ( ! $stripe_session_id || ! $payment_token || ! $site_id ) {
+			return new WP_Error(
+				'camptix_stripe_webhook_missing_session_data',
+				'The Stripe webhook payload did not contain enough session data to find the ticket order.',
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! get_site( $site_id ) ) {
+			return new WP_Error(
+				'camptix_stripe_webhook_invalid_site',
+				'The Stripe webhook payload referenced an unknown site.',
+				array( 'status' => 400 )
+			);
+		}
+
+		switch_to_blog( $site_id );
+		$response = $this->process_webhook_session_for_current_site( $event, $stripe_session_id, $payment_token );
+		restore_current_blog();
+
+		return $response;
+	}
+
+	/**
+	 * Process a webhook session after switching to the site that owns it.
+	 *
+	 * @param array  $event             The decoded Stripe event.
+	 * @param string $stripe_session_id Stripe Checkout Session ID.
+	 * @param string $payment_token     CampTix payment token.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	protected function process_webhook_session_for_current_site( $event, $stripe_session_id, $payment_token ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$order = $this->get_order( $payment_token );
+		if ( ! $order ) {
+			$camptix->log( 'Stripe webhook could not find an order for the payment token.', null, $event, 'stripe' );
+
+			return new WP_REST_Response(
+				array(
+					'status' => 'no_order',
+				),
+				200
+			);
+		}
+
+		$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
+		$session = $this->get_webhook_session_with_retry( $stripe, $stripe_session_id );
+
+		if ( is_wp_error( $session ) ) {
+			$camptix->log(
+				'Stripe webhook failed to fetch the latest Checkout Session.',
+				$order['attendee_id'],
+				$session,
+				'stripe'
+			);
+
+			return new WP_Error(
+				'camptix_stripe_webhook_session_lookup_failed',
+				'Could not fetch the latest Stripe Checkout Session.',
+				array( 'status' => 500 )
+			);
+		}
+
+		$event_type = $event['type'] ?? '';
+		$event_data = array(
+			'stripe_webhook_event' => array(
+				'id'   => sanitize_text_field( $event['id'] ?? '' ),
+				'type' => sanitize_text_field( $event_type ),
+			),
+		);
+
+		$status_changed = $this->process_payment_return_session(
+			$payment_token,
+			$session,
+			$order,
+			false, /* non-interactive */
+			$event_data
+		);
+
+		$camptix->log(
+			'Processed Stripe webhook.',
+			$order['attendee_id'],
+			array(
+				'event_id'       => $event['id'] ?? '',
+				'event_type'     => $event_type,
+				'status_changed' => $status_changed,
+			),
+			'stripe'
+		);
+
+		return new WP_REST_Response(
+			array(
+				'status'         => 'processed',
+				'status_changed' => (bool) $status_changed,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Retrieve a Stripe checkout session for webhook processing, retrying once on transient API errors.
+	 *
+	 * @param CampTix_Stripe_API_Client $stripe            The Stripe API client.
+	 * @param string                    $stripe_session_id The Stripe Checkout Session ID.
+	 *
+	 * @return array|WP_Error
+	 */
+	protected function get_webhook_session_with_retry( $stripe, $stripe_session_id ) {
+		$session = $stripe->get_session( $stripe_session_id );
+
+		if ( is_wp_error( $session ) ) {
+			$session = $stripe->get_session( $stripe_session_id );
+		}
+
+		return $session;
+	}
+
+	/**
+	 * Get the site ID from a Checkout Session.
+	 *
+	 * @param array $session Stripe Checkout Session.
+	 *
+	 * @return int
+	 */
+	protected function get_site_id_from_webhook_session( $session ) {
+		$client_reference = $this->get_client_reference_data_from_webhook_session( $session );
+
+		if ( ! empty( $client_reference['site_id'] ) && get_site( $client_reference['site_id'] ) ) {
+			return $client_reference['site_id'];
+		}
+
+		$url_parts = wp_parse_url( $session['success_url'] );
+		if ( ! $url_parts || empty( $url_parts['host'] ) || empty( $url_parts['path'] ) ) {
+			return 0;
+		}
+
+		$site = get_site_by_path( $url_parts['host'], $url_parts['path'] );
+
+		return $site ? (int) $site->blog_id : 0;
+	}
+
+	/**
+	 * Get the CampTix payment token from a Checkout Session.
+	 *
+	 * @param array $session Stripe Checkout Session.
+	 *
+	 * @return string
+	 */
+	protected function get_payment_token_from_webhook_session( $session ) {
+		$client_reference = $this->get_client_reference_data_from_webhook_session( $session );
+		if ( ! empty( $client_reference['payment_token'] ) ) {
+			return $client_reference['payment_token'];
+		}
+
+		$url_parts = wp_parse_url( $session['success_url'] );
+		parse_str( $url_parts['query'] ?? '', $query_args );
+
+		return sanitize_text_field( $query_args['tix_payment_token'] ?? '' );
+	}
+
+	/**
+	 * Read the CampTix data from a `site_id:payment_token` client reference ID.
+	 *
+	 * @param array $session Stripe Checkout Session.
+	 *
+	 * @return array
+	 */
+	protected function get_client_reference_data_from_webhook_session( $session ) {
+		if ( empty( $session['client_reference_id'] ) ) {
+			return array();
+		}
+
+		list( $site_id, $payment_token ) = explode( ':', $session['client_reference_id'], 2 );
+
+		return array(
+			'site_id'       => absint( $site_id ),
+			'payment_token' => sanitize_text_field( $payment_token ),
+		);
+	}
+}

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
@@ -112,7 +112,7 @@ trait CampTix_Payment_Method_Stripe_Webhook {
 			);
 		}
 
-		$webhook_session = $event['data']['object'] ?? array();
+		$webhook_session = $event['data']['object'] ?? false;
 		if ( ! is_array( $webhook_session ) ) {
 			return new WP_Error(
 				'camptix_stripe_webhook_missing_session',

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -60,7 +60,9 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
-		add_action( 'switch_blog', array( $this, 'reload_options' ) );
+
+		// Run after CampTix_Plugin::reload_options() refreshes the switched site's options.
+		add_action( 'switch_blog', array( $this, 'reload_options' ), 11 );
 
 		// register_rest_routes() is provided by CampTix_Payment_Method_Stripe_Webhook.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
@@ -364,6 +366,10 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	public function reload_options( $new_blog_id = null, $prev_blog_id = null, $context = null ) {
 		/** @var CampTix_Plugin $camptix */
 		global $camptix;
+
+		if ( doing_filter( 'camptix_options' ) ) {
+			return;
+		}
 
 		$this->camptix_options = $camptix->get_options();
 		$this->options         = array_merge(

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -1,6 +1,10 @@
 <?php
 
+require_once __DIR__ . '/payment-stripe-webhook.php';
+
 class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
+	use CampTix_Payment_Method_Stripe_Webhook;
+
 	public $id          = 'stripe';
 	public $name        = 'Credit Card (Stripe)';
 	public $description = 'Credit card processing, powered by Stripe.';
@@ -56,9 +60,11 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
+		add_action( 'switch_blog', array( $this, 'reload_options' ) );
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 
 		// Use specific name for INR as we support UPI via Stripe.
-		if ( 'INR' === $this->camptix_options['currency'] ?? '' ) {
+		if ( 'INR' === ( $this->camptix_options['currency'] ?? '' ) ) {
 			$this->name = 'Credit Card or UPI (Stripe)';
 			$this->description = 'Credit card and UPI processing, powered by Stripe.';
 		}
@@ -351,6 +357,163 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	}
 
 	/**
+	 * Refresh Stripe options after switching blogs.
+	 */
+	public function reload_options( $new_blog_id = null, $prev_blog_id = null, $context = null ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$this->camptix_options = $camptix->get_options();
+		$this->options         = array_merge(
+			array(
+				'api_predef'          => '',
+				'api_secret_key'      => '',
+				'api_public_key'      => '',
+				'api_test_secret_key' => '',
+				'api_test_public_key' => '',
+				'sandbox'             => true,
+			),
+			$this->get_payment_options()
+		);
+	}
+
+	/**
+	 * Get the payment data CampTix stores for a Stripe Checkout Session.
+	 *
+	 * @param array $session                   The Stripe Checkout Session.
+	 * @param array $transaction_details_extra Extra transaction details to store.
+	 *
+	 * @return array
+	 */
+	protected function get_payment_data_for_session( $session, $transaction_details_extra = array() ) {
+		$payment_intent = $session['payment_intent'] ?? array();
+		$transaction_id = is_array( $payment_intent ) ? ( $payment_intent['latest_charge'] ?? '' ) : '';
+		$details        = array_merge(
+			array(
+				'raw' => $session,
+			),
+			$transaction_details_extra
+		);
+
+		return array(
+			'transaction_id'      => $transaction_id,
+			'transaction_details' => $details,
+		);
+	}
+
+	/**
+	 * Process a fetched Stripe Checkout Session through the normal return flow.
+	 *
+	 * @param string $payment_token             CampTix payment token.
+	 * @param array  $session                   Stripe Checkout Session.
+	 * @param array  $order                     CampTix order data.
+	 * @param bool   $interactive               Whether this request can redirect/die.
+	 * @param array  $transaction_details_extra Extra transaction details to store.
+	 *
+	 * @return int|bool
+	 */
+	protected function process_payment_return_session( $payment_token, $session, $order, $interactive = true, $transaction_details_extra = array() ) {
+		/** @var $camptix CampTix_Plugin */
+		global $camptix;
+
+		$session_status = $session['status'] ?? '';
+		$payment_status = $session['payment_status'] ?? '';
+		$payment_intent = $session['payment_intent'] ?? array();
+		$intent_status  = is_array( $payment_intent ) ? ( $payment_intent['status'] ?? '' ) : '';
+
+		if ( ! $session_status ) {
+			$camptix->log( "Dying because couldn't get Payment status", $order['attendee_id'], compact( 'payment_token', 'session' ) );
+
+			if ( $interactive ) {
+				wp_die( 'could not find payment details' );
+			}
+
+			return false;
+		}
+
+		if ( 'expired' === $session_status ) {
+			return $camptix->payment_result(
+				$payment_token,
+				CampTix_Plugin::PAYMENT_STATUS_TIMEOUT,
+				$this->get_payment_data_for_session( $session, $transaction_details_extra ),
+				$interactive
+			);
+		}
+
+		if ( 'open' === $session_status || in_array( $intent_status, array( 'canceled', 'requires_payment_method' ), true ) ) {
+			return $this->process_payment_failed_session(
+				$payment_token,
+				$session,
+				$interactive,
+				array_merge(
+					array(
+						'error' => 'Error during Payment checkout',
+					),
+					$transaction_details_extra
+				),
+				$order['attendee_id']
+			);
+		}
+
+		if (
+			'complete' === $session_status &&
+			in_array( $payment_status, array( 'paid', 'no_payment_required' ), true )
+		) {
+			return $camptix->payment_result(
+				$payment_token,
+				CampTix_Plugin::PAYMENT_STATUS_COMPLETED,
+				$this->get_payment_data_for_session( $session, $transaction_details_extra ),
+				$interactive
+			);
+		}
+
+		if (
+			( 'complete' === $session_status && 'unpaid' === $payment_status ) ||
+			in_array( $intent_status, array( 'processing', 'requires_action', 'requires_capture', 'requires_confirmation' ), true )
+		) {
+			return $camptix->payment_result(
+				$payment_token,
+				CampTix_Plugin::PAYMENT_STATUS_PENDING,
+				$this->get_payment_data_for_session( $session, $transaction_details_extra ),
+				$interactive
+			);
+		}
+
+		$camptix->log( "Dying because couldn't determine Payment status", $order['attendee_id'], compact( 'payment_token', 'session' ) );
+
+		if ( $interactive ) {
+			wp_die( 'could not determine payment status' );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Process a fetched Stripe Checkout Session as a failed payment.
+	 *
+	 * @param string $payment_token             CampTix payment token.
+	 * @param array  $session                   Stripe Checkout Session.
+	 * @param bool   $interactive               Whether this request can redirect/die.
+	 * @param array  $transaction_details_extra Extra transaction details to store.
+	 * @param int    $attendee_id               The attendee ID to log against.
+	 *
+	 * @return int|bool
+	 */
+	protected function process_payment_failed_session( $payment_token, $session, $interactive = true, $transaction_details_extra = array(), $attendee_id = null ) {
+		/** @var $camptix CampTix_Plugin */
+		global $camptix;
+
+		$camptix->log( 'Error during post-stripe checkout.', $attendee_id, $session );
+
+		return $camptix->payment_result(
+			$payment_token,
+			CampTix_Plugin::PAYMENT_STATUS_FAILED,
+			$this->get_payment_data_for_session( $session, $transaction_details_extra ),
+			$interactive
+		);
+	}
+
+	/**
 	 * Handle a canceled payment
 	 *
 	 * Runs when the user cancels their payment during checkout at Stripe.
@@ -410,37 +573,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		$stripe  = new CampTix_Stripe_API_Client( $payment_token, $this->get_api_credentials()['api_secret_key'] );
 		$session = $stripe->get_session( $stripe_session );
 
-		if ( empty( $session['status'] ) ) {
-			$camptix->log( "Dying because couldn't get Payment status", $order['attendee_id'], compact( 'payment_token', 'payment_session' ) );
-			wp_die( 'could not find payment details' );
-		}
-
-		// Hmm.. Not finalised.
-		if ( 'open' === $session['status'] ) {
-			$payment_data = array(
-				'error' => 'Error during Payment checkout',
-				'data' => $session,
-			);
-			$camptix->log( 'Error during post-stripe checkout.', $order['attendee_id'], $session );
-			return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_FAILED, $payment_data );
-		}
-
-		// Success! (status can only be open, or completed)
-		// Technically there can be multiple charges (ie. partial payments / installments) but we don't have that enabled.
-		$transaction_id = $session['payment_intent']['latest_charge'] ?? '';
-
-		/**
-		 * Note that when returning a successful payment, CampTix will be
-		 * expecting the transaction_id and transaction_details array keys.
-		 */
-		$payment_data = array(
-			'transaction_id'      => $transaction_id,
-			'transaction_details' => array(
-				'raw' => $session,
-			),
-		);
-
-		return $camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, $payment_data );
+		return $this->process_payment_return_session( $payment_token, $session, $order );
 	}
 
 	/**
@@ -902,6 +1035,7 @@ class CampTix_Stripe_API_Client {
 			'submit_type'         => 'pay',
 			'success_url'         => $return_url,
 			'cancel_url'          => $cancel_url,
+			'client_reference_id' => get_current_blog_id() . ':' . $this->payment_token,
 			'line_items'          => $line_items,
 			'payment_intent_data' => array(
 				'description'          => $description, // Displayed in Stripe Dashboard.

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -61,6 +61,8 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
 		add_action( 'switch_blog', array( $this, 'reload_options' ) );
+
+		// register_rest_routes() is provided by CampTix_Payment_Method_Stripe_Webhook.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 
 		// Use specific name for INR as we support UPI via Stripe.

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -113,6 +113,7 @@ class CampTix_Plugin {
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'init', array( $this, 'schedule_events' ), 9 );
 		add_action( 'shutdown', array( $this, 'shutdown' ) );
+		add_action( 'switch_blog', array( $this, 'reload_options' ) );
 	}
 
 	/**
@@ -1305,6 +1306,20 @@ class CampTix_Plugin {
 		}
 
 		return $options;
+	}
+
+	/**
+	 * Reload request-scoped options after switching sites in a multisite request.
+	 *
+	 * CampTix caches options for the current request, but centralized webhooks need
+	 * to switch into the site where the ticket order lives before processing it.
+	 */
+	function reload_options( $new_blog_id = null, $prev_blog_id = null, $context = null ) {
+		$this->tmp = array();
+
+		unset( $this->options, $this->tickets_url );
+
+		$this->options = $this->get_options();
 	}
 
 	/*

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1315,6 +1315,10 @@ class CampTix_Plugin {
 	 * to switch into the site where the ticket order lives before processing it.
 	 */
 	function reload_options( $new_blog_id = null, $prev_blog_id = null, $context = null ) {
+		if ( doing_filter( 'camptix_options' ) ) {
+			return;
+		}
+
 		$this->tmp = array();
 
 		unset( $this->options, $this->tickets_url );

--- a/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
@@ -1,6 +1,10 @@
 <?php
 defined( 'WPINC' ) || die();
 
+if ( ! defined( 'WORDCAMP_CAMPTIX_STRIPE_LIVE_WEBHOOK_SECRET' ) ) {
+	define( 'WORDCAMP_CAMPTIX_STRIPE_LIVE_WEBHOOK_SECRET', 'whsec_test_secret' );
+}
+
 /**
  * @covers CampTix_Payment_Method_Stripe
  */
@@ -45,5 +49,32 @@ class Test_Camptix_Payment_Stripe_Addon extends \WP_UnitTestCase {
 		} catch ( Exception $e ) {
 			$this->assertEquals( 'Unknown currency multiplier for DUMMY.', $e->getMessage() );
 		}
+	}
+
+	/**
+	 * @covers CampTix_Payment_Method_Stripe::rest_stripe_webhook_permissions_check
+	 */
+	public function test_rest_stripe_webhook_permissions_check() {
+		$client    = new CampTix_Payment_Method_Stripe();
+		$payload   = wp_json_encode( array( 'id' => 'evt_test' ) );
+		$timestamp = time();
+		$signature = hash_hmac(
+			'sha256',
+			$timestamp . '.' . $payload,
+			WORDCAMP_CAMPTIX_STRIPE_LIVE_WEBHOOK_SECRET
+		);
+		$request   = new WP_REST_Request( 'POST', '/camptix/v1/stripe-webhook' );
+
+		$request->set_body( $payload );
+		$request->set_header( 'stripe-signature', 't=' . $timestamp . ',v1=' . $signature );
+
+		$this->assertTrue( $client->rest_stripe_webhook_permissions_check( $request ) );
+
+		$request->set_header( 'stripe-signature', 't=' . $timestamp . ',v1=invalid' );
+
+		$result = $client->rest_stripe_webhook_permissions_check( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'camptix_stripe_webhook_invalid_signature', $result->get_error_code() );
 	}
 }


### PR DESCRIPTION
> This PR was generated by Codex.

Fixes #1255

## What Changed

Adds a centralized Stripe webhook endpoint for CampTix at `camptix/v1/stripe-webhook`, registered only on the central WordCamp site.

The webhook verifies Stripe signatures in the REST permission callback, resolves the owning site from Checkout Session data, switches to that site, fetches the latest Checkout Session from Stripe, and processes the ticket payment from the fetched session state.

Checkout Sessions now include `client_reference_id` as `{$site_id}:{$payment_token}` so new payments can be routed directly. Existing payments can still be inferred from the return/cancel URLs in the session.

## Why

Stripe notifications can update Ticket state immediately even if the attendee does not return to the WordCamp site after checkout. Keeping the endpoint centralized means Stripe only needs one webhook URL for the multisite network instead of a separate webhook per event site.

## Validation

- `php -l public_html/wp-content/plugins/camptix/addons/payment-stripe.php`
- `php -l public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php`
- `php -l public_html/wp-content/plugins/camptix/camptix.php`
- `php -l public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php`
- `git diff --check`
