### PR TITLE
Reports: Align the meetup details export guard with sibling reports

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-details.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-details.php
@@ -245,7 +245,7 @@ class Meetup_Details extends Base_Details {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( $nonce, 'run-report' ) && current_user_can( CAPABILITY ) ) {
+		if ( ! wp_verify_nonce( $nonce, 'run-report' ) || ! current_user_can( CAPABILITY ) ) {
 			return;
 		}
 


### PR DESCRIPTION
`Meetup_Details::export_to_file()` combined its nonce and capability checks with `&&`, so the early-return guard did not require both conditions to hold. Every other report class in the plugin writes this guard so that both a valid `run-report` nonce **and** the `view_wordcamp_reports` capability are required — see `class-meetup-events.php`, `class-meetup-sponsors.php`, and `class-wordcamp-details.php`. This makes `Meetup_Details` consistent with them.

```diff
-		if ( ! wp_verify_nonce( $nonce, 'run-report' ) && current_user_can( CAPABILITY ) ) {
+		if ( ! wp_verify_nonce( $nonce, 'run-report' ) || ! current_user_can( CAPABILITY ) ) {
 			return;
 		}
```

### How to test the changes in this Pull Request:

1. As a user with the `view_wordcamp_reports` capability, open the Meetup Details report and export the CSV — it downloads as before.
2. Confirm the guard now matches the sibling report classes (both a valid nonce and the capability are required to proceed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)