### PR TITLE
Latest Site Hints: Share the flagship "next edition" guard with sunrise

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace WordCamp\Latest_Site_Hints;
-use function WordCamp\Sunrise\get_top_level_domain;
+use function WordCamp\Sunrise\get_flagship_canonical_url;
 use const WordCamp\Sunrise\{ PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_CITY_YEAR_TYPE_PATH };
 
 defined( 'WPINC' ) || die();
@@ -170,6 +170,17 @@ function get_latest_home_url( $current_domain, $current_path ) {
 	 */
 	if ( $end_date && time() < ( (int) $end_date + DAY_IN_SECONDS ) ) {
 		return false;
+	}
+
+	/*
+	 * Flagship camps create next year's site (and sometimes the one after) before the current edition is
+	 * over, so the query below would otherwise link to an event that hasn't happened yet. Until then, stay
+	 * on the current edition. The shared list of dates lives with the redirect logic in sunrise.
+	 */
+	$flagship_url = get_flagship_canonical_url( $current_domain );
+
+	if ( $flagship_url ) {
+		return $flagship_url;
 	}
 
 	if ( preg_match( PATTERN_YEAR_DOT_CITY_DOMAIN_PATH, $current_domain . $current_path ) ) {

--- a/public_html/wp-content/sunrise-wordcamp.php
+++ b/public_html/wp-content/sunrise-wordcamp.php
@@ -598,7 +598,6 @@ function get_corrected_root_relative_url( $domain, $path, $request_uri, $referer
 function get_canonical_year_url( $domain, $path ) {
 	global $wpdb;
 
-	$tld       = get_top_level_domain();
 	$cache_key = 'current_blog_' . $domain;
 
 	/**
@@ -633,30 +632,56 @@ function get_canonical_year_url( $domain, $path ) {
 	}
 
 	// Special cases where the redirect shouldn't go to next year's camp until this year's camp is over.
-	// See also `WordCamp\Sunrise\Latest_Site_Hints\get_latest_home_url()`.
-	switch ( $domain ) {
-		case "europe.wordcamp.$tld":
-			if ( time() <= strtotime( '2026-06-20' ) ) {
-				return "https://europe.wordcamp.$tld/2026/";
-			}
-			break;
+	$flagship_url = get_flagship_canonical_url( $domain );
 
-		case "us.wordcamp.$tld":
-			if ( time() <= strtotime( '2026-09-02' ) ) {
-				return "https://us.wordcamp.$tld/2026/";
-			}
-			break;
-
-		case "asia.wordcamp.$tld":
-			if ( time() <= strtotime( '2026-04-25' ) ) {
-				return "https://asia.wordcamp.$tld/2026/";
-			}
-			break;
+	if ( $flagship_url ) {
+		return $flagship_url;
 	}
 
 	$latest = get_latest_site( $domain );
 
 	return $latest ? 'https://' . $latest->domain . $latest->path : false;
+}
+
+/**
+ * Get the canonical URL for a flagship city whose next site is created before the current edition is over.
+ *
+ * The sites for next year's flagship camps -- and sometimes a placeholder for the year after that -- are
+ * often created well before the current edition is over. Until then, both the canonical redirect and the
+ * "latest site" banner should stay on the listed path rather than advancing to an event that hasn't
+ * happened yet. The dates are maintained here, in one place, for both callers to share.
+ *
+ * See also `get_canonical_year_url()` and `WordCamp\Latest_Site_Hints\get_latest_home_url()`.
+ *
+ * @param string $domain
+ *
+ * @return string|false The canonical URL, or false if the domain has no active special case.
+ */
+function get_flagship_canonical_url( $domain ) {
+	$tld = get_top_level_domain();
+
+	$upcoming = array(
+		"europe.wordcamp.$tld" => array(
+			'until' => '2026-06-20',
+			'path'  => '/2026/',
+		),
+		"us.wordcamp.$tld"     => array(
+			'until' => '2026-09-02',
+			'path'  => '/2026/',
+		),
+		"asia.wordcamp.$tld"   => array(
+			'until' => '2026-04-25',
+			'path'  => '/2026/',
+		),
+	);
+
+	$flagship = $upcoming[ $domain ] ?? null;
+
+	if ( $flagship && time() <= strtotime( $flagship['until'] ) ) {
+		return "https://{$domain}{$flagship['path']}";
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
## Problem

The "Check out the next edition" banner on past WordCamp sites links to the **highest-numbered year** for that city (`ORDER BY path DESC LIMIT 1` in `get_latest_home_url()`). But the site for next year — and sometimes a placeholder for the year after — is often created before the current edition is over.

On **WordCamp Europe**, `europe.wordcamp.org/2025/` showed a banner pointing at `/2027/` (created in advance, not yet scheduled) instead of the real next edition, `/2026/`.

## Fix

`get_canonical_year_url()` already guarded the flagship cities against this with a hardcoded `switch`, and its comment even pointed back at `get_latest_home_url()` — but the banner never had the matching guard.

Rather than duplicate the dates, this extracts them into a single shared helper, `WordCamp\Sunrise\get_flagship_canonical_url()`, that both the canonical redirect and the banner read from. `sunrise.php` loads before mu-plugins, and the banner already imports from the `WordCamp\Sunrise` namespace, so the list lives in one place:

```php
function get_flagship_canonical_url( $domain ) {
    $tld = get_top_level_domain();

    $upcoming = array(
        "europe.wordcamp.$tld" => array( 'until' => '2026-06-20', 'path' => '/2026/' ),
        "us.wordcamp.$tld"     => array( 'until' => '2026-09-02', 'path' => '/2026/' ),
        "asia.wordcamp.$tld"   => array( 'until' => '2026-04-25', 'path' => '/2026/' ),
    );

    $flagship = $upcoming[ $domain ] ?? null;

    if ( $flagship && time() <= strtotime( $flagship['until'] ) ) {
        return "https://{$domain}{$flagship['path']}";
    }

    return false;
}
```

Behavior for the canonical redirect is unchanged (same dates, same fall-through). The banner now gets the same guard.

## Verification

With `get_top_level_domain()` returning `org`, today: `europe.wordcamp.org` → `https://europe.wordcamp.org/2026/`, `us` likewise; `asia` (date already passed) and non-flagships fall through to the existing logic — matching the old `switch` exactly. Both files pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)