### PR TITLE
CampTix: Load options at call time instead of via switch_blog hook

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -43,7 +43,6 @@ add_action( 'admin_notices',                                 __NAMESPACE__ . '\a
 add_filter( 'wp_privacy_personal_data_erasers',              __NAMESPACE__ . '\modify_erasers',                  99 );
 
 // Miscellaneous
-add_filter( 'camptix_beta_features_enabled',                 '__return_true' );
 add_action( 'camptix_nt_file_log',                           '__return_false' );
 add_action( 'init',                                          __NAMESPACE__ . '\camptix_debug',                    9 ); // CampTix does this at 10.
 add_filter( 'camptix_default_addons',                        __NAMESPACE__ . '\load_addons'                         );

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
@@ -140,9 +140,24 @@ trait CampTix_Payment_Method_Stripe_Webhook {
 			);
 		}
 
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
 		switch_to_blog( $site_id );
+
+		// Load this site's options at call time. Many CampTix code paths
+		// (notably payment_result() and email_tickets()) read `$camptix->options`
+		// directly rather than going through get_options(), so the cache must
+		// be primed for the switched-to site before they run.
+		$camptix->get_options();
+
 		$response = $this->process_webhook_session_for_current_site( $event, $stripe_session_id, $payment_token );
+
 		restore_current_blog();
+
+		// Re-prime the cache for the original site so any later reads in this
+		// request (e.g. shutdown handlers) don't see the webhook's site data.
+		$camptix->get_options();
 
 		return $response;
 	}

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe-webhook.php
@@ -145,19 +145,22 @@ trait CampTix_Payment_Method_Stripe_Webhook {
 
 		switch_to_blog( $site_id );
 
-		// Load this site's options at call time. Many CampTix code paths
-		// (notably payment_result() and email_tickets()) read `$camptix->options`
-		// directly rather than going through get_options(), so the cache must
-		// be primed for the switched-to site before they run.
-		$camptix->get_options();
+		// Load this site's options. CampTix and the Stripe addon both cache
+		// options on the request, and many code paths read those caches
+		// directly (notably `$camptix->options` in payment_result() and
+		// email_tickets()). Refreshing both caches here keeps those reads
+		// pointing at the switched-to site.
+		$camptix->load_options();
+		$this->load_options();
 
 		$response = $this->process_webhook_session_for_current_site( $event, $stripe_session_id, $payment_token );
 
 		restore_current_blog();
 
-		// Re-prime the cache for the original site so any later reads in this
-		// request (e.g. shutdown handlers) don't see the webhook's site data.
-		$camptix->get_options();
+		// Restore the caches to the original site for any later code in this
+		// request that reads the cached options directly.
+		$camptix->load_options();
+		$this->load_options();
 
 		return $response;
 	}

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -46,7 +46,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	 * @see CampTix_Addon
 	 */
 	public function camptix_init() {
-		$this->options = $this->get_stripe_options();
+		$this->load_options();
 
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
@@ -62,16 +62,16 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	}
 
 	/**
-	 * Read the Stripe payment options for the current site.
+	 * Refresh `$this->camptix_options` and `$this->options` for the current site.
 	 *
-	 * Always loaded fresh so that callers running after `switch_to_blog()` (such
-	 * as the centralized webhook) see the switched-to site's credentials without
-	 * relying on a cached `$this->options` snapshot.
-	 *
-	 * @return array
+	 * Called from `camptix_init()` to populate the cache, and again from the
+	 * centralized webhook handler after `switch_to_blog()` to refresh the
+	 * cache for the switched-to site.
 	 */
