### PR TITLE
Local environment setup cleanups (follow-ups to #1752)

### DIFF
--- a/.docker/Dockerfile.php-fpm
+++ b/.docker/Dockerfile.php-fpm
@@ -1,8 +1,8 @@
 FROM php:8.4-fpm
 
-# Install additional packages.
+# Install OS packages.
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
         build-essential \
         git \
         less \
@@ -20,17 +20,19 @@ RUN apt-get update \
         ruby-dev \
         subversion \
         vim \
-        wget
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install additional PHP extensions.
-RUN docker-php-ext-configure intl
-RUN docker-php-ext-configure gd --with-jpeg
-RUN docker-php-ext-install -j "$(nproc)" \
-    gd \
-    intl \
-    mysqli \
-    opcache \
-    zip
+RUN docker-php-ext-configure intl \
+    && docker-php-ext-configure gd --with-jpeg \
+    && docker-php-ext-install -j "$(nproc)" \
+        gd \
+        intl \
+        mysqli \
+        opcache \
+        zip
 
 # Add PHP configurations.
 COPY config/opcache-recommended.ini /usr/local/etc/php/conf.d/opcache-recommended.ini
@@ -42,34 +44,29 @@ COPY wordcamp.test.pem     /etc/ssl/certs/wordcamp.test.pem
 COPY wordcamp.test.key.pem /etc/ssl/private/wordcamp.test.key.pem
 
 # Install `wkhtmltopdf` for WordCamp Docs, CampTix Invoices, etc. See https://stackoverflow.com/a/38336153/1845153
-RUN curl -L https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz > wkhtmltox.tar.xz
-RUN tar xvf wkhtmltox.tar.xz
-RUN mv wkhtmltox/bin/wkhtmlto* /usr/bin/
-RUN rm -rf wkhtmltox*
+RUN curl -L https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -o wkhtmltox.tar.xz \
+    && tar xf wkhtmltox.tar.xz \
+    && mv wkhtmltox/bin/wkhtmlto* /usr/bin/ \
+    && rm -rf wkhtmltox*
 
 # Install WP-CLI.
-RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-RUN chmod +x wp-cli.phar
-RUN mv wp-cli.phar /usr/local/bin/wp
+RUN curl -fsSL -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x /usr/local/bin/wp
 
-# Set up msmtp (used for MailCatcher).
-# The config file needs the right owner/permissions before msmtp can use it.
-COPY config/msmtprc /etc/msmtprc
-RUN chown www-data /etc/msmtprc
-RUN chmod 600 /etc/msmtprc
-
-# Install MailCatcher.
+# Install MailCatcher (captures outgoing mail for local testing).
 RUN gem install mailcatcher --no-document
 
-# todo Maybe install phpMyAdmin?
+# Set up msmtp (routes PHP mail to MailCatcher). The config needs the right owner/permissions.
+COPY config/msmtprc /etc/msmtprc
+RUN chown www-data /etc/msmtprc \
+    && chmod 600 /etc/msmtprc
 
-# Tweak the php.ini file
-RUN sed -i -e "s|;sendmail_path =|sendmail_path = /usr/bin/msmtp -C /etc/msmtprc -t |" /usr/local/etc/php/php.ini-development
-RUN sed -i -e "s/smtp_port = 25/smtp_port = 1025/" /usr/local/etc/php/php.ini-development
-RUN sed -i -e "s/memory_limit = 128/memory_limit = 256/" /usr/local/etc/php/php.ini-development
-
-# Initialize customized php.ini file.
-RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
+# Build a customized php.ini from the development template.
+RUN sed \
+        -e "s|;sendmail_path =|sendmail_path = /usr/bin/msmtp -C /etc/msmtprc -t |" \
+        -e "s/smtp_port = 25/smtp_port = 1025/" \
+        -e "s/memory_limit = 128/memory_limit = 256/" \
+        /usr/local/etc/php/php.ini-development > /usr/local/etc/php/php.ini
 
 WORKDIR /usr/src/public_html
 

--- a/.docker/Dockerfile.phpunit
+++ b/.docker/Dockerfile.phpunit
@@ -18,9 +18,14 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php -r "unlink('composer-setup.php');"
 
 # Run composer and phpunit installation.
-RUN composer require "phpunit/phpunit:^9" "yoast/phpunit-polyfills:^1.0" --prefer-source --no-interaction && \
+RUN composer require "phpunit/phpunit:^9" "yoast/phpunit-polyfills:^4.0" --prefer-source --no-interaction && \
     ln -s /tmp/vendor/bin/phpunit /usr/local/bin/phpunit
 
 # Set up the application directory.
 VOLUME ["/app"]
 WORKDIR /app
+
+# On startup, wait for the database and install the WP test suite if it isn't present yet,
+# then run php-fpm. This replaces the manual install-wp-tests.sh step.
+ENTRYPOINT ["bash", "/var/scripts/install-test-suite.sh"]
+CMD ["php-fpm"]

--- a/.docker/bin/install-test-suite.sh
+++ b/.docker/bin/install-test-suite.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Entrypoint for the PHPUnit container. Waits for the database, installs the WordPress
+# test suite on first run, then hands off to the container command (php-fpm). This
+# removes the previously-manual `install-wp-tests.sh` step from the test workflow.
+
+set -uo pipefail
+
+DB_HOST="${WP_TESTS_DB_HOST:-phpunit_db}"
+DB_NAME="${WP_TESTS_DB_NAME:-wordpress_test}"
+DB_USER="${WP_TESTS_DB_USER:-root}"
+DB_PASS="${WP_TESTS_DB_PASS:-}"
+WP_VERSION="${WP_TESTS_WP_VERSION:-latest}"
+TESTS_CONFIG="/tmp/wp/wordpress-tests-lib/wp-tests-config.php"
+
+db_ready() {
+	if command -v mariadb-admin >/dev/null 2>&1; then
+		mariadb-admin ping -h "$DB_HOST" --silent >/dev/null 2>&1
+	else
+		mysqladmin ping -h "$DB_HOST" --silent >/dev/null 2>&1
+	fi
+}
+
+echo "Waiting for database at ${DB_HOST}..."
+tries=0
+until db_ready; do
+	tries=$(( tries + 1 ))
+	if [ "$tries" -ge 30 ]; then
+		echo "WARNING: database did not become ready after 60s; starting anyway."
+		break
+	fi
+	sleep 2
+done
+
+if [ -f "$TESTS_CONFIG" ]; then
+	echo "WordPress test suite already installed."
+else
+	echo "Installing the WordPress test suite..."
+	if /var/scripts/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION" true; then
+		echo "WordPress test suite installed."
+	else
+		echo "WARNING: test-suite install failed (e.g. a download timeout). Re-run 'docker compose -f docker-compose.phpunit.yml up', or run /var/scripts/install-wp-tests.sh manually."
+	fi
+fi
+
+exec "$@"

--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -30,24 +30,18 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
     git checkout 6.9
     ```
 
-1. Install 3rd-party PHP packages used on WordCamp.org. For this, you must have [Composer](https://getcomposer.org/doc/00-intro.md) installed. Once it is, change back to the root directory of the project where the main **composer.json** file is located. (Not the one in .docker/config.)
-	```bash
-	cd ../../ # to the directory above public_html/
-	composer install
-	```
-
-1. Install 3rd-party JS packages and build the CSS & JS needed for some projects. You'll need [node](https://nodejs.org/) & npm (bundled with Node). Optionally you can use [nvm](https://github.com/nvm-sh/nvm) to keep your node version up to date. Running the following will install and build all of the projects in one step (omit `nvm` command if you're not using it).
+1. Install the PHP & JS dependencies and build the bundled projects. You'll need [Composer](https://getcomposer.org/doc/00-intro.md), [node](https://nodejs.org/) & npm (bundled with Node), and optionally [nvm](https://github.com/nvm-sh/nvm). From the project root:
     ```bash
-    nvm install && nvm use
-    npm install
-    npm run build --workspaces --if-present
+    nvm install && nvm use   # optional, if you use nvm
+    npm run setup
     ```
+
+    `npm run setup` runs `composer install`, then `npm ci`, then builds every workspace project — one command in place of the separate Composer and npm steps.
 
 1. Build and boot the Docker environment.
     ```bash
-    docker compose build --pull
-    docker compose up
-	```
+    docker compose up --build
+    ```
 
     This will provision the Docker containers and install 3rd-party plugins and themes used on WordCamp.org, if necessary. It could take some time depending upon the speed of your Internet connection. At the end of the process, you should see a message like this:
 
@@ -89,8 +83,7 @@ Follow these steps to setup a local WordCamp.org environment using [Docker](http
 
 1. Optional: Install Git hooks to automate code inspections during pre-commit:
     ```bash
-    rm -rf .git/hooks
-    ln -s .githooks .git/hooks
+    git config core.hooksPath .githooks
     ```
 
 
@@ -180,17 +173,13 @@ We have separate containers for PHPUnit, a web server & database, to keep the te
     phpunit_db_1  | […] [Note] mariadbd: ready for connections.
     ```
 
-2. The first time you run this, you'll need to install the tests (future runs can skip this step). First, open a shell inside the web container:
+2. The WordPress test framework installs **automatically** the first time you start the container above — watch for `Installing the WordPress test suite...`. The download occasionally times out; if it does, restart with `docker compose -f docker-compose.phpunit.yml up`, or install it manually from inside the container:
     ```bash
-    docker compose -f docker-compose.phpunit.yml exec phpunit_wp bash
+    docker compose -f docker-compose.phpunit.yml exec phpunit_wp \
+        /var/scripts/install-wp-tests.sh wordpress_test root '' phpunit_db latest true
     ```
 
-    Then run the install script. It will download WordPress & the unit test framework (this skips installing a database, since that is set up as part of the docker process).
-    ```bash
-    /var/scripts/install-wp-tests.sh wordpress_test root '' phpunit_db latest true
-    ```
-
-    Sometimes the download will time out. If that happens, you can delete `/tmp/wp` from the container, and re-run the install script. The test files will be added to the `.docker/test_suite` folder, which is ignored by git.
+    The test files are written to the `.docker/test_suite` folder, which is ignored by git.
 
 3. Now you can run `phpunit`. From the project folder on your machine:
     ```bash

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
 		"public_html/wp-content/themes/wporg-events-2023",
 		"public_html/wp-content/themes/wporg-flagship-landing"
 	],
+	"scripts": {
+		"setup": "composer install && npm ci && npm run build --workspaces --if-present",
+		"build": "npm run build --workspaces --if-present"
+	},
 	"devDependencies": {
 		"@wordpress/eslint-plugin": "25.4.0",
 		"@wordpress/jest-preset-default": "12.48.0",


### PR DESCRIPTION
Follow-ups to #1752, batching the safe local-environment setup cleanups from a review of `.docker/`. Opened as a **draft** for review.

## Changes

**1. One-command host setup** (`package.json`, `.docker/readme.md`)
`package.json` had no `scripts` block. Added:
- `npm run setup` → `composer install` + `npm ci` + `npm run build --workspaces --if-present`
- `npm run build` → the workspace build alone

The readme's separate "composer install" and "npm install / npm run build" steps collapse into a single `npm run setup`. (`npm ci` replaces `npm install` for reproducible installs against the committed lockfile.)

**2. Non-destructive git hooks** (`.docker/readme.md`)
`rm -rf .git/hooks && ln -s .githooks .git/hooks` → `git config core.hooksPath .githooks` (git ≥ 2.9). One command, doesn't delete the hooks dir.

**3. PHPUnit test suite auto-installs** (`.docker/Dockerfile.phpunit`, new `.docker/bin/install-test-suite.sh`, `.docker/readme.md`)
- New entrypoint waits for the DB, then installs the WP test suite on first run (idempotent; resilient — a failed download warns and still starts the container rather than crashing it). Removes the manual "exec in and run `install-wp-tests.sh`" step.
- Also fixes a version drift: the container pinned `yoast/phpunit-polyfills:^1.0` while `composer.json` requires `^4.0` — now aligned.

**4. Single Docker boot command** (`.docker/readme.md`)
`docker compose build --pull` + `docker compose up` → `docker compose up --build`.

**6. `Dockerfile.php-fpm` image hygiene** (no behavior change)
Same packages, extensions, and config — just consolidated the ~18 layers into a handful, added `--no-install-recommends` + `apt-get clean` + `rm -rf /var/lib/apt/lists/*`, and `&&`-chained the wkhtmltopdf / WP-CLI / php.ini steps so intermediate artifacts (the wkhtmltox tarball) don't bloat a layer. Mirrors the cleanup pattern `Dockerfile.phpunit` already uses.

> Item 5 from the review (clone WP trunk instead of a pinned branch) is in #1752, so this branch deliberately leaves `readme.md` step 4 untouched to avoid a conflict.

## Verification

- `package.json` is valid JSON; `npm run setup`/`build` resolve.
- `bash -n` clean on the new entrypoint script.
- `docker build --check` clean on both Dockerfiles.
- Full `docker build` of both images succeeds (exit 0). The **php-fpm** image smoke-tests clean: WP-CLI 2.12.0, `gd`/`intl`/`mysqli`/`zip`/`opcache` loaded, `memory_limit` = 256M, msmtp + mailcatcher present. The **phpunit** image installs `phpunit/phpunit 9.6.34` + `yoast/phpunit-polyfills 4.0.0` (drift fixed).
- The PHPUnit auto-install entrypoint's **runtime** path (DB wait + first-run install) wasn't exercised end-to-end here — worth a local `docker compose -f docker-compose.phpunit.yml up` before merging.
