### PR TITLE
Stripe: confirm the Checkout Session matches the order on return

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/addons/payment-stripe.php
@@ -414,6 +414,27 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		$payment_intent = $session['payment_intent'] ?? array();
 		$intent_status  = is_array( $payment_intent ) ? ( $payment_intent['status'] ?? '' ) : '';
 
+		// Confirm the fetched session actually belongs to this order before acting on
+		// it. The interactive return path (payment_return()) reads the CampTix payment
+		// token and the Stripe session id as two independent request values, so without
+		// this check any complete/paid session from this account could be replayed to
+		// complete any order. `client_reference_id` is the same value the webhook path
+		// already trusts to locate the order, so this is a no-op there.
+		$expected_reference = get_current_blog_id() . ':' . $payment_token;
+		if ( ( $session['client_reference_id'] ?? '' ) !== $expected_reference ) {
+			$camptix->log(
+				'Refusing Stripe session: client_reference_id does not belong to this order.',
+				$order['attendee_id'] ?? null,
+				compact( 'payment_token', 'expected_reference', 'session' )
+			);
+
+			if ( $interactive ) {
+				wp_die( 'could not verify payment for this order' );
+			}
+
+			return false;
+		}
+
 		if ( ! $session_status ) {
 			$camptix->log( "Dying because couldn't get Payment status", $order['attendee_id'], compact( 'payment_token', 'session' ) );
 
@@ -452,6 +473,39 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 			'complete' === $session_status &&
 			in_array( $payment_status, array( 'paid', 'no_payment_required' ), true )
 		) {
+			// Confirm the amount paid matches the order total before completing, so a
+			// correctly-referenced but cheaper session can't complete a pricier order.
+			// The expected total is summed per line item exactly as create_session()
+			// builds them (each item's fractional unit amount times its quantity), so
+			// it equals Stripe's amount_total. Converting the whole order total in one
+			// step would not match, because the per-unit fractional conversion truncates.
+			$expected_amount = $this->get_expected_fractional_total( $order );
+
+			if ( null === $expected_amount || (int) ( $session['amount_total'] ?? -1 ) !== $expected_amount ) {
+				$camptix->log(
+					'Stripe amount_total does not match the order total; marking the order pending for organizer review instead of completing it.',
+					$order['attendee_id'] ?? null,
+					compact( 'payment_token', 'expected_amount', 'session' )
+				);
+
+				// The buyer may well have been charged, so don't strand the order in
+				// draft. Mark it pending non-interactively (so we control the buyer
+				// message below); this surfaces it in the attendee list for an
+				// organizer to reconcile.
+				$camptix->payment_result(
+					$payment_token,
+					CampTix_Plugin::PAYMENT_STATUS_PENDING,
+					$this->get_payment_data_for_session( $session, $transaction_details_extra ),
+					false
+				);
+
+				if ( $interactive ) {
+					wp_die( esc_html__( 'We could not automatically confirm the amount paid for your order. If you were charged, your payment was received — please contact the event organizers to have your ticket confirmed.', 'wordcamporg' ) );
+				}
+
+				return false;
+			}
+
 			return $camptix->payment_result(
 				$payment_token,
 				CampTix_Plugin::PAYMENT_STATUS_COMPLETED,
@@ -479,6 +533,43 @@ class CampTix_Payment_Method_Stripe extends CampTix_Payment_Method {
 		}
 
 		return false;
+	}
+
+	/**
+	 * The order total in Stripe's fractional currency unit (e.g. cents).
+	 *
+	 * Stripe's amount_total is the sum of each line item's unit_amount times its
+	 * quantity, and create_session() sets unit_amount to
+	 * get_fractional_unit_amount( item price ). That conversion truncates, so the
+	 * expected total must be summed per line item the same way — converting the
+	 * whole order total in a single step can differ by a few fractional units and
+	 * would reject a legitimately fully-paid order.
+	 *
+	 * @param array $order The CampTix order (from get_order()).
+	 *
+	 * @return int|null Fractional total, or null if it cannot be determined.
+	 */
+	protected function get_expected_fractional_total( $order ) {
+		if ( empty( $order['items'] ) || ! is_array( $order['items'] ) ) {
+			return null;
+		}
+
+		$total = 0;
+
+		foreach ( $order['items'] as $item ) {
+			try {
+				$unit_amount = (int) $this->get_fractional_unit_amount(
+					$this->camptix_options['currency'],
+					$item['price'] ?? 0
+				);
+			} catch ( Exception $e ) {
+				return null;
+			}
+
+			$total += $unit_amount * (int) ( $item['quantity'] ?? 0 );
+		}
+
+		return $total;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
+++ b/public_html/wp-content/plugins/camptix/tests/addons/test-payment-stripe.php
@@ -77,4 +77,306 @@ class Test_Camptix_Payment_Stripe_Addon extends \WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertSame( 'camptix_stripe_webhook_invalid_signature', $result->get_error_code() );
 	}
+
+	/**
+	 * Build a draft CampTix order (attendee + tix_order meta) for the given token.
+	 *
+	 * @return array{0:string,1:int} [ payment_token, attendee_id ]
+	 */
+	protected function make_stripe_order( $token, $total ) {
+		$ticket = self::factory()->post->create(
+			array(
+				'post_type'   => 'tix_ticket',
+				'post_status' => 'publish',
+			)
+		);
+
+		$attendee = self::factory()->post->create(
+			array(
+				'post_type'   => 'tix_attendee',
+				'post_status' => 'draft',
+			)
+		);
+
+		update_post_meta( $attendee, 'tix_payment_token', $token );
+		update_post_meta( $attendee, 'tix_access_token', 'acc_' . $token );
+		update_post_meta(
+			$attendee,
+			'tix_order',
+			array(
+				'items' => array(
+					array(
+						'id'       => $ticket,
+						'name'     => 'Ticket',
+						'price'    => $total,
+						'quantity' => 1,
+					),
+				),
+				'total' => $total,
+			)
+		);
+
+		return array( $token, $attendee );
+	}
+
+	/**
+	 * Build a draft order with explicit line items.
+	 *
+	 * @param string $token
+	 * @param array  $items Each element: array( 'price' => float, 'quantity' => int ).
+	 *
+	 * @return array{0:string,1:int} [ payment_token, attendee_id ]
+	 */
+	protected function make_stripe_order_items( $token, $items ) {
+		$order_items = array();
+		$total       = 0;
+
+		foreach ( $items as $i => $item ) {
+			$ticket = self::factory()->post->create(
+				array(
+					'post_type'   => 'tix_ticket',
+					'post_status' => 'publish',
+				)
+			);
+
+			$order_items[] = array(
+				'id'       => $ticket,
+				'name'     => 'Ticket ' . $i,
+				'price'    => $item['price'],
+				'quantity' => $item['quantity'],
+			);
+			$total += $item['price'] * $item['quantity'];
+		}
+
+		$attendee = self::factory()->post->create(
+			array(
+				'post_type'   => 'tix_attendee',
+				'post_status' => 'draft',
+			)
+		);
+
+		update_post_meta( $attendee, 'tix_payment_token', $token );
+		update_post_meta( $attendee, 'tix_access_token', 'acc_' . $token );
+		update_post_meta(
+			$attendee,
+			'tix_order',
+			array(
+				'items' => $order_items,
+				'total' => $total,
+			)
+		);
+
+		return array( $token, $attendee );
+	}
+
+	/** A completed/paid Stripe Checkout Session with the given reference + amount. */
+	protected function complete_session( $client_reference_id, $amount_total ) {
+		return array(
+			'id'                  => 'cs_test',
+			'status'              => 'complete',
+			'payment_status'      => 'paid',
+			'amount_total'        => $amount_total,
+			'client_reference_id' => $client_reference_id,
+			'payment_intent'      => array(
+				'status'        => 'succeeded',
+				'latest_charge' => 'ch_test',
+			),
+		);
+	}
+
+	/** Invoke the protected return handler directly (non-interactive, like the webhook). */
+	protected function invoke_return( $stripe, $payment_token, $session ) {
+		$order  = $stripe->get_order( $payment_token );
+		$method = new ReflectionMethod( 'CampTix_Payment_Method_Stripe', 'process_payment_return_session' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $stripe, $payment_token, $session, $order, false, array() );
+	}
+
+	/**
+	 * A Stripe gateway instance with options loaded and the currency set to USD.
+	 *
+	 * @return CampTix_Payment_Method_Stripe
+	 */
+	protected function make_configured_stripe() {
+		$stripe = new CampTix_Payment_Method_Stripe();
+		$stripe->load_options();
+		$stripe->camptix_options['currency'] = 'USD';
+
+		return $stripe;
+	}
+
+	/**
+	 * Drive the real public entry point payment_return() with the two request
+	 * values set independently (as the interactive bypass would) and the Stripe
+	 * session fetch stubbed. wp_die() is made catchable so fail-closed paths can
+	 * be asserted.
+	 *
+	 * Only use this for paths expected to wp_die(); a successful completion inside
+	 * payment_result() calls die() directly, which cannot be caught here.
+	 *
+	 * @return string|null The wp_die() message, or null if it did not die.
+	 */
+	protected function drive_payment_return( $stripe, $payment_token, $stripe_session_id, $session ) {
+		$_REQUEST['tix_payment_token']  = $payment_token;
+		$_REQUEST['tix_stripe_session'] = $stripe_session_id;
+
+		$http_stub = function () use ( $session ) {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => wp_json_encode( $session ),
+				'headers'  => array(),
+			);
+		};
+		$die_handler = function () {
+			return function ( $message ) {
+				throw new Exception( esc_html( 'wp_die: ' . ( is_wp_error( $message ) ? $message->get_error_message() : $message ) ) );
+			};
+		};
+
+		add_filter( 'pre_http_request', $http_stub, 10, 3 );
+		add_filter( 'wp_die_handler', $die_handler );
+
+		$died = null;
+		try {
+			$stripe->payment_return();
+		} catch ( Exception $e ) {
+			$died = $e->getMessage();
+		} finally {
+			remove_filter( 'pre_http_request', $http_stub, 10 );
+			remove_filter( 'wp_die_handler', $die_handler );
+			unset( $_REQUEST['tix_payment_token'], $_REQUEST['tix_stripe_session'] );
+		}
+
+		return $died;
+	}
+
+	/**
+	 * A complete/paid session belonging to a DIFFERENT order must not complete
+	 * the order named in the request. Regression test for the interactive
+	 * payment-return verification bypass.
+	 *
+	 * @covers CampTix_Payment_Method_Stripe::process_payment_return_session
+	 */
+	public function test_return_rejects_session_bound_to_a_different_order() {
+		$stripe = $this->make_configured_stripe();
+		list( $victim_token, $victim_id ) = $this->make_stripe_order( 'tok_victim', 500 );
+
+		// A paid session for the CHEAP order, replayed against the victim's token.
+		$session = $this->complete_session( get_current_blog_id() . ':tok_cheap', 500 );
+		$result  = $this->invoke_return( $stripe, $victim_token, $session );
+
+		$this->assertFalse( $result );
+		$this->assertSame( 'draft', get_post_status( $victim_id ) );
+	}
+
+	/**
+	 * A correctly-referenced, fully-paid session still completes the order.
+	 *
+	 * @covers CampTix_Payment_Method_Stripe::process_payment_return_session
+	 */
+	public function test_return_completes_when_session_matches_order_and_amount() {
+		$stripe = $this->make_configured_stripe();
+		list( $token, $attendee_id ) = $this->make_stripe_order( 'tok_ok', 500 );
+
+		$expected = $stripe->get_fractional_unit_amount( 'USD', 500 ); // 50000
+		$session  = $this->complete_session( get_current_blog_id() . ':' . $token, $expected );
+
+		$this->invoke_return( $stripe, $token, $session );
+
+		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * A session bound to the right order but paid for less than the order total
+	 * must not complete it. The buyer may have been charged something, so the
+	 * order is parked as `pending` for an organizer to reconcile rather than
+	 * completed or left silently in draft.
+	 *
+	 * @covers CampTix_Payment_Method_Stripe::process_payment_return_session
+	 */
+	public function test_return_marks_pending_when_underpaid_for_the_correct_order() {
+		$stripe = $this->make_configured_stripe();
+		list( $token, $attendee_id ) = $this->make_stripe_order( 'tok_underpaid', 500 );
+
+		// Right order, but only 500 fractional units paid on a $500 (50000) order.
+		$session = $this->complete_session( get_current_blog_id() . ':' . $token, 500 );
+		$result  = $this->invoke_return( $stripe, $token, $session );
+
+		$this->assertFalse( $result );
+		$this->assertSame( 'pending', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * A multi-quantity order with a fractional per-ticket price must complete when
+	 * the session pays what Stripe actually charges: the per-item fractional amount
+	 * times quantity (the line item create_session() sends). Converting the whole
+	 * order total in one step truncates differently and used to reject this
+	 * fully-paid order.
+	 *
+	 * @covers CampTix_Payment_Method_Stripe::process_payment_return_session
+	 * @covers CampTix_Payment_Method_Stripe::get_expected_fractional_total
+	 */
+	public function test_return_completes_multi_quantity_decimal_order_matching_stripe_line_items() {
+		$stripe = $this->make_configured_stripe();
+		list( $token, $attendee_id ) = $this->make_stripe_order_items(
+			'tok_decimal',
+			array(
+				array(
+					'price'    => 19.99,
+					'quantity' => 3,
+				),
+			)
+		);
+
+		$stripe_amount = $stripe->get_fractional_unit_amount( 'USD', 19.99 ) * 3;
+		$session       = $this->complete_session( get_current_blog_id() . ':' . $token, $stripe_amount );
+
+		$this->invoke_return( $stripe, $token, $session );
+
+		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * The reported attack, through the real public entry point: an attacker names
+	 * the victim's payment token but supplies a paid session that belongs to a
+	 * different (cheap) order. payment_return() must fail closed and not complete
+	 * the victim's order.
+	 *
+	 * @covers CampTix_Payment_Method_Stripe::payment_return
+	 * @covers CampTix_Payment_Method_Stripe::process_payment_return_session
+	 */
+	public function test_payment_return_rejects_replayed_session_for_a_different_order() {
+		$stripe = $this->make_configured_stripe();
+		list( $victim_token, $victim_id ) = $this->make_stripe_order( 'tok_victim_i', 500 );
+
+		$session = $this->complete_session( get_current_blog_id() . ':tok_cheap', 500 );
+		$died    = $this->drive_payment_return( $stripe, $victim_token, 'cs_attacker', $session );
+
+		$this->assertNotNull( $died, 'payment_return() should have failed closed via wp_die().' );
+		$this->assertSame( 'draft', get_post_status( $victim_id ) );
+	}
+
+	/**
+	 * Through the real public entry point: a correctly-referenced session that
+	 * paid the wrong amount parks the order as pending and tells the buyer to
+	 * contact the organizers, rather than stranding a charged buyer in draft.
+	 *
+	 * @covers CampTix_Payment_Method_Stripe::payment_return
+	 * @covers CampTix_Payment_Method_Stripe::process_payment_return_session
+	 */
+	public function test_payment_return_parks_pending_and_warns_buyer_on_amount_mismatch() {
+		$stripe = $this->make_configured_stripe();
+		list( $token, $attendee_id ) = $this->make_stripe_order( 'tok_i_underpaid', 500 );
+
+		$session = $this->complete_session( get_current_blog_id() . ':' . $token, 500 );
+		$died    = $this->drive_payment_return( $stripe, $token, 'cs_underpaid', $session );
+
+		$this->assertNotNull( $died );
+		$this->assertStringContainsString( 'contact the event organizers', $died );
+		$this->assertSame( 'pending', get_post_status( $attendee_id ) );
+	}
 }


### PR DESCRIPTION
### What

The Stripe gateway's interactive return handler completes an order from two request values read **independently** — the CampTix payment token (which order to complete) and the Stripe Checkout Session id. `process_payment_return_session()` previously acted on the session's paid status alone, without confirming the session actually corresponds to the order being completed, or that the amount matches.

This adds two checks to that shared method:

1. **Session belongs to the order.** Confirm `client_reference_id` equals `<blog_id>:<payment_token>` before acting on it — the same value the webhook path already relies on to locate the order. Interactive requests `wp_die()` on mismatch; the webhook path returns `false` (and is a no-op, since it already uses this reference).
2. **Amount matches.** Confirm the session's `amount_total` equals the order total. The expected total is summed **per line item** via a new `get_expected_fractional_total()`, exactly as `create_session()` builds the line items — so it equals what Stripe charged. On mismatch the order is marked `PENDING` (see below) rather than completed.

### Why

The webhook path derives the token from the session's own `client_reference_id`, so session and order are always bound there. The interactive path lets the two be named separately, so it should **prove** the same binding rather than assume it. This aligns the two paths.

The amount total is summed per line item on purpose: `create_session()` sends each item as `unit_amount = get_fractional_unit_amount( item price )` × quantity, and that conversion truncates. Converting the whole order total in a single step produces a different figure for multi-quantity or fractional-price orders (e.g. 3 × 19.99), which would wrongly reject a fully-paid order.

### Handling a mismatch without stranding the buyer

An interactive return only happens after the buyer came back from Stripe, so on an amount mismatch they may already have been charged. Rather than leave the order silently in `draft`, it's marked `PENDING` — which surfaces it in the attendee list for an organizer to reconcile — and the buyer sees a message asking them to contact the organizers. The `client_reference_id` check stays a hard fail (it can't reject a genuine return).

### Compatibility

No behavior change for legitimate returns: `create_session()` sets `client_reference_id = <blog_id>:<payment_token>` at checkout and the charge is built from the same line items, so both checks always pass for a real payment. Check #1 is a no-op for the webhook path.

### Tests

`tests/addons/test-payment-stripe.php` covers, on both the shared method and the real `payment_return()` entry point (session fetch stubbed via `pre_http_request`, `wp_die` made catchable):

- a session bound to a different order is rejected (order stays `draft`);
- a correctly-referenced, full-amount session completes (`draft → publish`);
- a correctly-referenced under-amount session is parked `pending`;
- a multi-quantity fractional-price order (3 × 19.99) completes on the per-line-item total (regression for the truncation issue).
