### PR TITLE
CampTix: Fix CZK locale typo (hcs_CZ → cs_CZ)

### DIFF
--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-currencies.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-currencies.php
@@ -169,7 +169,7 @@ class CampTix_Currency {
 			),
 			'CZK' => array(
 				'label'         => __( 'Czech Koruna', 'wordcamporg' ),
-				'locale'        => 'hcs_CZ',
+				'locale'        => 'cs_CZ',
 				'decimal_point' => 2,
 			),
 			'DJF' => array(


### PR DESCRIPTION
The CZK currency entry in `class-camptix-currencies.php` uses `hcs_CZ` as its `NumberFormatter` locale, but `hcs` is not a valid ISO 639 language code. The intended Czech locale is `cs_CZ`.

On PHP 8.4 this typo causes `new NumberFormatter('hcs_CZ', NumberFormatter::CURRENCY)` to throw `ValueError`. #1712 made the call non-fatal by catching the throwable in `CampTix_Plugin::append_currency()`, but the locale string itself was never corrected. As a result, every CZK amount falls through to the generic fallback branch and renders as `CZK 1,234.50` instead of the localized `1 234,50 Kč` the entry was meant to produce.

This change is a one-character fix to the language subtag so the formatter is constructed with a valid locale and Czech buyers see properly localized koruna amounts.

See #1712

### Screenshots

N/A — backend currency formatting only.

### How to test the changes in this Pull Request:

1. On a test WordCamp site running PHP 8.4 with the `intl` extension loaded, set the CampTix currency to **CZK** under *Tickets → Setup → Payment*.
2. Create a paid ticket priced at, e.g., `1234.50`.
3. View the ticket on the front-end (and any admin screens that print the price, e.g. *Tickets → Tools → Revenue*).
4. **Before this fix:** the price renders as `CZK 1,234.50` (generic fallback because `NumberFormatter` threw `ValueError` and was caught by #1712).
5. **After this fix:** the price renders as a proper Czech-localized currency string, e.g. `1 234,50 Kč`.
6. Confirm no PHP warnings/errors are logged for the CZK code path.