### PR TITLE
Latest Site Hints: Fix mobile horizontal scroll and stop the banner covering page content

### DIFF
--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -126,7 +126,8 @@ function add_notification_styles() { ?>
  * margin has to make room for it. CSS can't measure the rendered banner, so the reserved space
  * is an estimate: one line of text on wide screens, two on small ones where the text wraps.
  */
-function add_notification_overlay_styles() { ?>
+function add_notification_overlay_styles() {
+	?>
 	<style type="text/css">
 		html:not(#specificity-hack) {
 			/* 44 = 10px x2 for padding, 24px for line height. */

--- a/public_html/wp-content/mu-plugins/latest-site-hints.php
+++ b/public_html/wp-content/mu-plugins/latest-site-hints.php
@@ -30,8 +30,11 @@ function maybe_add_latest_site_hints() {
 	// Hook in before `WordPressdotorg\SEO\Canonical::rel_canonical_link()`, so that callback can be removed.
 	add_action( 'wp_head', __NAMESPACE__ . '\canonical_link_past_home_pages_to_current_year', 9 );
 
-	// Add a banner with a link to the latest WordCamp.
+	// Add a banner with a link to the latest WordCamp. It prints at `wp_body_open` so it sits in
+	// the normal document flow; `wp_footer` is only a fallback for themes that never call
+	// `wp_body_open()`.
 	add_action( 'wp_head', __NAMESPACE__ . '\add_notification_styles' );
+	add_action( 'wp_body_open', __NAMESPACE__ . '\show_notification_about_latest_site' );
 	add_action( 'wp_footer', __NAMESPACE__ . '\show_notification_about_latest_site' );
 
 	// Close comments on past sites to prevent spam.
@@ -72,30 +75,30 @@ function canonical_link_past_home_pages_to_current_year() {
 
 /**
  * Simple styles for the notification.
+ *
+ * The banner sits in the normal document flow at the top of the page, so layout reserves exactly
+ * as much room as the text needs no matter how many lines it wraps to, and `position: sticky`
+ * keeps it pinned while scrolling.
  */
 function add_notification_styles() { ?>
   <style type="text/css">
-		html:not(#specificity-hack) {
-			/* 44 = 10px x2 for padding, 24px for line height. */
-			margin-top: calc(44px + var(--wp-admin--admin-bar--height, 0px)) !important;
-		}
-
 		.wordcamp-latest-site-notify {
+			box-sizing: border-box;
 			background: #1d2327;
 			text-align: center;
 			padding: 10px 20px;
 			font-size: 16px;
 			line-height: 1.5;
-			position: fixed;
+			position: sticky;
 			top: var(--wp-admin--admin-bar--height, 0);
-			left: 0;
 			width: 100%;
 			z-index: 99998;
 		}
 
 		@media screen and (max-width: 600px) {
 			.wordcamp-latest-site-notify {
-				position: absolute;
+				/* Scroll away with the page instead of permanently taking up small-screen space. */
+				position: static;
 			}
 		}
 
@@ -117,10 +120,50 @@ function add_notification_styles() { ?>
 <?php }
 
 /**
+ * Overlay styles for themes that never call `wp_body_open()`.
+ *
+ * The banner prints at `wp_footer` instead, so it has to overlay the viewport and the `html`
+ * margin has to make room for it. CSS can't measure the rendered banner, so the reserved space
+ * is an estimate: one line of text on wide screens, two on small ones where the text wraps.
+ */
+function add_notification_overlay_styles() { ?>
+	<style type="text/css">
+		html:not(#specificity-hack) {
+			/* 44 = 10px x2 for padding, 24px for line height. */
+			margin-top: calc(44px + var(--wp-admin--admin-bar--height, 0px)) !important;
+		}
+
+		.wordcamp-latest-site-notify--overlay {
+			position: fixed;
+			top: var(--wp-admin--admin-bar--height, 0);
+			left: 0;
+		}
+
+		@media screen and (max-width: 600px) {
+			html:not(#specificity-hack) {
+				/* 68 = padding plus two 24px lines, since the text usually wraps here. */
+				margin-top: calc(68px + var(--wp-admin--admin-bar--height, 0px)) !important;
+			}
+
+			.wordcamp-latest-site-notify--overlay {
+				position: absolute;
+			}
+		}
+	</style>
+<?php }
+
+/**
  * Show the actual notification containing link to latest site to user.
  */
 function show_notification_about_latest_site() {
 	global $current_blog;
+
+	$is_overlay = 'wp_footer' === current_action();
+
+	// The banner was already printed in the normal document flow at `wp_body_open`.
+	if ( $is_overlay && did_action( 'wp_body_open' ) ) {
+		return;
+	}
 
 	$latest_domain = get_latest_home_url( $current_blog->domain, $current_blog->path );
 
@@ -129,7 +172,11 @@ function show_notification_about_latest_site() {
 		return;
 	}
 
-	echo '<div class="wordcamp-latest-site-notify"><p>' .
+	if ( $is_overlay ) {
+		add_notification_overlay_styles();
+	}
+
+	echo '<div class="wordcamp-latest-site-notify' . ( $is_overlay ? ' wordcamp-latest-site-notify--overlay' : '' ) . '"><p>' .
 		wp_kses_post( wp_sprintf(
 			// translators: %1$s is the name of the WordCamp, %2$s is the URL of the next edition.
 			__( '%1$s is over. Check out <a href="%2$s">the next edition</a>!', 'wordcamporg' ),


### PR DESCRIPTION

Fixes #1764

### What's broken

The "«WordCamp X» is over. Check out the next edition!" banner prints at `wp_footer` as a `position: fixed` overlay, and the page makes room for it with a hardcoded `margin-top: 44px` on `<html>` — sized for exactly one line of text (10px ×2 padding + 24px line height).

1. **Page can be panned sideways on mobile** (the bug reported in #1764). The banner is `width: 100%` plus `padding: 10px 20px` with no `box-sizing: border-box`, so under the default `content-box` it renders 40px wider than the viewport. Below 600px the banner is `position: absolute`, which counts toward the document's scrollable overflow — users can pan the page sideways and content appears shifted/clipped. (Above 600px, `position: fixed` is excluded from scrollable overflow, so desktop never surfaced this.) Reproduced e.g. on asia.wordcamp.org/2026 (per the issue) and us.wordcamp.org.

2. **Content hidden behind the banner** — an additional bug in the same banner, fixed here too. Whenever the text wraps past one line, the banner is taller than the hardcoded 44px reservation and covers the top of the site. On phones the message virtually always wraps to two lines (~68px), hiding the top ~24px of every past camp's site — clipped logos and headers. It isn't strictly mobile-only: longer site names and verbose locales wrap on mid-size viewports too (measured: *"WordCamp Kathmandu Valley 2025 ha finalizado…"* at a 625px viewport → banner 68px, reserved 44px, 24px of content hidden on the desktop code path). Reproduced in production on europe.wordcamp.org (2025 and 2026), valencia.wordcamp.org and us.wordcamp.org.

### Root cause

CSS on its own can't size the `<html>` margin to another element's rendered height, and the banner's height is content-dependent: it varies with viewport width, site-name length, translation length, and theme font. Any hardcoded reservation is a guess that fails as soon as the text wraps.

### The fix (CSS-only, no JS)

The one-line `box-sizing: border-box` suggested in #1764 is included verbatim and resolves the horizontal scroll. This PR additionally moves the banner into normal flow to fix the overlap bug, since both stem from the same overlay markup:

Print the banner at **`wp_body_open`** instead, so it sits in the normal document flow at the top of the page. Layout then reserves exactly the space the text needs — any number of lines, any locale — and `position: sticky` keeps it pinned while scrolling. On ≤600px screens it becomes `position: static` so it scrolls away instead of permanently taking up small-screen space, preserving the previous mobile behavior. `box-sizing: border-box` fixes the sideways-pan overflow.

One known, graceful degradation: on themes that set `overflow-x: hidden` on `html`/`body` (a common theme pattern that disables `position: sticky`), the banner won't stay pinned while scrolling on desktop — it simply scrolls away with the page, like the mobile behavior. It still reserves exact space and never covers content.

Themes that never call `wp_body_open()` keep the previous behavior as a fallback: the banner still prints at `wp_footer` (guarded by `did_action( 'wp_body_open' )`) with a `--overlay` modifier class restoring `position: fixed` and the `<html>` margin reservation — now bumped to two lines (68px) under 600px, where the text almost always wraps. That path remains an estimate by nature (a three-line banner on a legacy theme could still overlap slightly), but every theme that supports `wp_body_open()` — including all block themes — is exact at every width.

### Measured before/after

Headless Chrome, exact plugin CSS/markup, WCEU string:

| Scenario | Before | After |
| --- | --- | --- |
| 390px (2-line banner) | banner 68px, reserved 44px, **24px content hidden**, **40px sideways overflow** | in flow, 0px hidden, 0px overflow |
| 625px, long name (desktop path) | banner 68px, reserved 44px, **24px content hidden** | in flow, 0px hidden, 0px overflow |
| ≥700px (1-line banner) | OK (44px = 44px) | in flow, 0px hidden, 0px overflow |
| Fallback path (no `wp_body_open`), 390px | — | absolute, reserved 68px = banner 68px, 0px hidden |

Also verified end-to-end on a local sandbox: past camp with a newer sibling site, banner renders in flow right after `<body>`, two lines, nothing clipped, `scrollWidth == clientWidth` (no element extends past the viewport).

### Testing instructions

1. Visit a past camp that has a newer edition (e.g. `europe.wordcamp.org/2025/`) in a ≤600px viewport — the site header/logo should start fully below the banner, however many lines it wraps to.
2. Same page: confirm the page cannot be panned sideways (no horizontal scroll).
3. Narrow a desktop window to ~625px on a camp with a long name/verbose locale — no content hidden.
4. Log in and confirm the banner clears the admin bar (sticky `top` uses `--wp-admin--admin-bar--height`).
5. Legacy check: switch a test site to a theme whose `header.php` doesn't call `wp_body_open()` — the banner should fall back to the fixed overlay with reserved space (one line ≥600px, two lines below).

### Screenshots

The mobile screenshots attached to #1764 show the horizontal-scroll symptom. The content-overlap symptom (site header/logo clipped behind the banner) is visible on any past camp where the banner text wraps — e.g. europe.wordcamp.org/2025, valencia.wordcamp.org or us.wordcamp.org at a phone-width viewport.
