### PR TITLE
Docker setup: follow WordPress trunk instead of a pinned branch

### DIFF
--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -21,13 +21,11 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 	mkcert -install
 	mkcert -cert-file wordcamp.test.pem -key-file wordcamp.test.key.pem wordcamp.test *.wordcamp.test events.wordpress.test
 	```
-1. Clone WordPress into the **public_html/mu** directory and check out the latest version's branch.
+1. Clone the development (trunk) version of WordPress into the **public_html/mu** directory. WordCamp.org runs against trunk, so there is no release branch to pin — the `WordPress/WordPress` mirror's default branch tracks it.
     ```bash
     cd ..
     cd public_html
-    git clone git://core.git.wordpress.org/ mu
-    cd mu
-    git checkout 6.9
+    git clone https://github.com/WordPress/WordPress.git mu
     ```
 
 1. Install 3rd-party PHP packages used on WordCamp.org. For this, you must have [Composer](https://getcomposer.org/doc/00-intro.md) installed. Once it is, change back to the root directory of the project where the main **composer.json** file is located. (Not the one in .docker/config.)


### PR DESCRIPTION
## What

Updates the local-environment setup (`.docker/readme.md`) so WordPress core is cloned from **trunk** rather than a hardcoded release branch:

```diff
-    git clone git://core.git.wordpress.org/ mu
-    cd mu
-    git checkout 6.9
+    git clone https://github.com/WordPress/WordPress.git mu
```

## Why

- **Follows trunk.** WordCamp.org now develops against WP trunk, so the local env should too. The pinned `6.9` was prose that silently drifts out of date.
- **HTTPS, not `git://`.** The old protocol is deprecated and frequently blocked by firewalls/proxies (and `https://core.git.wordpress.org` redirects away, so it isn't a usable git endpoint). The `WordPress/WordPress` GitHub mirror is the built-core source over HTTPS, and its default branch tracks trunk.
- **One step fewer.** No separate `cd mu && git checkout` — the default clone is already trunk.

## Verification

Cloned the new URL and confirmed it produces a valid built-core checkout on trunk:

- `wp-load.php` + `wp-admin/` present
- `wp-includes/version.php` → `$wp_version = '7.1-alpha-...'` (i.e. trunk/development, not a pinned release)

This is a docs/setup-instruction change only; it doesn't touch the Docker images, Compose files, or the composer/npm steps.
