### PR TITLE
CampTix: Do not cancel attendees whose payment was already processed

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6646,8 +6646,22 @@ class CampTix_Plugin {
 			update_post_meta( $attendee->ID, 'tix_transaction_details', $transaction_details );
 
 			if ( self::PAYMENT_STATUS_CANCELLED == $result ) {
-				$attendee->post_status = 'cancel';
-				wp_update_post( $attendee );
+				// A user-initiated cancel (e.g. clicking "Cancel" on the gateway's hosted
+				// checkout) can race with the gateway's webhook. If the webhook has already
+				// reported the payment as complete/pending/refunded, the charge stayed with
+				// the gateway and the attendee is the rightful ticket holder — refuse to
+				// downgrade. PAYMENT_STATUS_COMPLETED still transitions cancel → publish,
+				// so a webhook that arrives after a cancel still wins.
+				if ( in_array( $attendee->post_status, array( 'publish', 'pending', 'refund' ), true ) ) {
+					$this->log(
+						sprintf( 'Refusing to cancel attendee in %s status; payment was already processed.', $attendee->post_status ),
+						$attendee->ID,
+						$data
+					);
+				} else {
+					$attendee->post_status = 'cancel';
+					wp_update_post( $attendee );
+				}
 			}
 
 			if ( self::PAYMENT_STATUS_FAILED == $result ) {

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -105,6 +105,9 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 	 */
 	protected $attendee_ids = array();
 
+	/**
+	 * Delete any attendees created during the test so they don't leak into siblings.
+	 */
 	public function tear_down() {
 		foreach ( $this->attendee_ids as $id ) {
 			wp_delete_post( $id, true );
@@ -133,7 +136,10 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		update_post_meta( $attendee_id, 'tix_payment_token', $payment_token );
 		// email_tickets() is invoked on every successful status transition and
 		// iterates $order['items'], so seed a minimal but valid order shape.
-		update_post_meta( $attendee_id, 'tix_order', array( 'items' => array(), 'total' => 0 ) );
+		update_post_meta( $attendee_id, 'tix_order', array(
+			'items' => array(),
+			'total' => 0,
+		) );
 		update_post_meta( $attendee_id, 'tix_access_token', 'access_' . $attendee_id );
 		update_post_meta( $attendee_id, 'tix_receipt_email', 'receipt@example.test' );
 

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -136,10 +136,14 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		update_post_meta( $attendee_id, 'tix_payment_token', $payment_token );
 		// email_tickets() is invoked on every successful status transition and
 		// iterates $order['items'], so seed a minimal but valid order shape.
-		update_post_meta( $attendee_id, 'tix_order', array(
-			'items' => array(),
-			'total' => 0,
-		) );
+		update_post_meta(
+			$attendee_id,
+			'tix_order',
+			array(
+				'items' => array(),
+				'total' => 0,
+			)
+		);
 		update_post_meta( $attendee_id, 'tix_access_token', 'access_' . $attendee_id );
 		update_post_meta( $attendee_id, 'tix_receipt_email', 'receipt@example.test' );
 

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -99,7 +99,24 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Create a tix_attendee post in the given status with a payment token attached.
+	 * Attendee IDs created during a test, cleaned up in tear_down.
+	 *
+	 * @var int[]
+	 */
+	protected $attendee_ids = array();
+
+	public function tear_down() {
+		foreach ( $this->attendee_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+		$this->attendee_ids = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a tix_attendee post in the given status with the metadata
+	 * payment_result() and email_tickets() expect to read.
 	 *
 	 * @param string $payment_token Payment token shared by the order.
 	 * @param string $status        Initial post_status (draft, pending, publish, cancel, refund, failed).
@@ -114,6 +131,13 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		) );
 
 		update_post_meta( $attendee_id, 'tix_payment_token', $payment_token );
+		// email_tickets() is invoked on every successful status transition and
+		// iterates $order['items'], so seed a minimal but valid order shape.
+		update_post_meta( $attendee_id, 'tix_order', array( 'items' => array(), 'total' => 0 ) );
+		update_post_meta( $attendee_id, 'tix_access_token', 'access_' . $attendee_id );
+		update_post_meta( $attendee_id, 'tix_receipt_email', 'receipt@example.test' );
+
+		$this->attendee_ids[] = $attendee_id;
 
 		return $attendee_id;
 	}

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -97,4 +97,101 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		$camptix->load_options();
 		$this->assertSame( $primary_event_name, $camptix->get_options()['event_name'] );
 	}
+
+	/**
+	 * Create a tix_attendee post in the given status with a payment token attached.
+	 *
+	 * @param string $payment_token Payment token shared by the order.
+	 * @param string $status        Initial post_status (draft, pending, publish, cancel, refund, failed).
+	 *
+	 * @return int Attendee ID.
+	 */
+	protected function create_attendee( $payment_token, $status ) {
+		$attendee_id = wp_insert_post( array(
+			'post_type'   => 'tix_attendee',
+			'post_status' => $status,
+			'post_title'  => 'Test Attendee',
+		) );
+
+		update_post_meta( $attendee_id, 'tix_payment_token', $payment_token );
+
+		return $attendee_id;
+	}
+
+	/**
+	 * A user-initiated cancel that arrives after the gateway's webhook published the
+	 * order must not roll the attendee back to 'cancel' — the charge has been taken
+	 * and the attendee is entitled to their ticket.
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 */
+	public function test_payment_result_does_not_cancel_published_attendee() {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_already_published';
+		$attendee_id   = $this->create_attendee( $payment_token, 'publish' );
+
+		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_CANCELLED, array(), false );
+
+		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * Same protection applies when the gateway has reported the payment as pending
+	 * (async confirmation in progress) or refunded — both are post-payment states
+	 * that a user-initiated cancel must not downgrade.
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 * @testWith ["pending"]
+	 *           ["refund"]
+	 */
+	public function test_payment_result_does_not_cancel_post_payment_attendee( $status ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_' . $status;
+		$attendee_id   = $this->create_attendee( $payment_token, $status );
+
+		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_CANCELLED, array(), false );
+
+		$this->assertSame( $status, get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * The normal pre-payment cancel — user hits "Cancel" before the gateway captures
+	 * payment — must still flip the draft attendee to 'cancel'.
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 */
+	public function test_payment_result_cancels_draft_attendee() {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_draft';
+		$attendee_id   = $this->create_attendee( $payment_token, 'draft' );
+
+		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_CANCELLED, array(), false );
+
+		$this->assertSame( 'cancel', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * A late-arriving webhook reporting payment completion must be able to recover an
+	 * attendee that was previously cancelled (e.g. by a stale redirect-cancel that
+	 * landed before this fix, or a race we can't fully prevent).
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 */
+	public function test_payment_result_publishes_previously_cancelled_attendee() {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_recover';
+		$attendee_id   = $this->create_attendee( $payment_token, 'cancel' );
+
+		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, array(), false );
+
+		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
+	}
 }


### PR DESCRIPTION
A user-initiated cancel (e.g. clicking "Cancel" on the Stripe hosted checkout after payment was captured) can race with the gateway webhook. The webhook would publish the attendee, then the cancel redirect landed and downgraded the attendee back to `cancel` — leaving the buyer charged but without a ticket.

## Summary

- `payment_result()` now refuses to apply `PAYMENT_STATUS_CANCELLED` when the attendee is already in a post-payment status (`publish`, `pending`, or `refund`). Logged for audit; `draft`/`failed`/`cancel` still cancel as before.
- Applies to every gateway (Stripe, PayPal, SSLCommerz/BD), not just Stripe.
- The existing `PAYMENT_STATUS_COMPLETED` branch is unconditional, so a late-arriving webhook can still recover a previously-cancelled attendee to `publish` — verified by a new test.

## Test plan

- [x] `payment_result( CANCELLED )` against a `publish` attendee leaves status as `publish`.
- [x] Same for `pending` and `refund` (data provider via `@testWith`).
- [x] `payment_result( CANCELLED )` against a `draft` attendee still cancels it.
- [x] `payment_result( COMPLETED )` against a `cancel` attendee promotes it to `publish` (webhook recovery path).
- [x] PHPUnit runs in the existing `unit-tests.yml` workflow on PHP 8.1 / 8.4 / 8.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)