### PR TITLE
Campus Connect: email trigger on Needs Orientation

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -941,9 +941,13 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				do_action( 'wcpt_approved_for_pre_planning', $post );
 			} elseif ( 'wcpt-needs-schedule' == $old_status && 'wcpt-scheduled' == $new_status ) {
 				do_action( 'wcpt_added_to_final_schedule', $post );
+			} elseif ( 'wcpt-approved-pre-pl' === $new_status
+				&& 'campusconnect' === get_post_meta( $post->ID, 'event_subtype', true ) ) {
+				// Fires when a Campus Connect application is approved for pre-planning.
+				// Uses a dedicated action to avoid triggering the non-CC hooks that listen
+				// to wcpt_approved_for_pre_planning (e.g. add_organizer_to_central).
+				do_action( 'wcpt_cc_approved_for_pre_planning', $post );
 			}
-
-			// todo add new triggers - which ones?
 		}
 
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -941,12 +941,12 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				do_action( 'wcpt_approved_for_pre_planning', $post );
 			} elseif ( 'wcpt-needs-schedule' == $old_status && 'wcpt-scheduled' == $new_status ) {
 				do_action( 'wcpt_added_to_final_schedule', $post );
-			} elseif ( 'wcpt-approved-pre-pl' === $new_status
+			} elseif ( 'wcpt-needs-orientati' === $new_status
 				&& 'campusconnect' === get_post_meta( $post->ID, 'event_subtype', true ) ) {
-				// Fires when a Campus Connect application is approved for pre-planning.
+				// Fires when a Campus Connect application transitions to Needs Orientation.
 				// Uses a dedicated action to avoid triggering the non-CC hooks that listen
 				// to wcpt_approved_for_pre_planning (e.g. add_organizer_to_central).
-				do_action( 'wcpt_cc_approved_for_pre_planning', $post );
+				do_action( 'wcpt_cc_needs_orientation', $post );
 			}
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/test-wcor-mailer.php
@@ -183,6 +183,30 @@ class Test_WCOR_Mailer extends Database_TestCase {
 	}
 
 	/**
+	 * Test that the Campus Connect "Needs Orientation" trigger sends its reminder.
+	 *
+	 * @covers WCOR_Mailer::send_trigger_cc_needs_orientation
+	 */
+	public function test_cc_needs_orientation_trigger_message_sent() {
+		update_post_meta( self::$triggered_reminder_post_id, 'wcor_which_trigger', 'wcor_cc_needs_orientation' );
+
+		$wordcamp = get_post( self::$wordcamp_dayton_post_id );
+
+		$this->assertSame( '', $wordcamp->wcor_sent_email_ids );
+
+		do_action( 'wcpt_cc_needs_orientation', $wordcamp );
+
+		$this->assert_mail_succeeded(
+			'dayton@wordcamp.org',
+			'WordCamp Dayton has been added to the final schedule',
+			"<p>Huzzah! A new WordCamp is coming soon to Dayton, Ohio, USA! The lead organizer is janedoe, and the venue is at:</p>\n<p>3640 Colonel Glenn Hwy, Dayton, OH, US</p>\n"
+		);
+
+		$this->assertIsArray( $wordcamp->wcor_sent_email_ids );
+		$this->assertContains( self::$triggered_reminder_post_id, $wordcamp->wcor_sent_email_ids );
+	}
+
+	/**
 	 * Test that timed messages are sent.
 	 *
 	 * @dataProvider data_timed_messages_sent

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -75,12 +75,12 @@ class WCOR_Mailer {
 				),
 			),
 
-			'wcor_cc_approved_for_pre_planning' => array(
-				'name'    => 'Campus Connect application approved for pre-planning',
+			'wcor_cc_needs_orientation' => array(
+				'name'    => 'Campus Connect application needs orientation',
 				'actions' => array(
 					array(
-						'name'       => 'wcpt_cc_approved_for_pre_planning',
-						'callback'   => 'send_trigger_cc_approved_for_pre_planning',
+						'name'       => 'wcpt_cc_needs_orientation',
+						'callback'   => 'send_trigger_cc_needs_orientation',
 						'priority'   => 10,
 						'parameters' => 1,
 					),
@@ -925,17 +925,17 @@ class WCOR_Mailer {
 	}
 
 	/**
-	 * Sends e-mails hooked to the wcor_cc_approved_for_pre_planning trigger.
+	 * Sends e-mails hooked to the wcor_cc_needs_orientation trigger.
 	 *
-	 * This fires when a Campus Connect application transitions to wcpt-approved-pre-pl
+	 * This fires when a Campus Connect application transitions to wcpt-needs-orientati
 	 * status. A dedicated action is used (rather than reusing wcpt_approved_for_pre_planning)
-	 * so that CC approvals do not trigger the non-CC hooks that listen on that action
+	 * so that CC status changes do not trigger the non-CC hooks that listen on that action
 	 * (e.g. add_organizer_to_central, mark_date_added_to_planning_schedule).
 	 *
-	 * @param WP_Post $wordcamp The Campus Connect post that was approved.
+	 * @param WP_Post $wordcamp The Campus Connect post that needs orientation.
 	 */
