### PR TITLE
Restrict groups-site theme (and future network-specific themes) to its network

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -33,6 +33,7 @@ function manually_load_plugins() {
 	require_once dirname( __DIR__ ) . '/latest-site-hints.php';
 	require_once dirname( __DIR__ ) . '/trusted-deputy-capabilities.php';
 	require_once dirname( __DIR__ ) . '/wcorg-subroles.php';
+	require_once dirname( __DIR__ ) . '/wcorg-network-theme-control.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/mu-plugins/tests/test-wcorg-network-theme-control.php
+++ b/public_html/wp-content/mu-plugins/tests/test-wcorg-network-theme-control.php
@@ -32,13 +32,22 @@ class Test_WCORG_Network_Theme_Control extends Groups_TestCase {
 		search_theme_directories( true );
 	}
 
+	/**
+	 * Stash the current network global, so `set_current_network()` can
+	 * restore it in `tearDown()`.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->original_current_site = $GLOBALS['current_site'];
 	}
 
+	/**
+	 * Restore the network global that `set_current_network()` overwrote,
+	 * so state doesn't leak into other tests.
+	 */
 	protected function tearDown(): void {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring original state.
 		$GLOBALS['current_site'] = $this->original_current_site;
 
 		parent::tearDown();
@@ -54,6 +63,7 @@ class Test_WCORG_Network_Theme_Control extends Groups_TestCase {
 	 * `switch_to_blog()` alone.
 	 */
 	private function set_current_network( int $network_id ) {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Necessary for testing multisite global state.
 		$GLOBALS['current_site'] = get_network( $network_id );
 	}
 
@@ -106,7 +116,7 @@ class Test_WCORG_Network_Theme_Control extends Groups_TestCase {
 		$this->assertNotSame( 'groups-site', get_stylesheet() );
 		$this->assertSame( $previous_stylesheet, get_stylesheet() );
 
-		switch_theme( $previous_stylesheet );
+		// Already back on $previous_stylesheet -- the backstop reverted it above.
 		restore_current_blog();
 	}
 
@@ -124,6 +134,9 @@ class Test_WCORG_Network_Theme_Control extends Groups_TestCase {
 
 		$this->assertSame( 'groups-site', get_stylesheet() );
 
+		// Restore the previous theme and let the deferred switch clear itself,
+		// so the `theme_switched` option doesn't leak into other tests.
 		switch_theme( $previous_stylesheet );
+		check_theme_switched();
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-wcorg-network-theme-control.php
+++ b/public_html/wp-content/mu-plugins/tests/test-wcorg-network-theme-control.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use function WordCamp\Themes\Network\filter_prepared_themes;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/../wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group mu-plugins
+ * @group groups
+ */
+class Test_WCORG_Network_Theme_Control extends Groups_TestCase {
+	/**
+	 * @var \WP_Network
+	 */
+	private $original_current_site;
+
+	/**
+	 * `groups-site` (and its `wporg-parent-2021` parent) only exist in this
+	 * repo's `wp-content/themes`, not in the vanilla WP install that the
+	 * test suite runs against. Register the real theme directory so
+	 * `switch_theme( 'groups-site' )` resolves to the actual theme instead
+	 * of a nonexistent one.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		register_theme_directory( SUT_WP_CONTENT_DIR . 'themes' );
+		search_theme_directories( true );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_current_site = $GLOBALS['current_site'];
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['current_site'] = $this->original_current_site;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * `get_current_network_id()` reflects `$GLOBALS['current_site']`, i.e.
+	 * the network the request was bootstrapped for -- it does *not* change
+	 * when `switch_to_blog()` moves to a site on a different network.
+	 * That matches WordCamp.org's real architecture (each network is a
+	 * separate domain/request), so simulate "being on network X" by
+	 * swapping this global directly, rather than relying on
+	 * `switch_to_blog()` alone.
+	 */
+	private function set_current_network( int $network_id ) {
+		$GLOBALS['current_site'] = get_network( $network_id );
+	}
+
+	/**
+	 * @covers \WordCamp\Themes\Network\filter_prepared_themes()
+	 */
+	public function test_restricted_theme_hidden_on_wrong_network() {
+		$this->set_current_network( WORDCAMP_NETWORK_ID );
+
+		$prepared = filter_prepared_themes( array(
+			'groups-site'     => array( 'id' => 'groups-site' ),
+			'twentytwentyone' => array( 'id' => 'twentytwentyone' ),
+		) );
+
+		$this->assertArrayNotHasKey( 'groups-site', $prepared );
+		$this->assertArrayHasKey( 'twentytwentyone', $prepared );
+	}
+
+	/**
+	 * @covers \WordCamp\Themes\Network\filter_prepared_themes()
+	 */
+	public function test_restricted_theme_visible_on_its_own_network() {
+		$this->set_current_network( GROUPS_NETWORK_ID );
+
+		$prepared = filter_prepared_themes( array(
+			'groups-site'     => array( 'id' => 'groups-site' ),
+			'twentytwentyone' => array( 'id' => 'twentytwentyone' ),
+		) );
+
+		$this->assertArrayHasKey( 'groups-site', $prepared );
+		$this->assertArrayHasKey( 'twentytwentyone', $prepared );
+	}
+
+	/**
+	 * `after_switch_theme` doesn't fire synchronously from `switch_theme()`
+	 * -- core defers it to `check_theme_switched()`, hooked on `init` at
+	 * priority 99, so it runs on the *next* WP load after the switch (see
+	 * `theme_switched` option). Call it directly to simulate that next load
+	 * within the same test.
+	 */
+	public function test_activation_on_wrong_network_is_reverted() {
+		switch_to_blog( self::$central_site_id );
+		$this->set_current_network( WORDCAMP_NETWORK_ID );
+
+		$previous_stylesheet = get_stylesheet();
+
+		switch_theme( 'groups-site' );
+		check_theme_switched();
+
+		$this->assertNotSame( 'groups-site', get_stylesheet() );
+		$this->assertSame( $previous_stylesheet, get_stylesheet() );
+
+		switch_theme( $previous_stylesheet );
+		restore_current_blog();
+	}
+
+	/**
+	 * @covers \WordCamp\Themes\Network\revert_wrong_network_activation()
+	 */
+	public function test_activation_on_its_own_network_is_not_reverted() {
+		// Groups_TestCase::setUp() already switches to the groups-network fixture site.
+		$this->set_current_network( GROUPS_NETWORK_ID );
+
+		$previous_stylesheet = get_stylesheet();
+
+		switch_theme( 'groups-site' );
+		check_theme_switched();
+
+		$this->assertSame( 'groups-site', get_stylesheet() );
+
+		switch_theme( $previous_stylesheet );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wcorg-network-theme-control.php
+++ b/public_html/wp-content/mu-plugins/wcorg-network-theme-control.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Plugin Name:        WordCamp.org Network Theme Control
+ * Plugin Description: Restrict certain themes to specific WordCamp.org networks.
+ *
+ * Some themes are built to run only within a certain network's ecosystem —
+ * e.g. `groups-site` depends on GatherPress post types and the groups-only
+ * mu-plugin tweaks (event ordering, non-public venues, timezone display).
+ * Nothing in WordPress core prevents a theme from being activated on any
+ * site across a shared multisite install, so without this guard, an admin
+ * on an unrelated WordCamp or Central site could switch to one of these
+ * themes and end up with a broken-looking site.
+ *
+ * Follows the same pattern as `wcorg-network-plugin-control.php`.
+ *
+ * @package WordCamp\Themes\Network
+ */
+
+namespace WordCamp\Themes\Network;
+
+defined( 'WPINC' ) || die();
+
+add_filter( 'wp_prepare_themes_for_js', __NAMESPACE__ . '\filter_prepared_themes' );
+add_action( 'after_switch_theme', __NAMESPACE__ . '\revert_wrong_network_activation', 10, 2 );
+
+/**
+ * Map of theme stylesheet slug => network ID it's restricted to.
+ *
+ * When adding a network-specific theme, add it here.
+ *
+ * @access private
+ *
+ * @return array
+ */
+function _get_network_restricted_themes() {
+	return array(
+		'groups-site' => GROUPS_NETWORK_ID,
+	);
+}
+
+/**
+ * Hide restricted themes from the Appearance > Themes grid on the wrong network.
+ *
+ * @param array $prepared_themes Keyed by theme stylesheet slug.
+ *
+ * @return array
+ */
+function filter_prepared_themes( $prepared_themes ) {
+	foreach ( _get_network_restricted_themes() as $stylesheet => $network_id ) {
+		if ( $network_id !== get_current_network_id() ) {
+			unset( $prepared_themes[ $stylesheet ] );
+		}
+	}
+
+	return $prepared_themes;
+}
+
+/**
+ * Hard backstop: revert the theme switch if a restricted theme was activated
+ * on the wrong network (e.g. via `wp theme activate`, code, or REST).
+ *
+ * @param string    $old_name  Name of the theme that was active before the switch.
+ * @param \WP_Theme $old_theme WP_Theme instance of the previous theme.
+ */
+function revert_wrong_network_activation( $old_name, $old_theme ) {
+	$restricted = _get_network_restricted_themes();
+	$stylesheet = get_stylesheet();
+
+	if ( ! isset( $restricted[ $stylesheet ] ) || $restricted[ $stylesheet ] === get_current_network_id() ) {
+		return;
+	}
+
+	switch_theme( $old_theme->get_stylesheet() );
+
+	add_action(
+		'admin_notices',
+		function () use ( $stylesheet ) {
+			printf(
+				'<div class="notice notice-error"><p>%s</p></div>',
+				esc_html(
+					sprintf(
+						/* translators: %s: theme stylesheet slug */
+						__( 'The "%s" theme can only be activated on its intended network. Your site has been reverted to its previous theme.', 'wordcamporg' ),
+						$stylesheet
+					)
+				)
+			);
+		}
+	);
+}

--- a/public_html/wp-content/mu-plugins/wcorg-network-theme-control.php
+++ b/public_html/wp-content/mu-plugins/wcorg-network-theme-control.php
@@ -47,7 +47,7 @@ function _get_network_restricted_themes() {
  */
 function filter_prepared_themes( $prepared_themes ) {
 	foreach ( _get_network_restricted_themes() as $stylesheet => $network_id ) {
-		if ( $network_id !== get_current_network_id() ) {
+		if ( get_current_network_id() !== $network_id ) {
 			unset( $prepared_themes[ $stylesheet ] );
 		}
 	}
@@ -66,7 +66,7 @@ function revert_wrong_network_activation( $old_name, $old_theme ) {
 	$restricted = _get_network_restricted_themes();
 	$stylesheet = get_stylesheet();
 
-	if ( ! isset( $restricted[ $stylesheet ] ) || $restricted[ $stylesheet ] === get_current_network_id() ) {
+	if ( ! isset( $restricted[ $stylesheet ] ) || get_current_network_id() === $restricted[ $stylesheet ] ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #1800.

## Summary

Nothing in WordPress core prevents a theme from being activated on any site across the shared wordcamp.org multisite install — WordCamp, Central, or Campus — not just the Groups network. Since `groups-site` depends on GatherPress post types/blocks and the groups-network-only mu-plugin tweaks (event ordering, timezone stripping, non-public venues), activating it anywhere else produces a visibly broken site.

Adds `wcorg-network-theme-control.php`, a top-level always-loaded mu-plugin (runs on every network, following the same pattern as `wcorg-network-plugin-control.php`), with two guards:

1. `wp_prepare_themes_for_js` — hides restricted themes from the Appearance → Themes grid on any network other than their intended one.
2. `after_switch_theme` — hard backstop that reverts the switch (with an admin notice) if a restricted theme gets activated on the wrong network anyway (wp-cli, code, REST).

The restricted-theme map (`_get_network_restricted_themes()`) is a single array, so future network-specific themes can reuse this without new code — just add an entry.

## Test plan

- [x] Added a PHPUnit suite (`tests/test-wcorg-network-theme-control.php`) covering:
  - `groups-site` is hidden from `wp_prepare_themes_for_js` output on a non-Groups network, visible on the Groups network.
  - Forcing `switch_theme( 'groups-site' )` on a non-Groups network is reverted back to the previous theme (simulating the next WP load, since core defers `after_switch_theme` to `check_theme_switched()` on `init`).
  - The same switch on the Groups network is *not* reverted.
- [x] Ran the full PHPUnit suite locally (`398 tests, 747 assertions`, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)