### PR TITLE
CampTix: Catch invalid locale errors from NumberFormatter

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -482,12 +482,20 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		$currency = $camptix_currencies[ $currency_key ];
 
 		if ( isset( $currency['locale'] ) === true ) {
-			$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
-			$formatted_amount = $formatter->format( $amount );
-		} elseif ( isset( $currency['format'] ) && $currency['format'] ) {
-			$formatted_amount = sprintf( $currency['format'], number_format( $amount, $currency['decimal_point'] ) );
-		} else {
-			$formatted_amount = $currency_key . ' ' . number_format( $amount, $currency['decimal_point'] );
+			try {
+				$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
+				$formatted_amount = $formatter->format( $amount );
+			} catch ( \Throwable $e ) {
+				// PHP 8.4+ throws ValueError for unknown locales; fall through to the format/default path.
+			}
+		}
+
+		if ( ! isset( $formatted_amount ) ) {
+			if ( isset( $currency['format'] ) && $currency['format'] ) {
+				$formatted_amount = sprintf( $currency['format'], number_format( $amount, $currency['decimal_point'] ) );
+			} else {
+				$formatted_amount = $currency_key . ' ' . number_format( $amount, $currency['decimal_point'] );
+			}
 		}
 
 		return $formatted_amount;

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -481,16 +481,18 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 
 		$currency = $camptix_currencies[ $currency_key ];
 
+		// PHP 8.4+ throws ValueError when NumberFormatter is given an unknown locale; format() can also return false.
+		$formatted_amount = false;
 		if ( isset( $currency['locale'] ) === true ) {
 			try {
 				$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
 				$formatted_amount = $formatter->format( $amount );
 			} catch ( \Throwable $e ) {
-				// PHP 8.4+ throws ValueError for unknown locales; fall through to the format/default path.
+				$formatted_amount = false;
 			}
 		}
 