-	public function send_trigger_cc_approved_for_pre_planning( $wordcamp ) {
-		$this->send_triggered_emails( $wordcamp, 'wcor_cc_approved_for_pre_planning' );
+	public function send_trigger_cc_needs_orientation( $wordcamp ) {
+		$this->send_triggered_emails( $wordcamp, 'wcor_cc_needs_orientation' );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -74,6 +74,18 @@ class WCOR_Mailer {
 					),
 				),
 			),
+
+			'wcor_cc_approved_for_pre_planning' => array(
+				'name'    => 'Campus Connect application approved for pre-planning',
+				'actions' => array(
+					array(
+						'name'       => 'wcpt_cc_approved_for_pre_planning',
+						'callback'   => 'send_trigger_cc_approved_for_pre_planning',
+						'priority'   => 10,
+						'parameters' => 1,
+					),
+				),
+			),
 		);
 
 		add_action( 'wcor_send_timed_emails', array( $this, 'send_timed_emails' ) );
@@ -910,6 +922,20 @@ class WCOR_Mailer {
 	 */
 	public function send_trigger_approved_for_pre_planning( $wordcamp ) {
 		$this->send_triggered_emails( $wordcamp, 'wcor_approved_for_pre_planning' );
+	}
+
+	/**
+	 * Sends e-mails hooked to the wcor_cc_approved_for_pre_planning trigger.
+	 *
+	 * This fires when a Campus Connect application transitions to wcpt-approved-pre-pl
+	 * status. A dedicated action is used (rather than reusing wcpt_approved_for_pre_planning)
+	 * so that CC approvals do not trigger the non-CC hooks that listen on that action
+	 * (e.g. add_organizer_to_central, mark_date_added_to_planning_schedule).
+	 *
+	 * @param WP_Post $wordcamp The Campus Connect post that was approved.
+	 */
+	public function send_trigger_cc_approved_for_pre_planning( $wordcamp ) {
+		$this->send_triggered_emails( $wordcamp, 'wcor_cc_approved_for_pre_planning' );
 	}
 
 	/**


### PR DESCRIPTION
## What

Fires a Campus Connect–specific email trigger when a CC tracker entry is transitioned to **Needs Orientation** (`wcpt-needs-orientati`).

Previously the trigger fired on Approved For Pre-Planning (`wcpt-approved-pre-pl`), which is the wrong point in the CC workflow — orientation emails should go out as soon as the application is accepted and the organiser needs to begin onboarding, not at the pre-planning stage.

## Changes

**`wcpt-wordcamp/wordcamp-admin.php`** — `trigger_schedule_actions()`
- Status guard: `wcpt-approved-pre-pl` → `wcpt-needs-orientati`
- Action name: `wcpt_cc_approved_for_pre_planning` → `wcpt_cc_needs_orientation`

**`wordcamp-organizer-reminders/wcor-mailer.php`**
- Trigger key: `wcor_cc_approved_for_pre_planning` → `wcor_cc_needs_orientation`
- Trigger name: "Campus Connect application approved for pre-planning" → "Campus Connect application needs orientation"
- Action name: `wcpt_cc_approved_for_pre_planning` → `wcpt_cc_needs_orientation`
- Callback: `send_trigger_cc_approved_for_pre_planning()` → `send_trigger_cc_needs_orientation()`

No other logic changed. The `wcpt-needs-orientati` status is registered by PR #1728.

## Test plan

- [ ] Open a CC tracker entry (event_subtype = campusconnect) set to any status before Needs Orientation.
- [ ] Transition it to **Needs Orientation** via the status dropdown.
- [ ] Confirm `wcpt_cc_needs_orientation` fires: add a test hook (`add_action('wcpt_cc_needs_orientation', fn($p) => error_log('fired: '.$p->ID))`) and check the log.
- [ ] Confirm no email fires on transition to Approved For Pre-Planning for a CC entry.
- [ ] Confirm non-CC entries are unaffected (the `campusconnect` subtype guard prevents false positives).
- [ ] In Automated Reminders admin, confirm the "Campus Connect application needs orientation" trigger appears and can have emails attached to it.