### PR TITLE
Site Cloner: Load Customizer assets on block themes

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
+++ b/public_html/wp-content/plugins/wordcamp-site-cloner/wordcamp-site-cloner.php
@@ -28,7 +28,16 @@ function initialize() {
 		return;
 	}
 
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\register_scripts'               );
+	/*
+	 * The assets are only used inside the Customizer, and `customize.php` never fires
+	 * `admin_enqueue_scripts` itself. On classic themes it fires indirectly -- the Customizer's `widgets`
+	 * component calls `do_action( 'admin_enqueue_scripts', 'widgets.php' )` -- but block themes don't load
+	 * that component, so the assets must be registered on a hook that `customize.php` always fires.
+	 * Priority 1 so registration happens before `WP_Customize_Manager::enqueue_control_scripts()` runs
+	 * the controls' `enqueue()` callbacks at priority 10.
+	 */
+	add_action( 'customize_controls_enqueue_scripts', __NAMESPACE__ . '\register_scripts', 1 );
+
 	add_action( 'admin_menu',            __NAMESPACE__ . '\add_submenu_pages'              );
 	add_action( 'customize_register',    __NAMESPACE__ . '\register_customizer_components' );
 	add_action( 'rest_api_init',         __NAMESPACE__ . '\register_api_endpoints'         );


### PR DESCRIPTION
The "Clone Another WordCamp" screen renders as a dead shell whenever the active theme is a block theme: the section appears in the Customizer, but the site list never loads and search/filtering does nothing — no PHP or JS error anywhere. Since new WordCamp sites default to `twentytwentyfour`, every new organizer hits this. These are breakages 1 and 3 in #1315.

**Root cause:** the plugin registers its Customizer JS/CSS and the `_wcscSettings` localization (REST URL + nonce) only on `admin_enqueue_scripts`. `customize.php` never fires that hook itself — on classic themes it fires indirectly, because the Customizer's `widgets` component calls `do_action( 'admin_enqueue_scripts', 'widgets.php' )`. Since WordPress 5.9, the widgets component is not loaded when a block theme is active, so that indirect path disappears, `register_scripts()` never runs, and `Site_Control::enqueue()` silently no-ops on unregistered handles.

**Fix:** register the assets on `customize_controls_enqueue_scripts` — the hook `customize.php` always fires — at priority 1 so registration precedes `WP_Customize_Manager::enqueue_control_scripts()`. The assets are only consumed inside the Customizer, so registering them on every admin page was unnecessary anyway.

This restores cloning any classic-theme site regardless of the active theme. It deliberately does **not** address breakage 2 in #1315 (block-theme sites as clone *sources*) — that needs a larger rework, since a block-theme site's design lives in global styles/templates that the cloner's theme-switch + Additional-CSS payload doesn't capture.

See #1315.

Props dd32 (report & triage).

### Screenshots

Before: the empty "Clone Another WordCamp" section shown in #1315. After the change, the site list, search, and filters render as they do on classic themes.

### How to test the changes in this Pull Request:

1. On a WordCamp site, activate a block theme (e.g. Twenty Twenty-Five).
2. Go to Appearance → Clone Another WordCamp. Before this change the section is empty — no site list, no search. With it, the list loads and search/filters work.
3. Pick a site using a classic theme — the Customizer reloads with `?theme=<slug>`, previews it, and Publish performs the clone.
4. Switch back to a classic theme and repeat, to confirm no regression.