-	protected function get_stripe_options() {
-		return array_merge(
+	public function load_options() {
+		parent::load_options();
+
+		$this->options = array_merge(
 			array(
 				'api_predef'          => '',
 				'api_secret_key'      => '',
@@ -87,9 +87,9 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	/**
 	 * Get the credentials for the API account.
 	 *
-	 * Reads the latest Stripe options at call time so this returns the correct
-	 * credentials for the current site after a `switch_to_blog()`. If a
-	 * predefined account is configured, those credentials are used instead.
+	 * If a standard account is setup, this will just use the value that's
+	 * already in $this->options. If a predefined account is setup, though, it
+	 * will use those instead.
 	 *
 	 * SECURITY WARNING: This must be called on the fly, and saved in a local
 	 * variable instead of $this->options. Storing the predef credentials in
@@ -105,8 +105,7 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	 * @return array
 	 */
 	public function get_api_credentials() {
-		$options = $this->get_stripe_options();
-		$options = array_merge( $options, $this->get_predefined_account( $options['api_predef'] ) );
+		$options = array_merge( $this->options, $this->get_predefined_account( $this->options['api_predef'] ) );
 
 		$prefix = 'api_';
 		if ( true === $options['sandbox'] ) {

--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -46,23 +46,10 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	 * @see CampTix_Addon
 	 */
 	public function camptix_init() {
-		$this->options = array_merge(
-			array(
-				'api_predef'          => '',
-				'api_secret_key'      => '',
-				'api_public_key'      => '',
-				'api_test_secret_key' => '',
-				'api_test_public_key' => '',
-				'sandbox'             => true,
-			),
-			$this->get_payment_options()
-		);
+		$this->options = $this->get_stripe_options();
 
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
 		add_action( 'camptix_pre_attendee_timeout', array( $this, 'pre_attendee_timeout' ) );
-
-		// Run after CampTix_Plugin::reload_options() refreshes the switched site's options.
-		add_action( 'switch_blog', array( $this, 'reload_options' ), 11 );
 
 		// register_rest_routes() is provided by CampTix_Payment_Method_Stripe_Webhook.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
@@ -75,11 +62,34 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	}
 
 	/**
+	 * Read the Stripe payment options for the current site.
+	 *
+	 * Always loaded fresh so that callers running after `switch_to_blog()` (such
+	 * as the centralized webhook) see the switched-to site's credentials without
+	 * relying on a cached `$this->options` snapshot.
+	 *
+	 * @return array
+	 */
+	protected function get_stripe_options() {
+		return array_merge(
+			array(
+				'api_predef'          => '',
+				'api_secret_key'      => '',
+				'api_public_key'      => '',
+				'api_test_secret_key' => '',
+				'api_test_public_key' => '',
+				'sandbox'             => true,
+			),
+			$this->get_payment_options()
+		);
+	}
+
+	/**
 	 * Get the credentials for the API account.
 	 *
-	 * If a standard account is setup, this will just use the value that's
-	 * already in $this->options. If a predefined account is setup, though, it
-	 * will use those instead.
+	 * Reads the latest Stripe options at call time so this returns the correct
+	 * credentials for the current site after a `switch_to_blog()`. If a
+	 * predefined account is configured, those credentials are used instead.
 	 *
 	 * SECURITY WARNING: This must be called on the fly, and saved in a local
 	 * variable instead of $this->options. Storing the predef credentials in
@@ -95,7 +105,8 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 	 * @return array
 	 */
 	public function get_api_credentials() {
-		$options = array_merge( $this->options, $this->get_predefined_account( $this->options['api_predef'] ) );
+		$options = $this->get_stripe_options();
+		$options = array_merge( $options, $this->get_predefined_account( $options['api_predef'] ) );
 
 		$prefix = 'api_';
 		if ( true === $options['sandbox'] ) {
@@ -358,31 +369,6 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 				$this->payment_return();
 			}
 		}
-	}
-
-	/**
-	 * Refresh Stripe options after switching blogs.
-	 */
-	public function reload_options( $new_blog_id = null, $prev_blog_id = null, $context = null ) {
-		/** @var CampTix_Plugin $camptix */
-		global $camptix;
-
-		if ( doing_filter( 'camptix_options' ) ) {
-			return;
-		}
-
-		$this->camptix_options = $camptix->get_options();
-		$this->options         = array_merge(
-			array(
-				'api_predef'          => '',
-				'api_secret_key'      => '',
-				'api_public_key'      => '',
-				'api_test_secret_key' => '',
-				'api_test_public_key' => '',
-				'sandbox'             => true,
-			),
-			$this->get_payment_options()
-		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -15,7 +15,6 @@
 
 class CampTix_Plugin {
 	protected $options;
-	protected $options_blog_id;
 	protected $notices;
 	protected $errors;
 	protected $infos;
@@ -120,21 +119,9 @@ class CampTix_Plugin {
 	 * Fired during init, doh!
 	 */
 	function init() {
+		$this->load_options();
 		$this->debug = (bool) apply_filters( 'camptix_debug', false );
 		$this->beta_features_enabled = (bool) apply_filters( 'camptix_beta_features_enabled', false );
-
-		// Disable beta features unless explicitly enabled. Registered before the
-		// first get_options() call so it also applies whenever options are
-		// re-fetched after a blog switch.
-		if ( ! $this->beta_features_enabled ) {
-			add_filter( 'camptix_options', array( $this, '_disable_beta_features' ) );
-		}
-
-		// Invalidate any cached options populated during addon loading (before the
-		// beta-features filter was registered) so the filter applies.
-		$this->options         = null;
-		$this->options_blog_id = null;
-		$this->options         = $this->get_options();
 		$this->tmp = array();
 
 		// Capability mapping.
@@ -147,6 +134,11 @@ class CampTix_Plugin {
 			'delete_attendees' => 'manage_options',
 			'refund_all'       => 'manage_options',
 		) );
+
+		// Explicitly disable all beta features if beta features is off.
+		if ( ! $this->beta_features_enabled )
+			foreach ( $this->get_beta_features() as $beta_feature )
+				$this->options[$beta_feature] = false;
 
 		// The following three are just different kinds (colors) of user feedback.
 		// Don't use directly, instead use $this->notice / error / info methods.
@@ -1289,30 +1281,32 @@ class CampTix_Plugin {
 	/**
 	 * Returns an array of options stored in the database, or a set of defaults.
 	 *
-	 * The result is cached per-blog so multisite requests that `switch_to_blog()`
-	 * (such as the centralized Stripe webhook) load the correct site's options at
-	 * call time without needing to listen for `switch_blog`.
+	 * The result is cached in `$this->options` after the first call. Multisite
+	 * callers (such as the centralized Stripe webhook) should call
+	 * `load_options()` after `switch_to_blog()` to refresh the cache for the
+	 * switched-to site.
 	 */
 	function get_options() {
-		$current_blog_id = get_current_blog_id();
-
-		// Reuse the cached copy when it already matches the current blog.
-		if (
-			is_array( $this->options ) && ! empty( $this->options )
-			&& $this->options_blog_id === $current_blog_id
-		) {
+		// Allow other plugins to get CampTix options.
+		if ( isset( $this->options ) && is_array( $this->options ) && ! empty( $this->options ) ) {
 			return $this->options;
 		}
 
-		// Avoid reentrancy when `apply_filters( 'camptix_options' )` triggers
-		// another call to this method (e.g. from a filter callback that reads
-		// CampTix options).
-		if ( doing_filter( 'camptix_options' ) ) {
-			return is_array( $this->options ) ? $this->options : array();
-		}
+		return $this->load_options();
+	}
 
+	/**
+	 * Load the current site's CampTix options into `$this->options`.
+	 *
+	 * Called once during `init()`. Multisite callers can call this again after
+	 * `switch_to_blog()` to refresh `$this->options` (and any internal CampTix
+	 * code that reads it directly) for the switched-to site.
+	 *
+	 * @return array The freshly loaded options.
+	 */
+	function load_options() {
 		$default_options = $this->get_default_options();
-		$options = array_merge( $default_options, get_option( 'camptix_options', array() ) );
+		$options         = array_merge( $default_options, get_option( 'camptix_options', array() ) );
 
 		// Allow plugins to hi-jack or read the options.
 		$options = apply_filters( 'camptix_options', $options );
@@ -1328,8 +1322,7 @@ class CampTix_Plugin {
 			$this->upgrade( $options['version'] );
 		}
 
-		$this->options         = $options;
-		$this->options_blog_id = $current_blog_id;
+		$this->options = $options;
 
 		return $options;
 	}
@@ -1621,19 +1614,6 @@ class CampTix_Plugin {
 			'refund_all_enabled',
 			'archived',
 		);
-	}
-
-	/**
-	 * Force-disable beta features in the loaded options.
-	 *
-	 * Hooked into `camptix_options` so it applies on every option load,
-	 * including blog-aware re-fetches after `switch_to_blog()`.
-	 */
-	function _disable_beta_features( $options ) {
-		foreach ( $this->get_beta_features() as $beta_feature ) {
-			$options[ $beta_feature ] = false;
-		}
-		return $options;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -119,13 +119,9 @@ class CampTix_Plugin {
 	 * Fired during init, doh!
 	 */
 	function init() {
-		$this->debug                 = (bool) apply_filters( 'camptix_debug', false );
-		$this->beta_features_enabled = (bool) apply_filters( 'camptix_beta_features_enabled', false );
-
-		// Load options after `beta_features_enabled` is known so the
-		// beta-features kill-switch in load_options() applies on the first
-		// load and on every subsequent reload (e.g. after switch_to_blog).
 		$this->load_options();
+		$this->debug = (bool) apply_filters( 'camptix_debug', false );
+		$this->beta_features_enabled = (bool) apply_filters( 'camptix_beta_features_enabled', false );
 		$this->tmp = array();
 
 		// Capability mapping.
@@ -138,6 +134,11 @@ class CampTix_Plugin {
 			'delete_attendees' => 'manage_options',
 			'refund_all'       => 'manage_options',
 		) );
+
+		// Explicitly disable all beta features if beta features is off.
+		if ( ! $this->beta_features_enabled )
+			foreach ( $this->get_beta_features() as $beta_feature )
+				$this->options[$beta_feature] = false;
 
 		// The following three are just different kinds (colors) of user feedback.
 		// Don't use directly, instead use $this->notice / error / info methods.
@@ -1319,15 +1320,6 @@ class CampTix_Plugin {
 		// Let's see if we need to run an upgrade scenario.
 		if ( apply_filters( 'camptix_enable_automatic_upgrades', true ) && $options['version'] < $this->version ) {
 			$this->upgrade( $options['version'] );
-		}
-
-		// Explicitly disable all beta features if beta features is off. Done
-		// here (rather than once in init()) so reloads on a different site
-		// keep the kill-switch in effect.
-		if ( isset( $this->beta_features_enabled ) && ! $this->beta_features_enabled ) {
-			foreach ( $this->get_beta_features() as $beta_feature ) {
-				$options[ $beta_feature ] = false;
-			}
 		}
 
 		$this->options = $options;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -119,9 +119,13 @@ class CampTix_Plugin {
 	 * Fired during init, doh!
 	 */
 	function init() {
-		$this->load_options();
-		$this->debug = (bool) apply_filters( 'camptix_debug', false );
+		$this->debug                 = (bool) apply_filters( 'camptix_debug', false );
 		$this->beta_features_enabled = (bool) apply_filters( 'camptix_beta_features_enabled', false );
+
+		// Load options after `beta_features_enabled` is known so the
+		// beta-features kill-switch in load_options() applies on the first
+		// load and on every subsequent reload (e.g. after switch_to_blog).
+		$this->load_options();
 		$this->tmp = array();
 
 		// Capability mapping.
@@ -134,11 +138,6 @@ class CampTix_Plugin {
 			'delete_attendees' => 'manage_options',
 			'refund_all'       => 'manage_options',
 		) );
-
-		// Explicitly disable all beta features if beta features is off.
-		if ( ! $this->beta_features_enabled )
-			foreach ( $this->get_beta_features() as $beta_feature )
-				$this->options[$beta_feature] = false;
 
 		// The following three are just different kinds (colors) of user feedback.
 		// Don't use directly, instead use $this->notice / error / info methods.
@@ -1320,6 +1319,15 @@ class CampTix_Plugin {
 		// Let's see if we need to run an upgrade scenario.
 		if ( apply_filters( 'camptix_enable_automatic_upgrades', true ) && $options['version'] < $this->version ) {
 			$this->upgrade( $options['version'] );
+		}
+
+		// Explicitly disable all beta features if beta features is off. Done
+		// here (rather than once in init()) so reloads on a different site
+		// keep the kill-switch in effect.
+		if ( isset( $this->beta_features_enabled ) && ! $this->beta_features_enabled ) {
+			foreach ( $this->get_beta_features() as $beta_feature ) {
+				$options[ $beta_feature ] = false;
+			}
 		}
 
 		$this->options = $options;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -15,6 +15,7 @@
 
 class CampTix_Plugin {
 	protected $options;
+	protected $options_blog_id;
 	protected $notices;
 	protected $errors;
 	protected $infos;
@@ -113,16 +114,27 @@ class CampTix_Plugin {
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'init', array( $this, 'schedule_events' ), 9 );
 		add_action( 'shutdown', array( $this, 'shutdown' ) );
-		add_action( 'switch_blog', array( $this, 'reload_options' ) );
 	}
 
 	/**
 	 * Fired during init, doh!
 	 */
 	function init() {
-		$this->options = $this->get_options();
 		$this->debug = (bool) apply_filters( 'camptix_debug', false );
 		$this->beta_features_enabled = (bool) apply_filters( 'camptix_beta_features_enabled', false );
+
+		// Disable beta features unless explicitly enabled. Registered before the
+		// first get_options() call so it also applies whenever options are
+		// re-fetched after a blog switch.
+		if ( ! $this->beta_features_enabled ) {
+			add_filter( 'camptix_options', array( $this, '_disable_beta_features' ) );
+		}
+
+		// Invalidate any cached options populated during addon loading (before the
+		// beta-features filter was registered) so the filter applies.
+		$this->options         = null;
+		$this->options_blog_id = null;
+		$this->options         = $this->get_options();
 		$this->tmp = array();
 
 		// Capability mapping.
@@ -135,11 +147,6 @@ class CampTix_Plugin {
 			'delete_attendees' => 'manage_options',
 			'refund_all'       => 'manage_options',
 		) );
-
-		// Explicitly disable all beta features if beta features is off.
-		if ( ! $this->beta_features_enabled )
-			foreach ( $this->get_beta_features() as $beta_feature )
-				$this->options[$beta_feature] = false;
 
 		// The following three are just different kinds (colors) of user feedback.
 		// Don't use directly, instead use $this->notice / error / info methods.
@@ -1281,12 +1288,28 @@ class CampTix_Plugin {
 
 	/**
 	 * Returns an array of options stored in the database, or a set of defaults.
+	 *
+	 * The result is cached per-blog so multisite requests that `switch_to_blog()`
+	 * (such as the centralized Stripe webhook) load the correct site's options at
+	 * call time without needing to listen for `switch_blog`.
 	 */
 	function get_options() {
+		$current_blog_id = get_current_blog_id();
 
-		// Allow other plugins to get CampTix options.
-		if ( isset( $this->options ) && is_array( $this->options ) && ! empty( $this->options ) )
+		// Reuse the cached copy when it already matches the current blog.
+		if (
+			is_array( $this->options ) && ! empty( $this->options )
+			&& $this->options_blog_id === $current_blog_id
+		) {
 			return $this->options;
+		}
+
+		// Avoid reentrancy when `apply_filters( 'camptix_options' )` triggers
+		// another call to this method (e.g. from a filter callback that reads
+		// CampTix options).
+		if ( doing_filter( 'camptix_options' ) ) {
+			return is_array( $this->options ) ? $this->options : array();
+		}
 
 		$default_options = $this->get_default_options();
 		$options = array_merge( $default_options, get_option( 'camptix_options', array() ) );
@@ -1305,25 +1328,10 @@ class CampTix_Plugin {
 			$this->upgrade( $options['version'] );
 		}
 
+		$this->options         = $options;
+		$this->options_blog_id = $current_blog_id;
+
 		return $options;
-	}
-
-	/**
-	 * Reload request-scoped options after switching sites in a multisite request.
-	 *
-	 * CampTix caches options for the current request, but centralized webhooks need
-	 * to switch into the site where the ticket order lives before processing it.
-	 */
-	function reload_options( $new_blog_id = null, $prev_blog_id = null, $context = null ) {
-		if ( doing_filter( 'camptix_options' ) ) {
-			return;
-		}
-
-		$this->tmp = array();
-
-		unset( $this->options, $this->tickets_url );
-
-		$this->options = $this->get_options();
 	}
 
 	/*
@@ -1613,6 +1621,19 @@ class CampTix_Plugin {
 			'refund_all_enabled',
 			'archived',
 		);
+	}
+
+	/**
+	 * Force-disable beta features in the loaded options.
+	 *
+	 * Hooked into `camptix_options` so it applies on every option load,
+	 * including blog-aware re-fetches after `switch_to_blog()`.
+	 */
+	function _disable_beta_features( $options ) {
+		foreach ( $this->get_beta_features() as $beta_feature ) {
+			$options[ $beta_feature ] = false;
+		}
+		return $options;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -25,7 +25,6 @@ class CampTix_Plugin {
 
 	public $error_flags;
 	public $debug;
-	public $beta_features_enabled;
 	public $version     = 20180709;
 	public $css_version = 20180709;
 	public $js_version  = 20180709;
@@ -121,7 +120,6 @@ class CampTix_Plugin {
 	function init() {
 		$this->load_options();
 		$this->debug = (bool) apply_filters( 'camptix_debug', false );
-		$this->beta_features_enabled = (bool) apply_filters( 'camptix_beta_features_enabled', false );
 		$this->tmp = array();
 
 		// Capability mapping.

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -135,11 +135,6 @@ class CampTix_Plugin {
 			'refund_all'       => 'manage_options',
 		) );
 
-		// Explicitly disable all beta features if beta features is off.
-		if ( ! $this->beta_features_enabled )
-			foreach ( $this->get_beta_features() as $beta_feature )
-				$this->options[$beta_feature] = false;
-
 		// The following three are just different kinds (colors) of user feedback.
 		// Don't use directly, instead use $this->notice / error / info methods.
 		$this->infos = array();

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-admin-setup.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-admin-setup.php
@@ -92,10 +92,6 @@ class CampTix_Admin_Setup {
 				add_action( 'camptix_setup_buttons', array( $this, 'setup_buttons_reset_templates' ) );
 				break;
 			case 'beta':
-
-				if ( ! $this->plugin->beta_features_enabled )
-					break;
-
 				add_settings_section( 'general', __( 'Beta Features', 'wordcamporg' ), array( $this, 'menu_setup_section_beta' ), 'camptix_options' );
 
 				$this->add_settings_field_helper( 'reservations_enabled', __( 'Enable Reservations', 'wordcamporg' ), 'field_yesno', false,
@@ -187,11 +183,10 @@ class CampTix_Admin_Setup {
 		if ( isset( $input['refunds_date_end'], $input['refunds_enabled'] ) && (bool) $input['refunds_enabled'] && strtotime( $input['refunds_date_end'] ) )
 			$output['refunds_date_end'] = $input['refunds_date_end'];
 
-		$yesno_fields = array( 'refunds_enabled' );
-
-		// Beta features checkboxes
-		if ( $this->plugin->beta_features_enabled )
-			$yesno_fields = array_merge( $yesno_fields, $this->plugin->get_beta_features() );
+		$yesno_fields = array_merge(
+			array( 'refunds_enabled' ),
+			$this->plugin->get_beta_features()
+		);
 
 		foreach ( $yesno_fields as $field )
 			if ( isset( $input[ $field ] ) )
@@ -457,13 +452,11 @@ class CampTix_Admin_Setup {
 	function menu_setup_tabs() {
 		$current_section = $this->get_setup_section();
 		$sections = array(
-			'general' => __( 'General', 'wordcamporg' ),
-			'payment' => __( 'Payment', 'wordcamporg' ),
+			'general'         => __( 'General', 'wordcamporg' ),
+			'payment'         => __( 'Payment', 'wordcamporg' ),
 			'email-templates' => __( 'E-mail Templates', 'wordcamporg' ),
+			'beta'            => __( 'Beta', 'wordcamporg' ),
 		);
-
-		if ( $this->plugin->beta_features_enabled )
-			$sections['beta'] = __( 'Beta', 'wordcamporg' );
 
 		$sections = apply_filters( 'camptix_setup_sections', $sections );
 

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -364,18 +364,25 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 	}
 
 	/**
-	 * Get this payment method's options
+	 * Get this payment method's options.
+	 *
+	 * Reads the latest CampTix options at call time so this returns the values
+	 * for the current site after a `switch_to_blog()`, instead of relying on a
+	 * cached `$this->camptix_options` snapshot from when the addon was loaded.
 	 *
 	 * @return array
 	 */
 	function get_payment_options() {
-		$payment_options = array();
-		$option_key      = "payment_options_{$this->id}";
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
 
-		if ( isset( $this->camptix_options[ $option_key ] ) ) {
-			$payment_options = (array) $this->camptix_options[ $option_key ];
+		$option_key      = "payment_options_{$this->id}";
+		$camptix_options = $camptix->get_options();
+
+		if ( isset( $camptix_options[ $option_key ] ) ) {
+			return (array) $camptix_options[ $option_key ];
 		}
 
-		return $payment_options;
+		return array();
 	}
 }

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -364,25 +364,34 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 	}
 
 	/**
-	 * Get this payment method's options.
-	 *
-	 * Reads the latest CampTix options at call time so this returns the values
-	 * for the current site after a `switch_to_blog()`, instead of relying on a
-	 * cached `$this->camptix_options` snapshot from when the addon was loaded.
+	 * Get this payment method's options
 	 *
 	 * @return array
 	 */
 	function get_payment_options() {
+		$payment_options = array();
+		$option_key      = "payment_options_{$this->id}";
+
+		if ( isset( $this->camptix_options[ $option_key ] ) ) {
+			$payment_options = (array) $this->camptix_options[ $option_key ];
+		}
+
+		return $payment_options;
+	}
+
+	/**
+	 * Refresh `$this->camptix_options` from the current site's CampTix
+	 * options.
+	 *
+	 * Multisite callers can call this after `switch_to_blog()` to make sure
+	 * subsequent calls to `get_payment_options()` reflect the switched-to
+	 * site. Subclasses that maintain their own option snapshots should
+	 * override this and call `parent::load_options()` first.
+	 */
+	public function load_options() {
 		/** @var CampTix_Plugin $camptix */
 		global $camptix;
 
-		$option_key      = "payment_options_{$this->id}";
-		$camptix_options = $camptix->get_options();
-
-		if ( isset( $camptix_options[ $option_key ] ) ) {
-			return (array) $camptix_options[ $option_key ];
-		}
-
-		return array();
+		$this->camptix_options = $camptix->get_options();
 	}
 }

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -77,11 +77,12 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 
 		// Seed a distinct option directly on the secondary site, before any
 		// code on that site has loaded CampTix options.
-		switch_to_blog( $other_blog_id );
-		update_option( 'camptix_options', array(
+		$secondary_seed = array(
 			'event_name' => 'Secondary Event',
 			'version'    => $camptix->version,
-		) );
+		);
+		switch_to_blog( $other_blog_id );
+		update_option( 'camptix_options', $secondary_seed );
 		restore_current_blog();
 
 		switch_to_blog( $other_blog_id );

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -56,4 +56,42 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 
 		$this->assertSame( $expected_output, CampTix_Plugin::esc_csv( $test_input ) );
 	}
+
+	/**
+	 * Options should reflect the current site after `switch_to_blog()`,
+	 * so multisite callers like the centralized Stripe webhook can read
+	 * the switched-to site's settings without manually reloading them.
+	 *
+	 * @covers CampTix_Plugin::get_options
+	 * @group  ms-required
+	 */
+	public function test_get_options_is_blog_aware() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite is required for this test.' );
+		}
+
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$other_blog_id = self::factory()->blog->create();
+
+		// Seed a distinct option directly on the secondary site, before any
+		// code on that site has loaded CampTix options.
+		switch_to_blog( $other_blog_id );
+		update_option( 'camptix_options', array(
+			'event_name' => 'Secondary Event',
+			'version'    => $camptix->version,
+		) );
+		restore_current_blog();
+
+		switch_to_blog( $other_blog_id );
+		$secondary_options = $camptix->get_options();
+		$this->assertSame( 'Secondary Event', $secondary_options['event_name'] );
+		restore_current_blog();
+
+		// After restoring, the cached copy should be invalidated and re-fetched
+		// for the primary site, which has its own (different) event name.
+		$primary_options = $camptix->get_options();
+		$this->assertNotSame( 'Secondary Event', $primary_options['event_name'] );
+	}
 }

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -58,14 +58,15 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Options should reflect the current site after `switch_to_blog()`,
-	 * so multisite callers like the centralized Stripe webhook can read
-	 * the switched-to site's settings without manually reloading them.
+	 * `load_options()` should refresh `$camptix->options` for the current
+	 * site, so multisite callers (like the centralized Stripe webhook) can
+	 * pull in the switched-to site's settings before code that reads
+	 * `$camptix->options` directly runs.
 	 *
-	 * @covers CampTix_Plugin::get_options
+	 * @covers CampTix_Plugin::load_options
 	 * @group  ms-required
 	 */
-	public function test_get_options_is_blog_aware() {
+	public function test_load_options_refreshes_cache_for_current_site() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Multisite is required for this test.' );
 		}
@@ -75,8 +76,7 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 
 		$other_blog_id = self::factory()->blog->create();
 
-		// Seed a distinct option directly on the secondary site, before any
-		// code on that site has loaded CampTix options.
+		// Seed a distinct option directly on the secondary site.
 		$secondary_seed = array(
 			'event_name' => 'Secondary Event',
 			'version'    => $camptix->version,
@@ -85,14 +85,16 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		update_option( 'camptix_options', $secondary_seed );
 		restore_current_blog();
 
+		// Capture the primary site's event name before switching.
+		$primary_event_name = $camptix->get_options()['event_name'];
+
 		switch_to_blog( $other_blog_id );
-		$secondary_options = $camptix->get_options();
-		$this->assertSame( 'Secondary Event', $secondary_options['event_name'] );
+		$camptix->load_options();
+		$this->assertSame( 'Secondary Event', $camptix->get_options()['event_name'] );
 		restore_current_blog();
 
-		// After restoring, the cached copy should be invalidated and re-fetched
-		// for the primary site, which has its own (different) event name.
-		$primary_options = $camptix->get_options();
-		$this->assertNotSame( 'Secondary Event', $primary_options['event_name'] );
+		// Reload back into the primary site's options.
+		$camptix->load_options();
+		$this->assertSame( $primary_event_name, $camptix->get_options()['event_name'] );
 	}
 }


### PR DESCRIPTION
Follow-up to #1705 (centralized Stripe webhook). Removes the `switch_blog` action handler and `reload_options()` plumbing in favor of loading options at call time.

## Why

When the central webhook switches into the ticket-owning site, downstream code needs that site's `camptix_options` and Stripe credentials in scope. The merged approach hooked `switch_blog` and reset cached state globally, which fired on every `switch_to_blog()` in the request and needed a `doing_filter()` reentrancy guard to avoid infinite recursion through the `camptix_options` filter.

## What changed

- `CampTix_Plugin::get_options()` is now blog-aware: it caches per-blog and re-fetches when the current blog id differs from the cached one. Subsequent reads of `$this->options[...]` (e.g. inside `payment_result()` / `email_tickets()`) see the right site's data automatically once `get_options()` is called after a blog switch.
- The beta-features-disable shim moves from an inline mutation in `init()` to a `camptix_options` filter callback so it applies to every fresh fetch (including post-switch re-fetches), not just the first one.
- `CampTix_Payment_Method::get_payment_options()` now reads through `$camptix->get_options()` instead of the constructor-time `$this->camptix_options` snapshot.
- The Stripe addon centralizes option assembly in `get_stripe_options()`. `get_api_credentials()` calls it on the fly so credentials always come from the current site.
- Removed both `switch_blog` action handlers and both `reload_options()` methods.

## Webhook flow after the change

```
rest_stripe_webhook()           // central blog
  switch_to_blog( site_id )
  process_webhook_session_for_current_site()
    get_api_credentials()       // -> get_payment_options() -> $camptix->get_options() refreshes per-blog cache
    process_payment_return_session()
      $camptix->payment_result()  // reads $camptix->options[...] populated by the call above
  restore_current_blog()
```

No global hook, no reentrancy guard, no surprise side effects on unrelated `switch_to_blog()` calls in the same request.

## Test plan

- [x] Added `Test_CampTix_Plugin::test_get_options_is_blog_aware` covering the per-blog cache invalidation.
- [x] Existing `test_rest_stripe_webhook_permissions_check` and Stripe addon unit tests still pass (no behavioural change to signature check or fractional-amount logic).
- [ ] CI: PHPUnit on PHP 8.1 / 8.4 / 8.5 (multisite is enabled via `phpunit.xml.dist`).
- [ ] Manual: trigger a Stripe Checkout webhook against a non-central site through the central endpoint and verify the attendee post status updates with the correct event metadata.