### PR TITLE
Campus Connect: show admin notice and audit note on Needs Orientation

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -36,7 +36,8 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			add_action( 'transition_post_status', array( $this, 'trigger_schedule_actions' ), 10, 3 );
 			add_action( 'wcpt_approved_for_pre_planning', array( $this, 'add_organizer_to_central' ), 10 );
 			add_action( 'wcpt_approved_for_pre_planning', array( $this, 'mark_date_added_to_planning_schedule' ), 10 );
-			add_action( 'wcpt_cc_approved_for_pre_planning', array( $this, 'handle_cc_approved_for_pre_planning' ), 10 );
+			// Priority 11 so the organizer email (sent by WCOR_Mailer at 10) goes out first.
+			add_action( 'wcpt_cc_needs_orientation', array( $this, 'handle_cc_needs_orientation' ), 11 );
 
 			add_filter( 'wp_insert_post_data', array( $this, 'enforce_post_status' ), 10, 2 );
 
@@ -948,27 +949,22 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				// Uses a dedicated action to avoid triggering the non-CC hooks that listen
 				// to wcpt_approved_for_pre_planning (e.g. add_organizer_to_central).
 				do_action( 'wcpt_cc_needs_orientation', $post );
-			} elseif ( 'wcpt-approved-pre-pl' === $new_status
-				&& 'campusconnect' === get_post_meta( $post->ID, 'event_subtype', true ) ) {
-				// Fires when a Campus Connect application is approved for pre-planning.
-				// Uses a dedicated action to avoid triggering the non-CC hooks that listen
-				// to wcpt_approved_for_pre_planning (e.g. add_organizer_to_central).
-				do_action( 'wcpt_cc_approved_for_pre_planning', $post );
 			}
 		}
 
 
 		/**
-		 * Handle a Campus Connect application being approved for pre-planning.
+		 * Handle a Campus Connect application transitioning to Needs Orientation.
 		 *
-		 * Fires on wcpt_cc_approved_for_pre_planning (see trigger_schedule_actions()).
+		 * Fires on wcpt_cc_needs_orientation (see trigger_schedule_actions()), after
+		 * WCOR_Mailer has triggered the organizer notification email on the same action.
 		 * Writes a permanent audit note to the post log and queues a one-time admin
 		 * notice so the wrangler sees confirmation on the next page load.
 		 *
-		 * @param WP_Post $post The Campus Connect post that was approved.
+		 * @param WP_Post $post The Campus Connect post that needs orientation.
 		 */
-		public function handle_cc_approved_for_pre_planning( WP_Post $post ) {
-			// Audit log note — a permanent, timestamped record of the approval. The admin
+		public function handle_cc_needs_orientation( WP_Post $post ) {
+			// Audit log note — a permanent, timestamped record of the transition. The admin
 			// notice below is its transient, on-screen counterpart (similar, not identical, text).
 			add_post_meta(
 				$post->ID,
@@ -976,7 +972,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				array(
 					'timestamp' => time(),
 					'user_id'   => get_current_user_id(),
-					'message'   => __( 'Application approved for pre-planning.', 'wordcamporg' ),
+					'message'   => __( 'Application moved to Needs Orientation. Organizer notification email triggered.', 'wordcamporg' ),
 				)
 			);
 
@@ -1344,7 +1340,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 
 				5 => array(
 					'type'   => 'updated',
-					'notice' => __( 'This Campus Connect application has been approved for pre-planning. A note has been added to the log.', 'wordcamporg' ),
+					'notice' => __( 'This Campus Connect application has been moved to Needs Orientation. The organizer notification email has been triggered and a note has been added to the log.', 'wordcamporg' ),
 				),
 			);
 


### PR DESCRIPTION
> [!NOTE]
> This PR was written by an AI (Claude, via Claude Code) on behalf of @dd32.

## Summary

Follow-up to #1731 / #1714 point 5. When resolving the merge conflicts between #1730 and #1731, the notice/audit-log handler was left firing on **Approved For Pre-Planning**, as the PR code and description specified. That missed [the confirmation from @peiraisotta on #1731](https://github.com/WordPress/wordcamp.org/pull/1731#issuecomment-4544299137) that the banner should show when the status changes to **Needs Orientation**, right after the organizer email is sent.

## Changes

`wcpt-wordcamp/wordcamp-admin.php` only:

- The handler (renamed `handle_cc_needs_orientation()`) now hooks the existing `wcpt_cc_needs_orientation` action at priority 11, so it runs after `WCOR_Mailer` triggers the organizer email at priority 10.
- The admin notice and audit-log note fire on Needs Orientation and mention the email again, since the email genuinely fires on that transition: notice reads "This Campus Connect application has been moved to Needs Orientation. The organizer notification email has been triggered and a note has been added to the log."
- Removes the `wcpt_cc_approved_for_pre_planning` action from `trigger_schedule_actions()` — it no longer has any listeners.

## Test plan

- [ ] Transition a CC post (event_subtype = campusconnect) to **Needs Orientation**. After the save redirect, confirm the green banner appears and a note with the email wording is added to the private notes log.
- [ ] Transition a CC post to **Approved For Pre-Planning**. Confirm no notice and no note are added.
- [ ] Transition a non-CC post through any statuses. Confirm no CC notice/note appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)