### PR TITLE
Bump minimum PHP version to 8.4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.4', '8.5']
+        php-version: ['8.4', '8.5']
 
     services:
       mariadb:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.1"
+			"php": "8.4"
 		},
 		"vendor-dir": "public_html/wp-content/mu-plugins/vendor",
 		"_comment": "Work around `test:watch` timeout, see https://github.com/spatie/phpunit-watcher/issues/63#issuecomment-545633709",


### PR DESCRIPTION
Update the Composer platform constraint and the unit-tests workflow matrix to require PHP 8.4 as the minimum.

The rest of the project already targets 8.4:
- `.github/workflows/linter.yml` runs on PHP 8.4
- `phpcs.xml.dist` has `testVersion` set to `8.4-`
- `.docker/Dockerfile.php-fpm` and `.docker/Dockerfile.phpunit` are both `FROM php:8.4-fpm`

This change drops `8.1` from the unit-tests matrix and bumps `config.platform.php` in `composer.json` from `8.1` to `8.4`, so Composer resolves dependencies against the same PHP version that linting and production run on.

## Test plan
- [ ] Linter workflow passes
- [ ] Unit-tests workflow passes on both 8.4 and 8.5
- [ ] `composer install` completes without platform conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)