### PR TITLE
Add `wordcamp` support user to new sites and protect from edits

### DIFF
--- a/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
@@ -6,8 +6,7 @@
  *   support always has direct access without having to flip super-admin powers.
  * - Prevents non-super-admins from removing the `wordcamp` user from a site or
  *   changing its role there, so changes to it don't cause unintended side
- *   effects across the network. (`edit_user` / `delete_user` are already blocked
- *   for non-super-admins by core's multisite cap mapping.)
+ *   effects across the network.
  *
  * @package WordCamp\WordCampUser
  */

--- a/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
@@ -4,9 +4,10 @@
  *
  * - Adds the `wordcamp` user as an administrator on every newly created site, so
  *   support always has direct access without having to flip super-admin powers.
- * - Prevents non-super-admins from editing, deleting, removing, or promoting the
- *   `wordcamp` user from a site, so changes to it don't cause unintended side
- *   effects across the network.
+ * - Prevents non-super-admins from removing the `wordcamp` user from a site or
+ *   changing its role there, so changes to it don't cause unintended side
+ *   effects across the network. (`edit_user` / `delete_user` are already blocked
+ *   for non-super-admins by core's multisite cap mapping.)
  *
  * @package WordCamp\WordCampUser
  */
@@ -54,7 +55,10 @@ function add_to_new_site( $site ) {
 }
 
 /**
- * Block non-super-admins from editing, deleting, removing, or promoting the `wordcamp` user.
+ * Block non-super-admins from removing the `wordcamp` user from a site or changing its role.
+ *
+ * `edit_user` and `delete_user` are already restricted to super-admins by core's
+ * multisite cap mapping, so they don't need to be re-blocked here.
  *
  * @param string[] $required_caps Primitive caps the actor must have.
  * @param string   $cap           The meta cap being mapped.
@@ -64,7 +68,7 @@ function add_to_new_site( $site ) {
  * @return string[]
  */
 function protect_user( $required_caps, $cap, $acting_user, $args ) {
-	$protected = array( 'edit_user', 'delete_user', 'remove_user', 'promote_user' );
+	$protected = array( 'remove_user', 'promote_user' );
 
 	if ( ! in_array( $cap, $protected, true ) ) {
 		return $required_caps;

--- a/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Manage the shared `wordcamp` support user across the network.
+ *
+ * - Adds the `wordcamp` user as an administrator on every newly created site, so
+ *   support always has direct access without having to flip super-admin powers.
+ * - Prevents non-super-admins from editing, deleting, removing, or promoting the
+ *   `wordcamp` user from a site, so changes to it don't cause unintended side
+ *   effects across the network.
+ *
+ * @package WordCamp\WordCampUser
+ */
+
+namespace WordCamp\WordCampUser;
+
+defined( 'WPINC' ) || die();
+
+const USER_LOGIN = 'wordcamp';
+
+add_action( 'wp_initialize_site', __NAMESPACE__ . '\add_to_new_site', 100, 1 );
+add_filter( 'map_meta_cap', __NAMESPACE__ . '\protect_user', 10, 4 );
+
+
+/**
+ * Look up the ID of the `wordcamp` user once per request.
+ *
+ * Returns 0 if the user doesn't exist (e.g. on a network where it hasn't been created),
+ * so callers can short-circuit without breaking site creation or cap checks.
+ */
+function get_user_id() : int {
+	static $user_id = null;
+
+	if ( null === $user_id ) {
+		$user    = get_user_by( 'login', USER_LOGIN );
+		$user_id = $user ? (int) $user->ID : 0;
+	}
+
+	return $user_id;
+}
+
+/**
+ * Add the `wordcamp` user as an administrator to a newly created site.
+ *
+ * @param \WP_Site $site The newly created site.
+ */
+function add_to_new_site( $site ) {
+	$user_id = get_user_id();
+
+	if ( ! $user_id ) {
+		return;
+	}
+
+	add_user_to_blog( (int) $site->blog_id, $user_id, 'administrator' );
+}
+
+/**
+ * Block non-super-admins from editing, deleting, removing, or promoting the `wordcamp` user.
+ *
+ * @param string[] $required_caps Primitive caps the actor must have.
+ * @param string   $cap           The meta cap being mapped.
+ * @param int      $acting_user   The acting user's ID.
+ * @param array    $args          Additional args; $args[0] is the target user ID for these caps.
+ *
+ * @return string[]
+ */
+function protect_user( $required_caps, $cap, $acting_user, $args ) {
+	$protected = array( 'edit_user', 'delete_user', 'remove_user', 'promote_user' );
+
+	if ( ! in_array( $cap, $protected, true ) ) {
+		return $required_caps;
+	}
+
+	if ( empty( $args[0] ) ) {
+		return $required_caps;
+	}
+
+	$wordcamp_user_id = get_user_id();
+
+	if ( ! $wordcamp_user_id || (int) $args[0] !== $wordcamp_user_id ) {
+		return $required_caps;
+	}
+
+	if ( is_super_admin( $acting_user ) ) {
+		return $required_caps;
+	}
+
+	return array( 'do_not_allow' );
+}

--- a/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
@@ -27,7 +27,7 @@ add_filter( 'map_meta_cap', __NAMESPACE__ . '\protect_user', 10, 4 );
  * Returns 0 if the user doesn't exist (e.g. on a network where it hasn't been created),
  * so callers can short-circuit without breaking site creation or cap checks.
  */
-function get_user_id() : int {
+function get_user_id(): int {
 	static $user_id = null;
 
 	if ( null === $user_id ) {


### PR DESCRIPTION
## Summary
- Hooks `wp_initialize_site` to add the shared `wordcamp` user as an administrator on every newly created site, so site management functionalities that require a user always work.
- Filters `map_meta_cap` to block non-super-admins from `edit_user` / `delete_user` / `remove_user` / `promote_user` against the `wordcamp` user, so changes to it don't cause unintended side effects across the network.

This only covers **newly** created sites. Backfilling existing sites would be a separate one-time WP-CLI run.

## Test plan
- [ ] Create a new site as a super-admin and confirm the `wordcamp` user appears on it as an administrator.
- [ ] As a site administrator (not a super-admin), confirm the `wordcamp` user row in Users has no Edit / Delete / Remove links and that direct URL access to `user-edit.php?user_id=<wordcamp-id>` is denied.
- [ ] As a super-admin, confirm edit / delete / remove / promote on the `wordcamp` user still work as normal.
- [ ] Confirm site creation still succeeds if the `wordcamp` user somehow doesn't exist on the network (no fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)