### PR TITLE
Speaker Feedback: rebuild list-table view links from safe values

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/admin.php
@@ -755,24 +755,24 @@ function filter_list_table_views( $views ) {
 	// Feedback from an admin of the event site would probably be rare, so this one is unnecessary.
 	unset( $views['mine'] );
 
-	foreach ( $views as $status => $view ) {
-		// Note that the HTML here is wrapping href attributes with single quotes.
-		preg_match( '#href=[\'"]+([^\'"]+)[\'"]+#', $view, $orig_url );
-		$parsed_url = wp_parse_url( $orig_url[1] );
-		wp_parse_str( $parsed_url['query'], $query_args );
-
-		$new_url = add_query_arg( $query_args, get_subpage_url( $typenow ) );
-
-		$views[ $status ] = str_replace(
-			$orig_url[1],
-			$new_url,
-			$view
-		);
-	}
-
 	$link_base = get_subpage_url( $typenow );
 	if ( $post_id ) {
 		$link_base = add_query_arg( 'p', $post_id, $link_base );
+	}
+
+	// Core renders these status views pointing at the default comments screen; repoint each one
+	// at our subpage. A view's array key is its comment_status, so rebuild the href from that
+	// known-safe value rather than reflecting the request's query string: the previous code
+	// carried the unvalidated comment_type parameter through unescaped, which was reflected XSS.
+	// esc_url() re-escapes the result before it is spliced back into core's markup.
+	foreach ( $views as $status => $view ) {
+		if ( ! preg_match( '#href=[\'"]+([^\'"]+)[\'"]+#', $view, $orig_url ) ) {
+			continue;
+		}
+
+		$new_url = esc_url( add_query_arg( 'comment_status', $status, $link_base ) );
+
+		$views[ $status ] = str_replace( $orig_url[1], $new_url, $view );
 	}
 
 	$current_link_attributes = ' class="current" aria-current="page"';


### PR DESCRIPTION
## Summary

`filter_list_table_views()` (the `views_{$screen_id}` handler for the speaker-feedback list table) repointed core's status-view links at the plugin's subpage by extracting the URL from core's already-rendered anchor, decoding it, re-adding the query args, and splicing the result back into the markup without re-escaping.

Core's comments list table carries an unvalidated `comment_type` request parameter into those view links, so the decode step could reintroduce characters that break out of the `href` attribute — a reflected XSS on the feedback admin screen. The screen is reachable by Editor-and-above (`moderate_wc-speaker-feedback` maps to `edit_others_posts`).

## Change

- Rebuild each view link from known-safe values: a view's array key is its `comment_status`, so the `href` is built from that plus the plugin's own subpage base (`get_subpage_url()` + optional `p`), rather than from the reflected request URL.
- Drop the unused `comment_type` parameter — the feedback query forces its own comment type, so these links never needed it.
- `esc_url()` the rebuilt URL before it is placed back into core's markup.
- Skip a view that has no `href` instead of relying on an unchecked `preg_match`.

No change to the helpful/inappropriate views or to the query behaviour.

## Testing

- `php -l` clean.
- Verified the previously-reflected parameter no longer appears in the rendered view links, and the status / helpful / inappropriate links are unchanged.
