### PR TITLE
Groups: add site-provisioning admin tool, fix invisible settings modal, fix dbDelta schema bug

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/group-site-provisioning.php
+++ b/public_html/wp-content/mu-plugins/groups/group-site-provisioning.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Network-admin tool for provisioning new Group sites.
+ *
+ * Deputies/Program Managers can create a fully configured Group site
+ * (`events.wordpress.org/group/{slug}/`) from Network Admin > Sites, instead
+ * of hand-running `wp_insert_site()`/`wp site create` on the sandbox.
+ *
+ * Only loaded on the Groups network, via
+ * `load-other-mu-plugins.php::wcorg_include_network_only_plugins()`.
+ *
+ * @package WordCamp\Groups
+ */
+
+namespace WordCamp\Groups\Site_Provisioning;
+
+use WordCamp\Logger;
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+const PAGE_SLUG    = 'add-group-site';
+const NONCE_ACTION = 'wcorg_create_group_site';
+const NONCE_NAME   = 'wcorg_create_group_site_nonce';
+
+add_action( 'network_admin_menu', __NAMESPACE__ . '\register_admin_page' );
+add_action( 'admin_init', __NAMESPACE__ . '\handle_form_submission' );
+
+/**
+ * Add the "Add Group Site" screen under Network Admin > Sites.
+ */
+function register_admin_page() {
+	add_submenu_page(
+		'sites.php',
+		__( 'Add Group Site', 'wordcamporg' ),
+		__( 'Add Group Site', 'wordcamporg' ),
+		'manage_sites',
+		PAGE_SLUG,
+		__NAMESPACE__ . '\render_admin_page'
+	);
+}
+
+/**
+ * Handle the create-site form submission.
+ *
+ * Runs on `admin_init` so it completes before `render_admin_page()` renders
+ * on the same request -- no redirect needed, `settings_errors()` picks up
+ * whatever this adds to the global settings-errors list.
+ */
+function handle_form_submission() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified with check_admin_referer() below.
+	if ( empty( $_POST['wcorg_create_group_site'] ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'manage_sites' ) ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to create sites on this network.', 'wordcamporg' ) );
+	}
+
+	check_admin_referer( NONCE_ACTION, NONCE_NAME );
+
+	$title           = isset( $_POST['group_title'] ) ? sanitize_text_field( wp_unslash( $_POST['group_title'] ) ) : '';
+	$slug            = isset( $_POST['group_slug'] ) ? sanitize_text_field( wp_unslash( $_POST['group_slug'] ) ) : '';
+	$organizer_login = isset( $_POST['organizer_login'] ) ? sanitize_user( wp_unslash( $_POST['organizer_login'] ), true ) : '';
+	$timezone_string = isset( $_POST['timezone_string'] ) ? sanitize_text_field( wp_unslash( $_POST['timezone_string'] ) ) : '';
+
+	$result = create_group_site( $title, $slug, $organizer_login, $timezone_string );
+
+	if ( is_wp_error( $result ) ) {
+		add_settings_error( 'wcorg-add-group-site', $result->get_error_code(), $result->get_error_message() );
+		return;
+	}
+
+	add_settings_error(
+		'wcorg-add-group-site',
+		'success',
+		sprintf(
+			/* translators: 1: Site dashboard URL, 2: Site front-end URL. */
+			__( 'Group site created. <a href="%1$s">Dashboard</a> | <a href="%2$s">Visit site</a>', 'wordcamporg' ),
+			esc_url( get_admin_url( $result ) ),
+			esc_url( get_home_url( $result ) )
+		),
+		'success'
+	);
+}
+
+/**
+ * Render the "Add Group Site" form.
+ */
+function render_admin_page() {
+	if ( ! current_user_can( 'manage_sites' ) ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to create sites on this network.', 'wordcamporg' ) );
+	}
+
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Add Group Site', 'wordcamporg' ); ?></h1>
+
+		<?php settings_errors( 'wcorg-add-group-site' ); ?>
+
+		<form method="post" action="">
+			<?php wp_nonce_field( NONCE_ACTION, NONCE_NAME ); ?>
+			<input type="hidden" name="wcorg_create_group_site" value="1" />
+
+			<table class="form-table" role="presentation">
+				<tr>
+					<th scope="row"><label for="group_title"><?php esc_html_e( 'Group name', 'wordcamporg' ); ?></label></th>
+					<td><input name="group_title" type="text" id="group_title" class="regular-text" required="required" /></td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="group_slug"><?php esc_html_e( 'Slug', 'wordcamporg' ); ?></label></th>
+					<td>
+						<code><?php echo esc_html( get_network( GROUPS_NETWORK_ID )->domain . '/group/' ); ?></code>
+						<input name="group_slug" type="text" id="group_slug" class="regular-text" required="required" />
+						<code>/</code>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="organizer_login"><?php esc_html_e( 'Lead organizer (WordPress.org username)', 'wordcamporg' ); ?></label></th>
+					<td><input name="organizer_login" type="text" id="organizer_login" class="regular-text" required="required" /></td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="timezone_string"><?php esc_html_e( 'Timezone', 'wordcamporg' ); ?></label></th>
+					<td>
+						<select id="timezone_string" name="timezone_string">
+							<?php echo wp_timezone_choice( '', get_user_locale() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Core function, already escaped. ?>
+						</select>
+					</td>
+				</tr>
+			</table>
+
+			<?php submit_button( __( 'Create Group Site', 'wordcamporg' ) ); ?>
+		</form>
+	</div>
+	<?php
+}
+
+/**
+ * Create and configure a new Group site.
+ *
+ * Callers MUST verify the `manage_sites` capability before calling this --
+ * it performs no capability check of its own, matching the convention in
+ * `WordCamp_New_Site::_create_site()`.
+ *
+ * @param string $title           The group's display name.
+ * @param string $slug            The desired `/group/{slug}/` path segment.
+ * @param string $organizer_login The WordPress.org username of the lead organizer.
+ * @param string $timezone_string Optional. A PHP timezone identifier (e.g. `Australia/Brisbane`).
+ *
+ * @return int|WP_Error The new site's ID, or a WP_Error on failure.
+ */
+function create_group_site( string $title, string $slug, string $organizer_login, string $timezone_string = '' ) {
+	$slug = sanitize_title( $slug );
+
+	if ( '' === $slug || ! preg_match( '/^[\w-]+$/', $slug ) ) {
+		Logger\log( 'invalid_slug', compact( 'title', 'slug', 'organizer_login' ) );
+		return new WP_Error( 'invalid_slug', __( 'Please enter a valid slug.', 'wordcamporg' ) );
+	}
+
+	$network = get_network( GROUPS_NETWORK_ID );
+	$path    = "/group/{$slug}/";
+
+	if ( domain_exists( $network->domain, $path, GROUPS_NETWORK_ID ) ) {
+		Logger\log( 'slug_taken', compact( 'title', 'slug', 'organizer_login' ) );
+		return new WP_Error( 'slug_taken', __( 'That slug is already in use by another group.', 'wordcamporg' ) );
+	}
+
+	$organizer = get_user_by( 'login', $organizer_login );
+
+	if ( ! $organizer ) {
+		Logger\log( 'organizer_not_found', compact( 'title', 'slug', 'organizer_login' ) );
+		return new WP_Error( 'organizer_not_found', __( 'No user was found with that WordPress.org username.', 'wordcamporg' ) );
+	}
+
+	$site_id = wp_insert_site(
+		array(
+			'domain'     => $network->domain,
+			'path'       => $path,
+			'title'      => $title,
+			'network_id' => GROUPS_NETWORK_ID,
+			'user_id'    => $organizer->ID,
+		)
+	);
+
+	if ( is_wp_error( $site_id ) ) {
+		Logger\log( 'insert_site_failed', compact( 'title', 'slug', 'organizer_login', 'site_id' ) );
+		return $site_id;
+	}
+
+	switch_to_blog( $site_id );
+
+	switch_theme( 'groups-site' );
+
+	update_option( 'siteurl', set_url_scheme( get_option( 'siteurl' ), 'https' ) );
+	update_option( 'home', set_url_scheme( get_option( 'home' ), 'https' ) );
+
+	if ( $timezone_string ) {
+		update_option( 'timezone_string', $timezone_string );
+	}
+
+	// `wp_initialize_site()` seeds every new site with generic WP boilerplate
+	// ("Hello world!", "Sample Page") via `wp_install_defaults()`. A group
+	// site should start from the group template, not stock WP content.
+	foreach ( array( array( 'post', 'hello-world' ), array( 'page', 'sample-page' ) ) as list( $post_type, $post_name ) ) {
+		$stub = get_page_by_path( $post_name, OBJECT, $post_type );
+		if ( $stub ) {
+			wp_delete_post( $stub->ID, true );
+		}
+	}
+
+	// `templates/page-members.html` in the `groups-site` theme only resolves
+	// at `/members/` if a page with this slug actually exists.
+	wp_insert_post(
+		array(
+			'post_type'   => 'page',
+			'post_title'  => __( 'Members', 'wordcamporg' ),
+			'post_name'   => 'members',
+			'post_status' => 'publish',
+			'post_author' => $organizer->ID,
+		)
+	);
+
+	restore_current_blog();
+
+	Logger\log( 'finished', compact( 'title', 'slug', 'organizer_login', 'site_id' ) );
+
+	return $site_id;
+}

--- a/public_html/wp-content/mu-plugins/groups/group-site-provisioning.php
+++ b/public_html/wp-content/mu-plugins/groups/group-site-provisioning.php
@@ -172,6 +172,11 @@ function create_group_site( string $title, string $slug, string $organizer_login
 		return new WP_Error( 'organizer_not_found', __( 'No user was found with that WordPress.org username.', 'wordcamporg' ) );
 	}
 
+	if ( $timezone_string && ! in_array( $timezone_string, timezone_identifiers_list(), true ) ) {
+		Logger\log( 'invalid_timezone', compact( 'title', 'slug', 'organizer_login', 'timezone_string' ) );
+		return new WP_Error( 'invalid_timezone', __( 'Please select a valid timezone.', 'wordcamporg' ) );
+	}
+
 	$site_id = wp_insert_site(
 		array(
 			'domain'     => $network->domain,
@@ -210,15 +215,20 @@ function create_group_site( string $title, string $slug, string $organizer_login
 
 	// `templates/page-members.html` in the `groups-site` theme only resolves
 	// at `/members/` if a page with this slug actually exists.
-	wp_insert_post(
+	$members_page = wp_insert_post(
 		array(
 			'post_type'   => 'page',
 			'post_title'  => __( 'Members', 'wordcamporg' ),
 			'post_name'   => 'members',
 			'post_status' => 'publish',
 			'post_author' => $organizer->ID,
-		)
+		),
+		true
 	);
+
+	if ( is_wp_error( $members_page ) ) {
+		Logger\log( 'members_page_failed', compact( 'title', 'slug', 'organizer_login', 'site_id' ) );
+	}
 
 	restore_current_blog();
 

--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -27,7 +27,12 @@ function manually_load_plugin() {
 
 	require_once $gatherpress_file;
 
+	// `group-site-provisioning.php` calls `WordCamp\Logger\log()`, which isn't
+	// autoloaded in the test environment the way it is on a real request.
+	require_once dirname( __DIR__, 2 ) . '/1-logger.php';
+
 	require_once dirname( __DIR__ ) . '/gatherpress-groups-tweaks.php';
+	require_once dirname( __DIR__ ) . '/group-site-provisioning.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-site-provisioning.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-site-provisioning.php
@@ -20,6 +20,9 @@ class Test_Group_Site_Provisioning extends Groups_TestCase {
 	 */
 	protected static $organizer_id;
 
+	/**
+	 * @param \WP_UnitTest_Factory $factory
+	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-site-provisioning.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-site-provisioning.php
@@ -84,11 +84,13 @@ class Test_Group_Site_Provisioning extends Groups_TestCase {
 	 * An unknown organizer username is rejected before any site is created.
 	 */
 	public function test_rejects_unknown_organizer() {
+		$existing_count = count( get_sites( array( 'network_id' => GROUPS_NETWORK_ID ) ) );
+
 		$result = create_group_site( 'Nowhere Group', 'nowhere', 'this-user-does-not-exist' );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'organizer_not_found', $result->get_error_code() );
-		$this->assertNull( get_page_by_path( 'nowhere' ) ); // Sanity: nothing else ran.
+		$this->assertCount( $existing_count, get_sites( array( 'network_id' => GROUPS_NETWORK_ID ) ) );
 	}
 
 	/**
@@ -99,5 +101,19 @@ class Test_Group_Site_Provisioning extends Groups_TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'invalid_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * A timezone that isn't a real PHP timezone identifier is rejected before
+	 * any site is created.
+	 */
+	public function test_rejects_invalid_timezone() {
+		$existing_count = count( get_sites( array( 'network_id' => GROUPS_NETWORK_ID ) ) );
+
+		$result = create_group_site( 'Bad Timezone Group', 'bad-timezone', 'grouporganizer', 'Not/A_Real_Zone' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_timezone', $result->get_error_code() );
+		$this->assertCount( $existing_count, get_sites( array( 'network_id' => GROUPS_NETWORK_ID ) ) );
 	}
 }

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-site-provisioning.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-site-provisioning.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_Error;
+
+use function WordCamp\Groups\Site_Provisioning\create_group_site;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Group_Site_Provisioning extends Groups_TestCase {
+
+	/**
+	 * @var int
+	 */
+	protected static $organizer_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::$organizer_id = $factory->user->create( array( 'user_login' => 'grouporganizer' ) );
+	}
+
+	/**
+	 * Happy path: a valid request creates a fully configured Group site.
+	 */
+	public function test_creates_configured_group_site() {
+		$site_id = create_group_site( 'Narnia WordPress Meetup', 'narnia', 'grouporganizer', 'Australia/Brisbane' );
+
+		$this->assertIsInt( $site_id );
+
+		$site = get_site( $site_id );
+		$this->assertSame( 'events.wordpress.test', $site->domain );
+		$this->assertSame( '/group/narnia/', $site->path );
+
+		switch_to_blog( $site_id );
+
+		$this->assertSame( 'groups-site', get_stylesheet() );
+		$this->assertSame( 'Australia/Brisbane', get_option( 'timezone_string' ) );
+
+		$organizer = new \WP_User( self::$organizer_id );
+		$this->assertContains( 'administrator', $organizer->roles );
+
+		$members_page = get_page_by_path( 'members' );
+		$this->assertNotNull( $members_page );
+		$this->assertSame( 'publish', $members_page->post_status );
+
+		// The stock "Hello world!"/"Sample Page" boilerplate shouldn't survive --
+		// a group site should start from the group template, not generic WP content.
+		$this->assertNull( get_page_by_path( 'hello-world', OBJECT, 'post' ) );
+		$this->assertNull( get_page_by_path( 'sample-page' ) );
+
+		// Leaving `blogdescription` at its default is intentional -- it's
+		// what triggers the existing "Set up your group" nudge in
+		// `group-settings/render.php`.
+		$this->assertSame( '', get_option( 'blogdescription' ) );
+
+		restore_current_blog();
+	}
+
+	/**
+	 * A slug that's already in use by another group is rejected, and no new
+	 * site is created.
+	 */
+	public function test_rejects_duplicate_slug() {
+		$existing_count = count( get_sites( array( 'network_id' => GROUPS_NETWORK_ID ) ) );
+
+		$result = create_group_site( 'Duplicate Group', 'sunshine-coast-qld', 'grouporganizer' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_taken', $result->get_error_code() );
+		$this->assertCount( $existing_count, get_sites( array( 'network_id' => GROUPS_NETWORK_ID ) ) );
+	}
+
+	/**
+	 * An unknown organizer username is rejected before any site is created.
+	 */
+	public function test_rejects_unknown_organizer() {
+		$result = create_group_site( 'Nowhere Group', 'nowhere', 'this-user-does-not-exist' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'organizer_not_found', $result->get_error_code() );
+		$this->assertNull( get_page_by_path( 'nowhere' ) ); // Sanity: nothing else ran.
+	}
+
+	/**
+	 * An empty/unsanitizable slug is rejected before any site is created.
+	 */
+	public function test_rejects_invalid_slug() {
+		$result = create_group_site( 'No Slug Group', '!!!', 'grouporganizer' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_slug', $result->get_error_code() );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
@@ -32,13 +32,24 @@ const EVENT_MANAGER_ROLES = array( 'administrator', 'editor', 'author' );
  * REST layer's per-post capability checks (`edit_post`/`publish_post`)
  * already restrict them to events they own. Editors and administrators
  * ("Organisers") can manage everyone's events.
+ *
+ * Super admins are recognised explicitly because this is a role-array check
+ * rather than a `current_user_can()` capability check (see the docblock on
+ * `EVENT_MANAGER_ROLES`) — unlike `current_user_can_manage_group_settings()`,
+ * it doesn't automatically pick up core's super-admin capability elevation.
+ * Without this, a super admin whose nominal role on a given group is
+ * `subscriber` (e.g. a deputy who isn't the group's own organiser) would see
+ * the "Set up your group" button — gated by `current_user_can_manage_group_settings()`,
+ * which does elevate — but the modal would render invisibly, because the
+ * `wp-components`/`wp-block-editor` styles enqueued in `Modal::enqueue_supplementary_assets()`
+ * are gated on this function.
  */
 function current_user_can_manage_events(): bool {
 	if ( ! is_user_logged_in() ) {
 		return false;
 	}
 
-	$user_can = (bool) array_intersect( EVENT_MANAGER_ROLES, wp_get_current_user()->roles );
+	$user_can = is_super_admin() || (bool) array_intersect( EVENT_MANAGER_ROLES, wp_get_current_user()->roles );
 
 	/**
 	 * Filters the capability check used by the front-end event management UI.

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -92,9 +92,13 @@ class Test_Groups_Capabilities extends Groups_TestCase {
 		grant_super_admin( $user_id );
 		wp_set_current_user( $user_id );
 
-		$this->assertTrue( current_user_can_manage_events() );
-
-		revoke_super_admin( $user_id );
+		// `revoke_super_admin()` must run even if the assertion fails, or this
+		// user's super-admin status leaks into later tests in the suite.
+		try {
+			$this->assertTrue( current_user_can_manage_events() );
+		} finally {
+			revoke_super_admin( $user_id );
+		}
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -69,6 +69,35 @@ class Test_Groups_Capabilities extends Groups_TestCase {
 	}
 
 	/**
+	 * Regression test: a super admin whose nominal role on a given group is
+	 * `subscriber` (e.g. a deputy checking in on a group they don't
+	 * personally organise) must still be treated as able to manage events.
+	 *
+	 * `current_user_can_manage_group_settings()` naturally picks up core's
+	 * super-admin capability elevation (it calls `current_user_can()`), so
+	 * the "Set up your group" button renders for such a user. But this
+	 * function is a role-array check, which does NOT pick up that
+	 * elevation -- without the `is_super_admin()` check, the
+	 * `wp-components`/`wp-block-editor` styles gated on it in
+	 * `Modal::enqueue_supplementary_assets()` never load, and the settings
+	 * modal renders with no CSS (invisible, but present in the DOM).
+	 */
+	public function test_super_admin_can_manage_events_despite_subscriber_role() {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_userdata( $user_id );
+
+		// Overrides the `$super_admins` global directly rather than going through
+		// `grant_super_admin()`/the `site_admins` site option, which is shared,
+		// mutable state that other tests in the suite can leave in a bad shape.
+		$GLOBALS['super_admins'] = array( $user->user_login );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( current_user_can_manage_events() );
+
+		unset( $GLOBALS['super_admins'] );
+	}
+
+	/**
 	 * Regression test for the privilege-escalation bug fixed before #1793
 	 * shipped: editors were briefly granted `promote_users` so this plugin
 	 * could let them manage member roles, which also silently unlocked the

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -84,17 +84,17 @@ class Test_Groups_Capabilities extends Groups_TestCase {
 	 */
 	public function test_super_admin_can_manage_events_despite_subscriber_role() {
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
-		$user    = get_userdata( $user_id );
 
-		// Overrides the `$super_admins` global directly rather than going through
-		// `grant_super_admin()`/the `site_admins` site option, which is shared,
-		// mutable state that other tests in the suite can leave in a bad shape.
-		$GLOBALS['super_admins'] = array( $user->user_login );
+		// Reset to a clean array first -- `site_admins` is shared, mutable state
+		// scoped to the current network, and other tests in the suite can leave
+		// it in a shape `grant_super_admin()` doesn't expect.
+		update_site_option( 'site_admins', array() );
+		grant_super_admin( $user_id );
 		wp_set_current_user( $user_id );
 
 		$this->assertTrue( current_user_can_manage_events() );
 
-		unset( $GLOBALS['super_admins'] );
+		revoke_super_admin( $user_id );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -201,7 +201,7 @@ function upgrade_database() {
 			last_modified  datetime                  NOT NULL default '0000-00-00 00:00:00',
 
 			PRIMARY KEY (blog_id, invoice_id),
-			KEY status (status)
+			KEY status (status),
 			KEY last_modified (last_modified)
 		)
 		$charset_collate


### PR DESCRIPTION
Fixes #1782

## Summary
- **Add Group site provisioning** (#1782): a Network Admin > Sites > Add Group Site screen for deputies to create a fully configured Group site (theme, timezone, Members page, organiser) instead of hand-running `wp_insert_site()`/`wp site create` on the sandbox.
- **Fix invisible "Set up your group" modal**: `current_user_can_manage_events()` used a role-array check that didn't recognize super-admin capability elevation the way `current_user_can_manage_group_settings()` does, so a super admin without an explicit editor/admin role on a given group saw the settings button but the modal rendered with no CSS (mounted in the DOM, but invisible — `position: static`, transparent background).
- **Fix a pre-existing dbDelta schema bug** in `wordcamp-payments-network`: a missing comma between two `KEY` definitions corrupted `dbDelta()`'s index diffing, generating a malformed `ALTER TABLE ... ADD `` (``)` query that fataled every Network Admin page load on any install still missing the `last_modified` index. Found while verifying the above through the actual browser UI.

## Test plan

### Automated
- [x] `Test_Group_Site_Provisioning` (happy path, duplicate slug, unknown organizer, invalid slug) — new, passing.
- [x] `Test_Groups_Capabilities::test_super_admin_can_manage_events_despite_subscriber_role` — new regression test, passing.
- [x] Full "WordCamp Groups" PHPUnit suite (54 tests) — passing.
- [x] `BASE_REF=production php .github/bin/phpcs-branch.php` — clean.

### Manual (local dev — `events.wordpress.test`)
Steps below use the local Docker dev domain (`events.wordpress.test`); on a real deploy substitute `events.wordpress.org`.

**Group site provisioning**
1. As a network admin/deputy, go to **Network Admin > Sites > Add Group Site** on the Groups network (`events.wordpress.test/group/wp-admin/network/sites.php?page=add-group-site`).
2. Fill in a group name, slug, an existing user's WordPress.org username as lead organiser, and a timezone. Submit.

<img width="1023" height="610" alt="Screenshot 2026-08-04 at 13 02 41" src="https://github.com/user-attachments/assets/543b6042-d4b3-4ce7-990e-61b63a925593" />

3. Confirm: success notice with working Dashboard/Visit links; the new site appears in Network Admin > Sites at `events.wordpress.test/group/{slug}/`.
4. Visit the new site: confirm the `groups-site` theme is active, `/members/` resolves (not a 404) and lists the organiser, and there's no leftover "Hello world!"/"Sample Page" boilerplate.

<img width="789" height="1003" alt="Screenshot 2026-08-04 at 13 02 51" src="https://github.com/user-attachments/assets/51653d9d-c5e8-434f-9278-54f46937c626" />

5. Log in as the organiser: confirm the "Set up your group" nudge still appears (i.e. `blogdescription` was left blank on purpose).
6. Re-submit the form with the same slug — confirm it's rejected with "That slug is already in use by another group." and no second site is created.

**Settings modal visibility**
1. As a network super admin who is **not** an explicit editor/admin on a given group site (e.g. just a subscriber/member there), open that group's front page.
2. Click **Set up your group** (or **Settings**, if the group is already configured).
3. Before this fix: nothing visibly happens (the modal mounts with no styling and is invisible). After this fix: the full-screen settings modal renders normally with tabs (Events/Venues/Members/Design/About).

**dbDelta fix**
This only manifests on an install whose `{prefix}wcbd_sponsor_invoice_index` table already exists but predates the `last_modified` index (i.e. `wcbdsi_database_version` site option < 4 on a given network). On such an install, before this fix, any Network Admin page load fatals with `WordPress database error: ... ALTER TABLE ... ADD `` (``)`; after this fix, `dbDelta()` correctly generates `ALTER TABLE ... ADD KEY last_modified (last_modified)` and Network Admin loads normally on every network.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>