### PR TITLE
CampTix: cap issued tickets to the selected quantity at checkout

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6233,6 +6233,7 @@ class CampTix_Plugin {
 		}
 
 		do_action( 'camptix_checkout_start', $_POST['tix_attendee_info'], $this->order );
+		$issued_count_by_ticket = array();
 		foreach( (array) $_POST['tix_attendee_info'] as $i => $attendee_info ) {
 			$attendee = new stdClass;
 
@@ -6248,6 +6249,13 @@ class CampTix_Plugin {
 
 			$ticket = $this->tickets[ $attendee_info['ticket_id'] ];
 			if ( ! $this->is_ticket_valid_for_purchase( $ticket->ID ) ) {
+				$this->error_flags['tickets_excess'] = true;
+				continue;
+			}
+
+			// Cap issued tickets at the quantity that was priced into the order.
+			$issued_count_by_ticket[ $ticket->ID ] = ( $issued_count_by_ticket[ $ticket->ID ] ?? 0 ) + 1;
+			if ( $issued_count_by_ticket[ $ticket->ID ] > (int) ( $this->tickets_selected[ $ticket->ID ] ?? 0 ) ) {
 				$this->error_flags['tickets_excess'] = true;
 				continue;
 			}


### PR DESCRIPTION
## Summary

Checkout prices an order from `tix_tickets_selected` but builds the attendee records — the issued tickets — from a separate array, `tix_attendee_info`, and did not reconcile the two. As a result the number of tickets issued for a ticket type could differ from the quantity that was selected and priced.

`form_checkout()` now caps the attendees issued per ticket at `tickets_selected[ticket_id]`: once the running count for a ticket exceeds the selected quantity, the order is flagged and returned to the attendee form before any attendee is created. Orders within the selected quantity, including multi-ticket orders, are unaffected.

## Testing

- `php -l` clean.
- Verified an order issues exactly the selected quantity, and a valid multi-ticket order still completes through to payment.
