### PR TITLE
Groups: let Organisers edit group name and description

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace WordCamp\Groups\Frontend\Tests;
+
+use WP_UnitTestCase, WP_REST_Server, WP_REST_Request;
+
+use const WordCamp\Groups\Frontend\REST\NAMESPACE_V1;
+
+use function WordCamp\Groups\Frontend\REST\register_routes;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/capabilities.php';
+require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/rest.php';
+
+/**
+ * Tests for the `wporg-groups/v1/group-info` routes.
+ *
+ * These exist because core's `/wp/v2/settings` gates `blogname` and
+ * `blogdescription` behind `manage_options`, which Organisers don't have.
+ * The routes hand Organisers write access to two options that the group
+ * cannot restore from anywhere else in this UI, so the interesting cases
+ * are the ones where a write should be refused.
+ *
+ * @group mu-plugins
+ * @group groups-frontend
+ */
+class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
+	const ROUTE = '/' . NAMESPACE_V1 . '/group-info';
+
+	/**
+	 * Set up a REST server with this plugin's routes registered.
+	 *
+	 * The routes go on `rest_api_init` rather than being registered
+	 * directly, because core emits a `_doing_it_wrong()` for any route
+	 * registered outside that action.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		add_action( 'rest_api_init', 'WordCamp\Groups\Frontend\REST\register_routes' );
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		update_option( 'blogname', 'Warsaw WordPress Group' );
+		update_option( 'blogdescription', 'We meet monthly.' );
+	}
+
+	/**
+	 * Dispatch a request against the group-info route.
+	 *
+	 * @param string $method HTTP method.
+	 * @param array  $data   Body parameters.
+	 */
+	protected function dispatch( string $method, array $data = array() ) {
+		$request = new WP_REST_Request( $method, self::ROUTE );
+
+		foreach ( $data as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * An Organiser (editor) can read the group's name and description.
+	 */
+	public function test_editor_can_read_group_info() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch( 'GET' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'title'       => 'Warsaw WordPress Group',
+				'description' => 'We meet monthly.',
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * An Organiser (editor) can write both fields.
+	 */
+	public function test_editor_can_update_group_info() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch(
+			'POST',
+			array(
+				'title'       => 'Kraków WordPress Group',
+				'description' => 'Second Tuesday, every month.',
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Kraków WordPress Group', get_option( 'blogname' ) );
+		$this->assertSame( 'Second Tuesday, every month.', get_option( 'blogdescription' ) );
+	}
+
+	/**
+	 * A Member (subscriber) can neither read nor write.
+	 */
+	public function test_subscriber_is_denied() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertSame( 403, $this->dispatch( 'GET' )->get_status() );
+		$this->assertSame( 403, $this->dispatch( 'POST', array( 'title' => 'Hijacked' ) )->get_status() );
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+	}
+
+	/**
+	 * A logged-out request is refused.
+	 */
+	public function test_logged_out_is_denied() {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 401, $this->dispatch( 'GET' )->get_status() );
+	}
+
+	/**
+	 * An empty group name is rejected rather than saved.
+	 *
+	 * This is the tail of the data-loss path: a failed GET leaves the form
+	 * blank, and without this guard the next Save writes those blanks over
+	 * the real values, with nothing left to restore them from.
+	 */
+	public function test_empty_title_is_rejected() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch( 'POST', array( 'title' => '' ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'wporg_groups_empty_group_name', $response->get_data()['code'] );
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+	}
+
+	/**
+	 * A whitespace-only group name is rejected too.
+	 */
+	public function test_whitespace_only_title_is_rejected() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch( 'POST', array( 'title' => "  \n\t " ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+	}
+
+	/**
+	 * A group name that survives the client but not `sanitize_text_field()`
+	 * is rejected, not saved as an empty string.
+	 *
+	 * This is why the emptiness check runs after sanitization: the request
+	 * arrives non-empty and only becomes empty on the way in.
+	 */
+	public function test_title_emptied_by_sanitization_is_rejected() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch( 'POST', array( 'title' => '<script>alert(1)</script>' ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+	}
+
+	/**
+	 * Markup in the group name is stripped, and what's stored is what's
+	 * read back.
+	 */
+	public function test_title_is_sanitized_and_round_trips() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->dispatch( 'POST', array( 'title' => 'Gdynia <b>WordPress</b> Group' ) );
+
+		$this->assertSame( 'Gdynia WordPress Group', get_option( 'blogname' ) );
+		$this->assertSame( 'Gdynia WordPress Group', $this->dispatch( 'GET' )->get_data()['title'] );
+	}
+
+	/**
+	 * An empty description is allowed: a group may legitimately have no
+	 * tagline, and it can be typed back in from this same form.
+	 */
+	public function test_empty_description_is_allowed() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch( 'POST', array( 'description' => '' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '', get_option( 'blogdescription' ) );
+	}
+
+	/**
+	 * Sending one field leaves the other alone.
+	 */
+	public function test_omitted_field_is_not_clobbered() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->dispatch( 'POST', array( 'description' => 'Now quarterly.' ) );
+
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+		$this->assertSame( 'Now quarterly.', get_option( 'blogdescription' ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -242,10 +242,20 @@ function get_group_info(): WP_REST_Response {
  *
  * Only the fields present in the request are written, so a client can send
  * one without clobbering the other.
+ *
+ * @return WP_Error|WP_REST_Response
  */
-function update_group_info( WP_REST_Request $request ): WP_REST_Response {
+function update_group_info( WP_REST_Request $request ) {
 	$title       = $request->get_param( 'title' );
 	$description = $request->get_param( 'description' );
+
+	// An empty group name is not recoverable from this UI: the next load
+	// returns the blank value, so there is nothing left to restore it from.
+	// Checked after sanitization, because `sanitize_text_field()` can empty
+	// an input that was not empty when it was sent.
+	if ( null !== $title && '' === trim( $title ) ) {
+		return new WP_Error( 'wporg_groups_empty_group_name', 'Group name is required.', array( 'status' => 400 ) );
+	}
 
 	if ( null !== $title ) {
 		update_option( 'blogname', $title );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -15,8 +15,15 @@
  *   POST /event/{id}
  *        Updates an existing gatherpress_event.
  *
- * All routes require the `current_user_can_manage_events()` capability,
- * plus post-specific capabilities when operating on an existing event.
+ *   GET  /group-info
+ *   POST /group-info
+ *        Reads and writes the group's name and description. Exists because
+ *        core's /wp/v2/settings requires `manage_options`, which Organisers
+ *        (editors) do not have.
+ *
+ * The event routes require the `current_user_can_manage_events()` capability,
+ * plus post-specific capabilities when operating on an existing event. The
+ * group-info routes require `current_user_can_manage_group_settings()`.
  *
  * @package WordCamp\Groups\Frontend
  */
@@ -35,6 +42,7 @@ use WP_REST_Server;
 use const WordCamp\Groups\Frontend\Defaults\DESCRIPTION_BLOCK_NAMES;
 
 use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_events;
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group_settings;
 use function WordCamp\Groups\Frontend\Defaults\extract_description_blocks;
 use function WordCamp\Groups\Frontend\Defaults\get_default_event_data;
 use function WordCamp\Groups\Frontend\Defaults\get_event_venue_post_id;
@@ -170,6 +178,83 @@ function register_routes(): void {
 			) + event_args_schema(),
 		)
 	);
+
+	// ----- Group info -----------------------------------------------------
+	//
+	// The Settings > About tab edits `blogname` and `blogdescription`. Core's
+	// /wp/v2/settings gates both behind `manage_options`, which only network
+	// administrators have, so Organisers got a 403 on every read and write.
+	// These routes expose just those two fields, behind the same capability
+	// check that gates the settings UI itself.
+
+	register_rest_route(
+		NAMESPACE_V1,
+		'/group-info',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __NAMESPACE__ . '\get_group_info',
+				'permission_callback' => __NAMESPACE__ . '\manage_group_settings_permissions_check',
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => __NAMESPACE__ . '\update_group_info',
+				'permission_callback' => __NAMESPACE__ . '\manage_group_settings_permissions_check',
+				'args'                => array(
+					'title'       => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'description' => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Capability check for the group-info routes.
+ */
+function manage_group_settings_permissions_check(): bool {
+	return current_user_can_manage_group_settings();
+}
+
+/**
+ * Return the group's name and description.
+ */
+function get_group_info(): WP_REST_Response {
+	return new WP_REST_Response(
+		array(
+			'title'       => get_option( 'blogname', '' ),
+			'description' => get_option( 'blogdescription', '' ),
+		)
+	);
+}
+
+/**
+ * Update the group's name and description.
+ *
+ * Only the fields present in the request are written, so a client can send
+ * one without clobbering the other.
+ */
+function update_group_info( WP_REST_Request $request ): WP_REST_Response {
+	$title       = $request->get_param( 'title' );
+	$description = $request->get_param( 'description' );
+
+	if ( null !== $title ) {
+		update_option( 'blogname', $title );
+	}
+
+	if ( null !== $description ) {
+		update_option( 'blogdescription', $description );
+	}
+
+	return get_group_info();
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
@@ -13,7 +13,6 @@ import {
 } from '@wordpress/element';
 import {
 	TextControl,
-	TextareaControl,
 	Button,
 	Notice,
 	Spinner,
@@ -23,6 +22,7 @@ import { __ } from '@wordpress/i18n';
 
 export default function AboutTab() {
 	const [ loading, setLoading ] = useState( true );
+	const [ loadFailed, setLoadFailed ] = useState( false );
 	const [ saving, setSaving ] = useState( false );
 	const [ notice, setNotice ] = useState( '' );
 	const [ noticeType, setNoticeType ] = useState( 'success' );
@@ -42,7 +42,11 @@ export default function AboutTab() {
 			} )
 			.catch( ( err ) => {
 				// Don't leave the fields silently blank: a failed load looks
-				// identical to an empty group name otherwise.
+				// identical to an empty group name otherwise. Lock the form as
+				// well, so a save can't write those blanks back over the real
+				// values — a failed read followed by a successful write is all
+				// it takes to wipe the group's name and description.
+				setLoadFailed( true );
 				setNoticeType( 'error' );
 				setNotice(
 					err.message ||
@@ -95,14 +99,18 @@ export default function AboutTab() {
 			label: __( 'Group name', 'wporg-groups-frontend' ),
 			value: form.blogname,
 			onChange: ( v ) => setForm( { ...form, blogname: v } ),
+			disabled: loadFailed,
 			__nextHasNoMarginBottom: true,
 		} ),
-		h( TextareaControl, {
+		// Single-line on purpose: the value is stored in `blogdescription`
+		// and sanitized with `sanitize_text_field()`, which silently flattens
+		// line breaks, so a textarea would invite input it can't keep.
+		h( TextControl, {
 			label: __( 'Description', 'wporg-groups-frontend' ),
 			value: form.blogdescription,
 			onChange: ( v ) => setForm( { ...form, blogdescription: v } ),
-			rows: 3,
-			help: __( 'A short description of your group shown on the homepage.', 'wporg-groups-frontend' ),
+			disabled: loadFailed,
+			help: __( 'A short tagline for your group, used in the browser title and search results.', 'wporg-groups-frontend' ),
 			__nextHasNoMarginBottom: true,
 		} ),
 		h(
@@ -114,7 +122,7 @@ export default function AboutTab() {
 					variant: 'primary',
 					onClick: handleSave,
 					isBusy: saving,
-					disabled: saving,
+					disabled: saving || loadFailed || '' === form.blogname.trim(),
 				},
 				__( 'Save', 'wporg-groups-frontend' )
 			)

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
@@ -32,7 +32,7 @@ export default function AboutTab() {
 	} );
 
 	useEffect( () => {
-		apiFetch( { path: '/wp/v2/settings' } )
+		apiFetch( { path: '/wporg-groups/v1/group-info' } )
 			.then( ( data ) => {
 				setForm( {
 					blogname: data.title || '',
@@ -40,7 +40,16 @@ export default function AboutTab() {
 				} );
 				setLoading( false );
 			} )
-			.catch( () => setLoading( false ) );
+			.catch( ( err ) => {
+				// Don't leave the fields silently blank: a failed load looks
+				// identical to an empty group name otherwise.
+				setNoticeType( 'error' );
+				setNotice(
+					err.message ||
+						__( 'Could not load group settings.', 'wporg-groups-frontend' )
+				);
+				setLoading( false );
+			} );
 	}, [] );
 
 	const handleSave = async () => {
@@ -48,7 +57,7 @@ export default function AboutTab() {
 		setNotice( '' );
 		try {
 			await apiFetch( {
-				path: '/wp/v2/settings',
+				path: '/wporg-groups/v1/group-info',
 				method: 'POST',
 				data: {
 					title: form.blogname,


### PR DESCRIPTION
Fixes #1805.

# What

Settings > About renders blank for an Organiser (editor role) and saving fails with "Sorry, you are not allowed to do that." The top tier this plugin expects to run a group day to day can never change the group's name or description.

# Why

`about-tab.js` called core's `/wp/v2/settings`, whose permission callback requires `manage_options`. Only administrators have that, and Organisers are editors. Meanwhile the tab itself is gated by `current_user_can_manage_group_settings()` (`edit_others_posts`), which editors do have. So the UI offered a tab whose every request 403'd for exactly the audience it was built for.

# How

Two new routes in `wporg-groups/v1`, `GET` and `POST /group-info`, reading and writing `blogname` and `blogdescription`, both behind `manage_group_settings_permissions_check()`. That is the same check that gates the settings block, so the UI and the endpoint now agree instead of disagreeing.

Details:

- **Two fields, not a settings passthrough.** The route exposes only the two options the tab edits. Widening it later is easy; handing out a general option writer to editors is not something to do casually.
- **`POST` writes only the fields present in the request**, so a client can send one without clobbering the other. Both are `sanitize_text_field`, and `update_option` applies core's own `sanitize_option` on top.
- **`POST` returns the stored values** by delegating to the same reader, so the client sees what was actually persisted rather than an echo of its own payload.

I also stopped the load failure from being silent. `.catch( () => setLoading( false ) )` left the fields blank, which is indistinguishable from a group that genuinely has no name, and is why this presented as "renders blank" rather than as an error. Failures now surface in the existing `Notice`.

# Testing

As an editor-tier Organiser:

1. Open Settings > About. Current group name and description are pre-filled.
2. Change both, Save. Notice confirms, and `wp option get blogname` / `wp option get blogdescription` reflect the new values.
3. Reload the tab. The new values are still there.

Capability boundaries:

- `GET`/`POST /wporg-groups/v1/group-info` as a subscriber-tier member returns 403.
- Anonymous returns 401.
- Administrators are unaffected.

Before this change, step 1 shows empty fields with a silent 403 in the network tab, and step 2 fails with a visible permission error.

# Note on scope

The About tab's docblock mentions location and social links, but the component only renders name and description today, so this covers what actually exists. If those fields arrive later they will want their own storage anyway, not `/wp/v2/settings`.
