### PR TITLE
Groups: let organizers message event attendees

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -819,9 +819,10 @@ const NS =
 			return null;
 		}
 
-		if ( state.mode === 'message-all' ) {
+		if ( [ 'message-all', 'message-attendees' ].includes( state.mode ) ) {
 			return h( MessageMembersModal, {
 				eventId: state.eventId,
+				recipientMode: state.mode,
 				onClose: () => setState( { open: false, mode: 'create', eventId: 0 } ),
 			} );
 		}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/message-members-modal.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/message-members-modal.js
@@ -5,15 +5,30 @@
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Modal, Notice, TextareaControl } from '@wordpress/components';
+import { Button, CheckboxControl, Modal, Notice, TextareaControl } from '@wordpress/components';
 import { createElement as h, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-export default function MessageMembersModal( { eventId, onClose } ) {
+export default function MessageMembersModal( { eventId, recipientMode, onClose } ) {
+	const isAllMembers = 'message-all' === recipientMode;
 	const [ message, setMessage ] = useState( '' );
+	const [ recipients, setRecipients ] = useState( {
+		attending: true,
+		waiting_list: false,
+		not_attending: false,
+	} );
 	const [ sending, setSending ] = useState( false );
 	const [ error, setError ] = useState( '' );
 	const [ sent, setSent ] = useState( false );
+	const hasRecipients =
+		isAllMembers || recipients.attending || recipients.waiting_list || recipients.not_attending;
+
+	const updateRecipient = ( status, checked ) => {
+		setRecipients( ( current ) => ( {
+			...current,
+			[ status ]: checked,
+		} ) );
+	};
 
 	const onSubmit = ( event ) => {
 		event.preventDefault();
@@ -27,10 +42,10 @@ export default function MessageMembersModal( { eventId, onClose } ) {
 				post_id: eventId,
 				message,
 				send: {
-					all: true,
-					attending: false,
-					waiting_list: false,
-					not_attending: false,
+					all: isAllMembers,
+					attending: ! isAllMembers && recipients.attending,
+					waiting_list: ! isAllMembers && recipients.waiting_list,
+					not_attending: ! isAllMembers && recipients.not_attending,
 				},
 			},
 		} )
@@ -53,7 +68,9 @@ export default function MessageMembersModal( { eventId, onClose } ) {
 	return h(
 		Modal,
 		{
-			title: __( 'Message all members', 'wporg-groups-frontend' ),
+			title: isAllMembers
+				? __( 'Message all members', 'wporg-groups-frontend' )
+				: __( 'Message event attendees', 'wporg-groups-frontend' ),
 			onRequestClose: onClose,
 			className: 'wporg-groups-message-modal',
 			shouldCloseOnClickOutside: false,
@@ -76,11 +93,46 @@ export default function MessageMembersModal( { eventId, onClose } ) {
 					h(
 						'p',
 						{},
-						__(
-							'This message will be emailed to every opted-in member of this group.',
-							'wporg-groups-frontend'
-						)
+						isAllMembers
+							? __(
+									'This message will be emailed to every opted-in member of this group.',
+									'wporg-groups-frontend'
+							  )
+							: __(
+									'Choose which RSVP groups should receive this message.',
+									'wporg-groups-frontend'
+							  )
 					),
+					! isAllMembers &&
+						h(
+							'fieldset',
+							{ className: 'wporg-groups-message-modal__recipients' },
+							h( 'legend', {}, __( 'Recipients', 'wporg-groups-frontend' ) ),
+							h( CheckboxControl, {
+								label: __( 'Attending', 'wporg-groups-frontend' ),
+								checked: recipients.attending,
+								onChange: ( checked ) => updateRecipient( 'attending', checked ),
+								__nextHasNoMarginBottom: true,
+							} ),
+							h( CheckboxControl, {
+								label: __( 'Waiting list', 'wporg-groups-frontend' ),
+								checked: recipients.waiting_list,
+								onChange: ( checked ) => updateRecipient( 'waiting_list', checked ),
+								__nextHasNoMarginBottom: true,
+							} ),
+							h( CheckboxControl, {
+								label: __( 'Not attending', 'wporg-groups-frontend' ),
+								checked: recipients.not_attending,
+								onChange: ( checked ) => updateRecipient( 'not_attending', checked ),
+								__nextHasNoMarginBottom: true,
+							} )
+						),
+					! hasRecipients &&
+						h(
+							Notice,
+							{ status: 'warning', isDismissible: false },
+							__( 'Select at least one RSVP group.', 'wporg-groups-frontend' )
+						),
 					h( TextareaControl, {
 						label: __( 'Message', 'wporg-groups-frontend' ),
 						value: message,
@@ -107,7 +159,7 @@ export default function MessageMembersModal( { eventId, onClose } ) {
 								variant: 'primary',
 								type: 'submit',
 								isBusy: sending,
-								disabled: sending || ! message.trim(),
+								disabled: sending || ! message.trim() || ! hasRecipients,
 							},
 							__( 'Send message', 'wporg-groups-frontend' )
 						)

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
@@ -70,6 +70,13 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			data-wporg-groups-modal="message-all"
 			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
 		><?php esc_html_e( 'Message all members', 'wporg-groups-frontend' ); ?></button>
+
+		<button
+			type="button"
+			class="wporg-event-manage__button wporg-event-manage__button--message wp-element-button"
+			data-wporg-groups-modal="message-attendees"
+			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
+		><?php esc_html_e( 'Message attendees', 'wporg-groups-frontend' ); ?></button>
 	<?php endif; ?>
 
 	<?php if ( $show_create ) : ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -59,6 +59,19 @@
 	gap: 12px;
 }
 
+.wporg-groups-message-modal__recipients {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 16px;
+	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
+}
+
+.wporg-groups-message-modal__recipients legend {
+	padding: 0 4px;
+	font-weight: 600;
+}
+
 /* === Modal — override wp-components Modal defaults === */
 
 .wporg-groups-event-modal .components-modal__content {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * @group groups
+ *
+ * Covers the `wporg/event-manage` block's server-side render (render.php),
+ * specifically the "Message all members" / "Message attendees" buttons
+ * added alongside the RSVP-segmented messaging feature (#1822).
+ */
+class Test_Event_Manage_Block extends Groups_TestCase {
+
+	/**
+	 * Creates a published `gatherpress_event` post owned by the given user
+	 * and points the main query at its single view, matching the real
+	 * front-end context the render.php callback runs in.
+	 */
+	private function go_to_event_owned_by( int $author_id ): int {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			)
+		);
+
+		// A plain `?p=` query bypasses CPT rewrite-rule resolution, which
+		// isn't flushed for this fixture blog's freshly-registered
+		// `gatherpress_event` post type — matches how WP core's own test
+		// suite typically visits non-`post` singulars.
+		$this->go_to( home_url( "?p={$event_id}&post_type=gatherpress_event" ) );
+
+		return $event_id;
+	}
+
+	/**
+	 * An Organiser (editor) viewing any event, including one they don't
+	 * own, sees both messaging buttons — editors can edit any event via
+	 * `edit_others_posts`.
+	 */
+	public function test_message_buttons_rendered_for_organiser() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$event_id = $this->go_to_event_owned_by( $owner_id );
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
+
+		$this->assertStringContainsString( 'data-wporg-groups-modal="message-all"', $output );
+		$this->assertStringContainsString( 'data-wporg-groups-modal="message-attendees"', $output );
+		$this->assertStringContainsString( (string) $event_id, $output );
+	}
+
+	/**
+	 * An Event Organiser (author) viewing their own event sees both
+	 * messaging buttons.
+	 */
+	public function test_message_buttons_rendered_for_event_organiser_on_own_event() {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$this->go_to_event_owned_by( $author_id );
+
+		wp_set_current_user( $author_id );
+
+		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
+
+		$this->assertStringContainsString( 'data-wporg-groups-modal="message-all"', $output );
+		$this->assertStringContainsString( 'data-wporg-groups-modal="message-attendees"', $output );
+	}
+
+	/**
+	 * IDOR check mirroring `test_author_cannot_edit_another_authors_event`
+	 * in test-rest.php: an Event Organiser (author) viewing another
+	 * author's event lacks `edit_post` on it, so `$show_edit` is false and
+	 * neither messaging button — nor any other management UI — should
+	 * render, even though this author otherwise passes
+	 * `current_user_can_manage_events()`.
+	 */
+	public function test_message_buttons_absent_for_event_organiser_on_others_event() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$this->go_to_event_owned_by( $owner_id );
+
+		$other_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $other_author_id );
+
+		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
+
+		$this->assertStringNotContainsString( 'data-wporg-groups-modal="message-all"', $output );
+		$this->assertStringNotContainsString( 'data-wporg-groups-modal="message-attendees"', $output );
+	}
+
+	/**
+	 * An ordinary Member (subscriber) — including one viewing the event
+	 * they're RSVP'd to — never sees any event-management UI at all, per
+	 * `current_user_can_manage_events()`'s early return.
+	 */
+	public function test_message_buttons_absent_for_member() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$this->go_to_event_owned_by( $owner_id );
+
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
+
+		$this->assertSame( '', trim( (string) $output ) );
+	}
+
+	/**
+	 * A logged-out visitor sees no management UI either.
+	 */
+	public function test_message_buttons_absent_for_anonymous_visitor() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$this->go_to_event_owned_by( $owner_id );
+
+		wp_set_current_user( 0 );
+
+		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
+
+		$this->assertSame( '', trim( (string) $output ) );
+	}
+}

--- a/tests/e2e/event-manage-messaging.spec.js
+++ b/tests/e2e/event-manage-messaging.spec.js
@@ -1,0 +1,149 @@
+const { test, expect } = require( '@playwright/test' );
+const { login } = require( './utils/login' );
+
+/**
+ * The `wporg/event-manage` block's "Message attendees" action (#1822),
+ * stacked on top of the pre-existing "Message all members" action (#1821).
+ *
+ * Requires the `eventorganiser1` / `password` and `member1` / `password`
+ * test users from the groups-gatherpress-compat-test skill's
+ * environment-setup step.
+ */
+test.describe( 'event manage — message attendees', () => {
+	/**
+	 * Creates a fresh event as `eventorganiser1` via the wp-admin block
+	 * editor (same flow as event-organiser.spec.js) and returns its
+	 * front-end permalink, so this spec doesn't depend on any
+	 * hand-seeded event data.
+	 *
+	 * @param {import('@playwright/test').Page} page
+	 */
+	async function createEventAsOrganiser( page ) {
+		await login( page, 'eventorganiser1', 'password' );
+
+		await page.goto( 'wp-admin/post-new.php?post_type=gatherpress_event' );
+		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 20000 } );
+
+		const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
+		try {
+			await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
+			await page.keyboard.press( 'Escape' );
+		} catch {
+			// Guide didn't appear (already dismissed for this user) — nothing to do.
+		}
+
+		const title = `Messaging Test Event ${ Date.now() }`;
+		const editorCanvas = page.locator( 'iframe[name="editor-canvas"]' ).contentFrame();
+		await editorCanvas.getByRole( 'textbox', { name: 'Add title' } ).fill( title );
+		await editorCanvas.getByRole( 'textbox', { name: 'Add title' } ).press( 'Tab' );
+
+		const publishButton = page
+			.getByLabel( 'Editor top bar' )
+			.getByRole( 'button', { name: 'Publish', exact: true } );
+		await expect( publishButton ).toBeEnabled( { timeout: 10000 } );
+		await publishButton.click();
+
+		const confirmPublishButton = page
+			.getByLabel( 'Editor publish' )
+			.getByRole( 'button', { name: 'Publish', exact: true } );
+		await expect( confirmPublishButton ).toBeEnabled( { timeout: 10000 } );
+		await confirmPublishButton.click();
+
+		await expect( page.getByTestId( 'snackbar' ).getByText( 'Event published.' ) ).toBeVisible( {
+			timeout: 15000,
+		} );
+
+		// The homepage's "Upcoming events" widget is capped and, on a
+		// long-lived dev DB, fills up with same-day events from prior test
+		// runs — a newly published event isn't guaranteed a slot in it.
+		// The post id in the editor's URL is a direct, deterministic way to
+		// reach the permalink instead.
+		const editUrl = new URL( page.url() );
+		const postId = editUrl.searchParams.get( 'post' );
+		await page.goto( `?p=${ postId }&post_type=gatherpress_event` );
+		await page.waitForLoadState( 'networkidle' );
+
+		return page.url();
+	}
+
+	test( 'recipient checkboxes are independently selectable, require at least one, and send succeeds', async ( {
+		page,
+	} ) => {
+		test.slow(); // Shares the block editor's cold-boot cost from createEventAsOrganiser().
+
+		await createEventAsOrganiser( page );
+
+		await page.getByRole( 'button', { name: 'Message attendees' } ).click();
+
+		const modal = page.getByRole( 'dialog', { name: 'Message event attendees' } );
+		await expect( modal ).toBeVisible();
+
+		const attending = modal.getByRole( 'checkbox', { name: 'Attending', exact: true } );
+		const waitingList = modal.getByRole( 'checkbox', { name: 'Waiting list' } );
+		const notAttending = modal.getByRole( 'checkbox', { name: 'Not attending' } );
+		const sendButton = modal.getByRole( 'button', { name: 'Send message' } );
+
+		// "Attending" is checked by default; the others are not.
+		await expect( attending ).toBeChecked();
+		await expect( waitingList ).not.toBeChecked();
+		await expect( notAttending ).not.toBeChecked();
+
+		// Unchecking every recipient shows the validation notice and
+		// disables sending, even with a non-empty message.
+		await attending.uncheck();
+		await modal.getByLabel( 'Message' ).fill( 'This should not be sendable.' );
+		await expect( modal.getByText( 'Select at least one RSVP group.' ) ).toBeVisible();
+		await expect( sendButton ).toBeDisabled();
+
+		// Waiting list and Not attending can both be checked at once,
+		// independently of Attending — this is the core behavior #1822
+		// adds over the previous all-or-nothing "Message all members".
+		await waitingList.check();
+		await notAttending.check();
+		await expect( waitingList ).toBeChecked();
+		await expect( notAttending ).toBeChecked();
+		await expect( attending ).not.toBeChecked();
+		await expect( modal.getByText( 'Select at least one RSVP group.' ) ).toBeHidden();
+
+		// Reset to "Attending" only, matching the PR's own test plan, and send.
+		await waitingList.uncheck();
+		await notAttending.uncheck();
+		await attending.check();
+
+		const uniqueMessage = `E2E attendees-only message ${ Date.now() }`;
+		await modal.getByLabel( 'Message' ).fill( uniqueMessage );
+		await expect( sendButton ).toBeEnabled();
+		await sendButton.click();
+
+		await expect( modal.getByText( 'Your message has been scheduled for delivery.' ) ).toBeVisible();
+	} );
+
+	test( 'Message all members has no recipient checkboxes', async ( { page } ) => {
+		test.slow();
+
+		await createEventAsOrganiser( page );
+
+		await page.getByRole( 'button', { name: 'Message all members' } ).click();
+
+		const modal = page.getByRole( 'dialog', { name: 'Message all members' } );
+		await expect( modal ).toBeVisible();
+		await expect(
+			modal.getByText( 'This message will be emailed to every opted-in member of this group.' )
+		).toBeVisible();
+		await expect( modal.getByRole( 'checkbox' ) ).toHaveCount( 0 );
+	} );
+
+	test( 'an ordinary member sees neither messaging action', async ( { page, browser } ) => {
+		test.slow();
+
+		const organiserPage = await ( await browser.newContext() ).newPage();
+		const eventUrl = await createEventAsOrganiser( organiserPage );
+		await organiserPage.close();
+
+		await login( page, 'member1', 'password' );
+		await page.goto( eventUrl );
+
+		await expect( page.getByRole( 'button', { name: 'Message all members' } ) ).toHaveCount( 0 );
+		await expect( page.getByRole( 'button', { name: 'Message attendees' } ) ).toHaveCount( 0 );
+	} );
+} );


