### PR TITLE
Central: Normalize single-wordcamp-info.php line endings to LF

### DIFF
--- a/.github/bin/phpcs-branch.php
+++ b/.github/bin/phpcs-branch.php
@@ -24,20 +24,25 @@ function run_phpcs( $file, $bin_dir ) {
  */
 function run_phpcs_changed( $file, $git, $base_branch, $bin_dir ) {
 	$name = basename( $file );
+
+	// The temp filename must satisfy the filename sniff (lowercase, hyphens only),
+	// or violations on line 1 of a changed file get misattributed to the temp name.
+	$test_file = str_replace( '.', '-', $name ) . '-test.php';
+
 	exec( "$git diff $base_branch $file > $name.diff" );
 
-	exec( "$git show $base_branch:$file > $name.test.php" );
-	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs.xml.dist --report=json -snq > $name.orig.phpcs" );
+	exec( "$git show $base_branch:$file > $test_file" );
+	exec( "$bin_dir/phpcs $test_file --standard=./phpcs.xml.dist --report=json -snq > $name.orig.phpcs" );
 
-	exec( "cat $file > $name.test.php" );
-	exec( "$bin_dir/phpcs $name.test.php --standard=./phpcs.xml.dist --report=json -snq > $name.phpcs" );
+	exec( "cat $file > $test_file" );
+	exec( "$bin_dir/phpcs $test_file --standard=./phpcs.xml.dist --report=json -snq > $name.phpcs" );
 
 	$cmd = "$bin_dir/phpcs-changed --diff $name.diff --phpcs-orig $name.orig.phpcs --phpcs-new $name.phpcs";
 	exec( $cmd, $output, $exec_exit_status );
 	echo implode( "\n", $output );
 	echo "\n";
 
-	exec( "rm $name.diff $name.test.php $name.orig.phpcs $name.phpcs" );
+	exec( "rm $name.diff $test_file $name.orig.phpcs $name.phpcs" );
 	return $exec_exit_status;
 }
 

--- a/public_html/wp-content/themes/wordcamp-central-2012/single-wordcamp-info.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/single-wordcamp-info.php
@@ -3,7 +3,8 @@
  * Single WordCamp /info/ template.
  */
 
-get_header(); the_post();
+get_header();
+the_post();
 $wordcamp_title = wcpt_get_wordcamp_title();
 ?>
 


### PR DESCRIPTION
Whitespace-only normalization plus two small PHPCS fixes that its CI run surfaced:

1. **Line endings**: converts this template from CRLF to LF, matching what has been in the production SVN repository since its 2019 import (r3076). Because of the mismatch, every Git-to-SVN sync run flags the file as modified and threatens to commit line-ending churn to SVN.
2. **`get_header(); the_post();`** split onto separate lines — a pre-existing violation that `phpcs-changed` now reports because every line of the file counts as changed.
3. **CI harness fix**: `phpcs-branch.php` copies changed files to `<name>.php.test.php`, and the WordPress filename sniff rejects that temp name (dots instead of hyphens) whenever a PR touches line 1 of a file. The temp name is now sniff-compliant (`<name>-php-test.php`), fixing this for all future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)