### PR TITLE
CampTix: format EUR amounts via locale-aware NumberFormatter

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -1767,7 +1767,10 @@ class CampTix_Plugin {
 		if ( isset( $currency['locale'] ) ) {
 			try {
 				$formatter        = new NumberFormatter( $currency['locale'], NumberFormatter::CURRENCY );
-				$formatted_amount = $formatter->format( $amount );
+				// Use formatCurrency() with the explicit ISO code so the symbol always matches
+				// the configured currency, rather than format(), which would fall back to the
+				// locale's default currency (e.g. rendering EUR as "$" on an en_US site).
+				$formatted_amount = $formatter->formatCurrency( $amount, $currency_key );
 			} catch ( \Throwable $e ) {
 				$formatted_amount = false;
 			}

--- a/public_html/wp-content/plugins/camptix/inc/class-camptix-currencies.php
+++ b/public_html/wp-content/plugins/camptix/inc/class-camptix-currencies.php
@@ -204,6 +204,11 @@ class CampTix_Currency {
 			),
 			'EUR' => array(
 				'label'         => __( 'Euro', 'wordcamporg' ),
+				// The euro spans many locales whose conventions differ (symbol placement and
+				// decimal separator), so render it via NumberFormatter using the site/event
+				// locale. 'format' is retained only as a fallback for environments without
+				// the intl extension.
+				'locale'        => get_locale(),
 				'format'        => '€ %s',
 				'decimal_point' => 2,
 			),

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -1209,4 +1209,60 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		// In test environment there is no wordcamp post by default.
 		$this->assertFalse( self::$camptix->is_wordcamp_closed() );
 	}
+
+	/**
+	 * Verify EUR amounts place the euro sign per the site locale.
+	 *
+	 * For a French locale the euro sign should follow the amount (e.g. "40,00 €"),
+	 * not precede it. The exact string depends on the installed ICU version, so this
+	 * asserts the relative position of the digits and the symbol rather than an exact
+	 * match.
+	 */
+	public function test_append_currency_eur_places_symbol_after_amount_for_french_locale() {
+		if ( ! class_exists( 'NumberFormatter' ) ) {
+			$this->markTestSkipped( 'intl extension required for currency formatting.' );
+		}
+
+		$locale_filter = static function () {
+			return 'fr_FR';
+		};
+		add_filter( 'locale', $locale_filter );
+
+		$formatted = self::$camptix->append_currency( 40, false, 'EUR' );
+
+		remove_filter( 'locale', $locale_filter );
+
+		$euro_pos = strpos( $formatted, '€' );
+		preg_match( '/\d/', $formatted, $matches, PREG_OFFSET_CAPTURE );
+		$digit_pos = isset( $matches[0] ) ? $matches[0][1] : false;
+
+		$this->assertNotFalse( $euro_pos, "Formatted EUR amount should contain the euro sign, got: {$formatted}" );
+		$this->assertNotFalse( $digit_pos, "Formatted EUR amount should contain digits, got: {$formatted}" );
+		$this->assertGreaterThan( $digit_pos, $euro_pos, "Euro sign should follow the amount for fr_FR, got: {$formatted}" );
+	}
+
+	/**
+	 * Verify EUR always renders with the euro sign, even on an English locale.
+	 *
+	 * NumberFormatter::format() would fall back to the locale's default currency
+	 * (USD for en_US), rendering a euro price with a dollar sign. formatCurrency()
+	 * with the explicit ISO code prevents that regression.
+	 */
+	public function test_append_currency_eur_uses_euro_symbol_on_english_locale() {
+		if ( ! class_exists( 'NumberFormatter' ) ) {
+			$this->markTestSkipped( 'intl extension required for currency formatting.' );
+		}
+
+		$locale_filter = static function () {
+			return 'en_US';
+		};
+		add_filter( 'locale', $locale_filter );
+
+		$formatted = self::$camptix->append_currency( 40, false, 'EUR' );
+
+		remove_filter( 'locale', $locale_filter );
+
+		$this->assertStringContainsString( '€', $formatted, "EUR must render with the euro sign, got: {$formatted}" );
+		$this->assertStringNotContainsString( '$', $formatted, "EUR must not render with a dollar sign, got: {$formatted}" );
+	}
 }


### PR DESCRIPTION
When an event uses the Euro (`EUR`) as its ticket currency, CampTix rendered prices as `€ 40.00` — the euro sign **before** the amount with a **dot** decimal separator — regardless of the site/event locale. In most Eurozone countries the convention is the symbol **after** the amount with a **comma** decimal (`40,00 €`).

Both defects came from the same root cause: `EUR` was defined with a hard-coded `'€ %s'` format string and (unlike `GBP`/`en_GB` or `AUD`/`en_AU`) had no `locale`, so it never went through `NumberFormatter`.

### What this changes

- **`inc/class-camptix-currencies.php`** — `EUR` now gets a `'locale' => get_locale()` so it renders through the existing `NumberFormatter` branch, following the site/event locale for both symbol placement and decimal/thousands separators. The `'€ %s'` string is kept only as a fallback for environments without the `intl` extension.
- **`camptix.php`** — the `NumberFormatter` branch now uses `formatCurrency( $amount, $currency_key )` instead of `format( $amount )`. `format()` falls back to the *locale's default currency*, which would render a euro price with a **`$`** on an English-language (`en_US`) site. `formatCurrency()` forces the correct ISO currency symbol.

Rendering now follows the locale for every euro-using country, including the legitimate exceptions:

| Locale | Result |
|---|---|
| `fr_FR`, `de_DE`, `es_ES`, `it_IT` | `40,00 €` |
| `nl_NL` | `€ 40,00` |
| `en_IE` | `€40.00` |
| `en_US` | `€40.00` (was `$40.00`) |

**Output for all existing locale-based currencies is unchanged** — each one's locale-default currency already equals its ISO code, so `format()` and `formatCurrency()` produce byte-identical results (verified across all 18 of them against ICU 77).

Fixes #1766

### Screenshots

Live example of the current (incorrect) behavior: https://bretagne.wordcamp.org/2026/billetterie/ shows `€ 40.00` instead of the expected `40,00 €`.

### How to test the changes in this Pull Request:

1. On a site whose language is a Eurozone locale (e.g. French — `fr_FR`), set **Tickets → Setup → Currency** to `Euro (EUR)`.
2. Create a ticket with a price (e.g. `40`) and view any place that renders it (ticket/registration form).
3. Confirm the price shows as `40,00 €` (symbol after, comma decimal) instead of `€ 40.00`.
4. Switch the site language to English (`en_US`) and confirm the price shows as `€40.00` — with the euro sign, **not** `$40.00`.
5. Confirm non-euro currencies (e.g. `GBP`, `USD`, `AUD`) are unchanged.

Automated: `tests/test-camptix-admin.php` adds `test_append_currency_eur_places_symbol_after_amount_for_french_locale` and `test_append_currency_eur_uses_euro_symbol_on_english_locale` (both skip when `intl` is unavailable and avoid asserting exact ICU strings).
