### PR TITLE
Groups: let organizers message all members

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -45,6 +45,7 @@ import { parse, serialize } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import VenueEditor from './venue-editor';
+import MessageMembersModal from './message-members-modal';
 
 const NS =
 	( window.wporgGroupsEventModal &&
@@ -789,6 +790,13 @@ const NS =
 
 		if ( ! state.open ) {
 			return null;
+		}
+
+		if ( state.mode === 'message-all' ) {
+			return h( MessageMembersModal, {
+				eventId: state.eventId,
+				onClose: () => setState( { open: false, mode: 'create', eventId: 0 } ),
+			} );
 		}
 
 		return h( EventModal, {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/message-members-modal.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/message-members-modal.js
@@ -1,0 +1,117 @@
+/**
+ * Modal for sending an event-related message to all group members.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Modal, Notice, TextareaControl } from '@wordpress/components';
+import { createElement as h, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export default function MessageMembersModal( { eventId, onClose } ) {
+	const [ message, setMessage ] = useState( '' );
+	const [ sending, setSending ] = useState( false );
+	const [ error, setError ] = useState( '' );
+	const [ sent, setSent ] = useState( false );
+
+	const onSubmit = ( event ) => {
+		event.preventDefault();
+		setSending( true );
+		setError( '' );
+
+		apiFetch( {
+			path: '/gatherpress/v1/event/email',
+			method: 'POST',
+			data: {
+				post_id: eventId,
+				message,
+				send: {
+					all: true,
+					attending: false,
+					waiting_list: false,
+					not_attending: false,
+				},
+			},
+		} )
+			.then( ( response ) => {
+				if ( ! response?.success ) {
+					throw new Error( __( 'The message could not be scheduled.', 'wporg-groups-frontend' ) );
+				}
+
+				setSent( true );
+				setSending( false );
+			} )
+			.catch( ( requestError ) => {
+				setSending( false );
+				setError(
+					requestError?.message || __( 'The message could not be scheduled.', 'wporg-groups-frontend' )
+				);
+			} );
+	};
+
+	return h(
+		Modal,
+		{
+			title: __( 'Message all members', 'wporg-groups-frontend' ),
+			onRequestClose: onClose,
+			className: 'wporg-groups-message-modal',
+			shouldCloseOnClickOutside: false,
+		},
+		sent
+			? h(
+					'div',
+					{ className: 'wporg-groups-message-modal__success' },
+					h(
+						Notice,
+						{ status: 'success', isDismissible: false },
+						__( 'Your message has been scheduled for delivery.', 'wporg-groups-frontend' )
+					),
+					h( Button, { variant: 'primary', onClick: onClose }, __( 'Close', 'wporg-groups-frontend' ) )
+			  )
+			: h(
+					'form',
+					{ onSubmit, className: 'wporg-groups-message-modal__form' },
+					error && h( Notice, { status: 'error', isDismissible: false }, error ),
+					h(
+						'p',
+						{},
+						__(
+							'This message will be emailed to every opted-in member of this group.',
+							'wporg-groups-frontend'
+						)
+					),
+					h( TextareaControl, {
+						label: __( 'Message', 'wporg-groups-frontend' ),
+						value: message,
+						onChange: setMessage,
+						required: true,
+						rows: 8,
+						__nextHasNoMarginBottom: true,
+					} ),
+					h(
+						'div',
+						{ className: 'wporg-groups-message-modal__actions' },
+						h(
+							Button,
+							{
+								variant: 'tertiary',
+								onClick: onClose,
+								disabled: sending,
+							},
+							__( 'Cancel', 'wporg-groups-frontend' )
+						),
+						h(
+							Button,
+							{
+								variant: 'primary',
+								type: 'submit',
+								isBusy: sending,
+								disabled: sending || ! message.trim(),
+							},
+							__( 'Send message', 'wporg-groups-frontend' )
+						)
+					)
+			  )
+	);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
@@ -9,6 +9,7 @@
  */
 
 use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_events;
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group_settings;
 use function WordCamp\Groups\Frontend\REST\current_user_can_edit_event;
 
 if ( ! current_user_can_manage_events() ) {
@@ -42,6 +43,8 @@ if ( $show_edit && ( ! $event_post_id || ! current_user_can_edit_event( $event_p
 	$show_edit = false;
 }
 
+$show_edit_button = $show_edit && ! current_user_can_manage_group_settings();
+
 if ( ! $show_edit && ! $show_create ) {
 	return;
 }
@@ -51,13 +54,22 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<?php if ( $show_edit && $event_post_id ) : ?>
+	<?php if ( $show_edit_button && $event_post_id ) : ?>
 		<button
 			type="button"
 			class="wporg-event-manage__button wporg-event-manage__button--edit wp-element-button"
 			data-wporg-groups-modal="edit"
 			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
 		>&#9998; <?php esc_html_e( 'Edit this event', 'wporg-groups-frontend' ); ?></button>
+	<?php endif; ?>
+
+	<?php if ( $show_edit && $event_post_id ) : ?>
+		<button
+			type="button"
+			class="wporg-event-manage__button wporg-event-manage__button--message wp-element-button"
+			data-wporg-groups-modal="message-all"
+			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
+		><?php esc_html_e( 'Message all members', 'wporg-groups-frontend' ); ?></button>
 	<?php endif; ?>
 
 	<?php if ( $show_create ) : ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -4,6 +4,12 @@
 
 /* === Trigger buttons === */
 
+.wporg-event-manage {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .wporg-event-manage__button {
 	font-size: 14px;
 	cursor: pointer;
@@ -19,6 +25,38 @@
 	border-color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
 	color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
 	background: var(--wp--preset--color--blueberry-4, #eff2ff) !important;
+}
+
+.wporg-event-manage__button--message {
+	background: transparent !important;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9) !important;
+	color: var(--wp--preset--color--charcoal-3, #40464d) !important;
+}
+
+.wporg-event-manage__button--message:hover {
+	border-color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
+	color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
+	background: var(--wp--preset--color--blueberry-4, #eff2ff) !important;
+}
+
+/* === Message members modal === */
+
+.wporg-groups-message-modal .components-modal__content {
+	padding: 24px 32px 32px;
+}
+
+.wporg-groups-message-modal__form,
+.wporg-groups-message-modal__success {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	min-width: min(520px, 75vw);
+}
+
+.wporg-groups-message-modal__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
 }
 
 /* === Modal — override wp-components Modal defaults === */

--- a/public_html/wp-content/themes/groups-site/templates/single-event.html
+++ b/public_html/wp-content/themes/groups-site/templates/single-event.html
@@ -51,6 +51,8 @@
 
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
 
+			<!-- wp:wporg/event-manage {"lock":{"move":true,"remove":true},"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
+
 			<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
 
 			<!-- wp:wporg/event-speakers {"lock":{"move":true,"remove":true},"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /-->


### PR DESCRIPTION
Fixes #1771.

Adds a front-end **Message all members** modal for editable events and calls GatherPress's existing email route with its All Members segment. GatherPress continues to enforce permissions, group-scoped recipients, member opt-ins, and asynchronous delivery.

### Testing

1. Run `npm run build`, sign in as an organizer, and open https://events.wordpress.test/group/sunshine-coast-qld/event/revolution-101/.

   <kbd><img width="448" height="321" alt="image" src="https://github.com/user-attachments/assets/793c4a62-211a-41de-86b3-e432f8ba189f" /></kbd>

3. Send a unique message and confirm the modal displays **“Your message has been scheduled for delivery.”**

    <kbd><img width="620" height="501" alt="image" src="https://github.com/user-attachments/assets/adfd24f6-1590-4247-80ed-5d3e2ab373ee" /></kbd>

    <kbd><img width="623" height="274" alt="image" src="https://github.com/user-attachments/assets/277aa85c-9f60-4d87-95fd-1b62c1cee978" /></kbd>

5. Run `docker compose exec wordcamp.test wp cron event run --due-now`.
6. Open http://localhost:1080 and confirm only opted-in Sunshine Coast members received it.

    <kbd><img width="756" height="565" alt="image" src="https://github.com/user-attachments/assets/19e787da-8a39-429c-8043-d8a4ec5212f7" /></kbd>

7. Sign in as an ordinary member and confirm the action is hidden.
