### PR TITLE
CampTix: Fix undefined array key warning on payment settings screen

### DIFF
--- a/public_html/wp-content/plugins/camptix-bd-payments/includes/gateway/class-gateway-surjopay.php
+++ b/public_html/wp-content/plugins/camptix-bd-payments/includes/gateway/class-gateway-surjopay.php
@@ -45,7 +45,15 @@ class SurjoPay extends Base_Gateway {
 	 * Initialize hooks when gateway is enabled
 	 */
 	public function camptix_init() {
-		$this->options = $this->get_payment_options();
+		$this->options = array_merge(
+			[
+				'username' => '',
+				'password' => '',
+				'prefix'   => 'WC',
+				'sandbox'  => true,
+			],
+			$this->get_payment_options()
+		);
 		$this->setup_api_urls();
 
 		if ( ! $this->gateway_enabled() ) {

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-payment-method.php
@@ -357,7 +357,7 @@ abstract class CampTix_Payment_Method extends CampTix_Addon {
 			'payment_' . $this->id,
 			array(
 				'name' => $this->settings_field_name_attr( $option_name ),
-				'value' => $this->options[ $option_name ],
+				'value' => $this->options[ $option_name ] ?? '',
 				'description' => $description,
 			)
 		);


### PR DESCRIPTION
## Problem

Visiting the CampTix payment settings screen on a site with the SurjoPay gateway active (e.g. `rajshahi.wordcamp.org/2026`) triggers a warning before the gateway's settings have ever been saved:

```
E_WARNING: Undefined array key "username"
camptix/inc/class-camptix-payment-method.php:360
```

Stack: `SurjoPay->payment_settings_fields` → `CampTix_Payment_Method->add_settings_field_helper`.

## Cause

The SurjoPay gateway (added in #1741) sets `$this->options = $this->get_payment_options()`, which returns an empty array until the options have been saved once. `add_settings_field_helper()` then reads `$this->options[ $option_name ]` for each registered field (`username`, `password`, `prefix`, `sandbox`) without a fallback.

## Fix

- **SurjoPay**: merge defaults into `$this->options`, mirroring the sibling SSLCommerz gateway in the same plugin (including `sandbox => true` as the default, matching SSLCommerz). Saved values still take precedence via `array_merge()`.
- **`CampTix_Payment_Method::add_settings_field_helper()`**: fall back to `''` when the option key is missing, so any other gateway with unsaved options can't trigger the same warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)