### PR TITLE
Groups: fix empty X-WP-Nonce on group join/leave

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -29,6 +29,8 @@ $member_count    = $user_count['total_users'] ?? 0;
 $join_api        = rest_url( 'wporg-groups/v1/members/join' );
 $leave_api       = rest_url( 'wporg-groups/v1/members/leave' );
 $login_url       = wp_login_url( get_permalink() ?: home_url() );
+// Only logged-in visitors can join or leave, and only their markup should carry a nonce.
+$rest_nonce      = $is_logged_in ? wp_create_nonce( 'wp_rest' ) : '';
 $count_label     = sprintf(
 	_n( '%s member', '%s members', $member_count, 'wporg-groups-frontend' ),
 	number_format_i18n( $member_count )
@@ -47,6 +49,7 @@ $context = array(
 	'joinApi'       => $join_api,
 	'leaveApi'      => $leave_api,
 	'loginUrl'      => $login_url,
+	'nonce'         => $rest_nonce,
 	'loading'       => false,
 );
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/view.js
@@ -48,10 +48,14 @@ store( 'wporg/group-membership', {
 				const resp = await fetch( ctx.joinApi, {
 					method: 'POST',
 					credentials: 'same-origin',
-					headers: { 'X-WP-Nonce': await getNonce() },
+					headers: { 'X-WP-Nonce': ctx.nonce },
 				} );
 
 				const data = await resp.json();
+
+				if ( ! resp.ok ) {
+					throw new Error( data?.message || resp.statusText );
+				}
 
 				if ( data.success ) {
 					ctx.isMember = true;
@@ -60,8 +64,9 @@ store( 'wporg/group-membership', {
 					// Reload to get the full member UI server-rendered.
 					window.location.reload();
 				}
-			} catch {
-				// Silently fail.
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Group join failed:', error );
 			} finally {
 				ctx.loading = false;
 			}
@@ -84,44 +89,26 @@ store( 'wporg/group-membership', {
 				const resp = await fetch( ctx.leaveApi, {
 					method: 'DELETE',
 					credentials: 'same-origin',
-					headers: { 'X-WP-Nonce': await getNonce() },
+					headers: { 'X-WP-Nonce': ctx.nonce },
 				} );
 
 				const data = await resp.json();
+
+				if ( ! resp.ok ) {
+					throw new Error( data?.message || resp.statusText );
+				}
 
 				if ( data.success ) {
 					ctx.isMember = false;
 					ctx.memberCount = Math.max( 0, ctx.memberCount - 1 );
 					window.location.reload();
 				}
-			} catch {
-				// Silently fail.
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Group leave failed:', error );
 			} finally {
 				ctx.loading = false;
 			}
 		},
 	},
 } );
-
-let cachedNonce = null;
-
-async function getNonce() {
-	if ( cachedNonce ) {
-		return cachedNonce;
-	}
-	if ( window.wpApiSettings?.nonce ) {
-		cachedNonce = window.wpApiSettings.nonce;
-		return cachedNonce;
-	}
-	// Fallback: use the GatherPress nonce endpoint.
-	const apiBase = window.GatherPress?.urls?.eventApiUrl;
-	if ( apiBase ) {
-		const nonceResp = await fetch( apiBase + '/nonce', {
-			credentials: 'same-origin',
-		} );
-		const nonceData = await nonceResp.json();
-		cachedNonce = nonceData.nonce;
-		return cachedNonce;
-	}
-	return '';
-}


### PR DESCRIPTION
Fixes #1804.

# What

Join and leave on the `wporg/group-membership` block send an empty `X-WP-Nonce`, so every request is rejected with `403 rest_cookie_invalid_nonce`. Nobody can join or leave a group from the front end.

# Why

`view.js` resolved the nonce client side, from two sources that are not present on the pages where this block renders:

- `window.wpApiSettings.nonce` is localized by the `wp-api` script, which this page never enqueues. `group-membership` ships as a `viewScriptModule`, and script modules cannot pick up `wp_localize_script` data anyway.
- the fallback read `window.GatherPress.urls.eventApiUrl`, which only exists inside GatherPress's own templates, not on the group front page or `/members/`.

Both are `undefined`, so `getNonce()` fell through to its final `return ''`.

# How

The block already server-renders a `data-wp-context` payload containing `joinApi`, `leaveApi` and `loginUrl`. The nonce belongs there too, next to the endpoints it authenticates, so this adds `nonce` to that context and reads `ctx.nonce` in the two actions. That deletes `getNonce()` and its cache entirely, 22 lines, along with the dependency on globals that this block has no control over.

The nonce is only emitted for logged-in visitors. Anonymous markup is the cacheable case, and an anonymous visitor is redirected to `loginUrl` before any request is made, so there is nothing to authenticate.

I also stopped the two `catch` blocks from swallowing everything. This is what made the bug present as "the button does nothing": the response was a 403, but `data.success` was simply `undefined`, so neither branch ran and nothing reached the console. Non-2xx now throws, and the catch logs. Deliberately kept to `console.error` rather than adding user-facing error UI, since that is a design decision beyond this fix, and #1812 covers announcing state changes to assistive tech.

# Testing

Log in as a subscriber-tier member of a group site.

1. Click "Leave group" and confirm. Member count drops, page reloads, you are out.
2. Click "Join this group". Count goes up, page reloads, you are back in.
3. In the network tab, `X-WP-Nonce` is non-empty on both requests and both return 200.

Before this change both requests return `403 rest_cookie_invalid_nonce` with an empty header, and the console stays silent.

# Scope

Only `group-membership` is touched. `event-rsvp/view.js` also resolves a nonce at runtime, but through a server-provided `ctx.apiBase` (`rest_url( 'gatherpress/v1/event' )`) rather than a `window` global, so it does not share this failure and I have left it alone. `event-manage` and `group-settings` do not hand-roll nonces at all.
