### PR TITLE
WCPT: Resolve event URLs to the site they name

### DIFF
--- a/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
+++ b/public_html/wp-content/mu-plugins/4-helpers-wcpt.php
@@ -1,6 +1,6 @@
 <?php
 
-use function WordCamp\Sunrise\get_top_level_domain;
+use function WordCamp\Sunrise\{ get_top_level_domain, get_domain_network_id };
 
 use const WordCamp\Sunrise\{ PATTERN_CITY_SLASH_YEAR_DOMAIN_PATH, PATTERN_YEAR_DOT_CITY_DOMAIN_PATH };
 
@@ -90,13 +90,11 @@ function get_wordcamp_site_id( $wordcamp_post ) {
 
 	$site_id = get_post_meta( $wordcamp_post->ID, '_site_id', true );
 	if ( ! $site_id ) {
-		$url = parse_url( get_post_meta( $wordcamp_post->ID, 'URL', true ) );
+		$url = wp_parse_url( get_post_meta( $wordcamp_post->ID, 'URL', true ) );
 
 		if ( isset( $url['host'] ) && isset( $url['path'] ) ) {
-			$site = get_site_by_path( $url['host'], $url['path'] );
-			if ( $site ) {
-				$site_id = $site->blog_id;
-			}
+			// Not `get_site_by_path()`, which walks up the path and would resolve this to somebody else's site.
+			$site_id = domain_exists( $url['host'], $url['path'], get_domain_network_id( $url['host'], $url['path'] ) ) ?: '';
 		}
 	}
 

--- a/public_html/wp-content/mu-plugins/tests/test-4-helpers-wcpt-sites.php
+++ b/public_html/wp-content/mu-plugins/tests/test-4-helpers-wcpt-sites.php
@@ -76,11 +76,15 @@ class Test_Helpers_WCPT_Sites extends Database_TestCase {
 	/**
 	 * Create a `wordcamp` post with the given meta.
 	 *
+	 * Created on the root blog, which is where `get_wordcamp_site_id()` looks for it.
+	 *
 	 * @param array $meta
 	 *
 	 * @return WP_Post
 	 */
 	protected function create_wordcamp( array $meta ) {
+		switch_to_blog( WORDCAMP_ROOT_BLOG_ID );
+
 		$post_id = self::factory()->post->create( array(
 			'post_type'   => 'wordcamp',
 			'post_status' => 'publish',
@@ -90,6 +94,10 @@ class Test_Helpers_WCPT_Sites extends Database_TestCase {
 			add_post_meta( $post_id, $key, $value );
 		}
 
-		return get_post( $post_id );
+		$wordcamp = get_post( $post_id );
+
+		restore_current_blog();
+
+		return $wordcamp;
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-4-helpers-wcpt-sites.php
+++ b/public_html/wp-content/mu-plugins/tests/test-4-helpers-wcpt-sites.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace WordCamp\Helpers\WCPT\Tests;
+use WordCamp\Tests\Database_TestCase;
+use WP_Post;
+
+defined( 'WPINC' ) || die();
+
+
+/**
+ * Tests for `wordcamp` post helpers that need the mock network of sites.
+ *
+ * Split out from `Test_Helpers_WCPT` so that the rest of those tests don't pay for building it.
+ *
+ * @group mu-plugins
+ * @group helpers
+ * @group helpers-wcpt
+ */
+class Test_Helpers_WCPT_Sites extends Database_TestCase {
+	/**
+	 * `_site_id` is used when it's set.
+	 *
+	 * @covers ::get_wordcamp_site_id
+	 */
+	public function test_get_wordcamp_site_id_prefers_the_site_id_meta() {
+		$wordcamp = $this->create_wordcamp( array(
+			'URL'      => 'https://vancouver.wordcamp.test/2020/',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$this->assertEquals( self::$slash_year_2016_site_id, get_wordcamp_site_id( $wordcamp ) );
+	}
+
+	/**
+	 * The `URL` meta resolves to the site it names when `_site_id` is empty.
+	 *
+	 * @covers ::get_wordcamp_site_id
+	 */
+	public function test_get_wordcamp_site_id_falls_back_to_the_url_meta() {
+		$wordcamp = $this->create_wordcamp( array( 'URL' => 'https://vancouver.wordcamp.test/2016/' ) );
+
+		$this->assertEquals( self::$slash_year_2016_site_id, get_wordcamp_site_id( $wordcamp ) );
+	}
+
+	/**
+	 * The `URL` fallback only ever resolves to the site the URL names.
+	 *
+	 * Resolving by path prefix would walk up to somebody else's site, which is what the automation then acts on.
+	 *
+	 * @covers ::get_wordcamp_site_id
+	 *
+	 * @dataProvider data_get_wordcamp_site_id_ignores_sites_the_url_does_not_name
+	 *
+	 * @param string $url
+	 */
+	public function test_get_wordcamp_site_id_ignores_sites_the_url_does_not_name( $url ) {
+		$wordcamp = $this->create_wordcamp( array( 'URL' => $url ) );
+
+		$this->assertEmpty( get_wordcamp_site_id( $wordcamp ) );
+	}
+
+	/**
+	 * Test cases for `test_get_wordcamp_site_id_ignores_sites_the_url_does_not_name()`.
+	 *
+	 * @return array
+	 */
+	public function data_get_wordcamp_site_id_ignores_sites_the_url_does_not_name() {
+		return array(
+			'extra path segment'    => array( 'https://vancouver.wordcamp.test/2016/x/' ),
+			'domain with root site' => array( 'https://japan.wordcamp.test/2099/' ),
+			'events network root'   => array( 'https://events.wordpress.test/paris/2027/training/' ),
+			'no site at all'        => array( 'https://barcelona.wordcamp.test/2026/' ),
+		);
+	}
+
+	/**
+	 * Create a `wordcamp` post with the given meta.
+	 *
+	 * @param array $meta
+	 *
+	 * @return WP_Post
+	 */
+	protected function create_wordcamp( array $meta ) {
+		$post_id = self::factory()->post->create( array(
+			'post_type'   => 'wordcamp',
+			'post_status' => 'publish',
+		) );
+
+		foreach ( $meta as $key => $value ) {
+			add_post_meta( $post_id, $key, $value );
+		}
+
+		return get_post( $post_id );
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-new-site.php
@@ -1,15 +1,109 @@
 <?php
 
 namespace WordCamp\WCPT\Tests;
-use WP_UnitTestCase;
+
+use WordCamp\Tests\Database_TestCase;
 use WordCamp_New_Site;
+use WPDieException;
 
 defined( 'WPINC' ) || die();
 
 /**
+ * Tests for `WordCamp_New_Site`.
+ *
+ * Extends `Database_TestCase` because most of the class resolves real sites, so it needs the mock network.
+ *
  * @group wcpt
  */
-class Test_WordCamp_New_Site extends WP_UnitTestCase {
+class Test_WordCamp_New_Site extends Database_TestCase {
+	/**
+	 * The instance under test.
+	 *
+	 * @var WordCamp_New_Site
+	 */
+	protected $new_site;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->new_site = new WordCamp_New_Site();
+
+		// Turn `wp_die()` into a catchable exception, so that rejected saves can be asserted on.
+		add_filter(
+			'wp_die_handler',
+			static function () {
+				return static function ( $message ) {
+					throw new WPDieException( esc_html( $message ) );
+				};
+			}
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $_POST['wcpt_url'], $_POST['wcpt_secondary_site'] );
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create an event post with the given meta.
+	 *
+	 * `publish` stands in for a `wcpt-` status because those aren't registered here, and the status is irrelevant.
+	 *
+	 * @param array $meta
+	 *
+	 * @return int
+	 */
+	protected function create_event( array $meta = array() ) {
+		$post_id = self::factory()->post->create( array(
+			'post_type'   => WCPT_POST_TYPE_ID,
+			'post_status' => 'publish',
+		) );
+
+		foreach ( $meta as $key => $value ) {
+			add_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Switch the current user to a WordCamp wrangler.
+	 */
+	protected function become_wrangler() {
+		$wrangler = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		get_user_by( 'id', $wrangler )->add_cap( 'wordcamp_wrangle_wordcamps' );
+		wp_set_current_user( $wrangler );
+	}
+
+	/**
+	 * Save the primary URL field, reporting whether it was rejected.
+	 *
+	 * @param int    $wordcamp_id
+	 * @param string $url
+	 *
+	 * @return bool `true` if the save was rejected.
+	 */
+	protected function save_url( $wordcamp_id, $url ) {
+		$_POST['wcpt_url'] = $url;
+
+		try {
+			$this->new_site->save_site_url_field( 'URL', 'wc-url', $wordcamp_id );
+		} catch ( WPDieException $exception ) {
+			return true;
+		}
+
+		return false;
+	}
+
 	/**
 	 * @covers WordCamp_New_Site::url_matches_expected_format
 	 *
@@ -84,5 +178,298 @@ class Test_WordCamp_New_Site extends WP_UnitTestCase {
 				true,
 			),
 		);
+	}
+
+	/**
+	 * A URL for a site that doesn't exist yet is accepted.
+	 *
+	 * Events are always given a URL before their site is created, so this is the normal case.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 *
+	 * @dataProvider data_save_site_url_field_accepts_url_for_a_site_that_does_not_exist_yet
+	 *
+	 * @param string $url
+	 */
+	public function test_save_site_url_field_accepts_url_for_a_site_that_does_not_exist_yet( $url ) {
+		$event = $this->create_event();
+
+		$rejected = $this->save_url( $event, $url );
+
+		$this->assertFalse( $rejected );
+		$this->assertSame( $url, get_post_meta( $event, 'URL', true ) );
+		$this->assertSame( '', get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * Test cases for `test_save_site_url_field_accepts_url_for_a_site_that_does_not_exist_yet()`.
+	 *
+	 * The last two share a domain with an existing site, which no check may treat as a reason to reject them.
+	 *
+	 * @return array
+	 */
+	public function data_save_site_url_field_accepts_url_for_a_site_that_does_not_exist_yet() {
+		return array(
+			'unused domain'         => array( 'https://barcelona.wordcamp.test/2026/' ),
+			'events network'        => array( 'https://events.wordpress.test/paris/2027/training/' ),
+			'domain with root site' => array( 'https://japan.wordcamp.test/2099/' ),
+		);
+	}
+
+	/**
+	 * A wrangler can point an event at a site that already exists, and both meta values are stored.
+	 *
+	 * Also a canary: if the handler were bailing out early, the rejection tests would pass for the wrong reason.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_accepts_existing_site_for_a_wrangler() {
+		$this->become_wrangler();
+
+		$event    = $this->create_event();
+		$rejected = $this->save_url( $event, 'https://vancouver.wordcamp.test/2020/' );
+
+		$this->assertFalse( $rejected );
+		$this->assertSame( 'https://vancouver.wordcamp.test/2020/', get_post_meta( $event, 'URL', true ) );
+		$this->assertEquals( self::$slash_year_2020_site_id, get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * A URL that doesn't match the expected format is rejected.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_malformed_url() {
+		$event = $this->create_event();
+
+		$this->assertTrue( $this->save_url( $event, 'https://2020.vancouver.wordcamp.test/' ) );
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+	}
+
+	/**
+	 * A site that exists is off limits even when no event post claims it.
+	 *
+	 * Plenty of sites on the network aren't claimed, so checking for another event's claim isn't enough.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_an_existing_site_that_no_event_claims() {
+		$event = $this->create_event();
+
+		$this->assertTrue( $this->save_url( $event, 'https://vancouver.wordcamp.test/2020/' ) );
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+		$this->assertSame( '', get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * A legacy stored URL still counts as unchanged once normalised.
+	 *
+	 * Otherwise it would look like an edit, and an event that shares a site couldn't save at all.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_treats_a_legacy_stored_url_as_unchanged() {
+		$this->create_event( array(
+			'URL'      => 'https://vancouver.wordcamp.test/2016/',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$event = $this->create_event( array(
+			'URL'      => 'http://vancouver.wordcamp.test/2016',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$rejected = $this->save_url( $event, 'https://vancouver.wordcamp.test/2016/' );
+
+		$this->assertFalse( $rejected );
+		$this->assertEquals( self::$slash_year_2016_site_id, get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * Clearing the field clears both meta values.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_clears_meta_for_empty_url() {
+		$event = $this->create_event( array(
+			'URL'      => 'https://vancouver.wordcamp.test/2016/',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$rejected = $this->save_url( $event, '' );
+
+		$this->assertFalse( $rejected );
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+		$this->assertSame( '', get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * An event can't point itself at a site another event owns.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_site_owned_by_another_event() {
+		$other_event = $this->create_event( array(
+			'URL'      => 'https://vancouver.wordcamp.test/2016/',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$event    = $this->create_event();
+		$rejected = $this->save_url( $event, 'https://vancouver.wordcamp.test/2016/' );
+
+		$this->assertTrue( $rejected );
+		$this->assertSame( '', get_post_meta( $event, '_site_id', true ) );
+
+		// The URL meta matters as much, because `get_wordcamp_site_id()` falls back to it.
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+
+		// The other event's mapping is untouched.
+		$this->assertEquals( self::$slash_year_2016_site_id, get_post_meta( $other_event, '_site_id', true ) );
+	}
+
+	/**
+	 * A site claimed as another event's secondary site is protected too.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_site_owned_as_another_events_secondary_site() {
+		$this->create_event( array(
+			'Secondary Site'     => 'https://vancouver.wordcamp.test/2018-developers/',
+			'_secondary_site_id' => self::$slash_year_2018_dev_site_id,
+		) );
+
+		$event = $this->create_event();
+
+		$this->assertTrue( $this->save_url( $event, 'https://vancouver.wordcamp.test/2018-developers/' ) );
+		$this->assertSame( '', get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * The multi-valued `Secondary Site` field is guarded as well as `URL`.
+	 *
+	 * It takes a different branch through `save_site_url_field()`.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_claimed_site_in_secondary_site_field() {
+		$this->create_event( array(
+			'URL'      => 'https://vancouver.wordcamp.test/2016/',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$event    = $this->create_event();
+		$rejected = false;
+
+		$_POST['wcpt_secondary_site'] = array( 'https://vancouver.wordcamp.test/2016/' );
+
+		try {
+			$this->new_site->save_site_url_field( 'Secondary Site', 'wc-url', $event );
+		} catch ( WPDieException $exception ) {
+			$rejected = true;
+		}
+
+		$this->assertTrue( $rejected );
+		$this->assertSame( array(), get_post_meta( $event, 'Secondary Site', false ) );
+		$this->assertSame( array(), get_post_meta( $event, '_secondary_site_id', false ) );
+	}
+
+	/**
+	 * An event can't squat on the URL of a site that doesn't exist yet.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_url_claimed_before_the_site_exists() {
+		$url = 'https://vancouver.wordcamp.test/2099/';
+
+		$this->assertEmpty( domain_exists( 'vancouver.wordcamp.test', '/2099/', WORDCAMP_NETWORK_ID ) );
+
+		$this->create_event( array( 'URL' => $url ) );
+
+		$event = $this->create_event();
+
+		$this->assertTrue( $this->save_url( $event, $url ) );
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+	}
+
+	/**
+	 * A claim stored in a legacy spelling still blocks, even though the site doesn't exist yet.
+	 *
+	 * Legacy values don't match the normalised candidate, so `url_is_claimed()` looks for those spellings too.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_a_url_claimed_in_a_legacy_spelling() {
+		$this->assertEmpty( domain_exists( 'vancouver.wordcamp.test', '/2099/', WORDCAMP_NETWORK_ID ) );
+
+		$this->create_event( array( 'URL' => 'http://vancouver.wordcamp.test/2099' ) );
+
+		$event = $this->create_event();
+
+		$this->assertTrue( $this->save_url( $event, 'https://vancouver.wordcamp.test/2099/' ) );
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+	}
+
+	/**
+	 * A trashed event still holds on to its URL.
+	 *
+	 * Trashing the post doesn't delete the site, so releasing the URL would point the next claimant at a live one.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_rejects_a_url_claimed_by_a_trashed_event() {
+		$url = 'https://vancouver.wordcamp.test/2099/';
+
+		wp_trash_post( $this->create_event( array( 'URL' => $url ) ) );
+
+		$event = $this->create_event();
+
+		$this->assertTrue( $this->save_url( $event, $url ) );
+		$this->assertSame( '', get_post_meta( $event, 'URL', true ) );
+	}
+
+	/**
+	 * Wranglers can re-map an event onto an existing site, which is a normal part of their workflow.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_lets_wranglers_adopt_a_claimed_site() {
+		$this->create_event( array(
+			'URL'      => 'https://vancouver.wordcamp.test/2016/',
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$this->become_wrangler();
+
+		$event    = $this->create_event();
+		$rejected = $this->save_url( $event, 'https://vancouver.wordcamp.test/2016/' );
+
+		$this->assertFalse( $rejected );
+		$this->assertEquals( self::$slash_year_2016_site_id, get_post_meta( $event, '_site_id', true ) );
+	}
+
+	/**
+	 * A duplicate claim that predates these checks doesn't block saves that leave the URL alone.
+	 *
+	 * Without this, an organiser whose event already shares a site couldn't save their post at all.
+	 *
+	 * @covers WordCamp_New_Site::save_site_url_field
+	 */
+	public function test_save_site_url_field_allows_resaving_a_url_the_event_already_stores() {
+		$url = 'https://vancouver.wordcamp.test/2016/';
+
+		$this->create_event( array(
+			'URL'      => $url,
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$event = $this->create_event( array(
+			'URL'      => $url,
+			'_site_id' => self::$slash_year_2016_site_id,
+		) );
+
+		$rejected = $this->save_url( $event, $url );
+
+		$this->assertFalse( $rejected );
+		$this->assertEquals( self::$slash_year_2016_site_id, get_post_meta( $event, '_site_id', true ) );
 	}
 }

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-new-site.php
@@ -46,7 +46,10 @@ class Test_WordCamp_New_Site extends Database_TestCase {
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
+		global $wcorg_subroles;
+
 		unset( $_POST['wcpt_url'], $_POST['wcpt_secondary_site'] );
+		$wcorg_subroles = array();
 		wp_set_current_user( 0 );
 
 		parent::tear_down();
@@ -76,11 +79,16 @@ class Test_WordCamp_New_Site extends Database_TestCase {
 
 	/**
 	 * Switch the current user to a WordCamp wrangler.
+	 *
+	 * The capability has to come through the subroles system: `omit_usermeta_caps()` deliberately strips
+	 * anything granted with `WP_User::add_cap()`.
 	 */
 	protected function become_wrangler() {
+		global $wcorg_subroles;
+
 		$wrangler = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
-		get_user_by( 'id', $wrangler )->add_cap( 'wordcamp_wrangle_wordcamps' );
+		$wcorg_subroles = array( $wrangler => array( 'wordcamp_wrangler' ) );
 		wp_set_current_user( $wrangler );
 	}
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -181,8 +181,12 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 				return;
 			}
 
+			if ( ! current_user_can( 'wordcamp_manage_mentors' ) ) {
+				return;
+			}
+
 			//phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in `metabox_save` in class-event-admin.php.
-			$username = $_POST[ wcpt_key_to_str( 'Mentor WordPress.org User Name', 'wcpt_' ) ];
+			$username = $_POST[ wcpt_key_to_str( 'Mentor WordPress.org User Name', 'wcpt_' ) ] ?? '';
 
 			$this->add_mentor( get_post( $post_id ), $username );
 

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-new-site.php
@@ -182,7 +182,7 @@ class WordCamp_New_Site {
 			return;
 		}
 
-		$validate_url = static function ( $url ) use ( $wordcamp_id ) {
+		$validate_url       = static function ( $url ) use ( $wordcamp_id, $key ) {
 			$url = str_starts_with( $url, 'http' ) ? $url : 'http://' . $url;
 			$url = set_url_scheme( esc_url_raw( $url ), 'https' );
 
@@ -196,10 +196,44 @@ class WordCamp_New_Site {
 			$parsed_url = wp_parse_url( $url );
 
 			if ( ! self::url_matches_expected_format( $parsed_url['host'], $parsed_url['path'], $wordcamp_id ) ) {
-				wp_die( "The URL doesn't match the expected format. It should be either <code>city.wordcamp.org/year/</code>, <code>events.wordpress.org/city/year/type/</code>, or <code>campus.wordpress.org/campus-name/</code>. Please press the back button and update it." );
+				wp_die(
+					"The URL doesn't match the expected format. It should be either <code>city.wordcamp.org/year/</code>, <code>events.wordpress.org/city/year/type/</code>, or <code>campus.wordpress.org/campus-name/</code>.",
+					'',
+					array( 'back_link' => true )
+				);
 			}
 
-			return esc_url( $url );
+			$url = esc_url( $url );
+
+			// Normalised so that a save which leaves the field alone is always allowed through.
+			$stored_urls = array_map(
+				static function ( $stored_url ) {
+					return esc_url( trailingslashit( set_url_scheme( $stored_url, 'https' ) ) );
+				},
+				(array) get_post_meta( $wordcamp_id, $key, false )
+			);
+
+			if ( ! in_array( $url, $stored_urls, true ) && ! current_user_can( 'wordcamp_wrangle_wordcamps' ) ) {
+				// Site creation needs `manage_sites`, so anyone else naming a live site is aiming `_site_id` at another event's.
+				if ( self::url_names_an_existing_site( $url ) ) {
+					wp_die(
+						'That URL already belongs to a site on the network. Update it, or ask a WordCamp wrangler for help.',
+						'',
+						array( 'back_link' => true )
+					);
+				}
+
+				// The site doesn't exist yet, but two events waiting on the same URL would both resolve to it.
+				if ( self::url_is_claimed( $url, $wordcamp_id ) ) {
+					wp_die(
+						'That URL is already in use by another event. Update it, or ask a WordCamp wrangler for help.',
+						'',
+						array( 'back_link' => true )
+					);
+				}
+			}
+
+			return $url;
 		};
 		$find_existing_site = static function ( $url ) {
 			if ( ! $url ) {
@@ -207,7 +241,7 @@ class WordCamp_New_Site {
 			}
 
 			$parsed_url = wp_parse_url( $url );
-			$network_id = get_domain_network_id( $parsed_url['host'] );
+			$network_id = get_domain_network_id( $parsed_url['host'], $parsed_url['path'] );
 
 			return domain_exists( $parsed_url['host'], $parsed_url['path'], $network_id );
 		};
@@ -287,6 +321,68 @@ class WordCamp_New_Site {
 		}
 
 		return 1 === $match;
+	}
+
+	/**
+	 * Check if a URL names a site that already exists on the network.
+	 *
+	 * @param string $url The normalised URL being saved.
+	 *
+	 * @return bool
+	 */
+	protected static function url_names_an_existing_site( $url ) {
+		$parsed_url = wp_parse_url( $url );
+
+		if ( ! isset( $parsed_url['host'], $parsed_url['path'] ) ) {
+			return true;
+		}
+
+		return (bool) domain_exists( $parsed_url['host'], $parsed_url['path'], get_domain_network_id( $parsed_url['host'], $parsed_url['path'] ) );
+	}
+
+	/**
+	 * Check if a URL has already been claimed by a different event post.
+	 *
+	 * Callers reject URLs that name an existing site first, so nothing can be pointing a `_site_id` at it yet.
+	 *
+	 * @param string $url         The normalised URL being saved.
+	 * @param int    $wordcamp_id The event post being saved.
+	 *
+	 * @return bool
+	 */
+	protected static function url_is_claimed( $url, $wordcamp_id ) {
+		// Expanded rather than normalising the stored side, which would mean loading every event's URL meta.
+		$url_variants = array();
+
+		foreach ( array( 'https', 'http' ) as $scheme ) {
+			$variant        = set_url_scheme( $url, $scheme );
+			$url_variants[] = $variant;
+			$url_variants[] = untrailingslashit( $variant );
+		}
+
+		return (bool) get_posts( array(
+			'post_type'      => WCPT_POST_TYPE_ID,
+
+			// Not `any`, which would exclude trashed events -- their sites outlive the post.
+			'post_status'    => array_merge(
+				array_keys( WordCamp_Loader::get_post_statuses() ),
+				array( 'draft', 'pending', 'publish', 'private', 'future', 'trash' )
+			),
+
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'post__not_in'   => array( $wordcamp_id ),
+			'cache_results'  => false,
+
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Only runs when an event's URL is saved.
+			'meta_query'     => array(
+				array(
+					'key'     => array( 'URL', 'Secondary Site' ),
+					'value'   => array_values( array_unique( $url_variants ) ),
+					'compare' => 'IN',
+				),
+			),
+		) );
 	}
 
 	/**


### PR DESCRIPTION
## Why

`get_wordcamp_site_id()` falls back to `get_site_by_path()` when a post has no `_site_id`. That function walks up the path until it finds a match, and its candidate list always ends with `/` — so on a network that has a root site, every URL walks up to that root.

`events.wordpress.org` (blog 1474) and `campus.wordpress.org` (blog 1722) both have one, as does `japan.wordcamp.org` (blog 18). The practical effect is that an event whose site hasn't been created yet resolves to the network root rather than to nothing. Three events do this today:

| post | URL | resolves to |
| --- | --- | --- |
| 10392064 | `events.wordpress.org/quedadas/2025/summer-photo/` | 1474 |
| 12396088 | `events.wordpress.org/sevilla/2025/wordpress-day/` | 1474 |
| 10657857 | `events.wordpress.org/campusconnect/2025/cadiz/` | 1474 |

All three are cancelled or in pre-planning, so "no site yet" is the correct answer for them — and anything asking which site belongs to the event (the reports, organiser reminders, the site cloner, Central's front end) has been getting the events root instead.

## What changed

**`get_wordcamp_site_id()` uses `domain_exists()`**, so a URL only ever resolves to the site it names. Measured over all 2,572 `wordcamp` posts: 97 rely on this fallback, and only the three above change — each from "the events root" to "nothing".

**`save_site_url_field()` is clearer about what it accepts.** Creating a site needs `manage_sites`, so there's no flow in which somebody without `wordcamp_wrangle_wordcamps` names a site that already exists, or one another event is already waiting on. Both are now rejected, with a URL the post already stores exempted so that saves leaving the field alone — and events that legitimately share a site — still go through. Of the 1,777 posts with `URL` meta, 74 don't round-trip through that exemption and none of them resolve to an existing site, so nothing currently saveable stops being saveable.

**Smaller things:** `get_domain_network_id()` now gets the path, so URLs on the groups network resolve against the right network; the mentor field gets the `wordcamp_manage_mentors` check that `get_protected_fields()` already implies; `wp_die()` calls get a back link instead of telling people to press the browser's back button.

## Testing

`WordCamp_New_Site::save_site_url_field()` had no coverage, so this adds it — accepting new URLs (including on the events network and on a domain that already has a root site, which is what would regress if the resolution rules tighten too far), rejecting existing and already-claimed sites, and the exemption paths for stored and legacy-spelled URLs. `get_wordcamp_site_id()` gets its own tests in `mu-plugins/tests/`, split into a second class so the rest of that file doesn't pay for building the mock network.

Also verified by hand against a copy of production for the cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
