### PR TITLE
CI: cache node_modules and Composer downloads to speed up install steps

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,14 +46,38 @@ jobs:
       env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get Composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Composer downloads
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+        restore-keys: |
+          composer-${{ runner.os }}-
+
     - name: composer install
+      # The lock file is removed so that the latest wporg-mu-plugins dev-build is always installed.
       run: |
         rm composer.lock || true
         composer install
 
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          public_html/wp-content/**/node_modules
+        key: node-modules-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+
     - name: npm install and build
       run: |
-        npm ci
+        if [ "${{ steps.node-modules-cache.outputs.cache-hit }}" != 'true' ]; then
+          npm ci --no-audit --no-fund
+        fi
         npm run build --workspaces --if-present
 
     - name: Lint JavaScript and Styles

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,9 +35,21 @@ jobs:
         node-version: 20.x
         cache: npm
 
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          public_html/wp-content/**/node_modules
+        key: node-modules-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+
     - name: Install dependencies
       # We don't need to build, since jest can interpret the source files.
-      run: npm ci
+      run: |
+        if [ "${{ steps.node-modules-cache.outputs.cache-hit }}" != 'true' ]; then
+          npm ci --no-audit --no-fund
+        fi
 
     # Run the Blocks unit tests. If/when other workspaces get tests, those would be added here.
     - name: Running the tests
@@ -84,7 +96,20 @@ jobs:
       env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get Composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Composer downloads
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+        restore-keys: |
+          composer-${{ runner.os }}-
+
     - name: Install dependencies
+      # The lock file is removed so that the latest wporg-mu-plugins dev-build is always installed.
       run: |
         rm composer.lock || true
         composer install


### PR DESCRIPTION
## Why

The `npm install and build` step in the linter workflow consistently takes ~4 minutes (e.g. [this run](https://github.com/WordPress/wordcamp.org/actions/runs/27326842870/job/80729815954)), of which the webpack build is only ~20 seconds. The `cache: npm` on `setup-node` was already hitting, but it only caches downloaded tarballs (`~/.npm`) — `npm ci` still deletes `node_modules` and re-extracts all ~2,900 packages (plus lifecycle scripts) from scratch on every run. That reify phase is the ~3.5 minutes of silence in the log.

## What

For both `linter.yml` and `unit-tests.yml`:

- **Cache the installed `node_modules` tree** (root + workspaces) keyed on `package-lock.json` and the Node major version, and skip `npm ci` entirely on an exact hit. The existing `cache: npm` is kept as a fallback so cache-miss runs are still download-free. This should take the step from ~4 minutes to roughly 30-45 seconds on the common path.
- **Cache the Composer cache directory.** `composer.lock` is intentionally removed before install so the latest `wporg/wporg-mu-plugins` `dev-build` hash is always picked up — that behaviour is unchanged (and now documented with a comment), but re-resolution no longer needs to re-download every package. Keyed on `composer.json` with a `restore-keys` fallback since the resolved set drifts between runs.
- Pass `--no-audit --no-fund` to `npm ci` on the miss path, matching the existing `COMPOSER_NO_AUDIT` behaviour for Composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)