### PR TITLE
Groups: require an editing capability to read venues over REST

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -536,3 +536,69 @@ add_filter(
 	10,
 	2
 );
+
+/**
+ * Require an editing capability to read venues over the REST API.
+ *
+ * Making the post type non-public closes the front-end routes, but it does
+ * not close the REST ones: WP_REST_Posts_Controller gates anonymous reads on
+ * `show_in_rest` alone, and grants them for any `publish` post. GatherPress
+ * needs `show_in_rest` for block-editor venue authoring, so it cannot simply
+ * be turned off, and the collection endpoint otherwise hands out venue
+ * addresses, descriptions and meta to unauthenticated callers.
+ *
+ * Wrap the read handlers' permission callbacks rather than replacing them,
+ * so the controller's own checks still run for anyone who passes this gate.
+ * Front-end venue output is server-rendered (see the
+ * `render_block_gatherpress/venue` filter above) and the event form's venue
+ * list comes from `wporg-groups/v1`, so neither depends on these routes.
+ */
+add_filter(
+	'rest_endpoints',
+	static function ( array $endpoints ): array {
+		$post_type = get_post_type_object( 'gatherpress_venue' );
+
+		if ( ! $post_type || empty( $post_type->show_in_rest ) ) {
+			return $endpoints;
+		}
+
+		$base   = '/' . ( $post_type->rest_namespace ?: 'wp/v2' ) . '/' . ( $post_type->rest_base ?: $post_type->name );
+		$routes = array_filter(
+			array_keys( $endpoints ),
+			static function ( string $route ) use ( $base ): bool {
+				return $route === $base || str_starts_with( $route, $base . '/' );
+			}
+		);
+
+		foreach ( $routes as $route ) {
+			foreach ( $endpoints[ $route ] as $index => $handler ) {
+				$methods = $handler['methods'] ?? array();
+
+				if ( is_string( $methods ) ) {
+					$methods = array_fill_keys( array_map( 'trim', explode( ',', $methods ) ), true );
+				}
+
+				// Writes already require capabilities; only reads are open.
+				if ( empty( $methods['GET'] ) ) {
+					continue;
+				}
+
+				$original = $handler['permission_callback'] ?? null;
+
+				$endpoints[ $route ][ $index ]['permission_callback'] = static function ( $request ) use ( $original ) {
+					if ( ! current_user_can( 'edit_posts' ) ) {
+						return new \WP_Error(
+							'rest_forbidden',
+							__( 'Sorry, you are not allowed to view venues.', 'wporg-groups-frontend' ),
+							array( 'status' => rest_authorization_required_code() )
+						);
+					}
+
+					return is_callable( $original ) ? $original( $request ) : true;
+				};
+			}
+		}
+
+		return $endpoints;
+	}
+);


### PR DESCRIPTION
Fixes #1803.

# What

`GET /wp/v2/gatherpress_venues` returns venue titles, descriptions, addresses and meta to fully unauthenticated callers, bypassing the lockdown that made the post type non-public.

# Why

The existing `register_post_type_args` filter closes the front-end routes, and that part works: `/venue/<slug>/` still 301s to the group root. But it does not close the REST ones. `WP_REST_Posts_Controller` gates anonymous reads on `show_in_rest` alone:

- `get_items_permissions_check()` only checks a capability when `context=edit`, and returns `true` otherwise.
- `check_read_permission()` returns `true` for any post with status `publish`, without consulting `public` or `publicly_queryable`.

GatherPress registers the post type with `show_in_rest => true` because block-editor venue authoring needs it, so turning that off is not an option.

# How

Wrap the permission callback on the venue post type's readable REST endpoints and require `edit_posts`. `rest_authorization_required_code()` gives 401 to logged-out callers and 403 to logged-in ones without the capability.

Three details worth calling out:

- **The original callback is wrapped, not replaced.** Anyone who passes the capability gate still goes through the controller's own checks, so this only ever narrows access.
- **Only `GET` handlers are touched.** Writes already require capabilities through the post type's own caps, and re-gating them would be redundant.
- **The route prefix is derived from the post type object** (`rest_namespace`, `rest_base`) rather than hardcoded, and matched as `$base` or `$base . '/'` so a sibling route such as `/wp/v2/gatherpress_venues_extra` cannot be caught by accident.

`edit_posts` is the right threshold here rather than `read_private_posts`: it is what the Event Organiser (author) and Organiser (editor) tiers already have and what block-editor authoring requires, while Members (subscriber) get nothing, which is the intent of the lockdown.

# Testing

The repro from the issue, run anonymously:

```
$ curl -sk "https://events.wordpress.test/group/sunshine-coast-qld/wp-json/wp/v2/gatherpress_venues"
{"code":"rest_forbidden","message":"Sorry, you are not allowed to view venues.","data":{"status":401}}
```

Before this change the same request returns the full venue array. The single-item route behaves the same way.

Against the issue's acceptance criteria:

- [x] Anonymous collection and item reads return an auth error rather than venue data.
- [x] Users with `edit_posts` still read venues over REST, so block-editor venue authoring is unaffected.
- [x] `/venue/<slug>/` still 301-redirects to the group root. That path is handled by the `register_post_type_args` filter, which is untouched.
- [x] No regression to the venue rendering on events. `gatherpress/venue` output is server-rendered through the `render_block_gatherpress/venue` filter in this same file, and the event form's venue dropdown is served by `wporg-groups/v1/event-form-data`, so neither goes through the gated routes.

I also checked the route-selection and method-normalisation logic in isolation, confirming it gates the collection and item `GET` handlers, skips `POST`/`DELETE` handlers, and does not match sibling or unrelated routes. Happy to turn that into a real test once #1799 lands test infrastructure, since there is currently nowhere for it to live.
