### PR TITLE
Campus Connect: log silent email-trigger no-ops; fix overclaiming notice text (issue #1714 point 4)

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -972,7 +972,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				array(
 					'timestamp' => time(),
 					'user_id'   => get_current_user_id(),
-					'message'   => __( 'Application moved to Needs Orientation. Organizer notification email triggered.', 'wordcamporg' ),
+					'message'   => __( 'Application moved to Needs Orientation. Organizer notification email trigger fired.', 'wordcamporg' ),
 				)
 			);
 
@@ -1340,7 +1340,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 
 				5 => array(
 					'type'   => 'updated',
-					'notice' => __( 'This Campus Connect application has been moved to Needs Orientation. The organizer notification email has been triggered and a note has been added to the log.', 'wordcamporg' ),
+					'notice' => __( 'This Campus Connect application has been moved to Needs Orientation and a note has been added to the log. The organizer notification email is sent by the Automated Reminder assigned to the "Campus Connect application needs orientation" trigger — if no reminder is assigned, no email goes out.', 'wordcamporg' ),
 				),
 			);
 

--- a/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
+++ b/public_html/wp-content/plugins/wordcamp-organizer-reminders/wcor-mailer.php
@@ -1002,6 +1002,13 @@ class WCOR_Mailer {
 		$emails         = $this->get_triggered_posts( $trigger );
 		$is_repeatable  = ! empty( $this->triggers[ $trigger ]['repeatable'] );
 
+		if ( ! $emails ) {
+			log( 'Trigger fired, but no reminder posts are assigned to it.', compact( 'trigger', 'wordcamp' ) );
+			return;
+		}
+
+		$sent = 0;
+
 		foreach( $emails as $email ) {
 			if ( ! $this->applies_to_wordcamp( $wordcamp, $email ) ) {
 				continue;
@@ -1015,8 +1022,13 @@ class WCOR_Mailer {
 
 			if ( $this->mail( $recipient, $email->post_title, $email->post_content, array(), $email, $wordcamp ) ) {
 				$sent_email_ids[] = $email->ID;
+				$sent++;
 				update_post_meta( $wordcamp->ID, 'wcor_sent_email_ids', $sent_email_ids );
 			}
+		}
+
+		if ( ! $sent ) {
+			log( 'Trigger fired, but every assigned reminder was skipped or failed.', compact( 'trigger', 'wordcamp' ) );
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1730/#1731. Testing the Needs Orientation transition on a real Campus Connect application showed the private note and admin banner appear, but **no organizer email is sent**.

**Root cause — configuration, not code:** `WCOR_Mailer::send_triggered_emails()` only sends Automated Reminder posts (`organizer-reminder` CPT) whose `wcor_which_trigger` meta matches the fired trigger. No reminder post on Central is assigned to `wcor_cc_needs_orientation` — the trigger key first reached production with #1730's merge, so none can exist yet. The code path itself is verified working: `test_cc_needs_orientation_trigger_message_sent` passes precisely because the test fixture creates and assigns a reminder post — the step production is missing. **The email content must be created in wp-admin** (Automated Reminders → new reminder → trigger "Campus Connect application needs orientation"); that's the actual fix and needs no deploy.

This PR fixes the two things that made the gap invisible and misleading:

## Changes

### `wordcamp-organizer-reminders/wcor-mailer.php`
`send_triggered_emails()` was the **only** silent failure path in the mailer — `mail()` already logs invalid recipients and `wp_mail()` failures. Now logs via `\WordCamp\Logger\log()` when:
- a trigger fires with **no reminder posts assigned** to it (the case hit here), and
- reminders are assigned but **every one is skipped or fails** (subtype restriction, already-sent dedupe, send failure).

Both events are rare and always worth explaining, so log volume is negligible. No behaviour change when emails send normally.

### `wcpt/wcpt-wordcamp/wordcamp-admin.php`
The admin notice and audit note claimed "the organizer notification email **has been triggered**" — stated as fact even when no email exists to send, which is exactly what misled testing. Reworded both to claim only what the code guarantees (the trigger fired), following the same merge-resolution precedent applied to the point 5 text (#1731 [comment](https://github.com/WordPress/wordcamp.org/pull/1731#issuecomment-4677731428)). The notice now also names the Automated Reminders trigger so a wrangler knows where to look when no email arrives.

## Not in this PR (one-time admin action, no deploy needed)

Create the Automated Reminder on Central: **Automated Reminders → Add New** → title = subject, body = email content → "When to send": on a trigger → "Campus Connect application needs orientation" → recipients: "the organizing team" (resolves to the application's `E-mail Address`/`Email Address` meta) → restrict event subtype to Campus Connect. Note every WCOR email is already hard-CC'd to `support@wordcamp.org` by `mail()`, satisfying that requirement in #1714 automatically.

## Test plan

- [ ] `php -l` clean on both files (verified)
- [ ] Existing `test-wcor-mailer.php` suite passes unchanged (no behavioural change when reminders are assigned; `test_cc_needs_orientation_trigger_message_sent` and `test_repeatable_trigger_sends_multiple_times` cover the send paths)
- [ ] Transition a CC post to Needs Orientation with **no** reminder assigned → log entry "Trigger fired, but no reminder posts are assigned to it" appears; notice/note no longer claim an email was sent
- [ ] Assign a reminder to the trigger, repeat → email sends, CC'd to support@wordcamp.org, no log entry

See #1714 (point 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)