### PR DESCRIPTION
Fixes #1772.

Stacked on #1821.

Adds a front-end **Message attendees** action with independently selectable Attending, Waiting list, and Not attending segments. It reuses GatherPress's existing email route, permissions, RSVP recipient resolution—including anonymous RSVPs—opt-in enforcement, and asynchronous delivery.

### Testing

1. Run `npm run build`, sign in as an organizer, and open a test event, for example https://events.wordpress.test/group/sunshine-coast-qld/event/revolution-101/.

    <kbd><img width="461" height="347" alt="image" src="https://github.com/user-attachments/assets/b2a3aa41-d529-4397-aab7-7a9cc7551759" /></kbd>

3. Open **Message attendees** and confirm all three RSVP segments can be selected independently and at least one is required.

    <kbd><img width="640" height="680" alt="image" src="https://github.com/user-attachments/assets/87957b40-2266-4849-bb48-3c8f13c5e86b" /></kbd>

4. Send a unique message to Attending and confirm **“Your message has been scheduled for delivery.”**

    <kbd><img width="623" height="271" alt="image" src="https://github.com/user-attachments/assets/ec8212f7-525a-43ff-a79f-6cc9eb13f4e9" /></kbd>

5. Run `docker compose exec wordcamp.test wp cron event run --due-now`.
6. Open http://localhost:1080 and confirm only opted-in attendees received it.

    <kbd><img width="1276" height="485" alt="image" src="https://github.com/user-attachments/assets/e5ffab32-baca-4968-b06f-555f3657b0fa" /></kbd>

7. Sign in as an ordinary member and confirm the action is hidden.