-		if ( ! isset( $formatted_amount ) ) {
+		if ( false === $formatted_amount ) {
 			if ( isset( $currency['format'] ) && $currency['format'] ) {
 				$formatted_amount = sprintf( $currency['format'], number_format( $amount, $currency['decimal_point'] ) );
 			} else {

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1664,12 +1664,20 @@ class CampTix_Plugin {
 		}
 
 		if ( isset( $currency['locale'] ) ) {
-			$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
-			$formatted_amount = $formatter->format( $amount );
-		} elseif ( isset( $currency['format'] ) && $currency['format'] ) {
-			$formatted_amount = sprintf( $currency['format'], number_format( $amount, $currency['decimal_point'] ) );
-		} else {
-			$formatted_amount = $currency_key . ' ' . number_format( $amount, $currency['decimal_point'] );
+			try {
+				$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
+				$formatted_amount = $formatter->format( $amount );
+			} catch ( \Throwable $e ) {
+				// PHP 8.4+ throws ValueError for unknown locales; fall through to the format/default path.
+			}
+		}
+
+		if ( ! isset( $formatted_amount ) ) {
+			if ( isset( $currency['format'] ) && $currency['format'] ) {
+				$formatted_amount = sprintf( $currency['format'], number_format( $amount, $currency['decimal_point'] ) );
+			} else {
+				$formatted_amount = $currency_key . ' ' . number_format( $amount, $currency['decimal_point'] );
+			}
 		}
 
 		$formatted_amount = apply_filters( 'tix_append_currency', $formatted_amount, $currency, $amount );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1663,16 +1663,18 @@ class CampTix_Plugin {
 			$currency['decimal_point'] = 2;
 		}
 
+		// PHP 8.4+ throws ValueError when NumberFormatter is given an unknown locale; format() can also return false.
+		$formatted_amount = false;
 		if ( isset( $currency['locale'] ) ) {
 			try {
 				$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
 				$formatted_amount = $formatter->format( $amount );
 			} catch ( \Throwable $e ) {
-				// PHP 8.4+ throws ValueError for unknown locales; fall through to the format/default path.
+				$formatted_amount = false;
 			}
 		}
 
-		if ( ! isset( $formatted_amount ) ) {
+		if ( false === $formatted_amount ) {
 			if ( isset( $currency['format'] ) && $currency['format'] ) {
 				$formatted_amount = sprintf( $currency['format'], number_format( $amount, $currency['decimal_point'] ) );
 			} else {

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -66,20 +66,24 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		$start_date = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? gmdate( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
 		$end_date   = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? gmdate( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
 
-		// PHP 8.4+ throws ValueError for unknown locales; fall back to a plain number on failure.
+		// PHP 8.4+ throws ValueError for unknown locales; format()/formatCurrency() can also return false.
+		$formatted = false;
 		try {
-			$number_formatter   = new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
-			$sponsorship_amount = $number_formatter->format( (float) $sponsor_amount ) . " {$sponsor_currency}";
+			$number_formatter = new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
+			$formatted        = $number_formatter->format( (float) $sponsor_amount );
 		} catch ( \Throwable $e ) {
-			$sponsorship_amount = ( (float) $sponsor_amount ) . " {$sponsor_currency}";
+			$formatted = false;
 		}
+		$sponsorship_amount = ( false !== $formatted ? $formatted : (float) $sponsor_amount ) . " {$sponsor_currency}";
 
+		$formatted = false;
 		try {
-			$number_formatter       = new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
-			$sponsorship_amount_num = $number_formatter->formatCurrency( (float) $sponsor_amount, $sponsor_currency );
+			$number_formatter = new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
+			$formatted        = $number_formatter->formatCurrency( (float) $sponsor_amount, $sponsor_currency );
 		} catch ( \Throwable $e ) {
-			$sponsorship_amount_num = ( (float) $sponsor_amount ) . " {$sponsor_currency}";
+			$formatted = false;
 		}
+		$sponsorship_amount_num = false !== $formatted ? $formatted : ( (float) $sponsor_amount ) . " {$sponsor_currency}";
 
 		$data = wp_parse_args( $data, array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'sponsor_name'            => get_the_title( $sponsor_id ),

--- a/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/templates/sponsorship-agreement.php
@@ -66,11 +66,20 @@ class WordCamp_Docs_Template_Sponsorship_Agreement implements WordCamp_Docs_Temp
 		$start_date = ! empty( $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) ? gmdate( $date_format, $wordcamp->meta['Start Date (YYYY-mm-dd)'][0] ) : '';
 		$end_date   = ! empty( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   ? gmdate( $date_format, $wordcamp->meta['End Date (YYYY-mm-dd)'][0] )   : $start_date;
 
-		$number_formatter   = new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
-		$sponsorship_amount = $number_formatter->format( (float) $sponsor_amount ) . " {$sponsor_currency}";
+		// PHP 8.4+ throws ValueError for unknown locales; fall back to a plain number on failure.
+		try {
+			$number_formatter   = new NumberFormatter( get_locale(), NumberFormatter::SPELLOUT );
+			$sponsorship_amount = $number_formatter->format( (float) $sponsor_amount ) . " {$sponsor_currency}";
+		} catch ( \Throwable $e ) {
+			$sponsorship_amount = ( (float) $sponsor_amount ) . " {$sponsor_currency}";
+		}
 
-		$number_formatter       = new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
-		$sponsorship_amount_num = $number_formatter->formatCurrency( (float) $sponsor_amount, $sponsor_currency );
+		try {
+			$number_formatter       = new NumberFormatter( get_locale(), NumberFormatter::CURRENCY );
+			$sponsorship_amount_num = $number_formatter->formatCurrency( (float) $sponsor_amount, $sponsor_currency );
+		} catch ( \Throwable $e ) {
+			$sponsorship_amount_num = ( (float) $sponsor_amount ) . " {$sponsor_currency}";
+		}
 
 		$data = wp_parse_args( $data, array( // phpcs:ignore PEAR.Functions.FunctionCallSignature.MultipleArguments
 			'sponsor_name'            => get_the_title( $sponsor_id ),


### PR DESCRIPTION
Wraps the `NumberFormatter` construction in `CampTix_Plugin::append_currency()` with `try { } catch ( \Throwable $e )` so an invalid locale no longer fatals the request.

## Why

PHP 8.4 changed `NumberFormatter::__construct()` to throw `ValueError` for unknown locales (previously a warning). Production has been hitting:

```
PHP Fatal error:  Uncaught ValueError: NumberFormatter::__construct(): Argument #1 ($locale) "hcs_CZ" is invalid
  in /home/wordcamp/public_html/wp-content/plugins/camptix/camptix.php:1670
```

`hcs_CZ` is not a valid ICU locale, so `NumberFormatter` rejects it and the whole page dies.

## What

- Catch `\Throwable` around the `NumberFormatter` call.
- On failure, fall through to the existing `currency[format]` / default fallback path that the function already uses when no locale is configured, so the amount still renders.

## Test plan

- [ ] Render a ticket price for a currency with a valid locale (e.g. `en_US`) — output unchanged.
- [ ] Render a ticket price for a currency configured with an invalid locale (e.g. `hcs_CZ`) — no fatal; falls back to `format` / `currency_key` rendering.