### PR TITLE
CampTix: Fire camptix_payment_result on every payment_result call

### DIFF
--- a/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
+++ b/public_html/wp-content/mu-plugins/camptix-tweaks/camptix-tweaks.php
@@ -18,7 +18,7 @@ add_action( 'camptix_checkout_start',                        __NAMESPACE__ . '\c
 add_action( 'camptix_form_start_errors',                     __NAMESPACE__ . '\add_form_start_error_messages'       );
 add_filter( 'camptix_form_attendee_info_errors',             __NAMESPACE__ . '\show_throttle_notice'                );
 add_action( 'transition_post_status',                        __NAMESPACE__ . '\ticket_sales_opened',          10, 3 );
-add_action( 'camptix_payment_result',                        __NAMESPACE__ . '\track_payment_results',        10, 3 );
+add_action( 'camptix_payment_result',                        __NAMESPACE__ . '\track_payment_results',        10, 4 );
 add_action( 'camptix_payment_result',                        __NAMESPACE__ . '\clear_page_cache_on_payment',  10, 2 );
 add_filter( 'camptix_shortcode_contents',                    __NAMESPACE__ . '\modify_shortcode_contents',    10, 2 );
 add_filter( 'camptix_max_tickets_per_order',                 __NAMESPACE__ . '\limit_one_ticket_per_order'          );
@@ -331,8 +331,16 @@ function ticket_sales_opened( $new_status, $old_status, $tickets_page ) {
  * @param string $payment_token
  * @param int    $result
  * @param array  $data
+ * @param bool   $status_changed Whether this call transitioned the attendee status.
+ *                               camptix_payment_result fires on every payment_result()
+ *                               invocation; ignore non-transitions so the centralized
+ *                               Stripe webhook + interactive return don't double-count.
  */
-function track_payment_results( $payment_token, $result, $data ) {
+function track_payment_results( $payment_token, $result, $data, $status_changed = true ) {
+	if ( ! $status_changed ) {
+		return;
+	}
+
 	if ( is_sandboxed() ) {
 		return;
 	}

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -222,35 +222,30 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 			return;
 		}
 
-		// Bail if we've already created an invoice for this transaction.
-		// payment_result() can fire camptix_payment_result more than once for the
-		// same payment_token (centralized Stripe webhook + interactive return).
-		$txn_id = get_post_meta( $attendees[0]->ID, 'tix_transaction_id', true );
-		if ( $txn_id ) {
-			$existing = get_posts(
-				array(
-					'post_type'      => 'tix_invoice',
-					'post_status'    => 'any',
-					'posts_per_page' => 1,
-					'fields'         => 'ids',
-					'meta_query'     => array( // @codingStandardsIgnoreLine
-						array(
-							'key'   => 'transaction_id',
-							'value' => $txn_id,
-						),
-					),
-				)
-			);
-			if ( $existing ) {
-				return;
-			}
+		// Race-safe idempotency guard: payment_result() can fire camptix_payment_result
+		// more than once for the same payment_token (centralized Stripe webhook + interactive
+		// return run within ~1-2 seconds of each other). add_post_meta() with $unique=true
+		// is rejected by WordPress if the key already exists for this post, so only the first
+		// caller successfully claims invoice creation; concurrent callers bail. Keyed on the
+		// attendee rather than on tix_transaction_id so that no-transaction purchases
+		// (100% coupon, Stripe payment_status=no_payment_required) are also covered.
+		if ( get_post_meta( $attendees[0]->ID, '_invoice_id', true ) ) {
+			return;
+		}
+		if ( ! add_post_meta( $attendees[0]->ID, '_invoice_id', 0, true ) ) {
+			return;
 		}
 
 		$order      = get_post_meta( $attendees[0]->ID, 'tix_order', true );
 		$invoice_id = self::create_invoice( $attendees[0], $order, $metas );
-		if ( ! is_wp_error( $invoice_id ) && ! empty( $invoice_id ) ) {
-			self::send_invoice( $invoice_id );
+		if ( is_wp_error( $invoice_id ) || empty( $invoice_id ) ) {
+			// Release the lock so a later call can retry.
+			delete_post_meta( $attendees[0]->ID, '_invoice_id' );
+			return;
 		}
+
+		update_post_meta( $attendees[0]->ID, '_invoice_id', $invoice_id );
+		self::send_invoice( $invoice_id );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -218,13 +218,39 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		}//end if
 
 		$metas = get_post_meta( $attendees[0]->ID, 'invoice_metas', true );
-		if ( $metas ) {
-			$order      = get_post_meta( $attendees[0]->ID, 'tix_order', true );
-			$invoice_id = self::create_invoice( $attendees[0], $order, $metas );
-			if ( ! is_wp_error( $invoice_id ) && ! empty( $invoice_id ) ) {
-				self::send_invoice( $invoice_id );
-			}//end if
-		}//end if
+		if ( ! $metas ) {
+			return;
+		}
+
+		// Bail if we've already created an invoice for this transaction.
+		// payment_result() can fire camptix_payment_result more than once for the
+		// same payment_token (centralized Stripe webhook + interactive return).
+		$txn_id = get_post_meta( $attendees[0]->ID, 'tix_transaction_id', true );
+		if ( $txn_id ) {
+			$existing = get_posts(
+				array(
+					'post_type'      => 'tix_invoice',
+					'post_status'    => 'any',
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'meta_query'     => array( // @codingStandardsIgnoreLine
+						array(
+							'key'   => 'transaction_id',
+							'value' => $txn_id,
+						),
+					),
+				)
+			);
+			if ( $existing ) {
+				return;
+			}
+		}
+
+		$order      = get_post_meta( $attendees[0]->ID, 'tix_order', true );
+		$invoice_id = self::create_invoice( $attendees[0], $order, $metas );
+		if ( ! is_wp_error( $invoice_id ) && ! empty( $invoice_id ) ) {
+			self::send_invoice( $invoice_id );
+		}
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6691,6 +6691,13 @@ class CampTix_Plugin {
 		$from_status = $attendees_status;
 		$to_status = $attendees[0]->post_status;
 
+		// Fire the result action on every call, not just on status transitions.
+		// Webhooks and interactive returns can both invoke payment_result() for
+		// the same payment_token; whichever runs second sees $status_changed === false.
+		// Listeners (e.g. CampTix_Addon_Invoices::maybe_create_invoice) must be
+		// idempotent — see the matching guard there.
+		do_action( 'camptix_payment_result', $payment_token, $result, $data );
+
 		// If the status hasn't changed, there's nothing much we can do here.
 		if ( ! $status_changed ) {
 			if ( ! $interactive ) {
@@ -6709,7 +6716,6 @@ class CampTix_Plugin {
 
 		// Send out the tickets and receipt if necessary.
 		$this->email_tickets( $payment_token, $from_status, $to_status );
-		do_action( 'camptix_payment_result', $payment_token, $result, $data );
 
 		if ( ! $interactive ) {
 			return true;

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6691,12 +6691,28 @@ class CampTix_Plugin {
 		$from_status = $attendees_status;
 		$to_status = $attendees[0]->post_status;
 
-		// Fire the result action on every call, not just on status transitions.
-		// Webhooks and interactive returns can both invoke payment_result() for
-		// the same payment_token; whichever runs second sees $status_changed === false.
-		// Listeners (e.g. CampTix_Addon_Invoices::maybe_create_invoice) must be
-		// idempotent — see the matching guard there.
-		do_action( 'camptix_payment_result', $payment_token, $result, $data );
+		/**
+		 * Fires after a payment result has been recorded for an attendee group.
+		 *
+		 * This action fires on every payment_result() call, not just on status transitions.
+		 * Webhooks and interactive returns can both invoke payment_result() for the same
+		 * payment_token; whichever runs second sees $status_changed === false. Listeners
+		 * that should only run when the attendee status actually transitioned can check the
+		 * $status_changed argument; idempotent listeners (e.g. one that creates an invoice)
+		 * can run on every call and use their own dedup guard to avoid double-processing.
+		 *
+		 * @param string $payment_token  The payment token whose attendees were updated.
+		 * @param int    $result         The new payment status — one of the
+		 *                               CampTix_Plugin::PAYMENT_STATUS_* constants.
+		 * @param array  $data           Gateway-supplied payment data. May include
+		 *                               transaction_id, transaction_details, error_code,
+		 *                               refund_transaction_id, refund_transaction_details.
+		 * @param bool   $status_changed Whether this call actually transitioned the
+		 *                               attendee post_status. False for repeat calls that
+		 *                               re-report the same status (e.g. a duplicate
+		 *                               webhook arriving after the interactive return).
+		 */
+		do_action( 'camptix_payment_result', $payment_token, $result, $data, $status_changed );
 
 		// If the status hasn't changed, there's nothing much we can do here.
 		if ( ! $status_changed ) {


### PR DESCRIPTION
Fire `camptix_payment_result` on every `payment_result()` call rather than only on status transitions, so addon listeners (notably `CampTix_Addon_Invoices::maybe_create_invoice`) get a chance to run when the centralized Stripe webhook (#1705) and the interactive return path race for the same payment token. Add an idempotency guard in `maybe_create_invoice` so the now-possibly-double-firing action doesn't mint duplicate invoices.

Fixes #1713

### Background

Since #1705, two callers can invoke `CampTix_Plugin::payment_result()` for the same payment token:

1. The buyer's interactive return on the event site (`payment_return` template_redirect, `$interactive = true`).
2. The centralized Stripe webhook running on the central site after `switch_to_blog( $site_id )` (`$interactive = false`).

`payment_result()` previously fired `do_action( 'camptix_payment_result', … )` only when `$status_changed === true`. Whichever caller runs first transitions the attendee `draft → publish`; the second sees `$status_changed === false` and returns without firing the action. `CampTix_Addon_Invoices::maybe_create_invoice` is the only listener on this hook, so no `tix_invoice` post was created.

#1708 (option-loading refactor) made the webhook reliably win the race — the attendee is now in `publish` before the buyer's browser redirects back. This is the source of the regression reported in #1713.

### How to test the changes in this Pull Request:

1. On a multisite dev environment with CampTix and `camptix-invoices` active on an event site, configure Stripe to point to the centralized webhook at `/wp-json/camptix/v1/stripe-webhook` on the central site.
2. Purchase a ticket on the event site, check "I need an invoice", complete payment via Stripe.
3. Confirm exactly one `tix_invoice` post is created and the invoice email is sent.
4. Repeat with the buyer closing the tab before redirect (webhook-only path) — invoice still created.
5. Repeat with the Stripe webhook disabled (interactive-only path) — invoice still created.
6. Replay the same Stripe webhook event a second time — only one `tix_invoice` exists (idempotency guard in `maybe_create_invoice`).