### PR TITLE
Update wp-coding-standards/wpcs to 3.4.1 in wporg-events-2023

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/composer.json
+++ b/public_html/wp-content/themes/wporg-events-2023/composer.json
@@ -84,7 +84,6 @@
 			]
 		}
 	],
-	"require": {},
 	"require-dev": {
 		"composer/installers": "~1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -93,7 +92,7 @@
 		"wordpress-meta/pub": "1",
 		"wordpress-meta/wporg": "1",
 		"wordpress-meta/wporg-main": "1",
-		"wp-coding-standards/wpcs": "2.*",
+		"wp-coding-standards/wpcs": "^3.4.1",
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"wpackagist-plugin/gutenberg": "*",
 		"wpackagist-plugin/jetpack": "*",


### PR DESCRIPTION
Bumps the [wp-coding-standards/wpcs](https://github.com/WordPress/WordPress-Coding-Standards) constraint in `public_html/wp-content/themes/wporg-events-2023/composer.json` from `2.*` to `^3.4.1`. The theme directory has no `composer.lock`, so the constraint is the only change; a fresh `composer install` resolves to 3.4.1. (Composer also dropped the empty `require` stanza while editing.)

Part of an org-wide sweep to get all repos onto WPCS 3.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)