### PR TITLE
Groups: add frontend event email preferences

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
@@ -20,6 +20,7 @@ defined( 'WPINC' ) || die();
  *   GET    /wporg-groups/v1/members/{id}  — single member
  *   POST   /wporg-groups/v1/members/join  — join group
  *   DELETE /wporg-groups/v1/members/leave — leave group
+ *   POST   /wporg-groups/v1/members/notification-preference — update event email preference
  */
 class Members_Controller extends \WP_REST_Users_Controller {
 
@@ -165,6 +166,26 @@ class Members_Controller extends \WP_REST_Users_Controller {
 					'methods'             => \WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'leave_group' ),
 					'permission_callback' => array( $this, 'leave_permissions_check' ),
+				),
+			)
+		);
+
+		// Event email preference: POST /members/notification-preference.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/notification-preference',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'update_notification_preference' ),
+					'permission_callback' => array( $this, 'notification_preference_permissions_check' ),
+					'args'                => array(
+						'opt_in' => array(
+							'type'              => 'boolean',
+							'required'          => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						),
+					),
 				),
 			)
 		);
@@ -318,6 +339,54 @@ class Members_Controller extends \WP_REST_Users_Controller {
 		remove_user_from_blog( $user_id, $blog_id );
 
 		return rest_ensure_response( array( 'success' => true ) );
+	}
+
+	/**
+	 * Check permissions for updating the current user's notification preference.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function notification_preference_permissions_check() {
+		if ( ! is_user_logged_in() ) {
+			return new \WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in.', 'wporg-groups-frontend' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! is_user_member_of_blog() ) {
+			return new \WP_Error(
+				'not_a_member',
+				__( 'You are not a member of this group.', 'wporg-groups-frontend' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update the current user's GatherPress event email preference.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response
+	 */
+	public function update_notification_preference( $request ) {
+		$opt_in = (bool) $request->get_param( 'opt_in' );
+
+		update_user_meta(
+			get_current_user_id(),
+			'gatherpress_event_updates_opt_in',
+			$opt_in ? 1 : 0
+		);
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'optIn'   => $opt_in,
+			)
+		);
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -23,13 +23,17 @@ if ( $is_member ) {
 	$role_label = $labels[ $user_role ] ?? __( 'Member', 'wporg-groups-frontend' );
 }
 
-$is_organiser    = in_array( $user_role, array( 'administrator', 'editor' ), true );
-$user_count      = count_users( 'time', get_current_blog_id() );
-$member_count    = $user_count['total_users'] ?? 0;
-$join_api        = rest_url( 'wporg-groups/v1/members/join' );
-$leave_api       = rest_url( 'wporg-groups/v1/members/leave' );
-$login_url       = wp_login_url( get_permalink() ?: home_url() );
-$count_label     = sprintf(
+$is_organiser        = in_array( $user_role, array( 'administrator', 'editor' ), true );
+$user_count          = count_users( 'time', get_current_blog_id() );
+$member_count        = $user_count['total_users'] ?? 0;
+$join_api            = rest_url( 'wporg-groups/v1/members/join' );
+$leave_api           = rest_url( 'wporg-groups/v1/members/leave' );
+$preference_api      = rest_url( 'wporg-groups/v1/members/notification-preference' );
+$login_url           = wp_login_url( get_permalink() ?: home_url() );
+$notification_opt_in = $is_member
+	? \GatherPress\Core\User::get_instance()->has_event_updates_opt_in( get_current_user_id() )
+	: false;
+$count_label         = sprintf(
 	_n( '%s member', '%s members', $member_count, 'wporg-groups-frontend' ),
 	number_format_i18n( $member_count )
 );
@@ -46,8 +50,17 @@ $context = array(
 	'leaveConfirm' => __( 'Leave this group?', 'wporg-groups-frontend' ),
 	'joinApi'       => $join_api,
 	'leaveApi'      => $leave_api,
+	'preferenceApi' => $preference_api,
+	'restNonce'     => wp_create_nonce( 'wp_rest' ),
 	'loginUrl'      => $login_url,
 	'loading'       => false,
+	'notificationOptIn'     => $notification_opt_in,
+	'preferenceSaving'      => false,
+	'preferenceMessage'     => '',
+	'preferenceNoticeSuccess' => false,
+	'preferenceNoticeError'   => false,
+	'preferenceSavedLabel'  => __( 'Email preference saved.', 'wporg-groups-frontend' ),
+	'preferenceErrorLabel'  => __( 'The email preference could not be saved. Please try again.', 'wporg-groups-frontend' ),
 );
 
 wp_interactivity_state(
@@ -99,4 +112,30 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		);
 		?>
 	</span>
+
+	<?php if ( $is_member ) : ?>
+		<div class="wporg-group-membership__preference">
+			<label>
+				<input
+					type="checkbox"
+					<?php checked( $notification_opt_in ); ?>
+					data-wp-on--change="actions.updateNotificationPreference"
+					data-wp-bind--checked="context.notificationOptIn"
+					data-wp-bind--disabled="context.preferenceSaving"
+				/>
+				<span><?php esc_html_e( 'Email me updates and information about events from organisers.', 'wporg-groups-frontend' ); ?></span>
+			</label>
+			<span class="wporg-group-membership__preference-help">
+				<?php esc_html_e( 'This preference applies to all your groups.', 'wporg-groups-frontend' ); ?>
+			</span>
+			<span
+				class="wporg-group-membership__preference-status"
+				role="status"
+				aria-live="polite"
+				data-wp-text="context.preferenceMessage"
+				data-wp-class--is-success="context.preferenceNoticeSuccess"
+				data-wp-class--is-error="context.preferenceNoticeError"
+			></span>
+		</div>
+	<?php endif; ?>
 </div>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/style.css
@@ -44,3 +44,69 @@
 	font-size: 13px;
 	color: #656a71;
 }
