### PR TITLE
Groups: support online events in frontend forms

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/defaults.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/defaults.php
@@ -31,17 +31,21 @@ use GatherPress\Core\Venue\Setup as Venue_Setup;
  *     date:string,
  *     time_start:string,
  *     time_end:string,
- *     venue_id:int
+ *     venue_id:int,
+ *     is_online:bool,
+ *     online_event_link:string
  * }
  */
 function get_default_event_data(): array {
 	$defaults = array(
-		'title'       => '',
-		'description' => '',
-		'date'        => wp_date( 'Y-m-d', strtotime( '+7 days' ) ),
-		'time_start'  => '18:00',
-		'time_end'    => '20:00',
-		'venue_id'    => 0,
+		'title'             => '',
+		'description'       => '',
+		'date'              => wp_date( 'Y-m-d', strtotime( '+7 days' ) ),
+		'time_start'        => '18:00',
+		'time_end'          => '20:00',
+		'venue_id'          => 0,
+		'is_online'         => false,
+		'online_event_link' => '',
 	);
 
 	$most_recent = get_most_recent_event_id();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -26,6 +26,7 @@ namespace WordCamp\Groups\Frontend\REST;
 defined( 'WPINC' ) || die();
 
 use GatherPress\Core\Event\Event;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use GatherPress\Core\Venue\Venue;
 use WP_Error;
 use WP_REST_Request;
@@ -344,6 +345,18 @@ function event_args_schema(): array {
 			'default'           => 0,
 			'sanitize_callback' => 'absint',
 		),
+		'is_online'         => array(
+			'type'              => 'boolean',
+			'required'          => false,
+			'default'           => false,
+			'sanitize_callback' => 'rest_sanitize_boolean',
+		),
+		'online_event_link' => array(
+			'type'              => 'string',
+			'required'          => false,
+			'default'           => '',
+			'sanitize_callback' => 'esc_url_raw',
+		),
 		'new_venue_name'    => array(
 			'type'              => 'string',
 			'required'          => false,
@@ -399,6 +412,17 @@ function get_event_form_data( WP_REST_Request $request ): WP_REST_Response {
 		}
 
 		$fields['venue_id'] = get_event_venue_post_id( $event_id );
+
+		$venue_taxonomy = Venue_Setup::get_instance()->taxonomy_for_event_post_type( Event::POST_TYPE );
+		$venue_terms    = get_the_terms( $event_id, $venue_taxonomy );
+
+		$fields['is_online']         = is_array( $venue_terms )
+			&& in_array( 'online-event', wp_list_pluck( $venue_terms, 'slug' ), true );
+		$fields['online_event_link'] = (string) get_post_meta(
+			$event_id,
+			'gatherpress_online_event_link',
+			true
+		);
 
 		$thumb_id = (int) get_post_thumbnail_id( $event_id );
 		if ( $thumb_id ) {
@@ -543,7 +567,7 @@ function save_draft( WP_REST_Request $request ): WP_REST_Response {
 		);
 	}
 
-	// Venue — same path as the publish flow.
+	// Physical and online venues — same path as the publish flow.
 	$venue_id = resolve_venue_id(
 		array(
 			'venue_id'          => (int) $request->get_param( 'venue_id' ),
@@ -551,9 +575,16 @@ function save_draft( WP_REST_Request $request ): WP_REST_Response {
 			'new_venue_address' => (string) $request->get_param( 'new_venue_address' ),
 		)
 	);
-	if ( $venue_id > 0 ) {
-		assign_venue_to_event( $saved_id, $venue_id );
-	}
+	sync_event_venue_terms(
+		$saved_id,
+		$venue_id,
+		(bool) $request->get_param( 'is_online' )
+	);
+	sync_online_event_link(
+		$saved_id,
+		(bool) $request->get_param( 'is_online' ),
+		(string) $request->get_param( 'online_event_link' )
+	);
 
 	// Featured image.
 	$featured_image_id = (int) $request->get_param( 'featured_image_id' );
@@ -635,6 +666,8 @@ function persist_event( int $event_id, WP_REST_Request $request ) {
 		'time_start'        => (string) $request->get_param( 'time_start' ),
 		'time_end'          => (string) $request->get_param( 'time_end' ),
 		'venue_id'          => (int) $request->get_param( 'venue_id' ),
+		'is_online'         => (bool) $request->get_param( 'is_online' ),
+		'online_event_link' => (string) $request->get_param( 'online_event_link' ),
 		'new_venue_name'    => (string) $request->get_param( 'new_venue_name' ),
 		'new_venue_address' => (string) $request->get_param( 'new_venue_address' ),
 		'featured_image_id' => (int) $request->get_param( 'featured_image_id' ),
@@ -645,6 +678,13 @@ function persist_event( int $event_id, WP_REST_Request $request ) {
 	}
 	if ( $fields['time_start'] === $fields['time_end'] ) {
 		return new WP_Error( 'wporg_groups_bad_time_range', 'End time must be after start time.', array( 'status' => 400 ) );
+	}
+	if ( $fields['is_online'] && '' === $fields['online_event_link'] ) {
+		return new WP_Error(
+			'wporg_groups_missing_online_event_link',
+			'Online event link is required for online events.',
+			array( 'status' => 400 )
+		);
 	}
 
 	$post_args = array(
@@ -681,11 +721,10 @@ function persist_event( int $event_id, WP_REST_Request $request ) {
 		)
 	);
 
-	// Venue.
+	// Physical and online venues.
 	$venue_id = resolve_venue_id( $fields );
-	if ( $venue_id > 0 ) {
-		assign_venue_to_event( $saved_id, $venue_id );
-	}
+	sync_event_venue_terms( $saved_id, $venue_id, $fields['is_online'] );
+	sync_online_event_link( $saved_id, $fields['is_online'], $fields['online_event_link'] );
 
 	// Featured image — only if the current user is actually allowed to see
 	// it (public/inherited attachments, or their own private uploads).
@@ -774,20 +813,54 @@ function resolve_venue_id( array $fields ): int {
 }
 
 /**
- * Assign a venue to an event by setting the `_gatherpress_venue` term whose
- * slug matches the venue post.
+ * Synchronize an event's physical venue and online-event terms.
  *
- * The venue post type declares `gatherpress-shadow-source` support, so
- * `Shadow_Source::add_term()` already creates/maintains that term on
- * `save_post` — no need to insert it ourselves here.
+ * GatherPress models hybrid events by assigning both a physical venue's
+ * shadow term and the `online-event` sentinel term. Replacing the full term
+ * set here also clears a previously selected physical venue when an event is
+ * changed to online-only.
+ *
+ * @param int  $event_id     Event post ID.
+ * @param int  $venue_post_id Physical venue post ID, or zero for none.
+ * @param bool $is_online    Whether to assign the online-event term.
  */
-function assign_venue_to_event( int $event_id, int $venue_post_id ): void {
-	$venue = new Venue( $venue_post_id );
-	$term  = $venue->get_term();
+function sync_event_venue_terms( int $event_id, int $venue_post_id, bool $is_online ): void {
+	$taxonomy = Venue_Setup::get_instance()->taxonomy_for_event_post_type( Event::POST_TYPE );
+	$term_ids = array();
 
-	if ( ! $term ) {
+	if ( $venue_post_id > 0 ) {
+		$venue = new Venue( $venue_post_id );
+		$term  = $venue->get_term();
+
+		if ( $term ) {
+			$term_ids[] = (int) $term->term_id;
+		}
+	}
+
+	if ( $is_online ) {
+		$online_term = term_exists( 'online-event', $taxonomy );
+		if ( is_array( $online_term ) ) {
+			$term_ids[] = (int) $online_term['term_id'];
+		} elseif ( is_numeric( $online_term ) ) {
+			$term_ids[] = (int) $online_term;
+		}
+	}
+
+	wp_set_object_terms( $event_id, $term_ids, $taxonomy, false );
+}
+
+/**
+ * Synchronize the online meeting link with the event's online state.
+ *
+ * @param int    $event_id         Event post ID.
+ * @param bool   $is_online        Whether the event is online.
+ * @param string $online_event_link Online meeting URL.
+ */
+function sync_online_event_link( int $event_id, bool $is_online, string $online_event_link ): void {
+	if ( $is_online && '' !== $online_event_link ) {
+		update_post_meta( $event_id, 'gatherpress_online_event_link', esc_url_raw( $online_event_link ) );
 		return;
 	}
 
-	wp_set_object_terms( $event_id, array( $term->term_id ), $venue->get_taxonomy(), false );
+	delete_post_meta( $event_id, 'gatherpress_online_event_link' );
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -29,6 +29,7 @@ import {
 	TextControl,
 	Button,
 	SelectControl,
+	ToggleControl,
 	Notice,
 	Spinner,
 } from '@wordpress/components';
@@ -322,6 +323,8 @@ const NS =
 		time_end: '',
 		venue_id: 0,
 		venue_select: '',
+		is_online: false,
+		online_event_link: '',
 		new_venue_name: '',
 		new_venue_address: '',
 	};
@@ -395,6 +398,8 @@ const NS =
 						time_end: res.fields.time_end || '',
 						venue_id: res.fields.venue_id || 0,
 						venue_select: res.fields.venue_id ? String( res.fields.venue_id ) : '',
+						is_online: !! res.fields.is_online,
+						online_event_link: res.fields.online_event_link || '',
 						new_venue_name: '',
 						new_venue_address: '',
 					} );
@@ -440,6 +445,8 @@ const NS =
 				time_start: form.time_start,
 				time_end: form.time_end,
 				venue_id: isAddingNewVenue ? 0 : ( parseInt( form.venue_select, 10 ) || 0 ),
+				is_online: form.is_online,
+				online_event_link: form.is_online ? form.online_event_link : '',
 				new_venue_name: isAddingNewVenue ? form.new_venue_name : '',
 				new_venue_address: isAddingNewVenue ? form.new_venue_address : '',
 				featured_image_id: featuredImage.id,
@@ -717,6 +724,26 @@ const NS =
 							setVenueEditorOpen( true );
 						},
 					} ),
+
+					h(
+						'div',
+						{ className: 'wporg-groups-event-modal__online-event' },
+						h( ToggleControl, {
+							label: __( 'This is an online event', 'wporg-groups-frontend' ),
+							checked: form.is_online,
+							onChange: ( value ) => updateField( 'is_online', value ),
+							__nextHasNoMarginBottom: true,
+						} ),
+						form.is_online && h( TextControl, {
+							label: __( 'Online event link', 'wporg-groups-frontend' ),
+							type: 'url',
+							value: form.online_event_link,
+							onChange: ( value ) => updateField( 'online_event_link', value ),
+							placeholder: 'https://',
+							required: true,
+							__nextHasNoMarginBottom: true,
+						} )
+					),
 
 					h(
 						'div',

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -127,6 +127,22 @@
 	max-width: none;
 }
 
+/* === Online event === */
+
+.wporg-groups-event-modal__online-event {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 14px;
+	border: 1px solid #d9d9d9;
+	border-radius: 2px;
+	background: #f6f6f6;
+}
+
+.wporg-groups-event-modal__online-event input[type="url"] {
+	max-width: 600px;
+}
+
 /* === Loading === */
 
 .wporg-groups-event-modal__loading {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
@@ -20,6 +20,7 @@ import {
 	TextControl,
 	FormTokenField,
 	SelectControl,
+	ToggleControl,
 } from '@wordpress/components';
 import {
 	BlockEditorProvider,
@@ -176,7 +177,15 @@ function EventForm( { eventId, onDone, onCancel } ) {
 	const [ loading, setLoading ] = useState( true );
 	const [ saving, setSaving ] = useState( false );
 	const [ error, setError ] = useState( '' );
-	const [ form, setForm ] = useState( { title: '', date: '', time_start: '', time_end: '', venue_select: '' } );
+	const [ form, setForm ] = useState( {
+		title: '',
+		date: '',
+		time_start: '',
+		time_end: '',
+		venue_select: '',
+		is_online: false,
+		online_event_link: '',
+	} );
 	const [ initialDescription, setInitialDescription ] = useState( '' );
 	const [ featuredImage, setFeaturedImage ] = useState( { id: 0, url: '' } );
 	const [ venues, setVenues ] = useState( [] );
@@ -198,6 +207,8 @@ function EventForm( { eventId, onDone, onCancel } ) {
 					time_start: res.fields.time_start || '',
 					time_end: res.fields.time_end || '',
 					venue_select: res.fields.venue_id ? String( res.fields.venue_id ) : '',
+					is_online: !! res.fields.is_online,
+					online_event_link: res.fields.online_event_link || '',
 				} );
 				setInitialDescription( res.fields.description || '' );
 				setFeaturedImage( { id: res.fields.featured_image_id || 0, url: res.fields.featured_image_url || '' } );
@@ -254,6 +265,8 @@ function EventForm( { eventId, onDone, onCancel } ) {
 					title: form.title, description, date: form.date,
 					time_start: form.time_start, time_end: form.time_end,
 					venue_id: parseInt( form.venue_select, 10 ) || 0,
+					is_online: form.is_online,
+					online_event_link: form.is_online ? form.online_event_link : '',
 					featured_image_id: featuredImage.id,
 				},
 			} );
@@ -299,6 +312,23 @@ function EventForm( { eventId, onDone, onCancel } ) {
 			onSelect: ( v ) => updateField( 'venue_select', v ),
 			onOpenEditor: ( id ) => setVenueEditorId( id ),
 		} ),
