### PR TITLE
Docs: Switch to sandboxed wkhtmltopdf

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs-pdf-generator.php
+++ b/public_html/wp-content/plugins/wordcamp-docs/classes/class-wordcamp-docs-pdf-generator.php
@@ -69,11 +69,13 @@ class WordCamp_Docs_PDF_Generator {
 
 		$margins = ( ! empty( $args['margins'] ) && is_array( $args['margins'] ) && 4 == count( $args['margins'] ) ) ? $args['margins'] : array( 0, 0, 0, 0 );
 
+		chmod( $this->get_tmp_folder(), 0775 );
+
 		$file = $this->get_tmp_folder( $filename );
 
 		$command = sprintf(
 			// Allowing local file access is safe because the inputs to `$source_file` should have been escaped.
-			'wkhtmltopdf --enable-local-file-access -d %d -T %s -R %s -B %s -L %s %s %s',
+			'sudo -u wkhtmltopdf -g nogroup -H wkhtmltopdf --enable-external-links --enable-local-file-access -d %d -T %s -R %s -B %s -L %s %s %s',
 			$dpi,
 			escapeshellarg( $margins[0] ),
 			escapeshellarg( $margins[1] ),


### PR DESCRIPTION
Ports **r5686** from the production SVN repository to Git, so the next Git-to-SVN sync doesn't revert it.

The hotfix runs `wkhtmltopdf` as the dedicated `wkhtmltopdf` user via `sudo` instead of the web user, adds `--enable-external-links`, and makes the tmp folder group-writable so the sandboxed process can write the generated PDF.

No functional changes beyond what is already live — this is a straight port of the SVN commit ("wordcamp-docs: Switch to sandboxed wkhtmltopdf", 2026-07-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)