### PR TITLE
Latest Site Hints: Resolve the next edition from schedule blogmeta

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace WordCamp\Latest_Site_Hints;
-use function WordCamp\Sunrise\get_flagship_canonical_url;
 use const WordCamp\Sunrise\{ PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH };
 
 defined( 'WPINC' ) || die();
@@ -154,10 +153,33 @@ function show_notification_about_latest_site() {
  * @return bool|string
  */
 function get_latest_home_url( $current_domain, $current_path ) {
-	global $wpdb;
+	/*
+	 * `maybe_add_latest_site_hints()`, `canonical_link_past_home_pages_to_current_year()`, and
+	 * `show_notification_about_latest_site()` each call this during the same request, so memoize the result
+	 * to avoid repeating the database work.
+	 */
+	static $cache = array();
+	$cache_key = $current_domain . '|' . $current_path;
 
-	$wordcamp = get_wordcamp_post();
-	$end_date = absint( $wordcamp->meta['End Date (YYYY-mm-dd)'][0] ?? 0 );
+	if ( ! array_key_exists( $cache_key, $cache ) ) {
+		$cache[ $cache_key ] = determine_latest_home_url( $current_domain, $current_path );
+	}
+
+	return $cache[ $cache_key ];
+}
+
+/**
+ * Resolve the home URL of the most recent relevant event in a city.
+ *
+ * See `get_latest_home_url()`, which memoizes this.
+ *
+ * @param string $current_domain
+ * @param string $current_path
+ *
+ * @return bool|string
+ */
+function determine_latest_home_url( $current_domain, $current_path ) {
+	global $wpdb;
 
 	/**
 	 * In rare cases, the site for next year's camp will be created before this year's camp is over. When that
@@ -166,23 +188,21 @@ function get_latest_home_url( $current_domain, $current_path ) {
 	 * This won't prevent the link from being added to past years, but that edge case isn't significant enough
 	 * to warrant the extra complexity.
 	 *
-	 * See also `WordCamp\Sunrise\get_canonical_year_url()`.
+	 * The current site's end date is mirrored to blogmeta by `WordCamp\Schedule_Meta`. See also
+	 * `WordCamp\Sunrise\get_canonical_year_url()`.
 	 */
-	if ( $end_date && time() < ( (int) $end_date + DAY_IN_SECONDS ) ) {
+	$current_end_date = absint( get_site_meta( get_current_blog_id(), '_wc_event_end', true ) );
+
+	if ( $current_end_date && time() < $current_end_date + DAY_IN_SECONDS ) {
 		return false;
 	}
 
 	/*
-	 * Flagship camps create next year's site (and sometimes the one after) before the current edition is
-	 * over, so the query below would otherwise link to an event that hasn't happened yet. Until then, stay
-	 * on the current edition. The shared list of dates lives with the redirect logic in sunrise.
+	 * Each candidate query joins the `_wc_event_end` blogmeta written by `WordCamp\Schedule_Meta`, which is
+	 * present only for live, scheduled editions. Candidates are ordered newest-first and capped, then we pick
+	 * the current edition (see `get_current_edition()`) so the banner skips empty placeholder sites for a
+	 * future edition while a real one is still upcoming or only recently finished.
 	 */
-	$flagship_url = get_flagship_canonical_url( $current_domain );
-
-	if ( $flagship_url ) {
-		return $flagship_url;
-	}
-
 	if ( preg_match( PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		// Remove the year prefix.
 		$city_domain = substr(
@@ -191,23 +211,32 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		);
 
 		$query = $wpdb->prepare( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
+			SELECT blog.domain, blog.path, event_end.meta_value AS event_end
+			FROM `$wpdb->blogs` AS blog
+			LEFT JOIN `$wpdb->blogmeta` AS event_end
+				ON event_end.blog_id = blog.blog_id
+				AND event_end.meta_key = '_wc_event_end'
 			WHERE
-				`domain` LIKE %s AND
-				SUBSTR( domain, 1, 4 ) REGEXP '^-?[0-9]+$' -- exclude secondary language domains like 2013-fr.ottawa.wordcamp.org
-			ORDER BY `domain` DESC
-			LIMIT 1",
+				( blog.public AND NOT blog.deleted ) AND -- don't send visitors to sites that shouldn't receive traffic
+				blog.domain LIKE %s AND
+				SUBSTR( blog.domain, 1, 4 ) REGEXP '^-?[0-9]+$' -- exclude secondary language domains like 2013-fr.ottawa.wordcamp.org
+			ORDER BY blog.domain DESC
+			LIMIT 10",
 			'%.' . $city_domain
 		);
 
 	} elseif ( preg_match( PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, $current_domain . $current_path ) ) {
 		$query = $wpdb->prepare( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
-			WHERE `domain` = %s
-			ORDER BY `domain`, `path` DESC
-			LIMIT 1",
+			SELECT blog.domain, blog.path, event_end.meta_value AS event_end
+			FROM `$wpdb->blogs` AS blog
+			LEFT JOIN `$wpdb->blogmeta` AS event_end
+				ON event_end.blog_id = blog.blog_id
+				AND event_end.meta_key = '_wc_event_end'
+			WHERE
+				( blog.public AND NOT blog.deleted ) AND -- don't send visitors to sites that shouldn't receive traffic
+				blog.domain = %s
+			ORDER BY blog.domain, blog.path DESC
+			LIMIT 10",
 			$current_domain
 		);
 
@@ -217,13 +246,17 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		$latest_path = "/$city/%%/$type/";
 
 		$query = $wpdb->prepare( "
-			SELECT `domain`, `path`
-			FROM `$wpdb->blogs`
+			SELECT blog.domain, blog.path, event_end.meta_value AS event_end
+			FROM `$wpdb->blogs` AS blog
+			LEFT JOIN `$wpdb->blogmeta` AS event_end
+				ON event_end.blog_id = blog.blog_id
+				AND event_end.meta_key = '_wc_event_end'
 			WHERE
-				`domain` = %s AND
-				`path` LIKE %s
-			ORDER BY `path` DESC
-			LIMIT 1",
+				( blog.public AND NOT blog.deleted ) AND -- don't send visitors to sites that shouldn't receive traffic
+				blog.domain = %s AND
+				blog.path LIKE %s
+			ORDER BY blog.path DESC
+			LIMIT 10",
 			$current_domain,
 			$latest_path
 		);
@@ -232,11 +265,37 @@ function get_latest_home_url( $current_domain, $current_path ) {
 		return false;
 	}
 
-  $latest_site = $wpdb->get_results( $query ); // phpcs:ignore -- Prepared above.
+	$candidate_sites = $wpdb->get_results( $query ); // phpcs:ignore -- Prepared above.
 
-	if ( ! $latest_site ) {
+	if ( ! $candidate_sites ) {
 		return false;
 	}
 
-	return set_url_scheme( trailingslashit( '//' . $latest_site[0]->domain . $latest_site[0]->path ) );
+	$latest_site = get_current_edition( $candidate_sites );
+
+	return set_url_scheme( trailingslashit( '//' . $latest_site->domain . $latest_site->path ) );
+}
+
+/**
+ * Pick the edition a visitor should be sent to from a newest-first list of a city's sites.
+ *
+ * Returns the newest edition that's upcoming or only finished within the last month -- skipping any newer,
+ * not-yet-scheduled placeholder sites in front of it -- and otherwise the newest site, placeholder or not.
+ * This mirrors `WordCamp\Sunrise\get_current_edition_site()`, but operates on already-fetched rows.
+ *
+ * @param object[] $candidate_sites Rows with `domain`, `path`, and an `event_end` timestamp (empty for
+ *                                   unscheduled placeholders), ordered newest-first.
+ *
+ * @return object The chosen site row.
+ */
+function get_current_edition( array $candidate_sites ) {
+	foreach ( $candidate_sites as $site ) {
+		$event_end = absint( $site->event_end );
+
+		if ( $event_end && time() <= $event_end + MONTH_IN_SECONDS ) {
+			return $site;
+		}
+	}
+
+	return $candidate_sites[0];
 }

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -31,6 +31,7 @@ function manually_load_plugins() {
 	require_once dirname( __DIR__ ) . '/0-error-handling.php';
 	require_once dirname( __DIR__ ) . '/wordcamp/lets-encrypt-helper.php';
 	require_once dirname( __DIR__ ) . '/latest-site-hints.php';
+	require_once dirname( __DIR__ ) . '/wordcamp-schedule-meta.php';
 	require_once dirname( __DIR__ ) . '/trusted-deputy-capabilities.php';
 	require_once dirname( __DIR__ ) . '/wcorg-subroles.php';
 }

--- a/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/tests/test-latest-site-hints.php
@@ -106,6 +106,70 @@ class Test_WordCamp_SEO extends Database_TestCase {
 	}
 
 	/**
+	 * @covers WordCamp\Latest_Site_Hints\get_latest_home_url
+	 * @covers WordCamp\Latest_Site_Hints\get_current_edition
+	 *
+	 * While a real edition is current, the banner should skip a newer, not-yet-scheduled placeholder site.
+	 *
+	 * Uses a dedicated city so the per-request static cache in `get_latest_home_url()` can't collide with
+	 * the other cases (which reuse the shared fixture domains).
+	 */
+	public function test_skips_unscheduled_placeholder_site() {
+		$current     = self::factory()->blog->create( array(
+			'domain'     => 'skiptest.wordcamp.test',
+			'path'       => '/2025/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+		$placeholder = self::factory()->blog->create( array(
+			'domain'     => 'skiptest.wordcamp.test',
+			'path'       => '/2026/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+
+		// 2025 is upcoming / only just finished; 2026 is an empty placeholder with no schedule meta.
+		update_site_meta( $current, '_wc_event_end', strtotime( '+2 weeks' ) );
+
+		$this->assertSame(
+			'http://skiptest.wordcamp.test/2025/',
+			get_latest_home_url( 'skiptest.wordcamp.test', '/2025/' )
+		);
+
+		wp_delete_site( $current );
+		wp_delete_site( $placeholder );
+	}
+
+	/**
+	 * @covers WordCamp\Latest_Site_Hints\get_latest_home_url
+	 * @covers WordCamp\Latest_Site_Hints\get_current_edition
+	 *
+	 * Once the latest real edition is well in the past, the banner should fall through to the newest site,
+	 * even if that's an unscheduled placeholder.
+	 */
+	public function test_falls_through_to_newest_when_edition_long_over() {
+		$old         = self::factory()->blog->create( array(
+			'domain'     => 'overtest.wordcamp.test',
+			'path'       => '/2020/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+		$placeholder = self::factory()->blog->create( array(
+			'domain'     => 'overtest.wordcamp.test',
+			'path'       => '/2099/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+
+		// 2020 finished well over a month ago; 2099 is still an unscheduled placeholder.
+		update_site_meta( $old, '_wc_event_end', strtotime( '2020-08-01' ) );
+
+		$this->assertSame(
+			'http://overtest.wordcamp.test/2099/',
+			get_latest_home_url( 'overtest.wordcamp.test', '/2020/' )
+		);
+
+		wp_delete_site( $old );
+		wp_delete_site( $placeholder );
+	}
+
+	/**
 	 * Test cases for test_get_latest_home_url().
 	 *
 	 * @return array

--- a/public_html/wp-content/mu-plugins/tests/test-sunrise.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sunrise.php
@@ -503,6 +503,38 @@ class Test_Sunrise extends Database_TestCase {
 	}
 
 	/**
+	 * @covers WordCamp\Sunrise\get_current_edition_site
+	 * @covers WordCamp\Sunrise\get_canonical_year_url
+	 *
+	 * The bare city domain should resolve to the current edition while it's upcoming or recently finished --
+	 * skipping a newer, unscheduled placeholder -- and fall back to the newest site once it's well over.
+	 */
+	public function test_canonical_url_prefers_current_edition_over_placeholder() {
+		$placeholder = self::factory()->blog->create( array(
+			'domain'     => 'vancouver.wordcamp.test',
+			'path'       => '/2099/',
+			'network_id' => WORDCAMP_NETWORK_ID,
+		) );
+
+		// 2020 is current, 2099 is an empty placeholder: redirect to 2020.
+		update_site_meta( self::$slash_year_2020_site_id, '_wc_event_end', strtotime( '+2 weeks' ) );
+		$this->assertSame(
+			'https://vancouver.wordcamp.test/2020/',
+			get_canonical_year_url( 'vancouver.wordcamp.test', '/' )
+		);
+
+		// 2020 is well over and 2099 still isn't scheduled: fall back to the newest site.
+		update_site_meta( self::$slash_year_2020_site_id, '_wc_event_end', strtotime( '2020-08-01' ) );
+		$this->assertSame(
+			'https://vancouver.wordcamp.test/2099/',
+			get_canonical_year_url( 'vancouver.wordcamp.test', '/' )
+		);
+
+		delete_site_meta( self::$slash_year_2020_site_id, '_wc_event_end' );
+		wp_delete_site( $placeholder );
+	}
+
+	/**
 	 * Test cases for test_get_canonical_year_url().
 	 *
 	 * @return array

--- a/public_html/wp-content/mu-plugins/tests/test-wordcamp-schedule-meta.php
+++ b/public_html/wp-content/mu-plugins/tests/test-wordcamp-schedule-meta.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace WordCamp\Schedule_Meta\Tests;
+use WP_UnitTest_Factory;
+use WordCamp\Tests\Database_TestCase;
+
+use function WordCamp\Schedule_Meta\sync_wordcamp_schedule_meta;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group mu-plugins
+ * @group schedule-meta
+ */
+class Test_WordCamp_Schedule_Meta extends Database_TestCase {
+	/**
+	 * Create a `wordcamp` post on the central blog, linked to the given site, with the given dates/status.
+	 *
+	 * @return int The new post ID.
+	 */
+	protected function create_wordcamp( $site_id, $status, $start_date, $end_date = 0 ) {
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+
+		$meta = array(
+			'_site_id' => $site_id,
+
+			// `meta_input` is applied before the status transition fires, so this short-circuits wcpt's
+			// "WordCamp scheduled" Slack notification (which would otherwise run during the test).
+			'sent_scheduled_notification' => true,
+		);
+
+		if ( $start_date ) {
+			$meta['Start Date (YYYY-mm-dd)'] = $start_date;
+		}
+
+		if ( $end_date ) {
+			$meta['End Date (YYYY-mm-dd)'] = $end_date;
+		}
+
+		$post_id = wp_insert_post( array(
+			'post_type'   => 'wordcamp',
+			'post_title'  => 'WordCamp Test',
+			'post_status' => $status,
+			'meta_input'  => $meta,
+		) );
+
+		restore_current_blog();
+
+		return $post_id;
+	}
+
+	/**
+	 * Remove a `wordcamp` post and the schedule meta on a site, so tests don't leak into each other.
+	 */
+	protected function cleanup( $post_id, $site_id ) {
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+		wp_delete_post( $post_id, true );
+		restore_current_blog();
+
+		delete_site_meta( $site_id, '_wc_event_start' );
+		delete_site_meta( $site_id, '_wc_event_end' );
+		delete_site_meta( $site_id, '_wc_event_status' );
+	}
+
+	/**
+	 * @covers WordCamp\Schedule_Meta\sync_wordcamp_schedule_meta
+	 */
+	public function test_writes_dates_for_live_camp() {
+		$site_id = self::$year_dot_2019_site_id;
+		$start   = strtotime( '2025-06-01' );
+		$end     = strtotime( '2025-06-02' );
+		$post_id = $this->create_wordcamp( $site_id, 'wcpt-scheduled', $start, $end );
+
+		sync_wordcamp_schedule_meta( $post_id );
+
+		$this->assertSame( $start, (int) get_site_meta( $site_id, '_wc_event_start', true ) );
+		$this->assertSame( $end, (int) get_site_meta( $site_id, '_wc_event_end', true ) );
+		$this->assertSame( 'wcpt-scheduled', get_site_meta( $site_id, '_wc_event_status', true ) );
+
+		$this->cleanup( $post_id, $site_id );
+	}
+
+	/**
+	 * @covers WordCamp\Schedule_Meta\sync_wordcamp_schedule_meta
+	 */
+	public function test_end_date_falls_back_to_start_date() {
+		$site_id = self::$year_dot_2019_site_id;
+		$start   = strtotime( '2025-06-01' );
+		$post_id = $this->create_wordcamp( $site_id, 'wcpt-scheduled', $start );
+
+		sync_wordcamp_schedule_meta( $post_id );
+
+		$this->assertSame( $start, (int) get_site_meta( $site_id, '_wc_event_end', true ) );
+
+		$this->cleanup( $post_id, $site_id );
+	}
+
+	/**
+	 * @covers WordCamp\Schedule_Meta\sync_wordcamp_schedule_meta
+	 *
+	 * A camp that's scheduled and then cancelled keeps its dates on the post, but must not be advertised as a
+	 * live edition, so its date meta is removed.
+	 */
+	public function test_removes_dates_for_cancelled_camp() {
+		$site_id = self::$year_dot_2019_site_id;
+		$start   = strtotime( '2025-06-01' );
+		$post_id = $this->create_wordcamp( $site_id, 'wcpt-scheduled', $start, $start );
+
+		sync_wordcamp_schedule_meta( $post_id );
+		$this->assertNotEmpty( get_site_meta( $site_id, '_wc_event_end', true ) );
+
+		// Cancel it (dates remain on the post).
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+		wp_update_post( array(
+			'ID'          => $post_id,
+			'post_status' => 'wcpt-cancelled',
+		) );
+		restore_current_blog();
+
+		sync_wordcamp_schedule_meta( $post_id );
+
+		$this->assertSame( '', get_site_meta( $site_id, '_wc_event_start', true ) );
+		$this->assertSame( '', get_site_meta( $site_id, '_wc_event_end', true ) );
+		$this->assertSame( 'wcpt-cancelled', get_site_meta( $site_id, '_wc_event_status', true ) );
+
+		$this->cleanup( $post_id, $site_id );
+	}
+
+	/**
+	 * @covers WordCamp\Schedule_Meta\sync_wordcamp_schedule_meta
+	 *
+	 * Pre-planning camps can have a tentative Start Date saved but aren't on the official schedule yet, so
+	 * their dates must not be advertised as a live edition.
+	 */
+	public function test_does_not_write_dates_for_unscheduled_camp() {
+		$site_id = self::$year_dot_2019_site_id;
+		$start   = strtotime( '2025-06-01' );
+		$post_id = $this->create_wordcamp( $site_id, 'wcpt-needs-schedule', $start, $start );
+
+		sync_wordcamp_schedule_meta( $post_id );
+
+		$this->assertSame( '', get_site_meta( $site_id, '_wc_event_start', true ) );
+		$this->assertSame( '', get_site_meta( $site_id, '_wc_event_end', true ) );
+		$this->assertSame( 'wcpt-needs-schedule', get_site_meta( $site_id, '_wc_event_status', true ) );
+
+		$this->cleanup( $post_id, $site_id );
+	}
+
+	/**
+	 * @covers WordCamp\Schedule_Meta\sync_wordcamp_schedule_meta
+	 */
+	public function test_skips_camp_without_linked_site() {
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+		$post_id = wp_insert_post( array(
+			'post_type'   => 'wordcamp',
+			'post_title'  => 'Unlinked Camp',
+			'post_status' => 'wcpt-needs-site',
+		) );
+		update_post_meta( $post_id, 'Start Date (YYYY-mm-dd)', strtotime( '2025-06-01' ) );
+		restore_current_blog();
+
+		// Nothing to write to, and crucially no fatal/warning.
+		sync_wordcamp_schedule_meta( $post_id );
+
+		$this->assertSame( '', get_site_meta( self::$year_dot_2019_site_id, '_wc_event_start', true ) );
+
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+		wp_delete_post( $post_id, true );
+		restore_current_blog();
+	}
+}

--- a/public_html/wp-content/mu-plugins/wordcamp-schedule-meta.php
+++ b/public_html/wp-content/mu-plugins/wordcamp-schedule-meta.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace WordCamp\Schedule_Meta;
+
+defined( 'WPINC' ) || die();
+
+/*
+ * Mirror each WordCamp's schedule onto its site's blogmeta, so code that runs too early to read the central
+ * `wordcamp` posts can still tell which edition is current. In particular `sunrise.php` runs before the
+ * `wordcamp` post type is registered, so it can't query post meta -- but blogmeta is queryable that early.
+ *
+ * The keys below are written here and read by `WordCamp\Sunrise\get_current_edition_site()` (canonical
+ * redirect) and `WordCamp\Latest_Site_Hints\get_latest_home_url()` (next-edition banner). Keep the key names
+ * in sync with those readers.
+ *
+ *   _wc_event_start  Start Date as a Unix timestamp. Present only for live, scheduled editions (LIVE_STATUSES).
+ *   _wc_event_end    End Date (falls back to the Start Date) as a Unix timestamp. Always written alongside
+ *                    the start, so a single key tells readers when an edition is over.
+ *   _wc_event_status The `wordcamp` post status. Stored for observability/flexibility; the readers key off
+ *                    the dates above, not this.
+ */
+
+/**
+ * Statuses for editions that are actually happening, whose schedule should be advertised to visitors.
+ *
+ * These are the public WordCamp statuses (mirrors `WordCamp_Loader::get_public_post_statuses()`). Other
+ * statuses are excluded even when a Start/End date is present on the post: pre-planning camps (e.g.
+ * `wcpt-needs-schedule`) often have tentative dates saved by `Event_Admin::metabox_save()` but aren't on the
+ * official schedule yet, and cancelled/rejected camps keep their dates too. Using an allowlist of the public
+ * statuses is the authoritative "this edition is real" signal.
+ */
+const LIVE_STATUSES = array( 'wcpt-scheduled', 'wcpt-closed' );
+
+// Priority 20 runs after `Event_Admin::metabox_save()` (priority 10) has written the date meta and, for new
+// camps, after `maybe_create_new_sites()` has set `_site_id` -- so both are available here. `save_post` fires
+// on every edit path (normal, quick/bulk edit, the auto-close cron, programmatic updates), so this stays in
+// sync without a separate `transition_post_status` hook.
+add_action( 'save_post_wordcamp', __NAMESPACE__ . '\sync_on_save', 20, 2 );
+
+/**
+ * Re-derive the schedule blogmeta when a `wordcamp` post is saved.
+ *
+ * @param int      $post_id
+ * @param \WP_Post $post
+ */
+function sync_on_save( $post_id, $post ) {
+	if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) || 'auto-draft' === $post->post_status ) {
+		return;
+	}
+
+	sync_wordcamp_schedule_meta( $post_id );
+}
+
+/**
+ * Mirror a `wordcamp` post's schedule onto the blogmeta of each site it's linked to.
+ *
+ * Idempotent: it fully re-derives the meta from the post on every call, so an edition that later leaves the
+ * schedule (cancelled, or moved back to pre-planning) or has its dates cleared gets its date keys removed.
+ * The date keys are written only for editions that are actually happening -- a Start Date must be set and the
+ * post must be in a public status (see LIVE_STATUSES) -- so downstream "has a start date" reliably means
+ * "live, scheduled edition".
+ *
+ * Must be called on the central blog, where `wordcamp` posts live. `update_site_meta()` writes to the global
+ * `wp_blogmeta` table keyed by the passed site ID, so no `switch_to_blog()` to the event site is needed.
+ *
+ * @param int $post_id A `wordcamp` post ID.
+ */
+function sync_wordcamp_schedule_meta( $post_id ) {
+	$post = get_post( $post_id );
+
+	if ( ! $post || 'wordcamp' !== $post->post_type ) {
+		return;
+	}
+
+	$primary_site   = (array) get_post_meta( $post_id, '_site_id', true );
+	$secondary_site = (array) get_post_meta( $post_id, '_secondary_site_id', false );
+	$site_ids       = array_filter( array_map( 'absint', array_merge( $primary_site, $secondary_site ) ) );
+
+	if ( ! $site_ids ) {
+		return; // No site linked yet (e.g. an application that hasn't had its site created).
+	}
+
+	$start_date = absint( get_post_meta( $post_id, 'Start Date (YYYY-mm-dd)', true ) );
+	$end_date   = absint( get_post_meta( $post_id, 'End Date (YYYY-mm-dd)', true ) );
+	$is_live    = $start_date && in_array( $post->post_status, LIVE_STATUSES, true );
+
+	foreach ( $site_ids as $site_id ) {
+		update_site_meta( $site_id, '_wc_event_status', $post->post_status );
+
+		if ( $is_live ) {
+			update_site_meta( $site_id, '_wc_event_start', $start_date );
+			update_site_meta( $site_id, '_wc_event_end', $end_date ?: $start_date );
+		} else {
+			delete_site_meta( $site_id, '_wc_event_start' );
+			delete_site_meta( $site_id, '_wc_event_end' );
+		}
+	}
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	/**
+	 * Backfill the schedule blogmeta for every existing WordCamp.
+	 *
+	 * Run once after deploying this feature; `sync_on_save()` keeps it current thereafter.
+	 *
+	 *     wp wordcamp-schedule-meta backfill
+	 */
+	\WP_CLI::add_command(
+		'wordcamp-schedule-meta backfill',
+		function () {
+			switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+
+			$post_ids = get_posts( array(
+				'post_type'      => 'wordcamp',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			) );
+
+			foreach ( $post_ids as $post_id ) {
+				sync_wordcamp_schedule_meta( $post_id );
+			}
+
+			restore_current_blog();
+
+			\WP_CLI::success( sprintf( 'Synced schedule meta for %d WordCamps.', count( $post_ids ) ) );
+		}
+	);
+}

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -631,16 +631,62 @@ function get_canonical_year_url( $domain, $path ) {
 		return false;
 	}
 
-	// Special cases where the redirect shouldn't go to next year's camp until this year's camp is over.
-	$flagship_url = get_flagship_canonical_url( $domain );
-
-	if ( $flagship_url ) {
-		return $flagship_url;
-	}
-
-	$latest = get_latest_site( $domain );
+	/*
+	 * While a city's current edition is upcoming or only recently finished, keep its bare domain pointing at
+	 * that edition -- even when a site for a later edition already exists but hasn't been scheduled yet.
+	 * Otherwise fall back to the newest site.
+	 *
+	 * This was previously a hardcoded per-flagship date guard, because sunrise runs before the `wordcamp`
+	 * post type is registered and so couldn't read each camp's schedule. The schedule is now mirrored to
+	 * blogmeta (see `WordCamp\Schedule_Meta`), which is queryable this early, so every city is handled
+	 * generically. See also `WordCamp\Latest_Site_Hints\get_latest_home_url()`.
+	 */
+	$latest = get_current_edition_site( $domain ) ?: get_latest_site( $domain );
 
 	return $latest ? 'https://' . $latest->domain . $latest->path : false;
+}
+
+/**
+ * Get the site for a city's current edition, if one is upcoming or only recently finished.
+ *
+ * "Current" is the newest scheduled edition whose end date is in the future or within the last month. Sites
+ * for future editions are sometimes created before they're scheduled; this skips those empty placeholders so
+ * the bare domain keeps resolving to the real current edition until it's well over, at which point the caller
+ * falls back to the newest site.
+ *
+ * Reads the `_wc_event_end` blogmeta written by `WordCamp\Schedule_Meta`, which exists only for live,
+ * scheduled editions -- so this works during the `sunrise.php` bootstrap, before the `wordcamp` post type is
+ * registered. Timestamps are stored as digit strings; MySQL coerces them for the arithmetic below, so no
+ * CAST is needed.
+ *
+ * @param string $domain
+ *
+ * @return object|null Row with `blog_id`, `domain`, `path`, or null when there's no current edition.
+ */
+function get_current_edition_site( string $domain ) {
+	global $wpdb;
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Sunrise runs before caching is available.
+	return $wpdb->get_row( $wpdb->prepare( "
+		SELECT blog.blog_id, blog.domain, blog.path
+		FROM $wpdb->blogs AS blog
+		INNER JOIN $wpdb->blogmeta AS event_end
+			ON event_end.blog_id = blog.blog_id
+			AND event_end.meta_key = '_wc_event_end'
+		WHERE
+			( blog.public AND NOT blog.deleted ) AND
+			(
+				( blog.domain =    %s AND blog.path != '/' ) OR -- city/year, e.g. seattle.wordcamp.org/2020/
+				( blog.domain LIKE %s AND blog.path  = '/' )    -- year.city, e.g. 2020.seattle.wordcamp.org
+			) AND
+			event_end.meta_value + %d >= %d -- still upcoming, or finished within the last month
+		ORDER BY blog.path DESC, blog.domain DESC
+		LIMIT 1",
+		$domain,
+		"%.{$domain}",
+		MONTH_IN_SECONDS,
+		time()
+	) );
 }
 
 /**

--- a/public_html/wp-content/sunrise.php
+++ b/public_html/wp-content/sunrise.php
@@ -199,46 +199,4 @@ function get_renamed_site_url( string $domain, string $path ) {
 	return 'https://' . $site->domain . $site->path;
 }
 
-
-/**
- * Get the canonical URL for a flagship city whose next site is created before the current edition is over.
- *
- * The sites for next year's flagship camps -- and sometimes a placeholder for the year after that -- are
- * often created well before the current edition is over. Until then, both the canonical redirect and the
- * "latest site" banner should stay on the listed path rather than advancing to an event that hasn't
- * happened yet. The dates are maintained here, in one place, for both callers to share.
- *
- * See also `get_canonical_year_url()` and `WordCamp\Latest_Site_Hints\get_latest_home_url()`.
- *
- * @param string $domain
- *
- * @return string|false The canonical URL, or false if the domain has no active special case.
- */
-function get_flagship_canonical_url( $domain ) {
-	$tld = get_top_level_domain();
-
-	$upcoming = array(
-		"europe.wordcamp.$tld" => array(
-			'until' => '2026-06-20',
-			'path'  => '/2026/',
-		),
-		"us.wordcamp.$tld"     => array(
-			'until' => '2026-09-02',
-			'path'  => '/2026/',
-		),
-		"asia.wordcamp.$tld"   => array(
-			'until' => '2026-04-25',
-			'path'  => '/2026/',
-		),
-	);
-
-	$flagship = $upcoming[ $domain ] ?? null;
-
-	if ( $flagship && time() <= strtotime( $flagship['until'] ) ) {
-		return "https://{$domain}{$flagship['path']}";
-	}
-
-	return false;
-}
-
 load_network_sunrise();


### PR DESCRIPTION
## Problem

The "Check out the next edition" banner on past WordCamp sites, and the canonical bare-domain redirect (`city.wordcamp.org` → newest year), both picked the **highest-numbered year path** for a city. When a site for a future edition is created in advance but not yet scheduled, they pointed at that empty placeholder.

Reported case: `europe.wordcamp.org/2025/` linked to `/2027/` (status `needs-schedule`, no dates) instead of the real next edition `/2026/`. Same class of bug for other cities (e.g. `sofia.wordcamp.org`).

The canonical redirect previously worked around this with a **hardcoded per-flagship date guard** (#1736 shared that guard between the redirect and the banner). It exists because `get_canonical_year_url()` runs during the `sunrise.php` bootstrap — *before* the `wordcamp` post type is registered — so it couldn't read each camp's schedule. This PR removes the hardcode by making the schedule queryable that early.

## Approach

Denormalize each WordCamp's schedule onto its **site's blogmeta** (same mechanism as `old_home_url`). A new `WordCamp\Schedule_Meta` mu-plugin writes, whenever a `wordcamp` post is saved:

| Key | Value |
|---|---|
| `_wc_event_start` | Start Date (Unix ts). Written **only** for live, non-cancelled scheduled editions. |
| `_wc_event_end` | End Date, falling back to Start Date (Unix ts). Always written alongside the start. |
| `_wc_event_status` | The `wordcamp` post status. Observability/flexibility only; not load-bearing. |

The writer is **status-aware**: a scheduled-then-cancelled camp keeps its dates on the post, but its date keys are deleted, so downstream "has a start date" reliably means "live edition." It's idempotent (full re-derivation on every `save_post`), so quick/bulk edits, the auto-close cron, and programmatic updates all stay in sync.

Both readers now resolve the right edition from real dates:

- **`get_canonical_year_url()`** → `get_current_edition_site() ?: get_latest_site()`. Prefers the current edition (upcoming or finished within the last month) over a newer unscheduled placeholder, else the newest site. **`get_flagship_canonical_url()` and the hardcoded dates are removed.**
- **`get_latest_home_url()`** (banner) → same decision via a `_wc_event_end` JOIN, dropping the `switch_to_blog()` + `get_posts()` cross-blog lookup.

`get_current_edition_site()` keeps the SQL simple — one `_wc_event_end` JOIN, `event_end.meta_value + %d >= %d` with no CAST (MySQL coerces the digit-string timestamp), readable `blog`/`event_end` aliases.

`wp wordcamp-schedule-meta backfill` seeds the meta for existing camps.

## Deploy ordering

1. Ship the writer, 2. run the backfill, 3. then the readers go live. Until backfilled, a site with no meta simply looks like a placeholder and the readers fall back to "newest site" — i.e. **prior behavior**, never a fatal.

## Tests

Run against the WordCamp test DB harness (PHP 8.3, multisite), all green:

- `test-wordcamp-schedule-meta.php` (4) — writer writes dates for live camps, falls back end→start, **removes** dates on cancellation, skips camps with no linked site.
- `test-latest-site-hints.php` (14) — existing cases plus new placeholder-skip / fall-through.
- `test-sunrise.php` (71) — existing canonical cases (unchanged behavior with no schedule meta) plus the new placeholder-skip case.

With no schedule meta, both readers fall back to the newest site, so the existing data-provider tests are unaffected. `phpcs` clean on changed lines.

> Supersedes the hardcoded flagship guard from #1736 (merged into `production` and merged in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)