+
+.wporg-group-membership__preference {
+	display: flex;
+	flex-basis: 100%;
+	flex-direction: column;
+	gap: 2px;
+	font-size: 13px;
+}
+
+.wporg-group-membership__preference label {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	color: #1a1919;
+	cursor: pointer;
+}
+
+.wporg-group-membership__preference input {
+	margin-top: 3px;
+}
+
+.wporg-group-membership__preference-help {
+	padding-left: 24px;
+	color: #656a71;
+}
+
+.wporg-group-membership__preference-status:empty {
+	display: none;
+}
+
+.wporg-group-membership__preference-status:not(:empty) {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	margin-top: 10px;
+	padding: 12px 16px;
+	border: 1px solid;
+	border-radius: 2px;
+	font-weight: 600;
+	text-align: center;
+}
+
+.wporg-group-membership__preference-status.is-success {
+	border-color: #00a32a;
+	background: #edfaef;
+	color: #1a1919;
+}
+
+.wporg-group-membership__preference-status.is-success::before {
+	content: "\2713";
+	font-size: 18px;
+	line-height: 1;
+}
+
+.wporg-group-membership__preference-status.is-error {
+	border-color: #d63638;
+	background: #fcf0f1;
+	color: #8a2424;
+}
+
+.wporg-group-membership__preference-status.is-error::before {
+	content: "!";
+	font-size: 18px;
+	line-height: 1;
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/view.js
@@ -48,7 +48,7 @@ store( 'wporg/group-membership', {
 				const resp = await fetch( ctx.joinApi, {
 					method: 'POST',
 					credentials: 'same-origin',
-					headers: { 'X-WP-Nonce': await getNonce() },
+					headers: { 'X-WP-Nonce': await getNonce( ctx ) },
 				} );
 
 				const data = await resp.json();
@@ -84,7 +84,7 @@ store( 'wporg/group-membership', {
 				const resp = await fetch( ctx.leaveApi, {
 					method: 'DELETE',
 					credentials: 'same-origin',
-					headers: { 'X-WP-Nonce': await getNonce() },
+					headers: { 'X-WP-Nonce': await getNonce( ctx ) },
 				} );
 
 				const data = await resp.json();
@@ -100,13 +100,62 @@ store( 'wporg/group-membership', {
 				ctx.loading = false;
 			}
 		},
+
+		async updateNotificationPreference( event ) {
+			const ctx = getContext();
+
+			if ( ! ctx.isMember || ctx.preferenceSaving ) {
+				return;
+			}
+
+			const previousValue = ctx.notificationOptIn;
+			const optIn = Boolean( event.target.checked );
+
+			ctx.notificationOptIn = optIn;
+			ctx.preferenceSaving = true;
+			ctx.preferenceMessage = '';
+			ctx.preferenceNoticeSuccess = false;
+			ctx.preferenceNoticeError = false;
+
+			try {
+				const resp = await fetch( ctx.preferenceApi, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': await getNonce( ctx ),
+					},
+					body: JSON.stringify( { opt_in: optIn } ),
+				} );
+
+				const data = await resp.json();
+
+				if ( ! resp.ok || ! data.success ) {
+					throw new Error( 'Unable to save email preference.' );
+				}
+
+				ctx.notificationOptIn = Boolean( data.optIn );
+				ctx.preferenceMessage = ctx.preferenceSavedLabel;
+				ctx.preferenceNoticeSuccess = true;
+			} catch {
+				ctx.notificationOptIn = previousValue;
+				ctx.preferenceMessage = ctx.preferenceErrorLabel;
+				ctx.preferenceNoticeError = true;
+			} finally {
+				ctx.preferenceSaving = false;
+			}
+		},
 	},
 } );
 
 let cachedNonce = null;
 
-async function getNonce() {
+async function getNonce( ctx ) {
 	if ( cachedNonce ) {
+		return cachedNonce;
+	}
+	if ( ctx.restNonce ) {
+		cachedNonce = ctx.restNonce;
 		return cachedNonce;
 	}
 	if ( window.wpApiSettings?.nonce ) {


### PR DESCRIPTION
Fixes #1789.

Adds a front-end email-update preference for group members, reusing GatherPress's existing global user preference and filter-aware default. Includes an authenticated save endpoint and success/error feedback.

### Testing

1. Run `npm run build`, sign in as a member, and visit https://events.wordpress.test/group/sunshine-coast-qld/.
2. Toggle the email preference and confirm the saved notice appears.

    <kbd><img width="650" height="630" alt="image" src="https://github.com/user-attachments/assets/f06e7445-3711-4b91-8b4f-50eda250be4d" /></kbd>

4. Reload and confirm the preference persists.
5. Change the existing GatherPress setting at https://events.wordpress.test/group/sunshine-coast-qld/wp-admin/profile.php and confirm the front-end value stays in sync.

    <kbd><img width="783" height="465" alt="image" src="https://github.com/user-attachments/assets/dafcb806-1148-46b5-8a2b-a96ae0ae1599" /></kbd>

6. Sign out or use a non-member account and confirm the control is hidden.

    <kbd><img width="612" height="548" alt="image" src="https://github.com/user-attachments/assets/0f445a9f-2ba9-4049-8ca9-b7f07cf04fd4" /></kbd>