+		h( 'div', { className: 'wporg-event-form__online-event' },
+			h( ToggleControl, {
+				label: __( 'This is an online event', 'wporg-groups-frontend' ),
+				checked: form.is_online,
+				onChange: ( value ) => updateField( 'is_online', value ),
+				__nextHasNoMarginBottom: true,
+			} ),
+			form.is_online && h( TextControl, {
+				label: __( 'Online event link', 'wporg-groups-frontend' ),
+				type: 'url',
+				value: form.online_event_link,
+				onChange: ( value ) => updateField( 'online_event_link', value ),
+				placeholder: 'https://',
+				required: true,
+				__nextHasNoMarginBottom: true,
+			} )
+		),
 		h( 'div', { className: 'wporg-event-form__field' },
 			h( FormTokenField, {
 				label: __( 'Speakers', 'wporg-groups-frontend' ),
@@ -384,6 +414,8 @@ export default function EventsTab( { eventId: initialEventId, onClose } ) {
 				time_start: res.fields.time_start || '',
 				time_end: res.fields.time_end || '',
 				venue_id: res.fields.venue_id || 0,
+				is_online: !! res.fields.is_online,
+				online_event_link: res.fields.online_event_link || '',
 				featured_image_id: res.fields.featured_image_id || 0,
 			};
 			const result = await apiFetch( {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -291,6 +291,20 @@
 		margin-top: 4px;
 	}
 
+	&__online-event {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 14px;
+		border: 1px solid #d9d9d9;
+		border-radius: 2px;
+		background: #f6f6f6;
+
+		input[type="url"] {
+			max-width: 600px;
+		}
+	}
+
 	&__actions {
 		display: flex;
 		justify-content: flex-end;


### PR DESCRIPTION
Fixes #1808.

Adds an online-event toggle and meeting URL to both front-end event forms, reusing GatherPress's existing online-event term and gatherpress_online_event_link meta. Supports online-only and hybrid events, with server-side validation and cleanup.

### Screenshot

<kbd><img width="662" height="224" alt="image" src="https://github.com/user-attachments/assets/8dbfce7c-d454-4f4f-94eb-4e9f3fe33276" /></kbd>

<kbd><img width="435" height="280" alt="image" src="https://github.com/user-attachments/assets/7361764e-c317-4cfb-93db-a8989d6a0a93" /></kbd>

### Testing

1. Run npm run build, then visit https://events.wordpress.test/group/sunshine-coast-qld/ as an organizer and start creating an event.
2. Confirm the This is an online event toggle appears and enabling it reveals the required Online event link field.
3. Create online-only and hybrid events; open each event publicly and confirm its online and physical venue details are shown correctly.
4. Edit the event from both front-end forms; confirm the saved values load, changes appear publicly, and disabling online mode removes the meeting link.
