### PR TITLE
CampTix Invoices: Don't record the invoice PDF when generation fails

### DIFF
--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -424,6 +424,15 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		$upload_dir    = wp_upload_dir();
 		$tmp_path      = $pdf_generator->generate_pdf_from_string( $invoice_content, $filename );
 
+		global $camptix;
+
+		// Only record the document once the PDF verifiably exists, so a wkhtmltopdf
+		// failure can't leave the invoice pointing at a file that was never written.
+		if ( ! file_exists( $tmp_path ) || 0 === filesize( $tmp_path ) ) {
+			$camptix->log( __( 'Invoice PDF generation failed: wkhtmltopdf produced no output.', 'wordcamporg' ), $invoice_id, array( 'filename' => $filename ) );
+			return false;
+		}
+
 		if ( ! empty( $upload_dir['basedir'] ) ) {
 			$invoices_dirname = $upload_dir['basedir'] . '/camptix-invoices';
 			if ( ! file_exists( $invoices_dirname ) ) {
@@ -436,10 +445,14 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		// volume, so cross-device renames are never possible in this environment. Copy
 		// across and remove the source instead of attempting (and logging a warning for)
 		// a rename that cannot succeed.
-		if ( copy( $tmp_path, $invoices_dirname . '/' . $filename ) ) {
-			unlink( $tmp_path );
-			update_post_meta( $invoice_id, 'invoice_document', $filename );
+		if ( ! copy( $tmp_path, $invoices_dirname . '/' . $filename ) ) {
+			$camptix->log( __( 'Invoice PDF generation failed: could not move the PDF into the uploads directory.', 'wordcamporg' ), $invoice_id, array( 'filename' => $filename ) );
+			return false;
 		}
+
+		unlink( $tmp_path );
+
+		update_post_meta( $invoice_id, 'invoice_document', $filename );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1760.

## Problem

`create_invoice_document()` records the `invoice_document` post meta unconditionally. `WordCamp_Docs_PDF_Generator` runs `exec( 'wkhtmltopdf ...' )` with no error checking and returns the target path either way, and the `rename()` return value is ignored — so when PDF generation fails, the invoice still ends up pointing at a file that was never written. The "Download invoice" button then 404s, `send_invoice()` attaches a missing file, and nothing is logged anywhere organizers or support can see. This happened network-wide when wkhtmltopdf was temporarily unavailable on production in July 2026.

## Fix

Only record the document once the PDF verifiably exists:

- bail and log via `$camptix->log()` if the generated file is missing or zero bytes;
- bail and log if the `rename()` into `uploads/camptix-invoices/` fails;
- only then write the `invoice_document` meta.

Both callers ignore the function's return value, so the early `return false` requires no caller changes, and the shared `WordCamp_Docs_PDF_Generator` class is untouched. Invoices that hit the guard can be regenerated later simply by re-saving (the `save_post` handler already regenerates, reusing the stored filename when present).

## Testing

Verified in the local Docker environment (multisite, camptix-invoices active):

- **Failure path** (wkhtmltopdf unavailable): `create_invoice_document()` returns `false`, no `invoice_document` meta is written, and the expected log entry (message + filename) appears in the CampTix network log via camptix-network-tools. On the unpatched code the same scenario writes meta pointing at a nonexistent PDF — reproducing the July incident.
- **Happy path**: PDF is generated, moved into `uploads/camptix-invoices/`, and the meta is written exactly as before.
