### PR TITLE
Increase max-width of duration input to 4rem

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/css/editor.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/editor.css
@@ -33,7 +33,7 @@
 
 .wordcamp-panel-session-info__duration input {
 	-moz-appearance: textfield;
-	max-width: 4rem;
+	max-width: 5rem;
 }
 
 .wordcamp-panel-session-info__duration label + input {

--- a/public_html/wp-content/plugins/wc-post-types/css/editor.css
+++ b/public_html/wp-content/plugins/wc-post-types/css/editor.css
@@ -33,7 +33,7 @@
 
 .wordcamp-panel-session-info__duration input {
 	-moz-appearance: textfield;
-	max-width: 3rem;
+	max-width: 4rem;
 }
 
 .wordcamp-panel-session-info__duration label + input {


### PR DESCRIPTION
I encountered an issue where I couldn’t properly view a two-digit value.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #, See #

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
Issue - 
<img width="972" height="988" alt="image" src="https://github.com/user-attachments/assets/c82491cb-9ece-432d-98a1-d29e28d01e44" />

Fixed - 
<img width="756" height="1048" alt="image" src="https://github.com/user-attachments/assets/b2f82a87-bee9-4a7f-afc0-9c21b0218bb6" />


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Create Any session.
2. Go to the Session Info Tab
3. Then try to set minutes in 2 digit.

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
