### PR TITLE
CampTix: Show coupon name on Attendees search for tix_coupon_id:<ID>

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -178,6 +178,7 @@ class CampTix_Plugin {
 		add_action( 'camptix_notices', array( $this, 'do_notices' ) );
 		add_action( 'admin_notices', array( $this, 'do_admin_notices' ) );
 		add_action( 'admin_notices', array( $this, 'do_admin_errors' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_notice_coupon_search' ) );
 		$this->add_resend_notices();
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -7180,6 +7181,50 @@ class CampTix_Plugin {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Render a friendly notice on the Attendees list when the search query is
+	 * the internal `tix_coupon_id:<ID>` filter used by the Coupon column and
+	 * the Coupons "Used" count. Display-only — the underlying search is
+	 * unchanged.
+	 */
+	function maybe_notice_coupon_search() {
+		global $pagenow;
+
+		if ( 'edit.php' !== $pagenow ) {
+			return;
+		}
+
+		if ( empty( $_GET['post_type'] ) || 'tix_attendee' !== $_GET['post_type'] ) {
+			return;
+		}
+
+		$search = isset( $_GET['s'] ) ? wp_unslash( $_GET['s'] ) : '';
+		if ( ! preg_match( '/^tix_coupon_id:(\d+)$/', $search, $matches ) ) {
+			return;
+		}
+
+		$coupon = get_post( (int) $matches[1] );
+		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-info"><p>%s</p></div>',
+			wp_kses(
+				sprintf(
+					/* translators: 1: coupon code/title, 2: URL to edit the coupon. */
+					__( 'Showing attendees who used coupon: <strong>%1$s</strong> (<a href="%2$s">edit coupon</a>).', 'wordcamporg' ),
+					esc_html( $coupon->post_title ),
+					esc_url( get_edit_post_link( $coupon->ID ) )
+				),
+				array(
+					'strong' => array(),
+					'a'      => array( 'href' => array() ),
+				)
+			)
+		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -168,7 +168,7 @@ class CampTix_Plugin {
 		// Handle query extras for attendees, tickets, etc.
 		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_attendees_by_coupon' ) );
-		add_action( 'load-edit.php', array( $this, 'redirect_old_attendee_coupon_search' ) );
+		add_action( 'load-edit.php', array( $this, 'rewrite_old_attendee_coupon_search_query_args' ) );
 
 		// Used to update stats
 		add_action( 'transition_post_status', array( $this, 'transition_post_status' ), 10, 3 );
@@ -943,11 +943,7 @@ class CampTix_Plugin {
 	 * @return int Selected coupon post ID, or 0 when absent or malformed.
 	 */
 	function get_attendee_coupon_filter_id() {
-		if ( empty( $_GET['tix_coupon_id'] ) ) {
-			return 0;
-		}
-
-		$coupon_id = wp_unslash( $_GET['tix_coupon_id'] );
+		$coupon_id = $_GET['tix_coupon_id'] ?? 0;
 		if ( ! is_scalar( $coupon_id ) ) {
 			return 0;
 		}
@@ -956,59 +952,55 @@ class CampTix_Plugin {
 	}
 
 	/**
-	 * Redirect old attendee coupon search URLs to the coupon filter parameter.
+	 * Rewrite old attendee coupon search URLs to the coupon filter parameter.
 	 */
-	function redirect_old_attendee_coupon_search() {
-		$redirect_url = $this->get_old_attendee_coupon_search_redirect_url();
-		if ( ! $redirect_url ) {
+	function rewrite_old_attendee_coupon_search_query_args() {
+		$coupon_id = $this->get_old_attendee_coupon_search_filter_id();
+		if ( ! $coupon_id ) {
 			return;
 		}
 
-		wp_safe_redirect( $redirect_url );
-		exit;
+		$_GET['tix_coupon_id']     = (string) $coupon_id;
+		$_REQUEST['tix_coupon_id'] = (string) $coupon_id;
+
+		unset( $_GET['s'], $_REQUEST['s'] );
 	}
 
 	/**
-	 * Return a new attendee list URL for old tix_coupon_id:<ID> searches.
+	 * Return the coupon ID from old tix_coupon_id:<ID> attendee searches.
 	 *
-	 * @param string|null $request_uri Optional request URI. Defaults to the current request.
-	 *
-	 * @return string|false Redirect URL when applicable, otherwise false.
+	 * @return int Coupon post ID when applicable, otherwise 0.
 	 */
-	function get_old_attendee_coupon_search_redirect_url( $request_uri = null ) {
-		if ( empty( $_GET['post_type'] ) || 'tix_attendee' !== $_GET['post_type'] || ! isset( $_GET['s'] ) ) {
-			return false;
+	function get_old_attendee_coupon_search_filter_id() {
+		if ( empty( $_GET['post_type'] ) || ! isset( $_GET['s'] ) ) {
+			return 0;
+		}
+
+		$post_type = wp_unslash( $_GET['post_type'] );
+		if ( ! is_scalar( $post_type ) || 'tix_attendee' !== (string) $post_type ) {
+			return 0;
 		}
 
 		$search = wp_unslash( $_GET['s'] );
 		if ( ! is_scalar( $search ) ) {
-			return false;
+			return 0;
 		}
 
 		if ( ! preg_match( '/^tix_coupon_id:(\d+)$/', (string) $search, $matches ) ) {
-			return false;
+			return 0;
 		}
 
 		$coupon_id = absint( $matches[1] );
 		if ( ! $coupon_id ) {
-			return false;
+			return 0;
 		}
 
 		$coupon = get_post( $coupon_id );
 		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type ) {
-			return false;
+			return 0;
 		}
 
-		if ( null === $request_uri ) {
-			$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-		}
-
-		if ( empty( $request_uri ) || ! is_scalar( $request_uri ) ) {
-			return false;
-		}
-
-		$redirect_url = remove_query_arg( 's', (string) $request_uri );
-		return add_query_arg( 'tix_coupon_id', $coupon_id, $redirect_url );
+		return $coupon_id;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -167,6 +167,8 @@ class CampTix_Plugin {
 
 		// Handle query extras for attendees, tickets, etc.
 		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
+		add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_attendees_by_coupon' ) );
+		add_action( 'load-edit.php', array( $this, 'redirect_old_attendee_coupon_search' ) );
 
 		// Used to update stats
 		add_action( 'transition_post_status', array( $this, 'transition_post_status' ), 10, 3 );
@@ -178,7 +180,6 @@ class CampTix_Plugin {
 		add_action( 'camptix_notices', array( $this, 'do_notices' ) );
 		add_action( 'admin_notices', array( $this, 'do_admin_notices' ) );
 		add_action( 'admin_notices', array( $this, 'do_admin_errors' ) );
-		add_action( 'admin_notices', array( $this, 'maybe_notice_coupon_search' ) );
 		$this->add_resend_notices();
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -697,7 +698,7 @@ class CampTix_Plugin {
 				if ( $coupon_id ) {
 					$coupon = get_post_meta( $post_id, 'tix_coupon', true );
 					$attendees_url = get_admin_url( 0, '/edit.php?post_type=tix_attendee' );
-					$attendees_url = add_query_arg( 's', 'tix_coupon_id:' . intval( $coupon_id ), $attendees_url );
+					$attendees_url = add_query_arg( 'tix_coupon_id', intval( $coupon_id ), $attendees_url );
 					printf( '<a href="%s">%s</a>', esc_url( $attendees_url ), esc_html( $coupon ) );
 				}
 				break;
@@ -743,7 +744,7 @@ class CampTix_Plugin {
 				break;
 			case 'tix_used':
 				$attendees_url = get_admin_url( 0, '/edit.php?post_type=tix_attendee' );
-				$attendees_url = add_query_arg( 's', 'tix_coupon_id:' . intval( $post_id ), $attendees_url );
+				$attendees_url = add_query_arg( 'tix_coupon_id', intval( $post_id ), $attendees_url );
 				printf( '<a href="%s">%d</a>', esc_url( $attendees_url ), absint( $this->get_used_coupons_count( $post_id ) ) );
 				break;
 			case 'tix_remaining':
@@ -861,6 +862,27 @@ class CampTix_Plugin {
 		if ( ! $query->is_main_query() )
 			return;
 
+		$coupon_id = $this->get_attendee_coupon_filter_id();
+		if ( is_admin() && $coupon_id && $query->get('post_type') == 'tix_attendee' ) {
+			$coupon = get_post( $coupon_id );
+
+			if ( $coupon && 'tix_coupon' == $coupon->post_type ) {
+				$meta_query = $query->get( 'meta_query' );
+				if ( ! is_array( $meta_query ) ) {
+					$meta_query = array();
+				}
+
+				$meta_query[] = array(
+					'key' => 'tix_coupon_id',
+					'value' => $coupon_id,
+					'compare' => '=',
+					'type' => 'CHAR',
+				);
+
+				$query->set( 'meta_query', $meta_query );
+			}
+		}
+
 		// Allow ordering by the purchased ticket id.
 		if ( $query->get('orderby') == 'tix_ticket_id' && $query->get('post_type') == 'tix_attendee' ) {
 			$meta_query = array(
@@ -886,6 +908,107 @@ class CampTix_Plugin {
 
 			$query->set( 'meta_query', $meta_query );
 		}
+	}
+
+	/**
+	 * Render a coupon filter dropdown on the Attendees list table.
+	 */
+	public function restrict_manage_attendees_by_coupon() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'edit-tix_attendee' !== $screen->id ) {
+			return;
+		}
+
+		$coupons = $this->get_all_coupons();
+		if ( empty( $coupons ) ) {
+			return;
+		}
+
+		$selected_coupon_id = $this->get_attendee_coupon_filter_id();
+		?>
+		<select name="tix_coupon_id" id="filter-by-tix-coupon">
+			<option value=""><?php esc_html_e( 'All coupons', 'wordcamporg' ); ?></option>
+			<?php foreach ( $coupons as $coupon ) : ?>
+				<option value="<?php echo esc_attr( $coupon->ID ); ?>" <?php selected( $selected_coupon_id, $coupon->ID ); ?>>
+					<?php echo esc_html( $coupon->post_title ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Return the coupon ID selected in the Attendees list table filter.
+	 *
+	 * @return int Selected coupon post ID, or 0 when absent or malformed.
+	 */
+	function get_attendee_coupon_filter_id() {
+		if ( empty( $_GET['tix_coupon_id'] ) ) {
+			return 0;
+		}
+
+		$coupon_id = wp_unslash( $_GET['tix_coupon_id'] );
+		if ( ! is_scalar( $coupon_id ) ) {
+			return 0;
+		}
+
+		return absint( $coupon_id );
+	}
+
+	/**
+	 * Redirect old attendee coupon search URLs to the coupon filter parameter.
+	 */
+	function redirect_old_attendee_coupon_search() {
+		$redirect_url = $this->get_old_attendee_coupon_search_redirect_url();
+		if ( ! $redirect_url ) {
+			return;
+		}
+
+		wp_safe_redirect( $redirect_url );
+		exit;
+	}
+
+	/**
+	 * Return a new attendee list URL for old tix_coupon_id:<ID> searches.
+	 *
+	 * @param string|null $request_uri Optional request URI. Defaults to the current request.
+	 *
+	 * @return string|false Redirect URL when applicable, otherwise false.
+	 */
+	function get_old_attendee_coupon_search_redirect_url( $request_uri = null ) {
+		if ( empty( $_GET['post_type'] ) || 'tix_attendee' !== $_GET['post_type'] || ! isset( $_GET['s'] ) ) {
+			return false;
+		}
+
+		$search = wp_unslash( $_GET['s'] );
+		if ( ! is_scalar( $search ) ) {
+			return false;
+		}
+
+		if ( ! preg_match( '/^tix_coupon_id:(\d+)$/', (string) $search, $matches ) ) {
+			return false;
+		}
+
+		$coupon_id = absint( $matches[1] );
+		if ( ! $coupon_id ) {
+			return false;
+		}
+
+		$coupon = get_post( $coupon_id );
+		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type ) {
+			return false;
+		}
+
+		if ( null === $request_uri ) {
+			$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		}
+
+		if ( empty( $request_uri ) || ! is_scalar( $request_uri ) ) {
+			return false;
+		}
+
+		$redirect_url = remove_query_arg( 's', (string) $request_uri );
+		return add_query_arg( 'tix_coupon_id', $coupon_id, $redirect_url );
 	}
 
 	/**
@@ -7181,50 +7304,6 @@ class CampTix_Plugin {
 				);
 			}
 		}
-	}
-
-	/**
-	 * Render a friendly notice on the Attendees list when the search query is
-	 * the internal `tix_coupon_id:<ID>` filter used by the Coupon column and
-	 * the Coupons "Used" count. Display-only — the underlying search is
-	 * unchanged.
-	 */
-	function maybe_notice_coupon_search() {
-		global $pagenow;
-
-		if ( 'edit.php' !== $pagenow ) {
-			return;
-		}
-
-		if ( empty( $_GET['post_type'] ) || 'tix_attendee' !== $_GET['post_type'] ) {
-			return;
-		}
-
-		$search = isset( $_GET['s'] ) ? wp_unslash( $_GET['s'] ) : '';
-		if ( ! preg_match( '/^tix_coupon_id:(\d+)$/', $search, $matches ) ) {
-			return;
-		}
-
-		$coupon = get_post( (int) $matches[1] );
-		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type || 'publish' !== $coupon->post_status ) {
-			return;
-		}
-
-		printf(
-			'<div class="notice notice-info"><p>%s</p></div>',
-			wp_kses(
-				sprintf(
-					/* translators: 1: coupon code/title, 2: URL to edit the coupon. */
-					__( 'Showing attendees who used coupon: <strong>%1$s</strong> (<a href="%2$s">edit coupon</a>).', 'wordcamporg' ),
-					esc_html( $coupon->post_title ),
-					esc_url( get_edit_post_link( $coupon->ID ) )
-				),
-				array(
-					'strong' => array(),
-					'a'      => array( 'href' => array() ),
-				)
-			)
-		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -7206,7 +7206,7 @@ class CampTix_Plugin {
 		}
 
 		$coupon = get_post( (int) $matches[1] );
-		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type ) {
+		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type || 'publish' !== $coupon->post_status ) {
 			return;
 		}
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -873,10 +873,10 @@ class CampTix_Plugin {
 				}
 
 				$meta_query[] = array(
-					'key' => 'tix_coupon_id',
-					'value' => $coupon_id,
+					'key'     => 'tix_coupon_id',
+					'value'   => $coupon_id,
 					'compare' => '=',
-					'type' => 'CHAR',
+					'type'    => 'CHAR',
 				);
 
 				$query->set( 'meta_query', $meta_query );

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -972,35 +972,18 @@ class CampTix_Plugin {
 	 * @return int Coupon post ID when applicable, otherwise 0.
 	 */
 	function get_old_attendee_coupon_search_filter_id() {
-		if ( empty( $_GET['post_type'] ) || ! isset( $_GET['s'] ) ) {
-			return 0;
-		}
+		$search = $_GET['s'] ?? '';
 
-		$post_type = wp_unslash( $_GET['post_type'] );
-		if ( ! is_scalar( $post_type ) || 'tix_attendee' !== (string) $post_type ) {
-			return 0;
-		}
-
-		$search = wp_unslash( $_GET['s'] );
-		if ( ! is_scalar( $search ) ) {
-			return 0;
-		}
-
-		if ( ! preg_match( '/^tix_coupon_id:(\d+)$/', (string) $search, $matches ) ) {
+		if (
+			'tix_attendee' !== ( $_GET['post_type'] ?? '' ) ||
+			! is_scalar( $search ) ||
+			! preg_match( '/^tix_coupon_id:(\d+)$/', (string) $search, $matches )
+		) {
 			return 0;
 		}
 
 		$coupon_id = absint( $matches[1] );
-		if ( ! $coupon_id ) {
-			return 0;
-		}
-
-		$coupon = get_post( $coupon_id );
-		if ( ! $coupon || 'tix_coupon' !== $coupon->post_type ) {
-			return 0;
-		}
-
-		return $coupon_id;
+		return 'tix_coupon' === get_post_type( $coupon_id ) ? $coupon_id : 0;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -75,6 +75,8 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		self::$coupons   = array();
 		self::$attendees = array();
 
+		unset( $_GET['post_type'], $_GET['s'], $_GET['tix_coupon_id'] );
+
 		parent::tear_down();
 	}
 
@@ -184,6 +186,11 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		}
 		if ( ! empty( $args['coupon_id'] ) ) {
 			update_post_meta( $post_id, 'tix_coupon_id', $args['coupon_id'] );
+
+			$coupon = get_post( $args['coupon_id'] );
+			if ( $coupon ) {
+				update_post_meta( $post_id, 'tix_coupon', $coupon->post_title );
+			}
 		}
 		if ( ! empty( $args['payment_method'] ) ) {
 			update_post_meta( $post_id, 'tix_payment_method', $args['payment_method'] );
@@ -360,6 +367,131 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		$this->assertFalse( self::$camptix->get_coupon_by_code( 12345 ) );
 		$this->assertFalse( self::$camptix->get_coupon_by_code( null ) );
 		$this->assertFalse( self::$camptix->get_coupon_by_code( array( 'code' ) ) );
+	}
+
+	/**
+	 * Verify attendee coupon column links to the coupon filter.
+	 */
+	public function test_attendee_coupon_column_links_to_coupon_filter() {
+		$ticket_id   = $this->create_ticket();
+		$coupon_id   = $this->create_coupon( array( 'code' => 'EARLYBIRD' ) );
+		$attendee_id = $this->create_attendee( $ticket_id, array( 'coupon_id' => $coupon_id ) );
+
+		ob_start();
+		self::$camptix->manage_columns_attendee_action( 'tix_coupon', $attendee_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'tix_coupon_id=' . $coupon_id, $output );
+		$this->assertStringNotContainsString( 's=', $output );
+	}
+
+	/**
+	 * Verify coupon used column links to the coupon filter.
+	 */
+	public function test_coupon_used_column_links_to_coupon_filter() {
+		$ticket_id = $this->create_ticket();
+		$coupon_id = $this->create_coupon( array( 'code' => 'EARLYBIRD' ) );
+		$this->create_attendee( $ticket_id, array( 'coupon_id' => $coupon_id ) );
+
+		ob_start();
+		self::$camptix->manage_columns_coupon_action( 'tix_used', $coupon_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'tix_coupon_id=' . $coupon_id, $output );
+		$this->assertStringNotContainsString( 's=', $output );
+	}
+
+	/**
+	 * Verify the attendee coupon filter dropdown renders coupon names.
+	 */
+	public function test_attendee_coupon_filter_dropdown_renders_coupon_names() {
+		$coupon_id = $this->create_coupon( array( 'code' => 'EARLYBIRD' ) );
+		$_GET['tix_coupon_id'] = (string) $coupon_id;
+
+		set_current_screen( 'edit-tix_attendee' );
+
+		ob_start();
+		self::$camptix->restrict_manage_attendees_by_coupon();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="tix_coupon_id"', $output );
+		$this->assertStringContainsString( 'value="' . $coupon_id . '" selected=', $output );
+		$this->assertStringContainsString( 'EARLYBIRD', $output );
+	}
+
+	/**
+	 * Verify the attendee coupon filter adds a coupon meta query.
+	 */
+	public function test_attendee_coupon_filter_adds_meta_query() {
+		$coupon_id = $this->create_coupon( array( 'code' => 'EARLYBIRD' ) );
+		$_GET['tix_coupon_id'] = (string) $coupon_id;
+
+		$query = new WP_Query();
+		$query->set( 'post_type', 'tix_attendee' );
+
+		set_current_screen( 'edit-tix_attendee' );
+
+		$previous_wp_the_query   = isset( $GLOBALS['wp_the_query'] ) ? $GLOBALS['wp_the_query'] : null;
+		$GLOBALS['wp_the_query'] = $query;
+		self::$camptix->pre_get_posts( $query );
+		$GLOBALS['wp_the_query'] = $previous_wp_the_query;
+
+		$meta_query = $query->get( 'meta_query' );
+		$this->assertSame( 'tix_coupon_id', $meta_query[0]['key'] );
+		$this->assertSame( $coupon_id, $meta_query[0]['value'] );
+		$this->assertSame( '=', $meta_query[0]['compare'] );
+	}
+
+	/**
+	 * Verify malformed coupon filter values are ignored.
+	 */
+	public function test_attendee_coupon_filter_ignores_malformed_value() {
+		$_GET['tix_coupon_id'] = array( 'not-a-coupon' );
+
+		$query = new WP_Query();
+		$query->set( 'post_type', 'tix_attendee' );
+
+		set_current_screen( 'edit-tix_attendee' );
+
+		$previous_wp_the_query   = isset( $GLOBALS['wp_the_query'] ) ? $GLOBALS['wp_the_query'] : null;
+		$GLOBALS['wp_the_query'] = $query;
+		self::$camptix->pre_get_posts( $query );
+		$GLOBALS['wp_the_query'] = $previous_wp_the_query;
+
+		$this->assertEmpty( $query->get( 'meta_query' ) );
+	}
+
+	/**
+	 * Verify old coupon search URLs are rewritten to the coupon filter.
+	 */
+	public function test_old_coupon_search_redirect_url_uses_coupon_filter() {
+		$coupon_id = $this->create_coupon( array( 'code' => 'EARLYBIRD' ) );
+
+		$_GET['post_type'] = 'tix_attendee';
+		$_GET['s']         = 'tix_coupon_id:' . $coupon_id;
+
+		$redirect_url = self::$camptix->get_old_attendee_coupon_search_redirect_url(
+			'/wp-admin/edit.php?post_type=tix_attendee&s=tix_coupon_id%3A' . $coupon_id . '&paged=2'
+		);
+
+		$this->assertStringContainsString( 'post_type=tix_attendee', $redirect_url );
+		$this->assertStringContainsString( 'tix_coupon_id=' . $coupon_id, $redirect_url );
+		$this->assertStringContainsString( 'paged=2', $redirect_url );
+		$this->assertStringNotContainsString( '&s=', $redirect_url );
+	}
+
+	/**
+	 * Verify malformed old coupon search values are ignored.
+	 */
+	public function test_old_coupon_search_redirect_url_ignores_malformed_search() {
+		$_GET['post_type'] = 'tix_attendee';
+		$_GET['s']         = array( 'tix_coupon_id:123' );
+
+		$this->assertFalse(
+			self::$camptix->get_old_attendee_coupon_search_redirect_url(
+				'/wp-admin/edit.php?post_type=tix_attendee&s[]=tix_coupon_id%3A123'
+			)
+		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -75,7 +75,14 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		self::$coupons   = array();
 		self::$attendees = array();
 
-		unset( $_GET['post_type'], $_GET['s'], $_GET['tix_coupon_id'] );
+		unset(
+			$_GET['post_type'],
+			$_GET['s'],
+			$_GET['tix_coupon_id'],
+			$_REQUEST['post_type'],
+			$_REQUEST['s'],
+			$_REQUEST['tix_coupon_id']
+		);
 
 		parent::tear_down();
 	}
@@ -462,36 +469,39 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify old coupon search URLs are rewritten to the coupon filter.
+	 * Verify old coupon search args are rewritten to the coupon filter.
 	 */
-	public function test_old_coupon_search_redirect_url_uses_coupon_filter() {
+	public function test_old_coupon_search_query_args_are_rewritten_to_coupon_filter() {
 		$coupon_id = $this->create_coupon( array( 'code' => 'EARLYBIRD' ) );
 
-		$_GET['post_type'] = 'tix_attendee';
-		$_GET['s']         = 'tix_coupon_id:' . $coupon_id;
+		$_GET['post_type']     = 'tix_attendee';
+		$_GET['s']             = 'tix_coupon_id:' . $coupon_id;
+		$_REQUEST['post_type'] = $_GET['post_type'];
+		$_REQUEST['s']         = $_GET['s'];
 
-		$redirect_url = self::$camptix->get_old_attendee_coupon_search_redirect_url(
-			'/wp-admin/edit.php?post_type=tix_attendee&s=tix_coupon_id%3A' . $coupon_id . '&paged=2'
-		);
+		self::$camptix->rewrite_old_attendee_coupon_search_query_args();
 
-		$this->assertStringContainsString( 'post_type=tix_attendee', $redirect_url );
-		$this->assertStringContainsString( 'tix_coupon_id=' . $coupon_id, $redirect_url );
-		$this->assertStringContainsString( 'paged=2', $redirect_url );
-		$this->assertStringNotContainsString( '&s=', $redirect_url );
+		$this->assertSame( (string) $coupon_id, $_GET['tix_coupon_id'] );
+		$this->assertSame( (string) $coupon_id, $_REQUEST['tix_coupon_id'] );
+		$this->assertArrayNotHasKey( 's', $_GET );
+		$this->assertArrayNotHasKey( 's', $_REQUEST );
 	}
 
 	/**
-	 * Verify malformed old coupon search values are ignored.
+	 * Verify malformed old coupon search values are not rewritten.
 	 */
-	public function test_old_coupon_search_redirect_url_ignores_malformed_search() {
-		$_GET['post_type'] = 'tix_attendee';
-		$_GET['s']         = array( 'tix_coupon_id:123' );
+	public function test_old_coupon_search_query_args_ignore_malformed_search() {
+		$_GET['post_type']     = 'tix_attendee';
+		$_GET['s']             = array( 'tix_coupon_id:123' );
+		$_REQUEST['post_type'] = $_GET['post_type'];
+		$_REQUEST['s']         = $_GET['s'];
 
-		$this->assertFalse(
-			self::$camptix->get_old_attendee_coupon_search_redirect_url(
-				'/wp-admin/edit.php?post_type=tix_attendee&s[]=tix_coupon_id%3A123'
-			)
-		);
+		self::$camptix->rewrite_old_attendee_coupon_search_query_args();
+
+		$this->assertArrayNotHasKey( 'tix_coupon_id', $_GET );
+		$this->assertArrayNotHasKey( 'tix_coupon_id', $_REQUEST );
+		$this->assertSame( array( 'tix_coupon_id:123' ), $_GET['s'] );
+		$this->assertSame( array( 'tix_coupon_id:123' ), $_REQUEST['s'] );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -422,7 +422,10 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="tix_coupon_id"', $output );
-		$this->assertStringContainsString( 'value="' . $coupon_id . '" selected=', $output );
+		$this->assertMatchesRegularExpression(
+			'/<option[^>]+value="' . preg_quote( (string) $coupon_id, '/' ) . '"[^>]+selected=[\'"]selected[\'"]/',
+			$output
+		);
 		$this->assertStringContainsString( 'EARLYBIRD', $output );
 	}
 


### PR DESCRIPTION
The Coupon column on the Attendees list and the **Used** count on the Coupons screen both link to `?s=tix_coupon_id:<ID>`. WordPress then echoes the raw `Search results for "tix_coupon_id:10022"` header, forcing reviewers to mentally translate the numeric post ID back into the coupon code they recognize.

This PR adds a small admin notice on the Attendees list that fires only when `s` matches `^tix_coupon_id:(\d+)$` and the coupon post exists, showing the coupon's title with a link to edit it. If the coupon is in the trash, deleted, or `s` is anything else, the page renders exactly as it does today.

The search query, SQL, meta storage, and column rendering are unchanged — this is display-only.

Fixes #1723

### Screenshots

_Before_: header shows `Search results for "tix_coupon_id:10022"` with no indication of which coupon that is.

_After_: same header, plus a notice — `Showing attendees who used coupon: WORDCAMP25 (edit coupon).`

### How to test the changes in this Pull Request:

1. On a CampTix-enabled site, go to **Tickets → Coupons** and click the **Used** count next to any coupon that has been redeemed at least once. URL becomes `edit.php?post_type=tix_attendee&s=tix_coupon_id:<ID>`.
2. Verify a blue info notice appears above the attendees list reading **"Showing attendees who used coupon: <COUPON_CODE> (edit coupon)."** with the edit link pointing to the coupon's edit screen.
3. Click into any attendee and use the link on the **Coupon** column — confirm the same notice renders.
4. Move the coupon to Trash, then revisit the same `?s=tix_coupon_id:<ID>` URL. Confirm no notice renders, no PHP warning is logged, and the rest of the page is intact.
5. Search the Attendees screen by name, email, or transaction ID — confirm no notice is rendered and the existing search behaviour is unchanged.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->