### PR TITLE
Build: move dev-only WordPress packages to composer-dev.json

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install PHP dependencies
       # wporg-mu-plugins (installed via composer, then moved into place by a
-      # post-install script — see composer.json's installer-paths) is loaded
+      # post-install script — see composer-dev.json's installer-paths) is loaded
       # unconditionally by load-other-mu-plugins.php; without it every
       # request, including wp-cli, fatals.
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+        key: composer-${{ runner.os }}-${{ hashFiles('composer.json', 'composer-dev.json') }}
         restore-keys: |
           composer-${{ runner.os }}-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,7 @@ on:
     - .github/workflows/**
     - phpunit.*
     - composer.json
+    - composer-dev.json
   push:
     branches: [production]
     paths:
@@ -15,6 +16,7 @@ on:
     - .github/workflows/**
     - phpunit.*
     - composer.json
+    - composer-dev.json
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -104,7 +106,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+        key: composer-${{ runner.os }}-${{ hashFiles('composer.json', 'composer-dev.json') }}
         restore-keys: |
           composer-${{ runner.os }}-
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ google*.html
 wp-cli.yml
 script-backups/
 node_modules/
+.composer-dev/
+composer-dev.lock
 public_html/.well-known/
 public_html/mu/
 public_html/bin/

--- a/composer-dev.json
+++ b/composer-dev.json
@@ -1,0 +1,250 @@
+{
+	"name": "wordcamp/wordcamp-dev-environment",
+	"description": "WordPress plugins and themes installed into `wp-content` for local development only.",
+	"license": "GPL-2.0-or-later",
+	"_comment": "These are kept out of the root `composer.json` because their install paths are managed by `svn:externals` on the deploy checkout. Composer replaces a package's directory wholesale, which destroys the external's working copy -- so the deploy checkout must be able to install the production dependencies without ever touching these. The root manifest chains to this file from `post-install-cmd`/`post-update-cmd`, so `composer install` and `composer update` still set up everything in one step.",
+	"config": {
+		"platform": {
+			"php": "8.3"
+		},
+		"_vendor_dir_comment": "Deliberately NOT the root manifest's vendor dir. Two Composer projects sharing one vendor dir fight over `vendor/composer/installed.json` and uninstall each other's packages.",
+		"vendor-dir": ".composer-dev/vendor",
+		"allow-plugins": {
+			"composer/installers": true
+		}
+	},
+	"extra": {
+		"installer-paths": {
+			"public_html/wp-content/themes/{$name}": ["wporg/wporg-parent-2021"],
+			"public_html/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+			"public_html/wp-content/themes/{$name}/": ["type:wordpress-theme"]
+		}
+	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "git@github.com:WordPress/wporg-parent-2021.git"
+		},
+		{
+			"type": "package",
+			"package": [
+				{
+					"name": "wordpress-plugin/akismet",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/akismet.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/bbpress",
+					"type": "wordpress-plugin",
+					"version": "2.6",
+					"source": {
+						"type": "svn",
+						"url": "https://plugins.svn.wordpress.org/bbpress/",
+						"reference": "branches/2.6/"
+					}
+				},
+				{
+					"name": "wordpress-plugin/classic-editor",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/classic-editor.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/custom-content-width",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/custom-content-width.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/edit-flow",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/edit-flow.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/email-post-changes",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/email-post-changes.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/gutenberg",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/jetpack",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/jetpack.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/liveblog",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/liveblog.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/public-post-preview",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/public-post-preview.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/pwa",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/pwa.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/tagregator",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/tagregator.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/wordpress-importer",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/wordpress-importer.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/wp-cldr",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/wp-cldr.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-plugin/wp-super-cache",
+					"type": "wordpress-plugin",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/plugin/wp-super-cache.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-theme/p2",
+					"type": "wordpress-theme",
+					"version": "1.5.8",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/theme/p2.1.5.8.zip"
+					}
+				},
+				{
+					"name": "wordpress-theme/twentyten",
+					"type": "wordpress-theme",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/theme/twentyten.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-theme/twentytwentytwo",
+					"type": "wordpress-theme",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/theme/twentytwentytwo.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-theme/twentytwentythree",
+					"type": "wordpress-theme",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/theme/twentytwentythree.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-theme/twentytwentyfour",
+					"type": "wordpress-theme",
+					"version": "999",
+					"dist": {
+						"type": "zip",
+						"url": "https://downloads.wordpress.org/theme/twentytwentyfour.latest-stable.zip"
+					}
+				},
+				{
+					"name": "wordpress-meta/wporg-profiles-wp-activity-notifier",
+					"type": "wordpress-plugin",
+					"version": "1.1",
+					"source": {
+						"type": "svn",
+						"url": "https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/plugins/",
+						"reference": "wporg-profiles-wp-activity-notifier/"
+					}
+				}
+			]
+		}
+	],
+	"require": {
+		"composer/installers": "^2.2",
+		"wporg/wporg-parent-2021": "dev-build",
+		"wordpress-plugin/akismet": "*",
+		"wordpress-plugin/bbpress": "*",
+		"wordpress-plugin/classic-editor": "*",
+		"wordpress-plugin/custom-content-width": "*",
+		"wordpress-plugin/edit-flow": "*",
+		"wordpress-plugin/email-post-changes": "*",
+		"wordpress-plugin/gutenberg": "*",
+		"wordpress-plugin/jetpack": "*",
+		"wordpress-plugin/liveblog": "*",
+		"wordpress-plugin/public-post-preview": "*",
+		"wordpress-plugin/pwa": "*",
+		"wordpress-plugin/tagregator": "*",
+		"wordpress-plugin/wordpress-importer": "*",
+		"wordpress-plugin/wp-cldr": "*",
+		"wordpress-plugin/wp-super-cache": "*",
+		"wordpress-meta/wporg-profiles-wp-activity-notifier": "*",
+		"wordpress-theme/p2": "*",
+		"wordpress-theme/twentyten": "*",
+		"wordpress-theme/twentytwentytwo": "*",
+		"wordpress-theme/twentytwentythree": "*",
+		"wordpress-theme/twentytwentyfour": "*"
+	}
+}

--- a/composer-dev.json
+++ b/composer-dev.json
@@ -16,6 +16,7 @@
 	"extra": {
 		"installer-paths": {
 			"public_html/wp-content/themes/{$name}": ["wporg/wporg-parent-2021"],
+			"public_html/wp-content/mu-plugins-private/{$name}/tmp": ["wporg/wporg-mu-plugins"],
 			"public_html/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
 			"public_html/wp-content/themes/{$name}/": ["type:wordpress-theme"]
 		}
@@ -24,6 +25,10 @@
 		{
 			"type": "vcs",
 			"url": "git@github.com:WordPress/wporg-parent-2021.git"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/WordPress/wporg-mu-plugins.git"
 		},
 		{
 			"type": "package",
@@ -225,6 +230,7 @@
 	"require": {
 		"composer/installers": "^2.2",
 		"wporg/wporg-parent-2021": "dev-build",
+		"wporg/wporg-mu-plugins": "dev-build",
 		"wordpress-plugin/akismet": "*",
 		"wordpress-plugin/bbpress": "*",
 		"wordpress-plugin/classic-editor": "*",
@@ -246,5 +252,20 @@
 		"wordpress-theme/twentytwentytwo": "*",
 		"wordpress-theme/twentytwentythree": "*",
 		"wordpress-theme/twentytwentyfour": "*"
+	},
+	"scripts": {
+		"_pub_sync_comment": "`wporg/wporg-mu-plugins` installs to `tmp/`, and its mu-plugins are then moved into place. This lives here rather than in the root manifest because the deploy checkout gets `pub-sync/` from the `mu-plugins-private/wporg-mu-plugins` external -- where it is versioned -- so Composer must never write to it there.",
+		"post-install-cmd": [
+			"@pub-sync"
+		],
+		"post-update-cmd": [
+			"@pub-sync"
+		],
+		"pub-sync": [
+			"mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+			"rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/*",
+			"mv public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/mu-plugins/* public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
+			"rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/"
+		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -19,226 +19,23 @@
 		}
 	},
 	"extra": {
+		"_installer_paths_comment": "Nothing here may install into `wp-content/plugins` or `wp-content/themes` -- those paths are managed by `svn:externals` on the deploy checkout, and Composer replaces a package's directory wholesale. WordPress plugins and themes needed for local development live in `composer-dev.json` instead.",
 		"installer-paths": {
-			"public_html/wp-content/themes/{$name}": ["wporg/wporg-parent-2021"],
 			"public_html/wp-content/mu-plugins-private/{$name}/tmp": ["wporg/wporg-mu-plugins"],
 			"public_html/wp-content/mu-plugins/vendor/{$vendor}/{$name}/": ["wordpress/mcp-adapter"],
-			"public_html/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
-			"public_html/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
-			"public_html/wp-content/themes/{$name}/": ["type:wordpress-theme"]
+			"public_html/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"]
 		}
 	},
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "git@github.com:WordPress/wporg-parent-2021.git"
-		},
-		{
-			"type": "vcs",
 			"url": "https://github.com/WordPress/wporg-mu-plugins.git"
-		},
-		{
-			"type": "package",
-			"package": [
-				{
-					"name": "wordpress-plugin/akismet",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/akismet.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/bbpress",
-					"type": "wordpress-plugin",
-					"version": "2.6",
-					"source": {
-						"type": "svn",
-						"url": "https://plugins.svn.wordpress.org/bbpress/",
-						"reference": "branches/2.6/"
-					}
-				},
-				{
-					"name": "wordpress-plugin/classic-editor",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/classic-editor.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/custom-content-width",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/custom-content-width.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/edit-flow",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/edit-flow.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/email-post-changes",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/email-post-changes.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/gutenberg",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/jetpack",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/jetpack.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/liveblog",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/liveblog.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/public-post-preview",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/public-post-preview.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/pwa",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/pwa.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/tagregator",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/tagregator.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/wordpress-importer",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/wordpress-importer.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/wp-cldr",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/wp-cldr.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-plugin/wp-super-cache",
-					"type": "wordpress-plugin",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/plugin/wp-super-cache.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-theme/p2",
-					"type": "wordpress-theme",
-					"version": "1.5.8",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/theme/p2.1.5.8.zip"
-					}
-				},
-				{
-					"name": "wordpress-theme/twentyten",
-					"type": "wordpress-theme",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/theme/twentyten.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-theme/twentytwentytwo",
-					"type": "wordpress-theme",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/theme/twentytwentytwo.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-theme/twentytwentythree",
-					"type": "wordpress-theme",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/theme/twentytwentythree.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-theme/twentytwentyfour",
-					"type": "wordpress-theme",
-					"version": "999",
-					"dist": {
-						"type": "zip",
-						"url": "https://downloads.wordpress.org/theme/twentytwentyfour.latest-stable.zip"
-					}
-				},
-				{
-					"name": "wordpress-meta/wporg-profiles-wp-activity-notifier",
-					"type": "wordpress-plugin",
-					"version": "1.1",
-					"source": {
-						"type": "svn",
-						"url": "https://meta.svn.wordpress.org/sites/trunk/wordpress.org/public_html/wp-content/plugins/",
-						"reference": "wporg-profiles-wp-activity-notifier/"
-					}
-				}
-			]
 		}
 	],
 	"require": {
 		"adhocore/jwt": "^1.0",
 		"scssphp/scssphp": "^2.1.0",
-		"wordpress/mcp-adapter": "^0.5.0",
-		"wporg/wporg-parent-2021": "dev-build"
+		"wordpress/mcp-adapter": "^0.5.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
@@ -249,28 +46,7 @@
 		"spatie/phpunit-watcher": "^1.23",
 		"yoast/phpunit-polyfills": "^4.0",
 		"composer/installers": "^2.2",
-		"wordpress-plugin/akismet": "*",
-		"wordpress-plugin/bbpress": "*",
-		"wordpress-plugin/classic-editor": "*",
-		"wordpress-plugin/custom-content-width": "*",
-		"wordpress-plugin/edit-flow": "*",
-		"wordpress-plugin/email-post-changes": "*",
-		"wordpress-plugin/gutenberg": "*",
-		"wordpress-plugin/jetpack": "*",
-		"wordpress-plugin/liveblog": "*",
-		"wordpress-plugin/public-post-preview": "*",
-		"wordpress-plugin/pwa": "*",
-		"wordpress-plugin/tagregator": "*",
-		"wordpress-plugin/wordpress-importer": "*",
-		"wordpress-plugin/wp-cldr": "*",
-		"wordpress-plugin/wp-super-cache": "*",
-		"wordpress-meta/wporg-profiles-wp-activity-notifier": "*",
 		"wporg/wporg-mu-plugins": "dev-build",
-		"wordpress-theme/p2": "*",
-		"wordpress-theme/twentyten": "*",
-		"wordpress-theme/twentytwentytwo": "*",
-		"wordpress-theme/twentytwentythree": "*",
-		"wordpress-theme/twentytwentyfour": "*",
 		"quickbooks/v3-php-sdk": "*"
 	},
 	"scripts": {
@@ -289,7 +65,12 @@
 		"phpcbf": "phpcbf -p",
 		"tw": "@test:watch",
 		"twg": "@test:watch:group",
+		"_composer_dev_comment": "`composer-dev.json` installs the WordPress plugins and themes that only the local environment needs. Chaining it here keeps `composer install` and `composer update` doing what they always have. The deploy checkout skips it by passing `--no-scripts`, so Composer never touches the `svn:externals` directories there.",
+		"post-install-cmd": [
+			"[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer install --no-interaction"
+		],
 		"post-update-cmd": [
+			"[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer update --no-interaction",
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/*",
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || mv public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/mu-plugins/* public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",

--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,10 @@
 	"extra": {
 		"_installer_paths_comment": "Nothing here may install into `wp-content/plugins` or `wp-content/themes` -- those paths are managed by `svn:externals` on the deploy checkout, and Composer replaces a package's directory wholesale. WordPress plugins and themes needed for local development live in `composer-dev.json` instead.",
 		"installer-paths": {
-			"public_html/wp-content/mu-plugins-private/{$name}/tmp": ["wporg/wporg-mu-plugins"],
 			"public_html/wp-content/mu-plugins/vendor/{$vendor}/{$name}/": ["wordpress/mcp-adapter"],
 			"public_html/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"]
 		}
 	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/WordPress/wporg-mu-plugins.git"
-		}
-	],
 	"require": {
 		"adhocore/jwt": "^1.0",
 		"scssphp/scssphp": "^2.1.0",
@@ -46,7 +39,6 @@
 		"spatie/phpunit-watcher": "^1.23",
 		"yoast/phpunit-polyfills": "^4.0",
 		"composer/installers": "^2.2",
-		"wporg/wporg-mu-plugins": "dev-build",
 		"quickbooks/v3-php-sdk": "*"
 	},
 	"scripts": {
@@ -70,11 +62,7 @@
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer install --no-interaction"
 		],
 		"post-update-cmd": [
-			"[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer update --no-interaction",
-			"[ $COMPOSER_DEV_MODE -eq 0 ] || mkdir -p public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-			"[ $COMPOSER_DEV_MODE -eq 0 ] || rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync/*",
-			"[ $COMPOSER_DEV_MODE -eq 0 ] || mv public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/mu-plugins/* public_html/wp-content/mu-plugins-private/wporg-mu-plugins/pub-sync",
-			"[ $COMPOSER_DEV_MODE -eq 0 ] || rm -rf public_html/wp-content/mu-plugins-private/wporg-mu-plugins/tmp/"
+			"[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer update --no-interaction"
 		]
 	}
 }


### PR DESCRIPTION
## Problem

Composer and `svn:externals` both claim `wp-content/plugins/{name}` and `wp-content/themes/{name}`.

`composer.json` declares ~20 WordPress plugins and themes as dev dependencies, and `installer-paths` writes them to exactly the directories SVN manages as externals:

```json
"public_html/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
"public_html/wp-content/themes/{$name}/":  ["type:wordpress-theme"]
```

Composer replaces a package's directory wholesale when it installs, which destroys the external's working-copy registration. On the deploy checkout that leaves 20 directories unversioned — they keep their files but `svn info` reports "node not found", and because each name is also in `svn:ignore`, `svn status` shows them as `I` rather than `?`.

It recurs on every sync, because `sync-svn-with-git.php` runs `composer update` as its cleanup step. The only fix so far has been deleting the directories and re-running `svn up` — ~313 MB of re-checkout each time.

The three-way split that isolates the cause:

| Directory | In `svn:externals` | In `composer.json` | `svn info` |
|---|---|---|---|
| `plugins/gatherpress` | yes | **no** | points at the external URL — intact |
| `plugins/akismet` | yes | yes, zip dist | "node not found" |
| `plugins/bbpress` | yes | yes, svn source | works, but points at *Composer's* checkout |

Every external that survives is one Composer doesn't manage.

## Change

Move the WordPress plugins and themes that only the local environment needs into `composer-dev.json`, chained from the root manifest:

```json
"post-install-cmd": [
    "[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer install --no-interaction"
],
"post-update-cmd": [
    "[ $COMPOSER_DEV_MODE -eq 0 ] || COMPOSER=composer-dev.json composer update --no-interaction"
]
```

**No developer-facing commands change.** `composer install` and `composer update` set up the same tree as before, in one step. The `$COMPOSER_DEV_MODE` guard matches how the `pub-sync` steps already worked.

The deploy checkout opts out by passing `--no-scripts`, so Composer never touches the externals there. That's a change to `sync-svn-with-git.php`, which lives in SVN rather than this repo — it'll be committed separately, along with a `repair_externals()` backstop for anyone running Composer by hand on the sandbox.

### Notes for review

- **Separate vendor dir** (`.composer-dev/vendor`). Two Composer projects sharing one fight over `vendor/composer/installed.json` and uninstall each other's packages.
- **`wporg/wporg-parent-2021` moves too**, despite being in `require`. `composer/installers` is a dev dependency, so `composer update --no-dev` never applied its installer path anyway — which is why SVN has no `vendor/wporg/` directory. Production takes that theme from the external.
- **`wporg/wporg-mu-plugins` moves too, with its `pub-sync` steps** (second commit). Those steps do `rm -rf .../wporg-mu-plugins/pub-sync/*` and move the GitHub copy in — but on the deploy checkout `pub-sync/` is *versioned*, supplied by the `mu-plugins-private/wporg-mu-plugins` external:

  ```
  $ svn info pub-sync
  URL: https://dotorg.svn.wordpress.org/wordpress/website/wp-content/mu-plugins/pub-sync
  $ svn status pub-sync      # recursive
  (0 modifications)
  ```

  It's also load-bearing there — `load-other-mu-plugins.php`, `2-autoloader.php`, and `wporg-sso.php` all require files out of it. Moving it means the root manifest's only event scripts are the dev chain, so the deploy checkout's `--no-scripts` skips exactly that and nothing else. Local environments are unaffected: the dev manifest runs `pub-sync` from its own hooks.
- **`composer-dev.lock` is gitignored**, matching this repo's convention of not committing lock files (bb5747af).

### Verification

- Both manifests pass `composer validate`.
- Production dependency set is unchanged: same 12 packages at the same versions, so the SVN-committed `mu-plugins/vendor` tree is unaffected.
- Confirmed `composer update --no-dev` still writes `packages-dev` to the lock, so the deploy script's follow-up `composer install` restores dev dependencies — and that `composer install` with no lock file falls back to update behaviour rather than failing, which matters since lock files aren't committed here.
- Lock files regenerated with `--no-install --no-scripts`, so nothing touched disk.

### Not covered here

`svn:ignore` on `mu-plugins/vendor` still lists `psr`, which was correct when psr was dev-only. It isn't anymore — `league/uri` requires `psr/http-factory` in the production set, and the committed autoloader maps `Psr\Http\Message\` to `vendor/psr/…`, which isn't in SVN. PSR-4 is lazy so it only fatals if something instantiates those classes, but it's worth closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)