### PR TITLE
Lower minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set PHP version
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.4'
+        php-version: '8.3'
         coverage: none
         tools: composer:v2
       env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.4', '8.5']
+        php-version: ['8.3', '8.4', '8.5']
 
     services:
       mariadb:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.4"
+			"php": "8.3"
 		},
 		"vendor-dir": "public_html/wp-content/mu-plugins/vendor",
 		"_comment": "Work around `test:watch` timeout, see https://github.com/spatie/phpunit-watcher/issues/63#issuecomment-545633709",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -89,7 +89,7 @@
 	<config name="minimum_wp_version" value="6.8"/>
 
 	<!-- Check for PHP cross-version compatibility. -->
-	<config name="testVersion" value="8.4-"/>
+	<config name="testVersion" value="8.3-"/>
 	<rule ref="PHPCompatibilityWP"/>
 
 	<rule ref="WordPress-Core">


### PR DESCRIPTION
Roll back the minimum supported PHP version from 8.4 to 8.3.

## Changes
- `composer.json` — `config.platform.php`: `8.4` -> `8.3`
- `.github/workflows/linter.yml` — runner PHP version: `8.4` -> `8.3`
- `.github/workflows/unit-tests.yml` — matrix: `["8.4", "8.5"]` -> `["8.3", "8.4", "8.5"]`
- `phpcs.xml.dist` — PHPCompatibility `testVersion`: `8.4-` -> `8.3-`

The Dockerfiles (`.docker/Dockerfile.php-fpm`, `.docker/Dockerfile.phpunit`) remain on `php:8.4-fpm` for local development; this PR adjusts the floor used by CI linting, Composer resolution, and the test matrix.

## Test plan
- [ ] Linter passes on PHP 8.3
- [ ] Unit tests pass on 8.3, 8.4, and 8.5
- [ ] `composer install` resolves without platform errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)