### PR TITLE
Groups: add GatherPress compat-test skill, PHPUnit suite, and Playwright e2e infra

### DIFF
--- a/.claude/skills/groups-gatherpress-compat-test/SKILL.md
+++ b/.claude/skills/groups-gatherpress-compat-test/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: groups-gatherpress-compat-test
+description: Run the Groups/GatherPress front-end integration compatibility checklist — per-role browser pass, direct REST pass, GatherPress-off pass, and security/perf sanity checks. Use after any GatherPress version bump, or any change to mu-plugins/wporg-groups-frontend, mu-plugins/groups, or the groups-site theme.
+---
+
+# Groups / GatherPress compatibility checklist
+
+This checklist exists because GatherPress updates fairly often and its
+changes can silently break backwards compatibility with our Groups
+integration. It is self-contained — follow it with no other context. It
+covers three plugins: `mu-plugins/wporg-groups-frontend` (front-end
+event/member management), `mu-plugins/groups/gatherpress-groups-tweaks.php`
+(settings/capability/query overrides), and the `groups-site` block theme.
+
+Two automated layers exist alongside this manual checklist — run them
+first, then use this checklist for what they can't cover (real browser
+interaction, cross-plugin capability leaks, exploratory checks):
+
+- **PHPUnit** — `docker compose -f docker-compose.phpunit.yml up` (or your
+  usual local phpunit invocation). Covers the `WordCamp Groups` suite:
+  capability logic, `gatherpress-groups-tweaks.php` option/query overrides,
+  `Members_Controller` role rules, REST permission/IDOR checks, draft flow,
+  block registration.
+- **E2E (Playwright)** — `npx playwright test` (or trigger the
+  `e2e-tests.yml` GitHub Action manually — it's `workflow_dispatch`-only).
+  Covers anonymous front-page rendering, an author creating an event
+  end-to-end through the real browser UI, and the member directory.
+
+If either automated suite fails, stop and fix that before doing the manual
+pass below — don't duplicate debugging effort across layers.
+
+## 1. Environment setup
+
+```bash
+# Checkout & build
+npm ci
+npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend
+
+# Confirm the dev stack is up
+docker compose ps   # expect wordcamp.test + wordcamp.db running
+
+# Confirm GatherPress is installed & active on the groups site (gitignored,
+# not committed — install manually if missing):
+docker compose exec wordcamp.test wp plugin list --url=events.wordpress.test/group/sunshine-coast-qld/ | grep gatherpress
+# If missing/inactive:
+docker compose exec wordcamp.test wp plugin install \
+  https://github.com/GatherPress/gatherpress/releases/download/0.34.0-alpha.2/gatherpress.0.34.0-alpha.2.zip \
+  --activate --url=events.wordpress.test/group/sunshine-coast-qld/
+```
+
+Create one test user per role tier, with **both** a browser login password
+and a REST application password (the browser pass needs the former, the
+REST pass needs the latter):
+
+```bash
+for pair in "organiser1:editor" "eventorganiser1:author" "member1:subscriber"; do
+  u="${pair%%:*}"; role="${pair##*:}"
+  docker compose exec wordcamp.test wp user create "$u" "$u@example.test" \
+    --role="$role" --user_pass=password \
+    --url=events.wordpress.test/group/sunshine-coast-qld/
+  docker compose exec wordcamp.test wp user application-password create "$u" "compat-test" --porcelain \
+    --url=events.wordpress.test/group/sunshine-coast-qld/
+done
+```
+
+Save the printed application passwords, then:
+
+```bash
+ORG="organiser1:<app-password>"       # editor tier — "Organiser"
+AUTHOR="eventorganiser1:<app-password>" # author tier — "Event Organiser"
+MEM="member1:<app-password>"          # subscriber tier — "Member"
+BASE="https://events.wordpress.test/group/sunshine-coast-qld"
+```
+
+## 2. Direct REST pass (bypass the UI)
+
+Namespace `wporg-groups/v1` should expose these routes — confirm the full
+list first:
+
+```bash
+curl -sk "$BASE/wp-json/wporg-groups/v1" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for r in sorted(d['routes'].keys()): print(r)
+"
+```
+
+Expect: `event-form-data`, `event`, `event/{id}`, `drafts`, `draft`,
+`draft/{id}`, `draft/{id}/publish`, `members`, `members/{id}`,
+`members/{id}/role`, `members/join`, `members/leave` (plus the namespace
+root).
+
+Checks (run as anonymous + each role where relevant):
+
+- [ ] **`GET /event-form-data` as author** → 200, populated `fields` +
+  `venues`.
+- [ ] **`POST /event` as editor** → creates a published event, 200 with
+  `{id, permalink, title}`.
+- [ ] **Overnight rollover** — `date=2026-08-20 time_start=22:00 time_end=01:00`
+  → `gatherpress_datetime_end` meta on the created post is the *next*
+  calendar day, not rejected as zero-length:
+  ```bash
+  docker compose exec wordcamp.test wp post meta get <id> gatherpress_datetime_end --url=$BASE
+  ```
+- [ ] **IDOR — author cannot hijack another author's event**:
+  `POST /event/<other_authors_event_id>` as `$AUTHOR` → 403 `rest_forbidden`,
+  original title unchanged.
+- [ ] **Author CAN edit their own event** → 200.
+- [ ] **`GET /members`** — public, paginated (`per_page` default 100, max
+  250 via `Members_Controller::MAX_PER_PAGE`) — confirm `X-WP-Total`/
+  `X-WP-TotalPages` headers present and a `per_page=9999` request is capped,
+  not unbounded. Each member has `role`/`roleLabel`
+  (`editor→Organiser`, `author→Event Organiser`, `subscriber→Member`).
+- [ ] **Editor promotes subscriber → author**:
+  `POST /members/<member1_id>/role -d role=author` as `$ORG` → 200; confirm
+  via `wp user get <id> --field=roles`.
+- [ ] **Author blocked from role changes** → 403 `rest_cannot_edit_roles`
+  (author passes `current_user_can_manage_events()` but fails
+  `current_user_can_manage_group_settings()` — both are required).
+- [ ] **Editor blocked from `role=administrator`** → 400 `rest_invalid_param`
+  (rejected by `ASSIGNABLE_ROLES` at the schema/args layer, before the
+  permission callback even runs).
+- [ ] **Can't change your own role** → 403 `cannot_change_own_role`.
+- [ ] **Can't demote the last organiser** — with only one editor/admin on
+  the site, attempting to demote them → 403 `cannot_remove_last_organizer`.
+- [ ] **Draft flow** — `POST /draft` (save) → `GET /drafts` (list) →
+  `POST /draft/{id}` (update) → `POST /draft/{id}/publish`; confirm
+  `post_status` transitions draft → publish via `wp post get <id> --field=post_status`.
+- [ ] **`/members/leave` + `/members/join` round-trip** as `$MEM` — both
+  return `{"success":true}` (join includes `memberCount`); confirm nonce
+  header on the request is non-empty (this is the exact failure mode of
+  #1804 — a front-end-only bug, but worth confirming the REST layer itself
+  works when hit directly with a valid nonce/app-password).
+
+## 3. Per-role browser pass
+
+Log in as each role in turn (`$BASE/wp-login.php`) and walk the actual UI —
+don't just check curl responses render correctly, click through:
+
+- **Event create/edit** — via the front-end modal (not wp-admin). Confirm
+  the venue picker, date/time fields, and featured image work.
+- **RSVP** — as Member and as Event Organiser.
+- **Group settings tabs** (Events / Venues / Members / Design / About) —
+  confirm each tab loads without a console error or 403, and that
+  Organiser-only tabs are entirely absent (not just disabled) for lower
+  roles.
+- **Member directory** (`/members/`) — role labels correct, join/leave
+  buttons behave.
+- **wp-admin, not just the front end** — capability leaks (like the fixed
+  `promote_users` escalation) only show up here. Log in as each non-admin
+  role and check: can they reach Users → a role-promotion UI beyond what
+  the front-end allows? Can they reach Site Editor (should be yes for
+  editors, via the `edit_theme_options` grant — confirm that grant doesn't
+  also unlock anything broader)?
+- **Anonymous (logged out)** — public pages render; every interactive
+  action (RSVP, join, edit) redirects to login rather than silently
+  failing or 403ing with no feedback.
+
+Explicitly note what's *absent* for each lower role, not just what's
+disabled — a Member should see **no** event-management UI rendered at all,
+not a greyed-out button.
+
+## 4. GatherPress-deactivated pass
+
+**`wp plugin deactivate gatherpress` does NOT work in this environment** —
+`mu-plugins/wcorg-network-plugin-control.php` force-activates
+`gatherpress/gatherpress.php` on every request for the groups network
+(`GROUPS_NETWORK_ID`), silently re-activating it immediately after
+deactivation. Verified: `wp plugin deactivate gatherpress --network` reports
+success, but the plugin's REST routes/classes are still live on the very
+next request. To genuinely test with GatherPress absent, remove the plugin
+files instead:
+
+```bash
+docker compose exec wordcamp.test mv wp-content/plugins/gatherpress wp-content/plugins/gatherpress.disabled
+# ... run the checks below ...
+docker compose exec wordcamp.test mv wp-content/plugins/gatherpress.disabled wp-content/plugins/gatherpress
+```
+
+- [ ] Visit every groups-network page (front page, single event, single
+  venue, `/members/`) and wp-admin — confirm **no PHP fatals** anywhere in
+  the network, not just the groups site.
+- [ ] Grep both plugins for every GatherPress class/function reference and
+  confirm each call site is guarded:
+  ```bash
+  grep -rn "GatherPress\\\\Core\|gatherpress_" \
+    public_html/wp-content/mu-plugins/wporg-groups-frontend \
+    public_html/wp-content/mu-plugins/groups \
+    --include="*.php" | grep -v "class_exists\|function_exists"
+  ```
+  Any hit here that isn't inside a code path already gated by an earlier
+  `class_exists()`/`function_exists()` check (e.g. the plugin-level guard
+  in `wporg-groups-frontend.php`'s bootstrap, or
+  `gatherpress-groups-tweaks.php`'s per-function guards) is a gap.
+- [ ] Reactivate GatherPress and confirm everything returns to normal
+  before continuing.
+
+## 5. Security-focused pass
+
+- [ ] Enumerate every `user_has_cap`/`map_meta_cap` filter across both
+  plugins:
+  ```bash
+  grep -rn "user_has_cap\|map_meta_cap" \
+    public_html/wp-content/mu-plugins/wporg-groups-frontend \
+    public_html/wp-content/mu-plugins/groups --include="*.php"
+  ```
+  For each, confirm it grants only a plugin-scoped or clearly-intentional
+  capability (e.g. `edit_theme_options` for editors, for Site Editor
+  access) — and never an unscoped core capability reachable from stock
+  wp-admin without an equivalent plugin-level ceiling. This is the exact
+  shape of the fixed privilege-escalation bug (editors were granted
+  `promote_users`, which worked correctly through this plugin's own REST
+  route but also silently unlocked stock wp-admin's user-role screen).
+  Regression-check it explicitly: `wp eval 'var_dump( user_can( <editor_id>, "promote_users" ) );' --url=$BASE` → must be `false`.
+- [ ] `GET /members` is intentionally public (no auth) — this is a known,
+  tracked product/privacy question (see the repo's open issue tracker for
+  the current decision), not an oversight. Confirm the fields returned
+  match whatever the current decision is (as of writing: name, avatar,
+  profile link, bio, role — no email, no `registered` date).
+- [ ] Spot-check sanitization/escaping on user-controlled data that reaches
+  storage or output: event title/description (`persist_event()`/
+  `build_post_content()` in `inc/rest.php`), venue address
+  (`resolve_venue_id()`), draft fields. Try an XSS payload
+  (`<script>alert(1)</script>`) in an event title via `POST /event` and
+  confirm it's escaped on render, not executed.
+- [ ] `featured_image_id` on event create/update rejects an attachment ID
+  the current user can't read (`current_user_can_use_attachment()` in
+  `inc/rest.php`) — try passing another user's private attachment ID as a
+  lower-privileged role and confirm rejection.
+
+## 6. Performance sanity check
+
+- [ ] `GET /members` is paginated (see section 2) — not an unconditional
+  full-network user dump.
+- [ ] Front page / event archive / member directory queries don't scale
+  linearly with total network size — check for `posts_per_page`/`number`
+  caps in the relevant `WP_Query`/`WP_User_Query` calls
+  (`gatherpress-groups-tweaks.php`'s `pre_get_posts` filter,
+  `Members_Controller::get_items()`).
+- [ ] `group-members` and `event-rsvp` blocks batch their per-user meta
+  lookups rather than querying per row (this was a specific fix in #1793 —
+  confirm it hasn't regressed by checking query count on a page with many
+  members/RSVPs, e.g. via Query Monitor or `$wpdb->num_queries`).
+
+## Known-issues appendix
+
+Use this to distinguish "this checklist found something new" from
+"this is a known, already-filed issue." Check your repo's issue tracker for
+current status before treating any of these as new bugs:
+
+| Symptom | Exercised by | Notes |
+|---|---|---|
+| Join/leave silently 403s via the UI (nonce lookup finds nothing on the front end) | Section 3, join/leave click-through | Front-end-only bug — the REST layer itself works fine when hit directly with a valid nonce (section 2's join/leave check). |
+| Group Settings → About tab 403s for Organisers | Section 3, About tab | Calls a core admin-only REST endpoint directly instead of a plugin-scoped one. |
+| `wporg/event-manage` block registered but not placed in any template | Section 3/4 grep, or `wp eval` block-registry dump | Dead code, not a functional gap — Event Organisers manage events fine via wp-admin. |
+| `/members` fully public with no membership/auth requirement | Section 5 | Open product/privacy question, not a bug in itself — confirm current decision, don't assume it's wrong. |
+| `my-events` block empty for a user who created events but never RSVP'd | Section 3, per-role browser pass as an event creator | RSVP-attendance based by design — confirm this still matches the current product decision. |
+| `groups-site` theme activatable on non-groups-network sites | Not covered by this checklist (network-admin action, not a groups-site page) | If auditing this, attempt `wp theme activate groups-site --url=<non-groups-network-site>` and confirm it's blocked. |

--- a/.docker/Dockerfile.phpunit
+++ b/.docker/Dockerfile.phpunit
@@ -1,7 +1,7 @@
 FROM php:8.4-fpm
 
 # Run some Debian packages installation.
-ENV PACKAGES="curl git mariadb-client subversion wget zlib1g-dev libzip-dev"
+ENV PACKAGES="curl git mariadb-client subversion unzip wget zlib1g-dev libzip-dev"
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends $PACKAGES && \
     apt-get clean && \

--- a/.docker/bin/install-test-suite.sh
+++ b/.docker/bin/install-test-suite.sh
@@ -13,6 +13,12 @@ DB_PASS="${WP_TESTS_DB_PASS:-}"
 WP_VERSION="${WP_TESTS_WP_VERSION:-latest}"
 TESTS_CONFIG="/tmp/wp/wordpress-tests-lib/wp-tests-config.php"
 
+# Same pinned release used by local dev (see the groups-gatherpress-compat-test
+# skill and PR #1793's test plan). GatherPress is gitignored/third-party, so the
+# `wporg-groups-frontend`/`groups` PHPUnit suites need it installed before they run.
+GATHERPRESS_VERSION="0.34.0-alpha.2"
+GATHERPRESS_DIR="/app/public_html/wp-content/plugins/gatherpress"
+
 db_ready() {
 	if command -v mariadb-admin >/dev/null 2>&1; then
 		mariadb-admin ping -h "$DB_HOST" --silent >/dev/null 2>&1
@@ -40,6 +46,19 @@ else
 		echo "WordPress test suite installed."
 	else
 		echo "WARNING: test-suite install failed (e.g. a download timeout). Re-run 'docker compose -f docker-compose.phpunit.yml up', or run /var/scripts/install-wp-tests.sh manually."
+	fi
+fi
+
+if [ -f "$GATHERPRESS_DIR/gatherpress.php" ]; then
+	echo "GatherPress already installed."
+else
+	echo "Installing GatherPress ${GATHERPRESS_VERSION}..."
+	if curl -sL "https://github.com/GatherPress/gatherpress/releases/download/${GATHERPRESS_VERSION}/gatherpress.${GATHERPRESS_VERSION}.zip" -o /tmp/gatherpress.zip \
+		&& unzip -q -o /tmp/gatherpress.zip -d /app/public_html/wp-content/plugins/ \
+		&& rm -f /tmp/gatherpress.zip; then
+		echo "GatherPress installed."
+	else
+		echo "WARNING: GatherPress install failed (e.g. a download timeout). The WordCamp Groups PHPUnit suite will not run correctly without it."
 	fi
 fi
 

--- a/.docker/bin/install-test-suite.sh
+++ b/.docker/bin/install-test-suite.sh
@@ -58,7 +58,8 @@ else
 		&& rm -f /tmp/gatherpress.zip; then
 		echo "GatherPress installed."
 	else
-		echo "WARNING: GatherPress install failed (e.g. a download timeout). The WordCamp Groups PHPUnit suite will not run correctly without it."
+		echo "ERROR: GatherPress install failed (e.g. a download timeout). The WordCamp Groups PHPUnit suites cannot run without it." >&2
+		exit 1
 	fi
 fi
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,91 @@
+name: E2E Tests (Groups/GatherPress)
+
+# Manually triggered only, for now — this stands up real docker-based
+# provisioning (WordPress core checkout, TLS cert, DB import, third-party
+# plugin install) and is new/unproven infrastructure. Promote to a
+# `pull_request` trigger once it's shown to be stable.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  e2e:
+    name: Playwright E2E
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci --no-audit --no-fund
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+
+    - name: Build the groups frontend plugin
+      run: npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend
+
+    - name: Clone WordPress core (develop trunk) into public_html/mu
+      run: git clone --depth=1 https://github.com/WordPress/WordPress.git public_html/mu
+
+    - name: Generate a self-signed TLS cert for local hostnames
+      # Playwright's `ignoreHTTPSErrors: true` (see playwright.config.js)
+      # means this only needs to satisfy nginx, not a trust store — no
+      # mkcert/browser-trust step needed here, unlike the local dev setup
+      # documented in .docker/readme.md.
+      run: |
+        openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+          -keyout .docker/wordcamp.test.key.pem \
+          -out .docker/wordcamp.test.pem \
+          -subj "/CN=wordcamp.test" \
+          -addext "subjectAltName=DNS:wordcamp.test,DNS:*.wordcamp.test,DNS:events.wordpress.test,DNS:*.wordpress.test"
+
+    - name: Boot the docker environment
+      run: docker compose up --build -d
+
+    - name: Wait for the site to respond
+      run: |
+        for i in $(seq 1 30); do
+          if docker compose exec -T wordcamp.test wp core is-installed 2>/dev/null; then
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "WordPress did not become ready in time" >&2
+        exit 1
+
+    - name: Add local hostnames to /etc/hosts
+      run: |
+        echo "127.0.0.1 wordcamp.test central.wordcamp.test seattle.wordcamp.test shinynew.wordcamp.test events.wordpress.test" | sudo tee -a /etc/hosts
+
+    - name: Install GatherPress on the groups site
+      run: |
+        docker compose exec -T wordcamp.test wp plugin install \
+          https://github.com/GatherPress/gatherpress/releases/download/0.34.0-alpha.2/gatherpress.0.34.0-alpha.2.zip \
+          --activate --url=events.wordpress.test/group/sunshine-coast-qld/
+
+    - name: Create role-tier test users
+      run: |
+        docker compose exec -T wordcamp.test wp user create organiser1 organiser1@example.test \
+          --role=editor --user_pass=password --url=events.wordpress.test/group/sunshine-coast-qld/ || true
+        docker compose exec -T wordcamp.test wp user create eventorganiser1 eventorganiser1@example.test \
+          --role=author --user_pass=password --url=events.wordpress.test/group/sunshine-coast-qld/ || true
+        docker compose exec -T wordcamp.test wp user create member1 member1@example.test \
+          --role=subscriber --user_pass=password --url=events.wordpress.test/group/sunshine-coast-qld/ || true
+
+    - name: Run Playwright tests
+      run: npx playwright test
+
+    - name: Upload Playwright report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 14

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -129,6 +129,23 @@ jobs:
         create_user eventorganiser1 author
         create_user member1 subscriber
 
+    - name: Create required pages
+      # `page-members.html` (public_html/wp-content/themes/groups-site/templates/)
+      # is a block-theme template keyed on the page slug — it ignores
+      # post_content entirely, but only applies once a published Page with
+      # that slug actually exists. Not part of the wordcamp_dev.sql fixture.
+      run: |
+        SITE_URL=events.wordpress.test/group/sunshine-coast-qld/
+        create_page() {
+          if docker compose exec -T wordcamp.test wp post list --post_type=page --name="$1" --field=ID --url="$SITE_URL" | grep -q .; then
+            echo "Page '$1' already exists."
+            return 0
+          fi
+          docker compose exec -T wordcamp.test wp post create --post_type=page \
+            --post_title="$2" --post_name="$1" --post_status=publish --url="$SITE_URL"
+        }
+        create_page members Members
+
     - name: Run Playwright tests
       run: npx playwright test
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,12 +72,18 @@ jobs:
 
     - name: Create role-tier test users
       run: |
-        docker compose exec -T wordcamp.test wp user create organiser1 organiser1@example.test \
-          --role=editor --user_pass=password --url=events.wordpress.test/group/sunshine-coast-qld/ || true
-        docker compose exec -T wordcamp.test wp user create eventorganiser1 eventorganiser1@example.test \
-          --role=author --user_pass=password --url=events.wordpress.test/group/sunshine-coast-qld/ || true
-        docker compose exec -T wordcamp.test wp user create member1 member1@example.test \
-          --role=subscriber --user_pass=password --url=events.wordpress.test/group/sunshine-coast-qld/ || true
+        SITE_URL=events.wordpress.test/group/sunshine-coast-qld/
+        create_user() {
+          if docker compose exec -T wordcamp.test wp user get "$1" --field=ID --url="$SITE_URL" >/dev/null 2>&1; then
+            echo "User $1 already exists."
+            return 0
+          fi
+          docker compose exec -T wordcamp.test wp user create "$1" "$1@example.test" \
+            --role="$2" --user_pass=password --url="$SITE_URL"
+        }
+        create_user organiser1 editor
+        create_user eventorganiser1 author
+        create_user member1 subscriber
 
     - name: Run Playwright tests
       run: npx playwright test

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,24 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set PHP version
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        coverage: none
+        tools: composer:v2
+      env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install PHP dependencies
+      # wporg-mu-plugins (installed via composer, then moved into place by a
+      # post-install script — see composer.json's installer-paths) is loaded
+      # unconditionally by load-other-mu-plugins.php; without it every
+      # request, including wp-cli, fatals.
+      run: |
+        rm composer.lock || true
+        composer install
+
     - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,17 +62,13 @@ jobs:
 
     - name: Wait for the site to respond
       run: |
-        # A from-scratch CI runner has to build both images, cold-boot
-        # MariaDB, and import the wordcamp_dev.sql fixture before
-        # `wp core is-installed` can succeed — there's no persisted
-        # `.docker/mariadb-database` volume like local dev has after the
-        # first run, and no depends_on/healthcheck between the two
-        # containers, so give this more headroom than a warm local re-run
-        # would need.
-        for i in $(seq 1 60); do
-          if docker compose exec -T wordcamp.test wp core is-installed 2>/dev/null; then
+        # Don't swallow stderr here — a real (non-timing) failure needs to
+        # be visible in the log, not silently retried for the full timeout.
+        for i in $(seq 1 20); do
+          if docker compose exec -T wordcamp.test wp core is-installed; then
             exit 0
           fi
+          echo "Attempt $i/20 failed, retrying in 3s..."
           sleep 3
         done
         echo "WordPress did not become ready in time" >&2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,11 +1,22 @@
 name: E2E Tests (Groups/GatherPress)
 
-# Manually triggered only, for now — this stands up real docker-based
-# provisioning (WordPress core checkout, TLS cert, DB import, third-party
-# plugin install) and is new/unproven infrastructure. Promote to a
-# `pull_request` trigger once it's shown to be stable.
+# Runs on PRs that touch the Groups/GatherPress front end, plus manual
+# dispatch for ad-hoc runs. Scoped to these paths (rather than every PR)
+# because this stands up real docker-based provisioning (WordPress core
+# checkout, TLS cert, DB import, third-party plugin install).
 on:
+  pull_request:
+    paths:
+    - public_html/wp-content/mu-plugins/wporg-groups-frontend/**
+    - public_html/wp-content/mu-plugins/groups/**
+    - tests/e2e/**
+    - playwright.config.js
+    - .github/workflows/e2e-tests.yml
   workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   e2e:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,8 +63,11 @@ jobs:
     - name: Install Playwright browsers
       run: npx playwright install --with-deps chromium
 
-    - name: Build the groups frontend plugin
-      run: npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend
+    - name: Build all workspace assets
+      # The site fatals on boot (including for wp-cli) if any mu-plugin's
+      # built assets are missing — not just wporg-groups-frontend's — so
+      # build every workspace, same as `npm run setup` does for local dev.
+      run: npm run build
 
     - name: Clone WordPress core (develop trunk) into public_html/mu
       run: git clone --depth=1 https://github.com/WordPress/WordPress.git public_html/mu

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install SVN
+      # A composer dependency uses --prefer-source, which needs svn on PATH.
+      run: |
+        sudo rm -f /var/lib/man-db/auto-update # https://github.com/actions/runner-images/issues/10977
+        sudo apt-get update && sudo apt-get install -y subversion
+
     - name: Set PHP version
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,13 +62,23 @@ jobs:
 
     - name: Wait for the site to respond
       run: |
-        for i in $(seq 1 30); do
+        # A from-scratch CI runner has to build both images, cold-boot
+        # MariaDB, and import the wordcamp_dev.sql fixture before
+        # `wp core is-installed` can succeed — there's no persisted
+        # `.docker/mariadb-database` volume like local dev has after the
+        # first run, and no depends_on/healthcheck between the two
+        # containers, so give this more headroom than a warm local re-run
+        # would need.
+        for i in $(seq 1 60); do
           if docker compose exec -T wordcamp.test wp core is-installed 2>/dev/null; then
             exit 0
           fi
-          sleep 2
+          sleep 3
         done
         echo "WordPress did not become ready in time" >&2
+        echo "::group::docker compose logs"
+        docker compose logs
+        echo "::endgroup::"
         exit 1
 
     - name: Add local hostnames to /etc/hosts

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -120,5 +120,14 @@ jobs:
       run: |
         bash .docker/bin/install-wp-tests.sh wcorg_test root root "127.0.0.1:${DB_PORT}" latest true
 
+    - name: Install GatherPress
+      # Pinned to the same release used by local dev (see the
+      # groups-gatherpress-compat-test skill). GatherPress is gitignored/
+      # third-party; the WordCamp Groups PHPUnit suite needs it present.
+      run: |
+        curl -sL "https://github.com/GatherPress/gatherpress/releases/download/0.34.0-alpha.2/gatherpress.0.34.0-alpha.2.zip" -o /tmp/gatherpress.zip
+        unzip -q -o /tmp/gatherpress.zip -d public_html/wp-content/plugins/
+        rm -f /tmp/gatherpress.zip
+
     - name: Running unit tests
       run: ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -129,5 +129,19 @@ jobs:
         unzip -q -o /tmp/gatherpress.zip -d public_html/wp-content/plugins/
         rm -f /tmp/gatherpress.zip
 
+    - name: Use Node.js 20.x
+      # The WordCamp Groups PHPUnit suite asserts on registered block types,
+      # which register_block_type_from_metadata() silently no-ops for if
+      # build/blocks/ doesn't exist yet.
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+        cache: npm
+
+    - name: Build the groups frontend blocks
+      run: |
+        npm ci --no-audit --no-fund
+        npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend
+
     - name: Running unit tests
       run: ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ docker-compose.override.yaml
 # Misc
 #
 .phpunit
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
 google*.html
 wp-cli.yml
 script-backups/

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
 				"public_html/wp-content/themes/wporg-flagship-landing"
 			],
 			"devDependencies": {
+				"@playwright/test": "1.61.1",
+				"@wordpress/e2e-test-utils-playwright": "1.51.0",
 				"@wordpress/eslint-plugin": "25.4.0",
 				"@wordpress/jest-preset-default": "12.48.0",
 				"@wordpress/prettier-config": "4.48.0",
@@ -10267,13 +10269,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"playwright": "1.60.0"
+				"playwright": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -13790,9 +13791,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.48.0.tgz",
-			"integrity": "sha512-jLzobHMQha8ZUHkRhl4OJVCkk26jTVqbhN5hFpQruVTETMI3Z1PFJZH1DFAumJKKAIociVMVeH2MDD8XVp72ww==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.51.0.tgz",
+			"integrity": "sha512-ekxMfC8MUTf0fKjAQd2IO4m/l1jXC9NznveRf7r8ntmx9nXqd9IHOiYJcH2SBo20C53nWdA4w8+Mbqedf0qzEw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2",
@@ -30823,13 +30824,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -30842,11 +30842,10 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -30864,7 +30863,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
 	],
 	"scripts": {
 		"setup": "composer install && npm ci && npm run build --workspaces --if-present",
-		"build": "npm run build --workspaces --if-present"
+		"build": "npm run build --workspaces --if-present",
+		"test:e2e": "playwright test"
 	},
 	"devDependencies": {
+		"@playwright/test": "1.61.1",
+		"@wordpress/e2e-test-utils-playwright": "1.51.0",
 		"@wordpress/eslint-plugin": "25.4.0",
 		"@wordpress/jest-preset-default": "12.48.0",
 		"@wordpress/prettier-config": "4.48.0",

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -54,6 +54,8 @@ require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );
 require_once WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-payments-network/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/tests/bootstrap.php';
+require_once SUT_WPMU_PLUGIN_DIR . '/wporg-groups-frontend/tests/bootstrap.php';
+require_once SUT_WPMU_PLUGIN_DIR . '/groups/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-coming-soon-page/tests/bootstrap.php';
 
 /*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -67,6 +67,15 @@
 				./public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/
 			</directory>
 		</testsuite>
+
+		<testsuite name="WordCamp Groups">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/
+			</directory>
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/mu-plugins/groups/tests/
+			</directory>
+		</testsuite>
 	</testsuites>
 
 	<coverage cacheDirectory=".phpunit/coverage-cache">
@@ -89,6 +98,10 @@
 		<exclude>
 			<directory>./public_html/wp-content/mu-plugins/tests</directory>
 			<directory>./public_html/wp-content/mu-plugins/vendor</directory>
+			<directory>./public_html/wp-content/mu-plugins/wporg-groups-frontend/tests</directory>
+			<directory>./public_html/wp-content/mu-plugins/wporg-groups-frontend/build</directory>
+			<directory>./public_html/wp-content/mu-plugins/wporg-groups-frontend/node_modules</directory>
+			<directory>./public_html/wp-content/mu-plugins/groups/tests</directory>
 			<directory>./public_html/wp-content/plugins/*/tests</directory>
 			<directory>./public_html/wp-content/plugins/*/node_modules</directory>
 		</exclude>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,35 @@
+const { defineConfig, devices } = require( '@playwright/test' );
+
+/**
+ * E2E config for the Groups/GatherPress front-end integration.
+ *
+ * Assumes the local dev stack (`docker compose up`) is already running with
+ * GatherPress installed and active on the groups network — see the
+ * groups-gatherpress-compat-test skill for setup steps. This config does not
+ * start a webServer itself; it targets the existing dev site.
+ */
+module.exports = defineConfig( {
+	testDir: 'tests/e2e',
+	fullyParallel: true,
+	forbidOnly: !! process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	reporter: process.env.CI ? 'github' : 'list',
+	use: {
+		// Trailing slash matters: Playwright/URL resolution treats a
+		// leading-slash path in `page.goto()` as relative to the origin
+		// root, not to this path — specs must use relative paths without a
+		// leading slash (e.g. `page.goto( 'members/' )`, not `'/members/'`)
+		// or they'll silently drop the `/group/sunshine-coast-qld` prefix.
+		baseURL: 'https://events.wordpress.test/group/sunshine-coast-qld/',
+		// The local dev cert is self-signed (matches the `-k` flag used
+		// throughout the project's curl-based test plans).
+		ignoreHTTPSErrors: true,
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+	],
+} );

--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -298,29 +298,27 @@ add_action(
  *
  * Stores an array of user IDs who are speaking at the event.
  */
-add_action(
-	'init',
-	static function (): void {
-		register_post_meta(
-			'gatherpress_event',
-			'_event_speakers',
-			array(
-				'type'          => 'array',
-				'single'        => true,
-				'default'       => array(),
-				'show_in_rest'  => array(
-					'schema' => array(
-						'type'  => 'array',
-						'items' => array( 'type' => 'integer' ),
-					),
+function register_event_speakers_meta(): void {
+	register_post_meta(
+		'gatherpress_event',
+		'_event_speakers',
+		array(
+			'type'          => 'array',
+			'single'        => true,
+			'default'       => array(),
+			'show_in_rest'  => array(
+				'schema' => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'integer' ),
 				),
-				'auth_callback' => static function () {
-					return current_user_can( 'edit_posts' );
-				},
-			)
-		);
-	}
-);
+			),
+			'auth_callback' => static function () {
+				return current_user_can( 'edit_posts' );
+			},
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_event_speakers_meta' );
 
 /**
  * Rewrite the search block form action on the events archive to submit

--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugin(s) that we'll need to be active for the tests.
+ *
+ * GatherPress is gitignored/third-party (not a composer dependency), so it's
+ * only present if the phpunit environment installed it first — see
+ * `.docker/bin/install-test-suite.sh` / `.github/workflows/unit-tests.yml`.
+ */
+function manually_load_plugin() {
+	$gatherpress_file = WP_PLUGIN_DIR . '/gatherpress/gatherpress.php';
+
+	if ( file_exists( $gatherpress_file ) ) {
+		require_once $gatherpress_file;
+	}
+
+	require_once dirname( __DIR__ ) . '/gatherpress-groups-tweaks.php';
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -16,9 +16,13 @@ if ( 'cli' !== php_sapi_name() ) {
 function manually_load_plugin() {
 	$gatherpress_file = WP_PLUGIN_DIR . '/gatherpress/gatherpress.php';
 
-	if ( file_exists( $gatherpress_file ) ) {
-		require_once $gatherpress_file;
+	if ( ! file_exists( $gatherpress_file ) ) {
+		throw new \RuntimeException(
+			"GatherPress is required by this suite but was not found at {$gatherpress_file}. Run `.docker/bin/install-test-suite.sh` (see also `.github/workflows/unit-tests.yml`) first."
+		);
 	}
+
+	require_once $gatherpress_file;
 
 	require_once dirname( __DIR__ ) . '/gatherpress-groups-tweaks.php';
 }

--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -12,12 +12,15 @@ if ( 'cli' !== php_sapi_name() ) {
  * GatherPress is gitignored/third-party (not a composer dependency), so it's
  * only present if the phpunit environment installed it first — see
  * `.docker/bin/install-test-suite.sh` / `.github/workflows/unit-tests.yml`.
+ *
+ * @throws \RuntimeException If GatherPress isn't installed.
  */
 function manually_load_plugin() {
 	$gatherpress_file = WP_PLUGIN_DIR . '/gatherpress/gatherpress.php';
 
 	if ( ! file_exists( $gatherpress_file ) ) {
 		throw new \RuntimeException(
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message for developers.
 			"GatherPress is required by this suite but was not found at {$gatherpress_file}. Run `.docker/bin/install-test-suite.sh` (see also `.github/workflows/unit-tests.yml`) first."
 		);
 	}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
+
+	public function test_gatherpress_settings_overridden() {
+		$settings = get_option( 'gatherpress_settings' );
+
+		$this->assertSame( 0, $settings['show_timezone'] );
+		$this->assertSame( 0, $settings['enable_anonymous_rsvp'] );
+	}
+
+	public function test_comment_registration_required_on_groups_network() {
+		$this->assertSame( '1', get_option( 'comment_registration' ) );
+	}
+
+	/**
+	 * Editors ("Organisers") are granted `edit_theme_options` so they can use
+	 * the Site Editor to customise their group site — but nothing broader.
+	 * See the `promote_users` regression test in test-capabilities.php for
+	 * the capability that must NOT be granted this way.
+	 */
+	public function test_editor_has_edit_theme_options() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->assertTrue( user_can( $editor_id, 'edit_theme_options' ) );
+	}
+
+	public function test_subscriber_does_not_have_edit_theme_options() {
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$this->assertFalse( user_can( $subscriber_id, 'edit_theme_options' ) );
+	}
+
+	/**
+	 * `_event_speakers` is registered on `init`, which only fires once for
+	 * the whole test run; `WP_UnitTestCase::tearDown()` unregisters all meta
+	 * keys after every test (a known core testing quirk), so by the time
+	 * this test runs the registration from bootstrap is long gone. Re-fire
+	 * just this one `init` callback's effect directly (rather than
+	 * `do_action( 'init' )`, which would also re-run block registration and
+	 * trip "already registered" `_doing_it_wrong` notices) — this must stay
+	 * in sync with the real registration in `gatherpress-groups-tweaks.php`.
+	 */
+	public function test_event_speakers_meta_registered_with_array_default() {
+		register_post_meta(
+			'gatherpress_event',
+			'_event_speakers',
+			array(
+				'type'         => 'array',
+				'single'       => true,
+				'default'      => array(),
+				'show_in_rest' => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'integer' ),
+					),
+				),
+			)
+		);
+
+		$registered = get_registered_meta_keys( 'post', 'gatherpress_event' );
+
+		$this->assertArrayHasKey( '_event_speakers', $registered );
+		$this->assertSame( array(), $registered['_event_speakers']['default'] );
+		$this->assertSame( 'array', $registered['_event_speakers']['type'] );
+	}
+
+	/**
+	 * Venues are metadata on events, not their own front-end destination —
+	 * confirm the post type stays non-public even though GatherPress itself
+	 * registers it.
+	 */
+	public function test_gatherpress_venue_post_type_is_non_public() {
+		$post_type_object = get_post_type_object( 'gatherpress_venue' );
+
+		$this->assertNotNull( $post_type_object, 'GatherPress must be active for this assertion to be meaningful.' );
+		$this->assertFalse( $post_type_object->public );
+		$this->assertFalse( $post_type_object->publicly_queryable );
+		$this->assertFalse( $post_type_object->has_archive );
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
@@ -11,6 +11,10 @@ require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-
  */
 class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 
+	/**
+	 * Groups-network sites should never show a timezone suffix or offer
+	 * anonymous RSVP, regardless of GatherPress's own defaults.
+	 */
 	public function test_gatherpress_settings_overridden() {
 		$settings = get_option( 'gatherpress_settings' );
 
@@ -18,6 +22,9 @@ class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 		$this->assertSame( 0, $settings['enable_anonymous_rsvp'] );
 	}
 
+	/**
+	 * Login is required to comment on the groups network.
+	 */
 	public function test_comment_registration_required_on_groups_network() {
 		$this->assertSame( '1', get_option( 'comment_registration' ) );
 	}
@@ -34,6 +41,9 @@ class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 		$this->assertTrue( user_can( $editor_id, 'edit_theme_options' ) );
 	}
 
+	/**
+	 * The `edit_theme_options` grant is scoped to editors only.
+	 */
 	public function test_subscriber_does_not_have_edit_theme_options() {
 		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
@@ -55,27 +55,13 @@ class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 	 * the whole test run; `WP_UnitTestCase::tearDown()` unregisters all meta
 	 * keys after every test (a known core testing quirk), so by the time
 	 * this test runs the registration from bootstrap is long gone. Re-fire
-	 * just this one `init` callback's effect directly (rather than
+	 * the real registration function directly (rather than
 	 * `do_action( 'init' )`, which would also re-run block registration and
-	 * trip "already registered" `_doing_it_wrong` notices) — this must stay
-	 * in sync with the real registration in `gatherpress-groups-tweaks.php`.
+	 * trip "already registered" `_doing_it_wrong` notices) so there's only
+	 * one place the args can drift from.
 	 */
 	public function test_event_speakers_meta_registered_with_array_default() {
-		register_post_meta(
-			'gatherpress_event',
-			'_event_speakers',
-			array(
-				'type'         => 'array',
-				'single'       => true,
-				'default'      => array(),
-				'show_in_rest' => array(
-					'schema' => array(
-						'type'  => 'array',
-						'items' => array( 'type' => 'integer' ),
-					),
-				),
-			)
-		);
+		\WordCamp\Groups\GatherPress_Tweaks\register_event_speakers_meta();
 
 		$registered = get_registered_meta_keys( 'post', 'gatherpress_event' );
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WordCamp\Groups\Frontend\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugins that we'll need to be active for the tests.
+ *
+ * GatherPress is gitignored/third-party (not a composer dependency), so it's
+ * only present if the phpunit environment installed it first — see
+ * `.docker/bin/install-test-suite.sh` / `.github/workflows/unit-tests.yml`.
+ * Without it, this plugin's own bootstrap no-ops (see its `class_exists()`
+ * guard), so tests that need real behavior will fail with a clear reason
+ * rather than a fatal.
+ */
+function manually_load_plugins() {
+	$gatherpress_file = WP_PLUGIN_DIR . '/gatherpress/gatherpress.php';
+
+	if ( file_exists( $gatherpress_file ) ) {
+		require_once $gatherpress_file;
+	}
+
+	require_once dirname( __DIR__ ) . '/wporg-groups-frontend.php';
+
+	// The plugin's own bootstrap() only runs on `plugins_loaded`, gated on
+	// `\GatherPress\Core\Event\Event` existing — mirrors production loading.
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
@@ -12,16 +12,20 @@ if ( 'cli' !== php_sapi_name() ) {
  * GatherPress is gitignored/third-party (not a composer dependency), so it's
  * only present if the phpunit environment installed it first — see
  * `.docker/bin/install-test-suite.sh` / `.github/workflows/unit-tests.yml`.
- * Without it, this plugin's own bootstrap no-ops (see its `class_exists()`
- * guard), so tests that need real behavior will fail with a clear reason
- * rather than a fatal.
+ * Required unconditionally: without it, this plugin's own bootstrap no-ops
+ * (see its `class_exists()` guard) and the suite would report a misleading
+ * green run instead of failing with the actual cause.
  */
 function manually_load_plugins() {
 	$gatherpress_file = WP_PLUGIN_DIR . '/gatherpress/gatherpress.php';
 
-	if ( file_exists( $gatherpress_file ) ) {
-		require_once $gatherpress_file;
+	if ( ! file_exists( $gatherpress_file ) ) {
+		throw new \RuntimeException(
+			"GatherPress is required by this suite but was not found at {$gatherpress_file}. Run `.docker/bin/install-test-suite.sh` (see also `.github/workflows/unit-tests.yml`) first."
+		);
 	}
+
+	require_once $gatherpress_file;
 
 	require_once dirname( __DIR__ ) . '/wporg-groups-frontend.php';
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
@@ -15,12 +15,15 @@ if ( 'cli' !== php_sapi_name() ) {
  * Required unconditionally: without it, this plugin's own bootstrap no-ops
  * (see its `class_exists()` guard) and the suite would report a misleading
  * green run instead of failing with the actual cause.
+ *
+ * @throws \RuntimeException If GatherPress isn't installed.
  */
 function manually_load_plugins() {
 	$gatherpress_file = WP_PLUGIN_DIR . '/gatherpress/gatherpress.php';
 
 	if ( ! file_exists( $gatherpress_file ) ) {
 		throw new \RuntimeException(
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message for developers.
 			"GatherPress is required by this suite but was not found at {$gatherpress_file}. Run `.docker/bin/install-test-suite.sh` (see also `.github/workflows/unit-tests.yml`) first."
 		);
 	}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WordCamp\Tests\Database_TestCase;
+use WP_UnitTest_Factory;
+
+/**
+ * Extends the shared WordCamp.org network fixture with a groups-network site.
+ *
+ * `GROUPS_NETWORK_ID`/`GROUPS_ROOT_BLOG_ID` are already defined in
+ * `phpunit-bootstrap.php`, but `Database_TestCase` doesn't build that
+ * network/site — only the WordCamp/Events ones. Test classes that need a
+ * groups-network site should extend this instead of `Database_TestCase`.
+ */
+abstract class Groups_TestCase extends Database_TestCase {
+	/**
+	 * @var int
+	 */
+	protected static $groups_root_site_id;
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		$factory->network->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		self::$groups_root_site_id = $factory->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/sunshine-coast-qld/',
+				'blog_id'    => GROUPS_ROOT_BLOG_ID,
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		global $wpdb;
+
+		wp_delete_site( self::$groups_root_site_id );
+
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->sitemeta} WHERE site_id = %d", GROUPS_NETWORK_ID ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->site} WHERE id = %d", GROUPS_NETWORK_ID ) );
+
+		parent::wpTearDownAfterClass();
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		switch_to_blog( self::$groups_root_site_id );
+
+		// GatherPress creates its `{prefix}gatherpress_events` table on
+		// plugin activation; since these tests require the plugin file
+		// directly instead of truly activating it, the table never gets
+		// created for this fixture blog. `check_plugin_version()` is
+		// GatherPress's own public, idempotent self-heal for exactly this
+		// scenario ("site created before plugin activation") — safe to
+		// call every test.
+		if ( class_exists( '\GatherPress\Core\Setup' ) ) {
+			\GatherPress\Core\Setup::get_instance()->check_plugin_version();
+		}
+	}
+
+	protected function tearDown(): void {
+		restore_current_blog();
+		parent::tearDown();
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
@@ -72,9 +72,7 @@ abstract class Groups_TestCase extends Database_TestCase {
 		// GatherPress's own public, idempotent self-heal for exactly this
 		// scenario ("site created before plugin activation") — safe to
 		// call every test.
-		if ( class_exists( '\GatherPress\Core\Setup' ) ) {
-			\GatherPress\Core\Setup::get_instance()->check_plugin_version();
-		}
+		\GatherPress\Core\Setup::get_instance()->check_plugin_version();
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
@@ -43,6 +43,9 @@ abstract class Groups_TestCase extends Database_TestCase {
 		);
 	}
 
+	/**
+	 * Tears down the groups-network fixture created in wpSetUpBeforeClass().
+	 */
 	public static function wpTearDownAfterClass() {
 		global $wpdb;
 
@@ -54,6 +57,9 @@ abstract class Groups_TestCase extends Database_TestCase {
 		parent::wpTearDownAfterClass();
 	}
 
+	/**
+	 * Switches to the groups-network fixture site before each test.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -71,6 +77,9 @@ abstract class Groups_TestCase extends Database_TestCase {
 		}
 	}
 
+	/**
+	 * Restores the previously-current blog after each test.
+	 */
 	protected function tearDown(): void {
 		restore_current_blog();
 		parent::tearDown();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Groups_Blocks extends Groups_TestCase {
+
+	const EXPECTED_BLOCKS = array(
+		'wporg/event-manage',
+		'wporg/event-rsvp',
+		'wporg/event-speakers',
+		'wporg/group-members',
+		'wporg/group-membership',
+		'wporg/group-settings',
+		'wporg/my-events',
+		'wporg/page-content',
+	);
+
+	/**
+	 * Exactly these 8 `wporg/*` blocks should be registered. The original
+	 * set of 10 also included `event-rsvp-count` and `event-venue-name`;
+	 * both were intentionally removed in favor of GatherPress core's own
+	 * `gatherpress/rsvp-count` and `gatherpress/venue` blocks (see #1793's
+	 * "Review fixes" for why) — if either reappears, or a new custom block
+	 * duplicates core functionality again, this test should fail.
+	 */
+	public function test_exactly_the_expected_wporg_blocks_are_registered() {
+		$registered = array_keys( \WP_Block_Type_Registry::get_instance()->get_all_registered() );
+		$wporg_blocks = array_values(
+			array_filter(
+				$registered,
+				static function ( $name ) {
+					return str_starts_with( $name, 'wporg/' );
+				}
+			)
+		);
+
+		sort( $wporg_blocks );
+		$expected = self::EXPECTED_BLOCKS;
+		sort( $expected );
+
+		$this->assertSame( $expected, $wporg_blocks );
+	}
+
+	/**
+	 * The `render_block_gatherpress/rsvp-count` filter should suppress the
+	 * block entirely when the resolved RSVP count is 0, so a "0 RSVPs" line
+	 * never shows on a public page. Mirrors the `wp eval` check from #1793's
+	 * manual test plan.
+	 */
+	public function test_rsvp_count_block_hidden_when_zero() {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		global $post;
+		$post = get_post( $event_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		setup_postdata( $post );
+
+		$output = trim( (string) do_blocks( '<!-- wp:gatherpress/rsvp-count /-->' ) );
+
+		wp_reset_postdata();
+
+		$this->assertSame( '', $output );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -31,7 +31,7 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	 * duplicates core functionality again, this test should fail.
 	 */
 	public function test_exactly_the_expected_wporg_blocks_are_registered() {
-		$registered = array_keys( \WP_Block_Type_Registry::get_instance()->get_all_registered() );
+		$registered   = array_keys( \WP_Block_Type_Registry::get_instance()->get_all_registered() );
 		$wporg_blocks = array_values(
 			array_filter(
 				$registered,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_events;
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group_settings;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Groups_Capabilities extends Groups_TestCase {
+
+	public function data_manage_events_roles(): array {
+		return array(
+			'administrator manages events' => array( 'administrator', true ),
+			'editor manages events'        => array( 'editor', true ),
+			'author manages events'        => array( 'author', true ),
+			'contributor cannot'           => array( 'contributor', false ),
+			'subscriber cannot'            => array( 'subscriber', false ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_manage_events_roles
+	 */
+	public function test_current_user_can_manage_events_by_role( string $role, bool $expected ) {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertSame( $expected, current_user_can_manage_events() );
+	}
+
+	public function test_current_user_can_manage_events_false_when_logged_out() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( current_user_can_manage_events() );
+	}
+
+	public function data_manage_group_settings_roles(): array {
+		return array(
+			'administrator manages settings' => array( 'administrator', true ),
+			'editor manages settings'        => array( 'editor', true ),
+			'author cannot'                  => array( 'author', false ),
+			'subscriber cannot'              => array( 'subscriber', false ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_manage_group_settings_roles
+	 */
+	public function test_current_user_can_manage_group_settings_by_role( string $role, bool $expected ) {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertSame( $expected, current_user_can_manage_group_settings() );
+	}
+
+	/**
+	 * Regression test for the privilege-escalation bug fixed before #1793
+	 * shipped: editors were briefly granted `promote_users` so this plugin
+	 * could let them manage member roles, which also silently unlocked the
+	 * stock wp-admin Users screen for promoting anyone to Administrator.
+	 * Role management must go through this plugin's own REST layer
+	 * (`current_user_can_manage_group_settings()`), never a real core
+	 * capability grant.
+	 */
+	public function test_editor_does_not_have_promote_users() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->assertFalse( user_can( $user_id, 'promote_users' ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -14,6 +14,9 @@ require_once __DIR__ . '/class-groups-testcase.php';
  */
 class Test_Groups_Capabilities extends Groups_TestCase {
 
+	/**
+	 * Data provider for test_current_user_can_manage_events_by_role().
+	 */
 	public function data_manage_events_roles(): array {
 		return array(
 			'administrator manages events' => array( 'administrator', true ),
@@ -34,12 +37,18 @@ class Test_Groups_Capabilities extends Groups_TestCase {
 		$this->assertSame( $expected, current_user_can_manage_events() );
 	}
 
+	/**
+	 * Logged-out visitors can never manage events.
+	 */
 	public function test_current_user_can_manage_events_false_when_logged_out() {
 		wp_set_current_user( 0 );
 
 		$this->assertFalse( current_user_can_manage_events() );
 	}
 
+	/**
+	 * Data provider for test_current_user_can_manage_group_settings_by_role().
+	 */
 	public function data_manage_group_settings_roles(): array {
 		return array(
 			'administrator manages settings' => array( 'administrator', true ),

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_REST_Request;
+use WordCamp\Groups\Frontend\Members\Members_Controller;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Groups_Members_Controller extends Groups_TestCase {
+
+	/**
+	 * @var Members_Controller
+	 */
+	protected static $controller;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+		self::$controller = new Members_Controller();
+	}
+
+	private function request( string $method, string $route ): WP_REST_Request {
+		return new WP_REST_Request( $method, '/wporg-groups/v1' . $route );
+	}
+
+	public function test_role_labels_map_correctly() {
+		$editor     = self::factory()->user->create_and_get( array( 'role' => 'editor' ) );
+		$author     = self::factory()->user->create_and_get( array( 'role' => 'author' ) );
+		$subscriber = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+
+		$editor_request = $this->request( 'GET', '/members/' . $editor->ID );
+		$editor_request->set_param( 'id', $editor->ID );
+		$response = self::$controller->get_item( $editor_request );
+		$this->assertSame( 'Organiser', $response->get_data()['roleLabel'] );
+
+		$author_request = $this->request( 'GET', '/members/' . $author->ID );
+		$author_request->set_param( 'id', $author->ID );
+		$response = self::$controller->get_item( $author_request );
+		$this->assertSame( 'Event Organiser', $response->get_data()['roleLabel'] );
+
+		$subscriber_request = $this->request( 'GET', '/members/' . $subscriber->ID );
+		$subscriber_request->set_param( 'id', $subscriber->ID );
+		$response = self::$controller->get_item( $subscriber_request );
+		$this->assertSame( 'Member', $response->get_data()['roleLabel'] );
+	}
+
+	public function test_validate_assignable_role_rejects_administrator() {
+		// Mirrors the args schema `validate_callback` — administrator is
+		// intentionally excluded from ASSIGNABLE_ROLES so it can never be
+		// set through this endpoint, only via wp-admin directly.
+		$this->assertFalse( self::$controller->validate_assignable_role( 'administrator' ) );
+		$this->assertTrue( self::$controller->validate_assignable_role( 'editor' ) );
+		$this->assertTrue( self::$controller->validate_assignable_role( 'author' ) );
+		$this->assertTrue( self::$controller->validate_assignable_role( 'subscriber' ) );
+	}
+
+	public function test_author_blocked_from_role_changes() {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $author_id );
+
+		$request = $this->request( 'POST', "/members/{$member_id}/role" );
+		$request->set_param( 'id', $member_id );
+		$request->set_param( 'role', 'author' );
+
+		$result = self::$controller->update_member_role_permissions_check( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_cannot_edit_roles', $result->get_error_code() );
+	}
+
+	public function test_editor_promotes_subscriber_to_author() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $editor_id );
+
+		$request = $this->request( 'POST', "/members/{$member_id}/role" );
+		$request->set_param( 'id', $member_id );
+		$request->set_param( 'role', 'author' );
+
+		$permission = self::$controller->update_member_role_permissions_check( $request );
+		$this->assertTrue( $permission );
+
+		self::$controller->update_member_role( $request );
+
+		$this->assertContains( 'author', get_userdata( $member_id )->roles );
+	}
+
+	public function test_cannot_change_own_role() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request = $this->request( 'POST', "/members/{$editor_id}/role" );
+		$request->set_param( 'id', $editor_id );
+		$request->set_param( 'role', 'author' );
+
+		$result = self::$controller->update_member_role( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'cannot_change_own_role', $result->get_error_code() );
+	}
+
+	public function test_cannot_remove_last_organizer() {
+		// Clear any organisers left over from fixture/site creation so the
+		// count below is deterministic.
+		$existing_organizers = get_users(
+			array(
+				'blog_id'  => self::$groups_root_site_id,
+				'role__in' => array( 'administrator', 'editor' ),
+				'fields'   => 'ids',
+			)
+		);
+		foreach ( $existing_organizers as $uid ) {
+			remove_user_from_blog( $uid, self::$groups_root_site_id );
+		}
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		// A second organiser performs the (attempted) demotion so this isn't
+		// also blocked by the separate "can't change your own role" check.
+		$actor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		get_userdata( $actor_id )->set_role( 'subscriber' );
+
+		wp_set_current_user( $actor_id );
+
+		$request = $this->request( 'POST', "/members/{$editor_id}/role" );
+		$request->set_param( 'id', $editor_id );
+		$request->set_param( 'role', 'subscriber' );
+
+		$result = self::$controller->update_member_role( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'cannot_remove_last_organizer', $result->get_error_code() );
+	}
+
+	public function test_join_group() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		remove_user_from_blog( $member_id, self::$groups_root_site_id );
+
+		wp_set_current_user( $member_id );
+
+		$response = self::$controller->join_group( $this->request( 'POST', '/members/join' ) );
+
+		$this->assertTrue( $response->get_data()['success'] );
+		$this->assertTrue( is_user_member_of_blog( $member_id, self::$groups_root_site_id ) );
+	}
+
+	public function test_organiser_cannot_leave_without_demotion() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$response = self::$controller->leave_group( $this->request( 'DELETE', '/members/leave' ) );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'cannot_leave', $response->get_error_code() );
+	}
+
+	public function test_members_collection_per_page_is_capped() {
+		// MAX_PER_PAGE caps the collection regardless of requested per_page,
+		// so a public listing can't be used to pull the entire user table.
+		$this->assertFalse( self::$controller->validate_per_page( Members_Controller::MAX_PER_PAGE + 1 ) );
+		$this->assertTrue( self::$controller->validate_per_page( Members_Controller::MAX_PER_PAGE ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
@@ -19,15 +19,26 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 	 */
 	protected static $controller;
 
+	/**
+	 * Builds the shared fixture and a single controller instance for these tests.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 		self::$controller = new Members_Controller();
 	}
 
+	/**
+	 * Builds a REST request under the wporg-groups/v1 namespace.
+	 */
 	private function request( string $method, string $route ): WP_REST_Request {
 		return new WP_REST_Request( $method, '/wporg-groups/v1' . $route );
 	}
 
+	/**
+	 * Role labels should map editor/author/subscriber to their group-tier names.
+	 */
 	public function test_role_labels_map_correctly() {
 		$editor     = self::factory()->user->create_and_get( array( 'role' => 'editor' ) );
 		$author     = self::factory()->user->create_and_get( array( 'role' => 'author' ) );
@@ -49,16 +60,21 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertSame( 'Member', $response->get_data()['roleLabel'] );
 	}
 
+	/**
+	 * Mirrors the args schema `validate_callback` — administrator is
+	 * intentionally excluded from ASSIGNABLE_ROLES so it can never be
+	 * set through this endpoint, only via wp-admin directly.
+	 */
 	public function test_validate_assignable_role_rejects_administrator() {
-		// Mirrors the args schema `validate_callback` — administrator is
-		// intentionally excluded from ASSIGNABLE_ROLES so it can never be
-		// set through this endpoint, only via wp-admin directly.
 		$this->assertFalse( self::$controller->validate_assignable_role( 'administrator' ) );
 		$this->assertTrue( self::$controller->validate_assignable_role( 'editor' ) );
 		$this->assertTrue( self::$controller->validate_assignable_role( 'author' ) );
 		$this->assertTrue( self::$controller->validate_assignable_role( 'subscriber' ) );
 	}
 
+	/**
+	 * Authors (Event Organisers) can manage events but not member roles.
+	 */
 	public function test_author_blocked_from_role_changes() {
 		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
@@ -75,6 +91,9 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertSame( 'rest_cannot_edit_roles', $result->get_error_code() );
 	}
 
+	/**
+	 * Editors (Organisers) can promote a member to Event Organiser.
+	 */
 	public function test_editor_promotes_subscriber_to_author() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
@@ -93,6 +112,9 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertContains( 'author', get_userdata( $member_id )->roles );
 	}
 
+	/**
+	 * No one can change their own group role, even an Organiser.
+	 */
 	public function test_cannot_change_own_role() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
@@ -107,6 +129,9 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertSame( 'cannot_change_own_role', $result->get_error_code() );
 	}
 
+	/**
+	 * A group must always keep at least one organiser.
+	 */
 	public function test_cannot_remove_last_organizer() {
 		// Clear any organisers left over from fixture/site creation so the
 		// count below is deterministic.
@@ -140,6 +165,9 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertSame( 'cannot_remove_last_organizer', $result->get_error_code() );
 	}
 
+	/**
+	 * A logged-in non-member can join the group.
+	 */
 	public function test_join_group() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		remove_user_from_blog( $member_id, self::$groups_root_site_id );
@@ -152,6 +180,9 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertTrue( is_user_member_of_blog( $member_id, self::$groups_root_site_id ) );
 	}
 
+	/**
+	 * Organisers must be demoted before they can leave the group.
+	 */
 	public function test_organiser_cannot_leave_without_demotion() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
@@ -162,9 +193,11 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertSame( 'cannot_leave', $response->get_error_code() );
 	}
 
+	/**
+	 * MAX_PER_PAGE caps the collection regardless of requested per_page,
+	 * so a public listing can't be used to pull the entire user table.
+	 */
 	public function test_members_collection_per_page_is_capped() {
-		// MAX_PER_PAGE caps the collection regardless of requested per_page,
-		// so a public listing can't be used to pull the entire user table.
 		$this->assertFalse( self::$controller->validate_per_page( Members_Controller::MAX_PER_PAGE + 1 ) );
 		$this->assertTrue( self::$controller->validate_per_page( Members_Controller::MAX_PER_PAGE ) );
 	}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-gatherpress-off-guard.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-gatherpress-off-guard.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Pins the known bootstrap guard clauses that let both plugins no-op
+ * instead of fataling when GatherPress is deactivated.
+ *
+ * This can't be a true "deactivate GatherPress and hit the site" test
+ * within a single PHPUnit process — once GatherPress's classes are loaded,
+ * PHP can't unload them. That dynamic check is part of the
+ * `groups-gatherpress-compat-test` skill's GatherPress-deactivated pass
+ * instead. This test only guards against someone accidentally deleting the
+ * `class_exists()` checks these bootstraps depend on.
+ *
+ * @group groups
+ */
+class Test_Groups_GatherPress_Off_Guard extends WP_UnitTestCase {
+
+	public function test_frontend_plugin_bootstrap_is_guarded() {
+		$source = file_get_contents(
+			dirname( __DIR__ ) . '/wporg-groups-frontend.php'
+		);
+
+		$this->assertStringContainsString(
+			'class_exists( \'\GatherPress\Core\Event\Event\' )',
+			$source,
+			'wporg-groups-frontend.php should still guard its bootstrap() on GatherPress being loaded.'
+		);
+	}
+
+	public function test_groups_tweaks_is_guarded() {
+		$source = file_get_contents(
+			dirname( __DIR__, 2 ) . '/groups/gatherpress-groups-tweaks.php'
+		);
+
+		$this->assertStringContainsString(
+			'class_exists( \'\GatherPress\Core\Event\Setup\' )',
+			$source,
+			'gatherpress-groups-tweaks.php should still guard its GatherPress-dependent code path.'
+		);
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-gatherpress-off-guard.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-gatherpress-off-guard.php
@@ -21,7 +21,12 @@ defined( 'WPINC' ) || die();
  */
 class Test_Groups_GatherPress_Off_Guard extends WP_UnitTestCase {
 
+	/**
+	 * The main plugin file's bootstrap() must stay guarded on GatherPress
+	 * being loaded.
+	 */
 	public function test_frontend_plugin_bootstrap_is_guarded() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a local plugin file, not a remote URL.
 		$source = file_get_contents(
 			dirname( __DIR__ ) . '/wporg-groups-frontend.php'
 		);
@@ -33,7 +38,12 @@ class Test_Groups_GatherPress_Off_Guard extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * `gatherpress-groups-tweaks.php` must stay guarded on its
+	 * GatherPress-dependent code path.
+	 */
 	public function test_groups_tweaks_is_guarded() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a local plugin file, not a remote URL.
 		$source = file_get_contents(
 			dirname( __DIR__, 2 ) . '/groups/gatherpress-groups-tweaks.php'
 		);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_REST_Request;
+
+use function WordCamp\Groups\Frontend\REST\create_event;
+use function WordCamp\Groups\Frontend\REST\update_event;
+use function WordCamp\Groups\Frontend\REST\save_draft;
+use function WordCamp\Groups\Frontend\REST\publish_draft;
+use function WordCamp\Groups\Frontend\REST\list_drafts;
+use function WordCamp\Groups\Frontend\REST\publish_existing_event_permissions_check;
+use function WordCamp\Groups\Frontend\REST\current_user_can_use_attachment;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Groups_REST extends Groups_TestCase {
+
+	private function event_request( array $params ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/wporg-groups/v1/event' );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $request;
+	}
+
+	private function base_event_params(): array {
+		return array(
+			'title'      => 'Test Event',
+			'date'       => '2026-08-15',
+			'time_start' => '18:00',
+			'time_end'   => '20:00',
+		);
+	}
+
+	public function test_create_event_as_editor() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$response = create_event( $this->event_request( $this->base_event_params() ) );
+
+		$this->assertNotWPError( $response );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertSame( 'gatherpress_event', get_post_type( $data['id'] ) );
+		$this->assertSame( 'publish', get_post_status( $data['id'] ) );
+	}
+
+	public function test_zero_length_event_rejected() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$params               = $this->base_event_params();
+		$params['time_start'] = '18:00';
+		$params['time_end']   = '18:00';
+
+		$response = create_event( $this->event_request( $params ) );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'wporg_groups_bad_time_range', $response->get_error_code() );
+	}
+
+	/**
+	 * 22:00 to 01:00 crosses midnight — the end date should roll to the
+	 * next calendar day rather than being treated as a same-day, negative
+	 * (and thus rejected) time range.
+	 */
+	public function test_overnight_event_rolls_end_date_to_next_day() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$params               = $this->base_event_params();
+		$params['date']       = '2026-08-20';
+		$params['time_start'] = '22:00';
+		$params['time_end']   = '01:00';
+
+		$response = create_event( $this->event_request( $params ) );
+		$this->assertNotWPError( $response );
+
+		$event_id = $response->get_data()['id'];
+		$end      = get_post_meta( $event_id, 'gatherpress_datetime_end', true );
+
+		$this->assertSame( '2026-08-21 01:00:00', $end );
+	}
+
+	public function test_author_cannot_edit_another_authors_event() {
+		$author_a = self::factory()->user->create( array( 'role' => 'author' ) );
+		$author_b = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		wp_set_current_user( $author_a );
+		$create_response = create_event( $this->event_request( $this->base_event_params() ) );
+		$event_id        = $create_response->get_data()['id'];
+
+		wp_set_current_user( $author_b );
+		$request = $this->event_request( array( 'title' => 'HIJACKED' ) + $this->base_event_params() );
+		$request->set_param( 'id', $event_id );
+
+		$permission = publish_existing_event_permissions_check( $request );
+
+		$this->assertFalse( $permission );
+		$this->assertSame( 'Test Event', get_the_title( $event_id ), 'The original title must be untouched.' );
+	}
+
+	public function test_author_can_edit_own_event() {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_id );
+
+		$create_response = create_event( $this->event_request( $this->base_event_params() ) );
+		$event_id        = $create_response->get_data()['id'];
+
+		$request = $this->event_request( array( 'title' => 'Updated Title' ) + $this->base_event_params() );
+		$request->set_param( 'id', $event_id );
+
+		$this->assertTrue( publish_existing_event_permissions_check( $request ) );
+
+		$response = update_event( $request );
+		$this->assertNotWPError( $response );
+		$this->assertSame( 'Updated Title', get_the_title( $event_id ) );
+	}
+
+	public function test_venue_address_written_to_meta_not_post_content() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$params                       = $this->base_event_params();
+		$params['new_venue_name']    = 'Test Venue ' . uniqid();
+		$params['new_venue_address'] = '123 Example St, Testville';
+
+		$response = create_event( $this->event_request( $params ) );
+		$this->assertNotWPError( $response );
+
+		$event_id = $response->get_data()['id'];
+
+		$venue_posts = get_posts(
+			array(
+				'post_type'      => 'gatherpress_venue',
+				'title'          => $params['new_venue_name'],
+				'posts_per_page' => 1,
+			)
+		);
+		$this->assertNotEmpty( $venue_posts, 'A venue post should have been created.' );
+
+		$venue_post_id = $venue_posts[0]->ID;
+		$this->assertSame( $params['new_venue_address'], get_post_meta( $venue_post_id, 'gatherpress_address', true ) );
+		$this->assertStringNotContainsString( $params['new_venue_address'], (string) get_post_field( 'post_content', $venue_post_id ) );
+
+		$venue    = new \GatherPress\Core\Venue\Venue( $venue_post_id );
+		$term     = $venue->get_term();
+		$this->assertNotNull( $term, 'assign_venue_to_event() should resolve a shadow taxonomy term for the venue.' );
+		$this->assertTrue( has_term( $term->term_id, $venue->get_taxonomy(), $event_id ) );
+	}
+
+	public function test_featured_image_rejects_unreadable_attachment() {
+		$owner_id      = self::factory()->user->create( array( 'role' => 'author' ) );
+		$other_author  = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		wp_set_current_user( $owner_id );
+		$private_attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'        => 'private-image.jpg',
+				'post_status' => 'private',
+			)
+		);
+
+		wp_set_current_user( $other_author );
+		$this->assertFalse( current_user_can_use_attachment( $private_attachment_id ) );
+	}
+
+	public function test_draft_save_list_update_publish_flow() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		// Save a partial draft (title only).
+		$save_request = new WP_REST_Request( 'POST', '/wporg-groups/v1/draft' );
+		$save_request->set_param( 'title', 'Draft Test' );
+		$save_response = save_draft( $save_request );
+		$draft_id       = $save_response->get_data()['id'];
+
+		$this->assertSame( 'draft', get_post_status( $draft_id ) );
+
+		// List drafts.
+		$list_response = list_drafts();
+		$listed_ids     = wp_list_pluck( $list_response->get_data(), 'id' );
+		$this->assertContains( $draft_id, $listed_ids );
+
+		// Update with full details.
+		$update_request = new WP_REST_Request( 'POST', '/wporg-groups/v1/draft/' . $draft_id );
+		$update_request->set_param( 'id', $draft_id );
+		$update_request->set_param( 'title', 'Draft Test (updated)' );
+		$update_request->set_param( 'date', '2026-09-01' );
+		$update_request->set_param( 'time_start', '19:00' );
+		$update_request->set_param( 'time_end', '21:00' );
+		save_draft( $update_request );
+
+		$this->assertSame( 'draft', get_post_status( $draft_id ) );
+		$this->assertSame( 'Draft Test (updated)', get_the_title( $draft_id ) );
+
+		// Publish.
+		$publish_request = new WP_REST_Request( 'POST', '/wporg-groups/v1/draft/' . $draft_id . '/publish' );
+		$publish_request->set_param( 'id', $draft_id );
+		$publish_request->set_param( 'title', 'Draft Now Published' );
+		$publish_request->set_param( 'date', '2026-09-01' );
+		$publish_request->set_param( 'time_start', '19:00' );
+		$publish_request->set_param( 'time_end', '21:00' );
+		$publish_response = publish_draft( $publish_request );
+
+		$this->assertNotWPError( $publish_response );
+		$this->assertSame( 'publish', get_post_status( $draft_id ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -21,6 +21,9 @@ require_once __DIR__ . '/class-groups-testcase.php';
  */
 class Test_Groups_REST extends Groups_TestCase {
 
+	/**
+	 * Builds a POST /event request with the given params.
+	 */
 	private function event_request( array $params ): WP_REST_Request {
 		$request = new WP_REST_Request( 'POST', '/wporg-groups/v1/event' );
 		foreach ( $params as $key => $value ) {
@@ -29,6 +32,9 @@ class Test_Groups_REST extends Groups_TestCase {
 		return $request;
 	}
 
+	/**
+	 * A minimal valid set of event params, for tests to override from.
+	 */
 	private function base_event_params(): array {
 		return array(
 			'title'      => 'Test Event',
@@ -38,6 +44,9 @@ class Test_Groups_REST extends Groups_TestCase {
 		);
 	}
 
+	/**
+	 * An editor (Organiser) can create and publish an event in one request.
+	 */
 	public function test_create_event_as_editor() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
@@ -51,6 +60,9 @@ class Test_Groups_REST extends Groups_TestCase {
 		$this->assertSame( 'publish', get_post_status( $data['id'] ) );
 	}
 
+	/**
+	 * An event whose end time equals its start time is rejected.
+	 */
 	public function test_zero_length_event_rejected() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
@@ -88,6 +100,9 @@ class Test_Groups_REST extends Groups_TestCase {
 		$this->assertSame( '2026-08-21 01:00:00', $end );
 	}
 
+	/**
+	 * IDOR check: an author cannot edit another author's event.
+	 */
 	public function test_author_cannot_edit_another_authors_event() {
 		$author_a = self::factory()->user->create( array( 'role' => 'author' ) );
 		$author_b = self::factory()->user->create( array( 'role' => 'author' ) );
@@ -106,6 +121,9 @@ class Test_Groups_REST extends Groups_TestCase {
 		$this->assertSame( 'Test Event', get_the_title( $event_id ), 'The original title must be untouched.' );
 	}
 
+	/**
+	 * An author can edit an event they created.
+	 */
 	public function test_author_can_edit_own_event() {
 		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $author_id );
@@ -123,11 +141,15 @@ class Test_Groups_REST extends Groups_TestCase {
 		$this->assertSame( 'Updated Title', get_the_title( $event_id ) );
 	}
 
+	/**
+	 * A new venue's address is written to gatherpress_address meta, not
+	 * post_content, so GatherPress's own geocode handler can pick it up.
+	 */
 	public function test_venue_address_written_to_meta_not_post_content() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
 
-		$params                       = $this->base_event_params();
+		$params                      = $this->base_event_params();
 		$params['new_venue_name']    = 'Test Venue ' . uniqid();
 		$params['new_venue_address'] = '123 Example St, Testville';
 
@@ -149,15 +171,18 @@ class Test_Groups_REST extends Groups_TestCase {
 		$this->assertSame( $params['new_venue_address'], get_post_meta( $venue_post_id, 'gatherpress_address', true ) );
 		$this->assertStringNotContainsString( $params['new_venue_address'], (string) get_post_field( 'post_content', $venue_post_id ) );
 
-		$venue    = new \GatherPress\Core\Venue\Venue( $venue_post_id );
-		$term     = $venue->get_term();
+		$venue = new \GatherPress\Core\Venue\Venue( $venue_post_id );
+		$term  = $venue->get_term();
 		$this->assertNotNull( $term, 'assign_venue_to_event() should resolve a shadow taxonomy term for the venue.' );
 		$this->assertTrue( has_term( $term->term_id, $venue->get_taxonomy(), $event_id ) );
 	}
 
+	/**
+	 * A user can't set another user's private attachment as a featured image.
+	 */
 	public function test_featured_image_rejects_unreadable_attachment() {
-		$owner_id      = self::factory()->user->create( array( 'role' => 'author' ) );
-		$other_author  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$owner_id     = self::factory()->user->create( array( 'role' => 'author' ) );
+		$other_author = self::factory()->user->create( array( 'role' => 'author' ) );
 
 		wp_set_current_user( $owner_id );
 		$private_attachment_id = self::factory()->attachment->create_object(
@@ -171,6 +196,9 @@ class Test_Groups_REST extends Groups_TestCase {
 		$this->assertFalse( current_user_can_use_attachment( $private_attachment_id ) );
 	}
 
+	/**
+	 * Save → list → update → publish should transition post_status correctly.
+	 */
 	public function test_draft_save_list_update_publish_flow() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
@@ -179,13 +207,13 @@ class Test_Groups_REST extends Groups_TestCase {
 		$save_request = new WP_REST_Request( 'POST', '/wporg-groups/v1/draft' );
 		$save_request->set_param( 'title', 'Draft Test' );
 		$save_response = save_draft( $save_request );
-		$draft_id       = $save_response->get_data()['id'];
+		$draft_id      = $save_response->get_data()['id'];
 
 		$this->assertSame( 'draft', get_post_status( $draft_id ) );
 
 		// List drafts.
 		$list_response = list_drafts();
-		$listed_ids     = wp_list_pluck( $list_response->get_data(), 'id' );
+		$listed_ids    = wp_list_pluck( $list_response->get_data(), 'id' );
 		$this->assertContains( $draft_id, $listed_ids );
 
 		// Update with full details.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
@@ -7,14 +7,7 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
-// Run early (before other plugins' `pre_get_comments` callbacks) so this
-// reads the caller's actual requested `type`/`type__in`, not a value another
-// plugin has already normalized/expanded. GatherPress, for example, rewrites
-// an empty `type` into an explicit list of every comment_type present in the
-// table (minus its own) — read at priority 99, that expansion makes it look
-// like the caller explicitly asked for feedback comments, defeating this
-// exclusion entirely.
-add_action( 'pre_get_comments', __NAMESPACE__ . '\pre_get_comments', 1 );
+add_action( 'pre_get_comments', __NAMESPACE__ . '\pre_get_comments', 99 );
 
 /**
  * Only return feedback comments from the query when that type is specifically called for.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/query.php
@@ -7,7 +7,14 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 
 defined( 'WPINC' ) || die();
 
-add_action( 'pre_get_comments', __NAMESPACE__ . '\pre_get_comments', 99 );
+// Run early (before other plugins' `pre_get_comments` callbacks) so this
+// reads the caller's actual requested `type`/`type__in`, not a value another
+// plugin has already normalized/expanded. GatherPress, for example, rewrites
+// an empty `type` into an explicit list of every comment_type present in the
+// table (minus its own) — read at priority 99, that expansion makes it look
+// like the caller explicitly asked for feedback comments, defeating this
+// exclusion entirely.
+add_action( 'pre_get_comments', __NAMESPACE__ . '\pre_get_comments', 1 );
 
 /**
  * Only return feedback comments from the query when that type is specifically called for.

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -178,10 +178,24 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 * The assertions here assume that a filter has been applied to the comment query
 	 * to exclude feedback comments unless they are specifically requested.
 	 *
+	 * `\WordCamp\SpeakerFeedback\Query\pre_get_comments()` must run at priority 1,
+	 * before GatherPress's own `pre_get_comments` callback (priority 99) expands an
+	 * empty `type` into an explicit list of every comment_type present, which would
+	 * make this exclusion look like an explicit request for feedback comments. This
+	 * suite alone can't reproduce that regression (GatherPress isn't loaded here),
+	 * so the priority is pinned directly below rather than relying on interaction
+	 * with another plugin's callback.
+	 *
 	 * @covers \WordCamp\SpeakerFeedback\Comment\get_feedback()
 	 * @covers \WordCamp\SpeakerFeedback\Query\pre_get_comments()
 	 */
 	public function test_get_feedback_exclude_other_comments() {
+		$this->assertSame(
+			1,
+			has_filter( 'pre_get_comments', 'WordCamp\SpeakerFeedback\Query\pre_get_comments' ),
+			'pre_get_comments() must run at priority 1 so it reads the caller\'s actual requested type, before another plugin (e.g. GatherPress at priority 99) can normalize/expand it.'
+		);
+
 		self::factory()->comment->create_many( 3 );
 		self::factory()->comment->create_many(
 			3,

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-comment.php
@@ -178,23 +178,28 @@ class Test_SpeakerFeedback_Comment extends WP_UnitTestCase {
 	 * The assertions here assume that a filter has been applied to the comment query
 	 * to exclude feedback comments unless they are specifically requested.
 	 *
-	 * `\WordCamp\SpeakerFeedback\Query\pre_get_comments()` must run at priority 1,
-	 * before GatherPress's own `pre_get_comments` callback (priority 99) expands an
-	 * empty `type` into an explicit list of every comment_type present, which would
-	 * make this exclusion look like an explicit request for feedback comments. This
-	 * suite alone can't reproduce that regression (GatherPress isn't loaded here),
-	 * so the priority is pinned directly below rather than relying on interaction
-	 * with another plugin's callback.
+	 * The shared PHPUnit bootstrap (`phpunit-bootstrap.php`) loads every plugin's
+	 * bootstrapper into one process regardless of which `--testsuite` is running,
+	 * so GatherPress's `Rsvp\Query::exclude_rsvp_from_comment_query()` (default
+	 * priority 10 on `pre_get_comments`) is active here even though this suite has
+	 * nothing to do with GatherPress. When the caller's `type` is empty, that
+	 * callback expands it into an explicit list of every comment_type present in
+	 * the table — which would make this test's feedback comments look like an
+	 * explicit request for them, defeating the exclusion this test is checking.
+	 * GatherPress and Speaker Feedback aren't expected to run against the same
+	 * query in production, so rather than reordering `pre_get_comments` priorities
+	 * for real requests, neutralize that one callback for the scope of this test.
 	 *
 	 * @covers \WordCamp\SpeakerFeedback\Comment\get_feedback()
 	 * @covers \WordCamp\SpeakerFeedback\Query\pre_get_comments()
 	 */
 	public function test_get_feedback_exclude_other_comments() {
-		$this->assertSame(
-			1,
-			has_filter( 'pre_get_comments', 'WordCamp\SpeakerFeedback\Query\pre_get_comments' ),
-			'pre_get_comments() must run at priority 1 so it reads the caller\'s actual requested type, before another plugin (e.g. GatherPress at priority 99) can normalize/expand it.'
-		);
+		if ( class_exists( '\GatherPress\Core\Rsvp\Query' ) ) {
+			remove_action(
+				'pre_get_comments',
+				array( \GatherPress\Core\Rsvp\Query::get_instance(), 'exclude_rsvp_from_comment_query' )
+			);
+		}
 
 		self::factory()->comment->create_many( 3 );
 		self::factory()->comment->create_many(

--- a/tests/e2e/anonymous.spec.js
+++ b/tests/e2e/anonymous.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * A logged-out visitor should be able to browse the group site normally,
+ * and should never see any event/member management UI (that's gated to
+ * Organiser/Event Organiser roles — see the group settings + event-manage
+ * block permission checks in the groups-gatherpress-compat-test skill).
+ */
+test.describe( 'anonymous visitor', () => {
+	test( 'front page renders', async ( { page } ) => {
+		const response = await page.goto( '' );
+		expect( response.status() ).toBe( 200 );
+	} );
+
+	test( 'no management UI is rendered on the front page', async ( { page } ) => {
+		await page.goto( '/' );
+
+		// The "Manage" button from the `wporg/event-manage` block should be
+		// entirely absent for a logged-out visitor, not merely disabled.
+		await expect( page.locator( '.wp-element-button', { hasText: /manage/i } ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/anonymous.spec.js
+++ b/tests/e2e/anonymous.spec.js
@@ -13,7 +13,7 @@ test.describe( 'anonymous visitor', () => {
 	} );
 
 	test( 'no management UI is rendered on the front page', async ( { page } ) => {
-		await page.goto( '/' );
+		await page.goto( '' );
 
 		// The "Manage" button from the `wporg/event-manage` block should be
 		// entirely absent for a logged-out visitor, not merely disabled.

--- a/tests/e2e/event-organiser.spec.js
+++ b/tests/e2e/event-organiser.spec.js
@@ -1,0 +1,57 @@
+const { test, expect } = require( '@playwright/test' );
+const { login } = require( './utils/login' );
+
+/**
+ * Event Organisers (author role) manage events through wp-admin's native
+ * GatherPress editor — the custom `wporg/event-manage` front-end block is
+ * registered but not placed in any template (a known, tracked issue; see
+ * the "Known-issues appendix" in the groups-gatherpress-compat-test skill),
+ * so this exercises the actual working path rather than the unreachable one.
+ *
+ * Requires the `eventorganiser1` / `password` test user from the skill's
+ * environment-setup step.
+ */
+test.describe( 'event organiser (author role)', () => {
+	test( 'can create and publish an event via wp-admin, and it appears on the front page', async ( { page } ) => {
+		test.slow(); // The block editor can be slow to boot on a cold local dev stack.
+
+		await login( page, 'eventorganiser1', 'password' );
+
+		await page.goto( 'wp-admin/post-new.php?post_type=gatherpress_event' );
+		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 20000 } );
+
+		// First-time editor visits show a "Welcome to the editor" guide modal
+		// (client-side preference, so it reappears in every fresh browser
+		// context) that blocks the rest of the UI until dismissed.
+		const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
+		try {
+			await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
+			await page.keyboard.press( 'Escape' );
+		} catch {
+			// Guide didn't appear (already dismissed for this user) — nothing to do.
+		}
+
+		const title = `E2E Test Event ${ Date.now() }`;
+		// The block editor's canvas (including the title field) renders
+		// inside an iframe.
+		const editorCanvas = page.locator( 'iframe[name="editor-canvas"]' ).contentFrame();
+		await editorCanvas.getByRole( 'textbox', { name: 'Add title' } ).fill( title );
+		await editorCanvas.getByRole( 'textbox', { name: 'Add title' } ).press( 'Tab' );
+
+		// Both the toolbar toggle and (once open) the confirm button inside
+		// the publish panel are named exactly "Publish" — scope each to its
+		// own labelled region to avoid a strict-mode ambiguity.
+		const publishButton = page.getByLabel( 'Editor top bar' ).getByRole( 'button', { name: 'Publish', exact: true } );
+		await expect( publishButton ).toBeEnabled( { timeout: 10000 } );
+		await publishButton.click();
+
+		const confirmPublishButton = page.getByLabel( 'Editor publish' ).getByRole( 'button', { name: 'Publish', exact: true } );
+		await expect( confirmPublishButton ).toBeEnabled( { timeout: 10000 } );
+		await confirmPublishButton.click();
+
+		await expect( page.getByTestId( 'snackbar' ).getByText( 'Event published.' ) ).toBeVisible( { timeout: 15000 } );
+
+		await page.goto( '' );
+		await expect( page.getByText( title ) ).toBeVisible();
+	} );
+} );

--- a/tests/e2e/member-directory.spec.js
+++ b/tests/e2e/member-directory.spec.js
@@ -1,0 +1,20 @@
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * The public member directory (`wporg/group-members` block, rendered on
+ * the `/members/` page) should list seeded members with correct role
+ * labels, with no login required.
+ */
+test.describe( 'member directory', () => {
+	test( 'lists members with correct role labels', async ( { page } ) => {
+		const response = await page.goto( 'members/' );
+		expect( response.status() ).toBe( 200 );
+
+		const grid = page.locator( '.wporg-group-members__grid' );
+		await expect( grid ).toBeVisible();
+
+		await expect( grid.locator( '.wporg-group-members__role--editor' ).first() ).toHaveText( /Organiser/ );
+		await expect( grid.locator( '.wporg-group-members__role--author' ).first() ).toHaveText( /Event Organiser/ );
+		await expect( grid.locator( '.wporg-group-members__role--subscriber' ).first() ).toHaveText( /Member/ );
+	} );
+} );

--- a/tests/e2e/utils/login.js
+++ b/tests/e2e/utils/login.js
@@ -1,0 +1,19 @@
+/**
+ * Logs a Playwright `page` into wp-login.php for the current baseURL.
+ *
+ * Uses standard core wp-login.php field IDs — no plugin-specific login UI
+ * exists for the groups front end, so this is the same for every role.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} username
+ * @param {string} password
+ */
+async function login( page, username, password ) {
+	await page.goto( 'wp-login.php' );
+	await page.locator( '#user_login' ).fill( username );
+	await page.locator( '#user_pass' ).fill( password );
+	await page.locator( '#wp-submit' ).click();
+	await page.waitForLoadState( 'networkidle' );
+}
+
+module.exports = { login };

--- a/tests/e2e/utils/login.js
+++ b/tests/e2e/utils/login.js
@@ -14,6 +14,12 @@ async function login( page, username, password ) {
 	await page.locator( '#user_pass' ).fill( password );
 	await page.locator( '#wp-submit' ).click();
 	await page.waitForLoadState( 'networkidle' );
+
+	// Fail here, with the real reason, rather than downstream on a missing
+	// group-site element, if authentication did not actually succeed.
+	if ( new URL( page.url() ).pathname.endsWith( 'wp-login.php' ) ) {
+		throw new Error( `login( '${ username }' ) failed — still on wp-login.php.` );
+	}
 }
 
 module.exports = { login };


### PR DESCRIPTION
Adds three testing layers for the Groups/GatherPress front-end integration (#1799):

- **Agentic checklist skill** (`.claude/skills/groups-gatherpress-compat-test/`): environment setup, direct REST pass, per-role browser pass, GatherPress-off pass, security pass, perf check, and a known-issues appendix.
- **PHPUnit suite** ("WordCamp Groups" in `phpunit.xml.dist`): capability checks (including a regression pin for the fixed `promote_users` privilege escalation), `Members_Controller` role/IDOR rules, REST CRUD + draft flow + overnight rollover, block registration, and a GatherPress-off guard. Wires a pinned GatherPress install into the phpunit environment (local Docker + CI), since the plugin's real behavior can't be exercised without it — a missing/failed install now hard-fails the container and the test bootstraps (see below) rather than silently running the suites with the plugins under test inert.
- **Playwright e2e**: `playwright.config.js` + 3 specs (anonymous visitor, event organiser via wp-admin, member directory), plus a `workflow_dispatch`-only CI job (`.github/workflows/e2e-tests.yml`).
- **Speaker Feedback test isolation**: loading GatherPress in the shared PHPUnit bootstrap (needed for the suite above; `phpunit-bootstrap.php` loads every plugin's bootstrapper into one process regardless of which `--testsuite` runs) exposed GatherPress's `Rsvp\Query::exclude_rsvp_from_comment_query()` interfering with an unrelated Speaker Feedback test — it expands an empty `type` query var before Speaker Feedback's own exclusion filter reads it. GatherPress and Speaker Feedback aren't expected to run against the same query in production, so rather than reordering `pre_get_comments` priorities for real requests, the one affected test (`test-comment.php`) now neutralizes that specific GatherPress callback for its own scope (auto-restored by `WP_UnitTestCase` after the test).

**Review fixes** (d0029069, e924ef6f, 843601a8): the fail-open gaps and other issues @gedex flagged are addressed — see [the review](https://github.com/WordPress/wordcamp.org/pull/1816#pullrequestreview-4805111359) for details on each.

## How to test

**PHPUnit:**
```bash
docker compose -f docker-compose.phpunit.yml up --build -d
docker compose -f docker-compose.phpunit.yml exec phpunit_wp phpunit -c phpunit.xml.dist --testsuite "WordCamp Groups"
```
Expect `38 tests, 74 assertions, OK`. (The container needs outbound network access to `develop.svn.wordpress.org`/`wordpress.org` and `github.com` to install the WP test suite and GatherPress on first run — a blocking proxy will now make the container exit non-zero with a clear `ERROR:`/bootstrap `RuntimeException`, instead of a silent green run with GatherPress absent.)

Also worth a run of the Speaker Feedback suite, given the cross-plugin fix above:
```bash
docker compose -f docker-compose.phpunit.yml exec phpunit_wp phpunit -c phpunit.xml.dist --testsuite "WordCamp Speaker Feedback"
```

**Playwright e2e** (needs the regular dev stack up with GatherPress active on `sunshine-coast-qld`, and the `organiser1`/`eventorganiser1`/`member1` test users from the skill's setup step):
```bash
npm ci
npx playwright install chromium
npx playwright test
```
Expect 4/4 passing.

**Agentic checklist:**
```
/groups-gatherpress-compat-test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

