### PR TITLE
Scope WordCamp status dropdown and transitions to Campus Connect entries (issue #1714, point 1)

### DIFF
--- a/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
+++ b/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
@@ -58,9 +58,28 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 
 							<span id="post-status-display">
 							<select name="post_status">
-								<?php $transitions = $event_admin->get_valid_status_transitions( $post->post_status );
+								<?php
+								$available_statuses = $event_admin->get_post_statuses();
+								$transitions        = $event_admin->get_valid_status_transitions( $post->post_status );
+
+								/*
+								 * If the post's current status is not in the available list (e.g. a non-CC
+								 * post whose subtype was changed after it reached a CC-only status, or a CC
+								 * post grandfathered into a pre-CC status), inject it as a disabled selected
+								 * option so the metabox always reflects reality and saving does not silently
+								 * mutate the status.
+								 */
+								if ( ! array_key_exists( $post->post_status, $available_statuses ) ) {
+									$current_status_obj = get_post_status_object( $post->post_status );
+									$current_label      = $current_status_obj ? $current_status_obj->label : $post->post_status;
+									printf(
+										'<option value="%s" selected disabled>%s</option>',
+										esc_attr( $post->post_status ),
+										esc_html( $current_label ) . ' ' . esc_html__( '(current)', 'wordcamporg' )
+									);
+								}
 								?>
-								<?php foreach ( $event_admin->get_post_statuses() as $key => $post_status_label ) : ?>
+								<?php foreach ( $available_statuses as $key => $post_status_label ) : ?>
 									<?php $status = get_post_status_object( $key ); ?>
 									<option value="<?php echo esc_attr( $status->name ); ?>" <?php
 									if ( $post->post_status == $status->name ) {
@@ -79,8 +98,8 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 
 							<span id="post-status-display">
 							<?php
-								$all_statuses    = $event_admin->get_post_statuses();
-								$current_label   = $all_statuses[ $post->post_status ] ?? get_post_status_object( $post->post_status )->label;
+								$all_statuses  = $event_admin->get_post_statuses();
+								$current_label = $all_statuses[ $post->post_status ] ?? get_post_status_object( $post->post_status )->label;
 								echo esc_html( $current_label );
 							?>
 						</span>

--- a/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
+++ b/public_html/wp-content/plugins/wcpt/views/wordcamp/metabox-status.php
@@ -69,7 +69,7 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 										echo ' disabled ';
 									}
 									?>>
-										<?php echo esc_html( $status->label ); ?>
+										<?php echo esc_html( $post_status_label ); ?>
 									</option>
 								<?php endforeach; ?>
 							</select>
@@ -79,8 +79,9 @@ function render_event_metabox( $event_admin, $post, $event_type, $label, $edit_c
 
 							<span id="post-status-display">
 							<?php
-								$status = get_post_status_object( $post->post_status );
-								echo esc_html( $status->label );
+								$all_statuses    = $event_admin->get_post_statuses();
+								$current_label   = $all_statuses[ $post->post_status ] ?? get_post_status_object( $post->post_status )->label;
+								echo esc_html( $current_label );
 							?>
 						</span>
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -334,9 +334,9 @@ abstract class Event_Admin {
 	 * @param WP_Post $post   The post being transitioned.
 	 * @return string Human-readable label, or the raw slug if no label is found.
 	 */
-	protected function get_status_label( $status, $post ) {
+	protected function get_status_label( $status, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $post is available for subclass overrides.
 		$status_obj = get_post_status_object( $status );
-		return $status_obj->label ?? $status;
+		return $status_obj ? $status_obj->label : $status;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-admin.php
@@ -302,16 +302,13 @@ abstract class Event_Admin {
 		// Ensure status labels are in English.
 		$locale_switched = switch_to_locale( 'en_US' );
 
-		$old_status_obj = get_post_status_object( $old_status );
-		$new_status_obj = get_post_status_object( $new_status );
-
 		$log_id = add_post_meta(
 			$post->ID,
 			'_status_change',
 			array(
 				'timestamp' => time(),
 				'user_id'   => get_current_user_id(),
-				'message'   => sprintf( '%s &rarr; %s', $old_status_obj->label ?? $old_status, $new_status_obj->label ?? $new_status ),
+				'message'   => sprintf( '%s &rarr; %s', $this->get_status_label( $old_status, $post ), $this->get_status_label( $new_status, $post ) ),
 			)
 		);
 
@@ -325,6 +322,21 @@ abstract class Event_Admin {
 		if ( $locale_switched ) {
 			restore_previous_locale();
 		}
+	}
+
+	/**
+	 * Return the human-readable label for a post status slug, for use in log messages.
+	 *
+	 * Subclasses can override this to return event-subtype-specific labels
+	 * (e.g. Campus Connect uses a different label for `wcpt-approved-pre-pl`).
+	 *
+	 * @param string  $status The post status slug.
+	 * @param WP_Post $post   The post being transitioned.
+	 * @return string Human-readable label, or the raw slug if no label is found.
+	 */
+	protected function get_status_label( $status, $post ) {
+		$status_obj = get_post_status_object( $status );
+		return $status_obj->label ?? $status;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-functions.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-functions.php
@@ -124,3 +124,34 @@ function wcpt_add_note_metabox( $post ) {
 
 	require_once __DIR__ . '/views/common/metabox-notes.php';
 }
+
+/**
+ * Programmatically add a private note to a wordcamp post.
+ *
+ * This is the low-level counterpart to Event_Admin::validate_and_add_note(),
+ * which requires a form submission. Use this when notes are created outside the
+ * admin UI — e.g. from a REST API endpoint or a cron job.
+ *
+ * @param int    $post_id  Post ID.
+ * @param string $message  Note text (plain text; HTML is stripped).
+ * @param int    $user_id  Author user ID. Pass 0 to attribute to the system
+ *                         (displayed as "WordCamp Bot" in the log).
+ * @return int|false       Meta ID on success, false on failure.
+ */
+function wcpt_add_private_note( $post_id, $message, $user_id = 0 ) {
+	$message = sanitize_textarea_field( $message );
+
+	if ( empty( $message ) ) {
+		return false;
+	}
+
+	return add_post_meta(
+		absint( $post_id ),
+		'_note',
+		array(
+			'timestamp' => time(),
+			'user_id'   => absint( $user_id ),
+			'message'   => $message,
+		)
+	);
+}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wp-rest-vetting-controller.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wp-rest-vetting-controller.php
@@ -244,8 +244,10 @@ class WordCamp_REST_Vetting_Controller extends WP_REST_Controller {
 			return $result;
 		}
 
-		// 3. Log the transition (WordCamp_Admin::log_status_changes() is not
-		//    available outside the admin context, so we write the entry directly).
+		/*
+		 * 3. Log the transition (WordCamp_Admin::log_status_changes() is not
+		 *    available outside the admin context, so we write the entry directly).
+		 */
 		$this->log_status_transition( $post_id, $old_status, 'wcpt-needs-action' );
 
 		return rest_ensure_response(

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wp-rest-vetting-controller.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wp-rest-vetting-controller.php
@@ -1,0 +1,297 @@
+<?php
+defined( 'WPINC' ) || die();
+
+/**
+ * REST API controller for the Campus Connect vetting queue.
+ *
+ * Exposes two endpoints:
+ *
+ *   GET  /wordcamp/v1/vetting/queue   — list Campus Connect posts awaiting vetting
+ *   POST /wordcamp/v1/vetting/process — attach a vetting note and advance to Needs Action
+ *
+ * Both endpoints require the caller to be authenticated and hold the
+ * `wordcamp_wrangle_wordcamps` capability (the same capability checked by
+ * WordCamp_Admin::enforce_post_status() for status changes made through the UI).
+ *
+ * Because WordPress only loads WordCamp_Admin when is_admin() is true, status-change
+ * logging (normally handled via the transition_post_status hook in that class) must
+ * be performed explicitly by this controller.
+ */
+class WordCamp_REST_Vetting_Controller extends WP_REST_Controller {
+
+	/**
+	 * REST API namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wordcamp/v1';
+
+	/**
+	 * REST API base route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'vetting';
+
+	/**
+	 * Register the /queue and /process routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/queue',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_queue' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/process',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'process_application' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_process_args(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Verify the caller can wrangle WordCamps.
+	 *
+	 * Mirrors the capability check in WordCamp_Admin::enforce_post_status().
+	 *
+	 * @return true|WP_Error
+	 */
+	public function check_permission() {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to use the vetting API.', 'wordcamporg' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage WordCamp applications.', 'wordcamporg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return all Campus Connect posts that are pending vetting.
+	 *
+	 * Results are ordered oldest-first so the agent processes them in submission order.
+	 *
+	 * @param WP_REST_Request $request Full request details.
+	 * @return WP_REST_Response
+	 */
+	public function get_queue( $request ) {
+		$posts = get_posts(
+			array(
+				'post_type'      => WCPT_POST_TYPE_ID,
+				'post_status'    => 'wcpt-needs-vetting',
+				'meta_key'       => 'event_subtype',
+				'meta_value'     => 'campusconnect',
+				'posts_per_page' => 100,
+				'orderby'        => 'date',
+				'order'          => 'ASC',
+			)
+		);
+
+		$items = array_map(
+			function ( $post ) use ( $request ) {
+				return $this->prepare_item_for_response( $post, $request );
+			},
+			$posts
+		);
+
+		return rest_ensure_response( $items );
+	}
+
+	/**
+	 * Build the response shape for a single queue entry.
+	 *
+	 * Returns the post ID, title, status, submission date, content (application
+	 * text), admin edit URL, and a `meta` object with the key organizer fields
+	 * the vetting agent needs to evaluate.
+	 *
+	 * @param WP_Post         $post    The wordcamp post.
+	 * @param WP_REST_Request $request Full request details.
+	 * @return array
+	 */
+	public function prepare_item_for_response( $post, $request ) {
+		$meta_fields = array(
+			'Organizer Name',
+			'WordPress.org Username',
+			'Email Address',
+			'Location',
+			'Number of Anticipated Attendees',
+		);
+
+		$meta = array();
+		foreach ( $meta_fields as $field ) {
+			$meta[ $field ] = get_post_meta( $post->ID, $field, true );
+		}
+
+		return array(
+			'id'       => $post->ID,
+			'title'    => $post->post_title,
+			'status'   => $post->post_status,
+			'date'     => $post->post_date,
+			'content'  => $post->post_content,
+			'edit_url' => get_edit_post_link( $post->ID, 'raw' ),
+			'meta'     => $meta,
+		);
+	}
+
+	/**
+	 * Declare the accepted parameters for the /process endpoint.
+	 *
+	 * @return array
+	 */
+	protected function get_process_args() {
+		return array(
+			'post_id' => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'description'       => __( 'The ID of the Campus Connect post to process.', 'wordcamporg' ),
+			),
+			'note'    => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'description'       => __( 'Vetting notes to attach as a private note on the post.', 'wordcamporg' ),
+			),
+		);
+	}
+
+	/**
+	 * Attach a vetting note and advance the post to "Needs Action".
+	 *
+	 * Validates that the post exists, is a Campus Connect entry, and is currently
+	 * in "Needs Vetting". On success it:
+	 *   1. Writes the note via wcpt_add_private_note().
+	 *   2. Changes the status to wcpt-needs-action via wp_update_post().
+	 *   3. Writes a status-change log entry (since WordCamp_Admin is not loaded
+	 *      in the REST context, this cannot rely on the transition_post_status hook).
+	 *
+	 * @param WP_REST_Request $request Full request details.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function process_application( $request ) {
+		$post_id = $request->get_param( 'post_id' );
+		$note    = $request->get_param( 'note' );
+
+		$post = get_post( $post_id );
+
+		if ( ! $post || WCPT_POST_TYPE_ID !== $post->post_type ) {
+			return new WP_Error(
+				'wcpt_vetting_invalid_post',
+				__( 'Post not found.', 'wordcamporg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'campusconnect' !== get_post_meta( $post_id, 'event_subtype', true ) ) {
+			return new WP_Error(
+				'wcpt_vetting_not_campus_connect',
+				__( 'This post is not a Campus Connect application.', 'wordcamporg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( 'wcpt-needs-vetting' !== $post->post_status ) {
+			return new WP_Error(
+				'wcpt_vetting_wrong_status',
+				/* translators: %s: current post status slug */
+				sprintf(
+					__( 'Expected status wcpt-needs-vetting, got %s.', 'wordcamporg' ),
+					$post->post_status
+				),
+				array( 'status' => 409 )
+			);
+		}
+
+		// 1. Attach the vetting note.
+		wcpt_add_private_note( $post_id, $note, get_current_user_id() );
+
+		// 2. Advance the status.
+		$old_status = $post->post_status;
+
+		$result = wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'wcpt-needs-action',
+			),
+			true
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// 3. Log the transition (WordCamp_Admin::log_status_changes() is not
+		//    available outside the admin context, so we write the entry directly).
+		$this->log_status_transition( $post_id, $old_status, 'wcpt-needs-action' );
+
+		return rest_ensure_response(
+			array(
+				'id'         => $post_id,
+				'old_status' => $old_status,
+				'new_status' => 'wcpt-needs-action',
+			)
+		);
+	}
+
+	/**
+	 * Write a status-change log entry for a Campus Connect post.
+	 *
+	 * Uses CC-specific labels from WordCamp_Loader::get_campus_connect_statuses()
+	 * and follows the same storage format as Event_Admin::log_status_changes().
+	 *
+	 * @param int    $post_id    Post ID.
+	 * @param string $old_status Old post status slug.
+	 * @param string $new_status New post status slug.
+	 */
+	protected function log_status_transition( $post_id, $old_status, $new_status ) {
+		// Ensure status labels are stored in English, consistent with log_status_changes().
+		$locale_switched = switch_to_locale( 'en_US' );
+
+		$cc_statuses = WordCamp_Loader::get_campus_connect_statuses();
+		$old_label   = $cc_statuses[ $old_status ] ?? $old_status;
+		$new_label   = $cc_statuses[ $new_status ] ?? $new_status;
+
+		$log_id = add_post_meta(
+			$post_id,
+			'_status_change',
+			array(
+				'timestamp' => time(),
+				'user_id'   => get_current_user_id(),
+				'message'   => sprintf( '%s &rarr; %s', $old_label, $new_label ),
+			)
+		);
+
+		// Mirror the secondary index key written by log_status_changes().
+		if ( $log_id ) {
+			add_post_meta( $post_id, '_status_change_log_' . WCPT_POST_TYPE_ID . ' ' . $log_id, time() );
+		}
+
+		if ( $locale_switched ) {
+			restore_previous_locale();
+		}
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1064,6 +1064,23 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				if ( ! in_array( $post_data['post_status'], $statuses ) ) {
 					$post_data['post_status'] = $statuses[0];
 				}
+
+				/*
+				 * Prevent Campus Connect-only statuses from being applied to non-CC posts.
+				 * This guards against direct REST or programmatic updates that bypass the UI.
+				 * Read the submitted subtype first (it hasn't been persisted yet at this hook),
+				 * falling back to the stored meta value.
+				 */
+				$cc_only_statuses = array( 'wcpt-needs-action', 'wcpt-needs-more-info' );
+				if ( in_array( $post_data['post_status'], $cc_only_statuses, true ) ) {
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce checked in metabox_save.
+					$submitted_subtype = isset( $_POST['event_subtype'] ) ? sanitize_text_field( wp_unslash( $_POST['event_subtype'] ) ) : '';
+					$event_subtype     = $submitted_subtype ?: get_post_meta( absint( $post_data_raw['ID'] ), 'event_subtype', true );
+
+					if ( 'campusconnect' !== $event_subtype ) {
+						$post_data['post_status'] = $post->post_status;
+					}
+				}
 			}
 
 			return $post_data;
@@ -1086,6 +1103,18 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 
 			$required_needs_site_fields = $this->get_required_fields( 'needs-site', $post_data_raw['ID'] );
 			$required_scheduled_fields  = $this->get_required_fields( 'scheduled', $post_data_raw['ID'] );
+
+			/*
+			 * Resolve the event subtype once, before any field loops.
+			 *
+			 * The subtype meta is not yet persisted at this hook (wp_insert_post_data fires
+			 * before meta is saved), so read the submitted value from $_POST first and fall
+			 * back to stored meta only if the request did not include the field.
+			 *
+			 * phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce checked in metabox_save.
+			 */
+			$submitted_subtype = isset( $_POST['event_subtype'] ) ? sanitize_text_field( wp_unslash( $_POST['event_subtype'] ) ) : '';
+			$event_subtype     = $submitted_subtype ?: get_post_meta( absint( $post_data_raw['ID'] ), 'event_subtype', true );
 
 			// Needs Site.
 			if ( 'wcpt-needs-site' == $post_data['post_status'] && absint( $post_data_raw['ID'] ) > $min_site_id ) {
@@ -1111,7 +1140,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					if ( empty( $value ) || 'null' == $value ) {
 						// Campus Connect posts revert to Approved For Pre-Planning on failure;
 						// non-CC posts use the standard Needs to be Added to Official Schedule fallback.
-						if ( 'campusconnect' === get_post_meta( absint( $post_data_raw['ID'] ), 'event_subtype', true ) ) {
+						if ( 'campusconnect' === $event_subtype ) {
 							$post_data['post_status'] = 'wcpt-approved-pre-pl';
 						} else {
 							$post_data['post_status'] = 'wcpt-needs-schedule';

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1109,7 +1109,13 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					$value = $_POST[ wcpt_key_to_str( $field, 'wcpt_' ) ] ?? '';
 
 					if ( empty( $value ) || 'null' == $value ) {
-						$post_data['post_status']     = 'wcpt-needs-schedule';
+						// Campus Connect posts revert to Approved For Pre-Planning on failure;
+						// non-CC posts use the standard Needs to be Added to Official Schedule fallback.
+						if ( 'campusconnect' === get_post_meta( absint( $post_data_raw['ID'] ), 'event_subtype', true ) ) {
+							$post_data['post_status'] = 'wcpt-approved-pre-pl';
+						} else {
+							$post_data['post_status'] = 'wcpt-needs-schedule';
+						}
 						$this->active_admin_notices[] = 3;
 						break;
 					}
@@ -1322,6 +1328,10 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		 * @return array
 		 */
 		public static function get_valid_status_transitions( $status ) {
+			if ( self::is_campus_connect_post() ) {
+				return WordCamp_Loader::get_campus_connect_status_transitions( $status );
+			}
+
 			return WordCamp_Loader::get_valid_status_transitions( $status );
 		}
 
@@ -1331,7 +1341,61 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 		 * @return array
 		 */
 		public static function get_post_statuses() {
-			return WordCamp_Loader::get_post_statuses();
+			if ( self::is_campus_connect_post() ) {
+				return WordCamp_Loader::get_campus_connect_statuses();
+			}
+
+			// For all non-Campus-Connect subtypes: return the full list but strip
+			// the two statuses that are exclusive to Campus Connect.
+			$statuses = WordCamp_Loader::get_post_statuses();
+			unset( $statuses['wcpt-needs-action'], $statuses['wcpt-needs-more-info'] );
+
+			return $statuses;
+		}
+
+		/**
+		 * Return the human-readable label for a post status slug.
+		 *
+		 * For Campus Connect posts, returns the CC-specific label so that status-change
+		 * log entries (e.g. "Approved For Pre-Planning" instead of
+		 * "Approved for Pre-Planning Pending Agreement") match the dropdown the user sees.
+		 *
+		 * @param string  $status The post status slug.
+		 * @param WP_Post $post   The post being transitioned.
+		 * @return string Human-readable label.
+		 */
+		protected function get_status_label( $status, $post ) {
+			if ( 'campusconnect' === get_post_meta( $post->ID, 'event_subtype', true ) ) {
+				$cc_statuses = WordCamp_Loader::get_campus_connect_statuses();
+				if ( isset( $cc_statuses[ $status ] ) ) {
+					return $cc_statuses[ $status ];
+				}
+			}
+
+			return parent::get_status_label( $status, $post );
+		}
+
+		/**
+		 * Check whether the post currently being edited is a Campus Connect event.
+		 *
+		 * A wordcamp entry is Campus Connect when its `event_subtype` meta value
+		 * equals `campusconnect`.
+		 *
+		 * @return bool
+		 */
+		protected static function is_campus_connect_post() {
+			$post_id = get_the_ID();
+
+			// Fallback for admin edit screens where get_the_ID() may not be set yet.
+			if ( ! $post_id && ! empty( $_GET['post'] ) ) {
+				$post_id = absint( $_GET['post'] );
+			}
+
+			if ( ! $post_id ) {
+				return false;
+			}
+
+			return 'campusconnect' === get_post_meta( $post_id, 'event_subtype', true );
 		}
 
 		/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -405,7 +405,7 @@ class WordCamp_Loader extends Event_Loader {
 			'wcpt-needs-more-info' => array( 'wcpt-needs-action', 'wcpt-approved-pre-pl', 'wcpt-rejected', 'wcpt-cancelled' ),
 			'wcpt-approved-pre-pl' => array( 'wcpt-scheduled', 'wcpt-rejected', 'wcpt-cancelled' ),
 			'wcpt-scheduled'       => array( 'wcpt-closed', 'wcpt-rejected', 'wcpt-cancelled' ),
-			'wcpt-closed'          => array(),
+			'wcpt-closed'          => array( 'wcpt-rejected', 'wcpt-cancelled' ),
 			'wcpt-rejected'        => $all,  // Declined can go to any CC status.
 			'wcpt-cancelled'       => $all,  // Cancelled can go to any CC status.
 		);

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -25,7 +25,7 @@ class WordCamp_Loader extends Event_Loader {
 		add_filter( 'query_vars',                      array( $this, 'query_vars'                        ) );
 		add_filter( 'rest_wordcamp_collection_params', array( $this, 'set_rest_post_status_default'      ) );
 		add_action( 'rest_api_init',                   array( $this, 'register_rest_public_fields'       ) );
-		add_action( 'rest_api_init',                   array( $this, 'register_vetting_rest_routes'      ) );
+		add_action( 'rest_api_init',                   array( $this, 'register_vetting_rest_routes' ) );
 		add_action( 'init',                            array( $this, 'register_post_capabilities' ) );
 	}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -25,6 +25,7 @@ class WordCamp_Loader extends Event_Loader {
 		add_filter( 'query_vars',                      array( $this, 'query_vars'                        ) );
 		add_filter( 'rest_wordcamp_collection_params', array( $this, 'set_rest_post_status_default'      ) );
 		add_action( 'rest_api_init',                   array( $this, 'register_rest_public_fields'       ) );
+		add_action( 'rest_api_init',                   array( $this, 'register_vetting_rest_routes'      ) );
 		add_action( 'init',                            array( $this, 'register_post_capabilities' ) );
 	}
 
@@ -38,6 +39,7 @@ class WordCamp_Loader extends Event_Loader {
 	function includes() {
 		// Load the files
 		require_once WCPT_DIR . 'wcpt-wordcamp/class-wp-rest-wordcamps-controller.php';
+		require_once WCPT_DIR . 'wcpt-wordcamp/class-wp-rest-vetting-controller.php';
 		require_once WCPT_DIR . 'wcpt-wordcamp/wordcamp-template.php';
 
 		// Quick admin check and load if needed
@@ -493,6 +495,16 @@ class WordCamp_Loader extends Event_Loader {
 				},
 			)
 		);
+	}
+
+	/**
+	 * Register the Campus Connect vetting REST endpoints.
+	 *
+	 * @hooked action rest_api_init
+	 */
+	public function register_vetting_rest_routes() {
+		$controller = new WordCamp_REST_Vetting_Controller();
+		$controller->register_routes();
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -178,6 +178,8 @@ class WordCamp_Loader extends Event_Loader {
 	public static function get_post_statuses() {
 		return array(
 			'wcpt-needs-vetting'   => _x( 'Needs Vetting',                               'wordcamp status', 'wordcamporg' ),
+			'wcpt-needs-action'    => _x( 'Needs Action',                                'wordcamp status', 'wordcamporg' ),
+			'wcpt-needs-more-info' => _x( 'Needs More Info',                             'wordcamp status', 'wordcamporg' ),
 			'wcpt-needs-orientati' => _x( 'Needs Orientation/Interview',                 'wordcamp status', 'wordcamporg' ),
 			'wcpt-more-info-reque' => _x( 'On Hold',                                     'wordcamp status', 'wordcamporg' ),
 			'wcpt-interview-sched' => _x( 'Interview/Orientation Scheduled',             'wordcamp status', 'wordcamporg' ),
@@ -248,6 +250,8 @@ class WordCamp_Loader extends Event_Loader {
 	public static function get_active_wordcamp_statuses() {
 		return array_merge(
 			array(
+				'wcpt-needs-action',
+				'wcpt-needs-more-info',
 				'wcpt-approved-pre-pl',
 				'wcpt-needs-email',
 				'wcpt-needs-site',
@@ -281,6 +285,8 @@ class WordCamp_Loader extends Event_Loader {
 	public static function map_statuses_to_milestones() {
 		$milestones = array(
 			'wcpt-needs-vetting'   => 'Application received',
+			'wcpt-needs-action'    => 'Application vetted',
+			'wcpt-needs-more-info' => 'Application vetted',
 			'wcpt-needs-orientati' => 'Application vetted',
 			'wcpt-more-info-reque' => 'Application vetted',
 			'wcpt-interview-sched' => 'Interview scheduled',
@@ -346,6 +352,65 @@ class WordCamp_Loader extends Event_Loader {
 		}
 
 		if ( empty( $transitions[ $status ] ) ) {
+			return array( 'wcpt-needs-vetting' );
+		}
+
+		return $transitions[ $status ];
+	}
+
+	/**
+	 * Get the eight statuses available for Campus Connect events.
+	 *
+	 * These replace the full WordCamp status list for entries where
+	 * `Event Subtype` equals `campusconnect`, keeping the workflow simple.
+	 *
+	 * @return array Associative array of slug => label.
+	 */
+	public static function get_campus_connect_statuses() {
+		$all  = self::get_post_statuses();
+		$keys = array(
+			'wcpt-needs-vetting',
+			'wcpt-needs-action',
+			'wcpt-needs-more-info',
+			'wcpt-approved-pre-pl',
+			'wcpt-rejected',
+			'wcpt-cancelled',
+			'wcpt-scheduled',
+			'wcpt-closed',
+		);
+
+		$statuses = array_intersect_key( $all, array_flip( $keys ) );
+
+		// Campus Connect uses a shorter label for this status.
+		$statuses['wcpt-approved-pre-pl'] = _x( 'Approved For Pre-Planning', 'wordcamp status', 'wordcamporg' );
+
+		return $statuses;
+	}
+
+	/**
+	 * Get the valid status transitions for Campus Connect events.
+	 *
+	 * Only entries where `Event Subtype` equals `campusconnect` use this
+	 * simplified transition map.
+	 *
+	 * @param string $status Current status slug.
+	 * @return array Array of valid next-status slugs.
+	 */
+	public static function get_campus_connect_status_transitions( $status ) {
+		$all = array_keys( self::get_campus_connect_statuses() );
+
+		$transitions = array(
+			'wcpt-needs-vetting'   => array( 'wcpt-needs-action', 'wcpt-needs-more-info', 'wcpt-approved-pre-pl', 'wcpt-rejected', 'wcpt-cancelled' ),
+			'wcpt-needs-action'    => array( 'wcpt-needs-more-info', 'wcpt-approved-pre-pl', 'wcpt-scheduled', 'wcpt-rejected', 'wcpt-cancelled' ),
+			'wcpt-needs-more-info' => array( 'wcpt-needs-action', 'wcpt-approved-pre-pl', 'wcpt-rejected', 'wcpt-cancelled' ),
+			'wcpt-approved-pre-pl' => array( 'wcpt-scheduled', 'wcpt-rejected', 'wcpt-cancelled' ),
+			'wcpt-scheduled'       => array( 'wcpt-closed', 'wcpt-rejected', 'wcpt-cancelled' ),
+			'wcpt-closed'          => array(),
+			'wcpt-rejected'        => $all,  // Declined can go to any CC status.
+			'wcpt-cancelled'       => $all,  // Cancelled can go to any CC status.
+		);
+
+		if ( ! isset( $transitions[ $status ] ) ) {
 			return array( 'wcpt-needs-vetting' );
 		}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -364,7 +364,7 @@ class WordCamp_Loader extends Event_Loader {
 	 * Get the eight statuses available for Campus Connect events.
 	 *
 	 * These replace the full WordCamp status list for entries where
-	 * `Event Subtype` equals `campusconnect`, keeping the workflow simple.
+	 * `event_subtype` equals `campusconnect`, keeping the workflow simple.
 	 *
 	 * @return array Associative array of slug => label.
 	 */


### PR DESCRIPTION
## Summary

Implements point 1 of #1714: restricts the WordCamp Status dropdown, transition map, and status-change log to Campus Connect–specific values for entries where `event_subtype` equals `campusconnect`. Non-CC event subtypes (WordCamp, DoAction, Student Club, Other Event) are unaffected.

## Changes

### `wcpt-wordcamp/wordcamp-loader.php`
- Added `wcpt-needs-action` and `wcpt-needs-more-info` to `get_post_statuses()`. Both are registered globally so WordPress is aware of them, but excluded from non-CC dropdowns via the `WordCamp_Admin` override.
- New `get_campus_connect_statuses()`: returns the eight CC-specific statuses with the shortened label "Approved For Pre-Planning" for `wcpt-approved-pre-pl`.
- New `get_campus_connect_status_transitions()`: dedicated transition map for CC entries.

### `wcpt-wordcamp/wordcamp-admin.php`
- `get_post_statuses()` override: CC posts → 8 CC statuses; non-CC posts → original list with `wcpt-needs-action` and `wcpt-needs-more-info` stripped.
- `get_valid_status_transitions()` override: CC posts → CC transition map; non-CC posts → original map, unchanged.
- New `is_campus_connect_post()`: reads `get_post_meta( $id, 'event_subtype' )` to determine whether the post being edited is a CC entry.
- New `get_status_label()` override: returns CC-specific labels for log entries on CC posts; falls back to parent for everything else.
- `require_complete_meta_to_publish_wordcamp()`: when scheduling validation fails on a CC post, reverts to `wcpt-approved-pre-pl` instead of the non-CC `wcpt-needs-schedule`.

### `wcpt-event/class-event-admin.php`
- `log_status_changes()`: replaced direct `get_post_status_object()->label` calls with a new overridable `get_status_label( $status, $post )` method.
- New `get_status_label()` base implementation wraps `get_post_status_object()`; subclasses can override for event-subtype–specific labels. No behaviour change for non-CC event types.

### `views/wordcamp/metabox-status.php`
- Dropdown options now render `$post_status_label` (from the `get_post_statuses()` foreach) instead of `$status->label` (globally registered), so subtype-specific labels are respected at render time.
- Read-only status display uses the same label lookup for consistency.

## Campus Connect transition map

| From | Can transition to |
|---|---|
| Needs Vetting | Needs Action, Needs More Info, Approved For Pre-Planning, Declined, Cancelled |
| Needs Action | Needs More Info, Approved For Pre-Planning, WordCamp Scheduled, Declined, Cancelled |
| Needs More Info | Needs Action, Approved For Pre-Planning, Declined, Cancelled |
| Approved For Pre-Planning | WordCamp Scheduled, Declined, Cancelled |
| WordCamp Scheduled | WordCamp Closed, Declined, Cancelled |
| WordCamp Closed | Declined, Cancelled |
| Declined | Any CC status |
| Cancelled | Any CC status |

## Test plan

- [ ] Open a CC post (`event_subtype = campusconnect`). Confirm the status dropdown shows exactly the 8 CC statuses and no others.
- [ ] Confirm "Approved For Pre-Planning" appears as the label for `wcpt-approved-pre-pl` in the CC dropdown. Confirm non-CC posts still show "Approved for Pre-Planning Pending Agreement" for the same slug.
- [ ] On a CC post in Needs Vetting, confirm only the expected next statuses are enabled (Needs Action, Needs More Info, Approved For Pre-Planning, Declined, Cancelled). Confirm all others are disabled.
- [ ] Transition a CC post through several statuses. Confirm the status-change log entries use CC-specific labels.
- [ ] On a CC post in Approved For Pre-Planning, attempt to save with status WordCamp Scheduled while leaving required fields empty. Confirm the post remains in Approved For Pre-Planning and the validation error is shown.
- [ ] Open a non-CC post (WordCamp, DoAction, etc.). Confirm the full original status list is shown, `wcpt-needs-action` and `wcpt-needs-more-info` are absent, and transition enforcement is unchanged.
- [ ] On a CC post in WordCamp Closed, confirm only Declined and Cancelled are enabled in the status dropdown and all other statuses are disabled.

Closes #1714 (point 1 only).
