### PR TITLE
Groups: add global sponsors management

### DIFF
--- a/public_html/wp-content/mu-plugins/events/wporg-groups-sponsors.php
+++ b/public_html/wp-content/mu-plugins/events/wporg-groups-sponsors.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Loads the global sponsors store on the events network.
+ *
+ * The sponsors themselves render on the group sites (groups network), but the
+ * posts live on the events root site — see the file header of
+ * `wporg-groups-frontend/inc/sponsors.php` for why. That site is on this
+ * network, so the post type and its admin screens have to be registered here
+ * as well; `mu-plugins/groups/wporg-groups-frontend.php` covers the reading
+ * side.
+ *
+ * Only the sponsors file is loaded, not the whole `wporg-groups-frontend`
+ * plugin: nothing else in it applies to a site that has no group and no
+ * GatherPress.
+ *
+ * @package WordCamp\Groups
+ */
+
+namespace WordCamp\Groups\Events_Loader;
+
+use WordCamp\Groups\Frontend\Sponsors;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/sponsors.php';
+
+Sponsors\bootstrap();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/blocks.php
@@ -32,6 +32,7 @@ function register_blocks(): void {
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/event-speakers' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/my-events' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/page-content' );
+	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/sponsors' );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
@@ -1,0 +1,432 @@
+<?php
+/**
+ * Global sponsors for the groups network.
+ *
+ * Sponsors are network-level data: the same list is shown on every group
+ * site, so it can't live in a per-site table the way events, venues and
+ * members do. The store is a `wporg_sponsor` post type on the events root
+ * site (`EVENTS_ROOT_BLOG_ID`), edited in wp-admin there by network admins,
+ * and read at render time by every group site via `switch_to_blog()`.
+ * Nothing is copied into the group sites, so there is exactly one copy of
+ * each sponsor to keep up to date (cf. the `multi-event-sponsors` plugin on
+ * central.wordcamp.org, which forks its posts out to each camp site and then
+ * has to push edits back over them).
+ *
+ * The events root rather than the groups network root, which would otherwise
+ * be the obvious home, because sponsor logos are attachments and have to be
+ * publicly fetchable: this network serves uploads through ms-files rewriting,
+ * and `sunrise-groups.php` bounces every non-admin request for the groups
+ * root site to the events root — including its own `/group/files/…` uploads,
+ * which 302 away instead of serving. `events.wordpress.org/files/…` serves
+ * normally, so the logos load with no rewrite or redirect changes needed.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+namespace WordCamp\Groups\Frontend\Sponsors;
+
+use WP_Post;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * The sponsor post type. Registered on every group site (so `get_post_type_object()`
+ * resolves when the block reads the store site's posts) but only editable on the
+ * store site — see `register_post_type()` below.
+ */
+const POST_TYPE = 'wporg_sponsor';
+
+/**
+ * Post meta holding the sponsor's website URL.
+ */
+const URL_META_KEY = '_wporg_sponsor_url';
+
+/**
+ * Transient caching the render-ready sponsor list.
+ *
+ * Lives on the store site itself, not on the sites that read it: the store is
+ * on the events network while the group sites are on the groups network, so a
+ * *network*-scoped transient written when a sponsor is saved would never be
+ * the one a group site reads. Invalidated whenever a sponsor changes; the
+ * expiry is only a backstop for edits this plugin doesn't see (e.g. a direct
+ * database change, or an attachment being edited).
+ */
+const CACHE_KEY = 'wporg_groups_sponsors';
+
+/**
+ * How long the sponsor list stays cached, in seconds.
+ */
+const CACHE_TTL = HOUR_IN_SECONDS;
+
+/**
+ * Bootstrap the sponsors feature.
+ *
+ * Runs on both the groups network (where the block reads sponsors) and the
+ * events network (where they're edited — see
+ * `mu-plugins/events/wporg-groups-sponsors.php`). Deliberately called outside
+ * the main plugin's GatherPress guard: sponsors don't touch events, and the
+ * store site doesn't run GatherPress at all.
+ */
+function bootstrap(): void {
+	add_action( 'init', __NAMESPACE__ . '\register_post_type' );
+	add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_meta_boxes' );
+	add_action( 'save_post_' . POST_TYPE, __NAMESPACE__ . '\save_sponsor_url' );
+
+	// Keep the cached list honest.
+	add_action( 'save_post_' . POST_TYPE, __NAMESPACE__ . '\flush_cache' );
+	add_action( 'deleted_post', __NAMESPACE__ . '\flush_cache_for_post', 10, 2 );
+	add_action( 'trashed_post', __NAMESPACE__ . '\flush_cache_for_post' );
+	add_action( 'untrashed_post', __NAMESPACE__ . '\flush_cache_for_post' );
+}
+
+/**
+ * The blog ID that stores the sponsors — see the file header for why it's
+ * this site.
+ *
+ * Returns 0 when the constant isn't defined (an environment that predates
+ * it), which callers treat as "no sponsors".
+ */
+function get_store_blog_id(): int {
+	return defined( 'EVENTS_ROOT_BLOG_ID' ) ? (int) EVENTS_ROOT_BLOG_ID : 0;
+}
+
+/**
+ * Run a callback in the store site's context.
+ *
+ * @param callable $callback Receives no arguments; its return value is passed through.
+ * @return mixed The callback's return value, or null when there's no store site.
+ */
+function with_store_site( callable $callback ) {
+	$store_blog_id = get_store_blog_id();
+
+	if ( ! $store_blog_id ) {
+		return null;
+	}
+
+	$switched = get_current_blog_id() !== $store_blog_id;
+
+	if ( $switched ) {
+		switch_to_blog( $store_blog_id );
+	}
+
+	try {
+		return $callback();
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Register the sponsor post type.
+ *
+ * The admin UI is only exposed on the store site, so a group organiser never
+ * sees the post type on their own site, and every capability maps to
+ * `manage_network` so only network admins can add, edit or delete sponsors
+ * even if they somehow reach the screen.
+ */
+function register_post_type(): void {
+	$is_store = get_current_blog_id() === get_store_blog_id();
+
+	// Every primitive capability the post type can ask for, all mapped to
+	// `manage_network`. `map_meta_cap` then resolves `edit_post`/`delete_post`
+	// through these, so there's no route to editing a sponsor without being a
+	// network admin.
+	$network_admin_only = array_fill_keys(
+		array(
+			'edit_post',
+			'read_post',
+			'delete_post',
+			'edit_posts',
+			'edit_others_posts',
+			'edit_published_posts',
+			'edit_private_posts',
+			'publish_posts',
+			'read_private_posts',
+			'delete_posts',
+			'delete_others_posts',
+			'delete_published_posts',
+			'delete_private_posts',
+			'create_posts',
+		),
+		'manage_network'
+	);
+
+	\register_post_type(
+		POST_TYPE,
+		array(
+			'labels'          => array(
+				'name'               => __( 'Sponsors', 'wporg-groups-frontend' ),
+				'singular_name'      => __( 'Sponsor', 'wporg-groups-frontend' ),
+				'add_new_item'       => __( 'Add New Sponsor', 'wporg-groups-frontend' ),
+				'edit_item'          => __( 'Edit Sponsor', 'wporg-groups-frontend' ),
+				'new_item'           => __( 'New Sponsor', 'wporg-groups-frontend' ),
+				'view_item'          => __( 'View Sponsor', 'wporg-groups-frontend' ),
+				'search_items'       => __( 'Search Sponsors', 'wporg-groups-frontend' ),
+				'not_found'          => __( 'No sponsors found', 'wporg-groups-frontend' ),
+				'not_found_in_trash' => __( 'No sponsors found in Trash', 'wporg-groups-frontend' ),
+				'all_items'          => __( 'Sponsors', 'wporg-groups-frontend' ),
+				'menu_name'          => __( 'Sponsors', 'wporg-groups-frontend' ),
+			),
+			// Sponsors have no pages of their own — they're rendered by the
+			// `wporg/sponsors` block and link out to the sponsor's own site.
+			'public'          => false,
+			'show_ui'         => $is_store,
+			'show_in_menu'    => $is_store,
+			'show_in_rest'    => $is_store,
+			'menu_icon'       => 'dashicons-awards',
+			'menu_position'   => 25,
+			'hierarchical'    => false,
+			'has_archive'     => false,
+			'rewrite'         => false,
+			'query_var'       => false,
+			'map_meta_cap'    => true,
+			'capability_type' => POST_TYPE,
+			'capabilities'    => $network_admin_only,
+			// `page-attributes` gives admins an explicit sponsor order via
+			// `menu_order`; `excerpt` is the short description in the block.
+			'supports'        => array( 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes', 'revisions' ),
+		)
+	);
+
+	register_post_meta(
+		POST_TYPE,
+		URL_META_KEY,
+		array(
+			'type'              => 'string',
+			'single'            => true,
+			'default'           => '',
+			'sanitize_callback' => 'sanitize_url',
+			'show_in_rest'      => $is_store,
+			'auth_callback'     => function () {
+				return current_user_can( 'manage_network' );
+			},
+		)
+	);
+}
+
+/**
+ * Add the sponsor website meta box.
+ */
+function add_meta_boxes(): void {
+	add_meta_box(
+		'wporg-sponsor-url',
+		__( 'Sponsor Website', 'wporg-groups-frontend' ),
+		__NAMESPACE__ . '\render_url_meta_box',
+		POST_TYPE,
+		'side'
+	);
+}
+
+/**
+ * Render the sponsor website meta box.
+ *
+ * @param WP_Post $post The sponsor being edited.
+ */
+function render_url_meta_box( WP_Post $post ): void {
+	wp_nonce_field( 'wporg_sponsor_url', 'wporg_sponsor_url_nonce' );
+	$url = (string) get_post_meta( $post->ID, URL_META_KEY, true );
+	?>
+	<p>
+		<label class="screen-reader-text" for="wporg-sponsor-url-field">
+			<?php esc_html_e( 'Sponsor website URL', 'wporg-groups-frontend' ); ?>
+		</label>
+		<input
+			type="url"
+			class="widefat"
+			id="wporg-sponsor-url-field"
+			name="wporg_sponsor_url"
+			value="<?php echo esc_attr( $url ); ?>"
+			placeholder="https://example.org/"
+		/>
+	</p>
+	<p class="description">
+		<?php esc_html_e( 'Where the sponsor card links to. Leave empty to render the sponsor without a link.', 'wporg-groups-frontend' ); ?>
+	</p>
+	<?php
+}
+
+/**
+ * Persist the sponsor website URL.
+ *
+ * @param int $post_id The sponsor being saved.
+ */
+function save_sponsor_url( int $post_id ): void {
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	// The block editor saves meta through the REST API, so an absent field
+	// here means "this request isn't the meta box" rather than "clear it".
+	if ( ! isset( $_POST['wporg_sponsor_url'] ) ) {
+		return;
+	}
+
+	if ( ! isset( $_POST['wporg_sponsor_url_nonce'] )
+		|| ! wp_verify_nonce( sanitize_key( $_POST['wporg_sponsor_url_nonce'] ), 'wporg_sponsor_url' )
+	) {
+		return;
+	}
+
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	$url = sanitize_url( wp_unslash( $_POST['wporg_sponsor_url'] ) );
+
+	if ( '' === $url ) {
+		delete_post_meta( $post_id, URL_META_KEY );
+	} else {
+		update_post_meta( $post_id, URL_META_KEY, $url );
+	}
+}
+
+/**
+ * Drop the cached sponsor list.
+ */
+function flush_cache(): void {
+	with_store_site(
+		function () {
+			delete_transient( CACHE_KEY );
+		}
+	);
+}
+
+/**
+ * Drop the cached sponsor list when a sponsor post is trashed or deleted.
+ *
+ * @param int          $post_id The post being removed.
+ * @param WP_Post|null $post    The post object, when the hook passes one.
+ */
+function flush_cache_for_post( int $post_id, ?WP_Post $post = null ): void {
+	$post_type = $post ? $post->post_type : get_post_type( $post_id );
+
+	if ( POST_TYPE === $post_type ) {
+		flush_cache();
+	}
+}
+
+/**
+ * Get the network's sponsors, ready for rendering.
+ *
+ * Each entry is a flat array — `name`, `description`, `url`, `logo`,
+ * `logo_width`, `logo_height` — rather than a `WP_Post`, because the posts
+ * belong to another site: passing them back would leave callers calling
+ * `get_the_title()` and friends in the wrong blog context. Resolving
+ * everything here, inside the `switch_to_blog()`, keeps that boundary in one
+ * place and makes the result cacheable as-is.
+ *
+ * @return array<int, array<string, mixed>> Sponsors in display order.
+ */
+function get_sponsors(): array {
+	$sponsors = with_store_site(
+		function () {
+			$cached = get_transient( CACHE_KEY );
+
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
+
+			$posts = get_posts(
+				array(
+					'post_type'        => POST_TYPE,
+					'post_status'      => 'publish',
+					'numberposts'      => 100,
+					'orderby'          => array(
+						'menu_order' => 'ASC',
+						'title'      => 'ASC',
+					),
+					'suppress_filters' => false,
+				)
+			);
+
+			$sponsors = array_map( __NAMESPACE__ . '\prepare_sponsor', $posts );
+
+			set_transient( CACHE_KEY, $sponsors, CACHE_TTL );
+
+			return $sponsors;
+		}
+	);
+
+	return is_array( $sponsors ) ? $sponsors : array();
+}
+
+/**
+ * Repair an attachment URL resolved while `switch_to_blog()` is active.
+ *
+ * On a network with ms-files rewriting — which this one uses, so uploads live
+ * at `…/group/files/…` rather than `wp-content/uploads/…` — `_wp_upload_dir()`
+ * deliberately ignores the `UPLOADS` constant whenever the site is switched,
+ * because `ms_upload_constants()` hardcodes that constant to the blog the
+ * request started on. The upshot is that every sponsor logo we resolve from a
+ * group site comes back pointing at a path that doesn't exist, and 404s.
+ *
+ * The base URL core would have produced if we weren't switched is
+ * `siteurl` + `/files`, and `get_option()` is already blog-scoped, so it can
+ * be rebuilt from inside the switch. The conditions below mirror
+ * `_wp_upload_dir()` so this only rewrites URLs core actually got wrong:
+ * with rewriting disabled it appends `/sites/{id}` using the *switched* blog
+ * ID, which is correct as-is.
+ *
+ * @param string $url An attachment URL resolved in the store site's context.
+ * @return string The URL a visitor can actually load.
+ */
+function correct_switched_upload_url( string $url ): string {
+	if ( '' === $url || ! ms_is_switched() || ! defined( 'UPLOADS' ) ) {
+		return $url;
+	}
+
+	if ( ! get_site_option( 'ms_files_rewriting' ) ) {
+		return $url;
+	}
+
+	if ( is_main_network() && is_main_site() && defined( 'MULTISITE' ) ) {
+		return $url;
+	}
+
+	$uploads = wp_get_upload_dir();
+
+	return str_replace(
+		untrailingslashit( $uploads['baseurl'] ),
+		trailingslashit( get_option( 'siteurl' ) ) . 'files',
+		$url
+	);
+}
+
+/**
+ * Flatten a sponsor post into the array the block renders from.
+ *
+ * Must be called in the store site's context — see `get_sponsors()`.
+ *
+ * @param WP_Post $post A `wporg_sponsor` post.
+ * @return array<string, mixed>
+ */
+function prepare_sponsor( WP_Post $post ): array {
+	$description = $post->post_excerpt
+		? $post->post_excerpt
+		: wp_strip_all_tags( strip_shortcodes( $post->post_content ) );
+
+	$logo        = '';
+	$logo_width  = 0;
+	$logo_height = 0;
+	$thumbnail   = get_post_thumbnail_id( $post );
+
+	if ( $thumbnail ) {
+		$image = wp_get_attachment_image_src( $thumbnail, 'medium' );
+
+		if ( $image ) {
+			list( $logo, $logo_width, $logo_height ) = $image;
+			$logo                                    = correct_switched_upload_url( $logo );
+		}
+	}
+
+	return array(
+		'name'        => $post->post_title,
+		'description' => trim( wp_trim_words( $description, 20, "\u{2026}" ) ),
+		'url'         => (string) get_post_meta( $post->ID, URL_META_KEY, true ),
+		'logo'        => (string) $logo,
+		'logo_width'  => (int) $logo_width,
+		'logo_height' => (int) $logo_height,
+	);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
@@ -263,9 +263,15 @@ function save_sponsor_url( int $post_id ): void {
 		return;
 	}
 
-	if ( ! isset( $_POST['wporg_sponsor_url_nonce'] )
-		|| ! wp_verify_nonce( sanitize_key( $_POST['wporg_sponsor_url_nonce'] ), 'wporg_sponsor_url' )
-	) {
+	// Sanitised with `sanitize_text_field()` rather than `sanitize_key()`: the
+	// latter lowercases, which only happens to be harmless because
+	// `wp_create_nonce()` returns lowercase hex from `wp_hash()`. No reason to
+	// depend on that.
+	$nonce = isset( $_POST['wporg_sponsor_url_nonce'] )
+		? sanitize_text_field( wp_unslash( $_POST['wporg_sponsor_url_nonce'] ) )
+		: '';
+
+	if ( ! wp_verify_nonce( $nonce, 'wporg_sponsor_url' ) ) {
 		return;
 	}
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
@@ -54,9 +54,23 @@ const URL_META_KEY = '_wporg_sponsor_url';
 const CACHE_KEY = 'wporg_groups_sponsors';
 
 /**
- * How long the sponsor list stays cached, in seconds.
+ * How long a non-empty sponsor list stays cached, in seconds.
  */
 const CACHE_TTL = HOUR_IN_SECONDS;
+
+/**
+ * How long an *empty* sponsor list stays cached, in seconds.
+ *
+ * Empty results are cached, because "no sponsors yet" is the normal state of
+ * a group site and leaving it uncached would mean a `switch_to_blog()` and a
+ * query on every page view of every group site. But an empty result is also
+ * what a failure looks like — a database blip, a stray `pre_get_posts`
+ * filter, `EVENTS_ROOT_BLOG_ID` pointing at a site that no longer exists —
+ * and those are indistinguishable from the real thing here. A shorter expiry
+ * keeps the common path cached while bounding how long a bad read can hide
+ * every sponsor network-wide.
+ */
+const EMPTY_CACHE_TTL = 5 * MINUTE_IN_SECONDS;
 
 /**
  * Bootstrap the sponsors feature.
@@ -71,6 +85,7 @@ function bootstrap(): void {
 	add_action( 'init', __NAMESPACE__ . '\register_post_type' );
 	add_action( 'add_meta_boxes', __NAMESPACE__ . '\add_meta_boxes' );
 	add_action( 'save_post_' . POST_TYPE, __NAMESPACE__ . '\save_sponsor_url' );
+	add_action( 'admin_notices', __NAMESPACE__ . '\render_invalid_url_notice' );
 
 	// Keep the cached list honest.
 	add_action( 'save_post_' . POST_TYPE, __NAMESPACE__ . '\flush_cache' );
@@ -279,13 +294,72 @@ function save_sponsor_url( int $post_id ): void {
 		return;
 	}
 
-	$url = sanitize_url( wp_unslash( $_POST['wporg_sponsor_url'] ) );
+	$raw = trim( (string) wp_unslash( $_POST['wporg_sponsor_url'] ) );
+	$url = sanitize_url( $raw );
 
-	if ( '' === $url ) {
+	if ( '' === $raw ) {
 		delete_post_meta( $post_id, URL_META_KEY );
-	} else {
-		update_post_meta( $post_id, URL_META_KEY, $url );
+
+		return;
 	}
+
+	// `sanitize_url()` returns '' for anything it can't parse — a mistyped
+	// scheme (`htps://…`), a disallowed one (`javascript:…`) — which is
+	// indistinguishable from the field having been cleared. Deleting on that
+	// would let a typo silently wipe a working sponsor link, so keep what's
+	// stored and tell whoever saved it that their input didn't take.
+	if ( '' === $url ) {
+		set_transient( invalid_url_notice_key( $post_id ), $raw, MINUTE_IN_SECONDS );
+
+		return;
+	}
+
+	update_post_meta( $post_id, URL_META_KEY, $url );
+}
+
+/**
+ * Transient key for the "that URL wasn't usable" notice.
+ *
+ * Scoped to the user as well as the post so a notice raised by one editor
+ * isn't shown to — or swallowed by — another editing the same sponsor.
+ *
+ * @param int $post_id The sponsor being edited.
+ */
+function invalid_url_notice_key( int $post_id ): string {
+	return sprintf( 'wporg_sponsor_url_invalid_%d_%d', $post_id, get_current_user_id() );
+}
+
+/**
+ * Show the notice raised by `save_sponsor_url()` for an unusable URL.
+ */
+function render_invalid_url_notice(): void {
+	$screen = get_current_screen();
+
+	if ( ! $screen || POST_TYPE !== $screen->post_type || 'post' !== $screen->base ) {
+		return;
+	}
+
+	$post_id = (int) get_the_ID();
+	$key     = invalid_url_notice_key( $post_id );
+	$raw     = get_transient( $key );
+
+	if ( false === $raw ) {
+		return;
+	}
+
+	delete_transient( $key );
+
+	wp_admin_notice(
+		sprintf(
+			/* translators: %s: the URL the user entered. */
+			esc_html__( '%s isn\'t a usable web address, so the sponsor\'s existing link was kept. Include a full address, e.g. https://example.org/.', 'wporg-groups-frontend' ),
+			'<code>' . esc_html( $raw ) . '</code>'
+		),
+		array(
+			'type'               => 'warning',
+			'additional_classes' => array( 'is-dismissible' ),
+		)
+	);
 }
 
 /**
@@ -349,7 +423,11 @@ function get_sponsors(): array {
 
 			$sponsors = array_map( __NAMESPACE__ . '\prepare_sponsor', $posts );
 
-			set_transient( CACHE_KEY, $sponsors, CACHE_TTL );
+			set_transient(
+				CACHE_KEY,
+				$sponsors,
+				$sponsors ? CACHE_TTL : EMPTY_CACHE_TTL
+			);
 
 			return $sponsors;
 		}
@@ -379,25 +457,58 @@ function get_sponsors(): array {
  * @return string The URL a visitor can actually load.
  */
 function correct_switched_upload_url( string $url ): string {
-	if ( '' === $url || ! ms_is_switched() || ! defined( 'UPLOADS' ) ) {
-		return $url;
-	}
-
-	if ( ! get_site_option( 'ms_files_rewriting' ) ) {
-		return $url;
-	}
-
-	if ( is_main_network() && is_main_site() && defined( 'MULTISITE' ) ) {
+	if ( ! upload_url_needs_correcting( $url ) ) {
 		return $url;
 	}
 
 	$uploads = wp_get_upload_dir();
 
-	return str_replace(
-		untrailingslashit( $uploads['baseurl'] ),
-		trailingslashit( get_option( 'siteurl' ) ) . 'files',
-		$url
+	return rebase_url(
+		$url,
+		$uploads['baseurl'],
+		trailingslashit( get_option( 'siteurl' ) ) . 'files'
 	);
+}
+
+/**
+ * Whether `correct_switched_upload_url()` has anything to fix.
+ *
+ * Split out from the rewriting itself so the rewriting can be tested without
+ * a live ms-files network: the conditions here are all process-level state
+ * (`UPLOADS`, the switch stack) that a test can't reasonably fake.
+ *
+ * @param string $url The URL about to be rewritten.
+ */
+function upload_url_needs_correcting( string $url ): bool {
+	if ( '' === $url || ! ms_is_switched() || ! defined( 'UPLOADS' ) ) {
+		return false;
+	}
+
+	if ( ! get_site_option( 'ms_files_rewriting' ) ) {
+		return false;
+	}
+
+	// Mirrors `_wp_upload_dir()`: the main site of the main network keeps
+	// using `wp-content/uploads`, so its URLs are already right.
+	return ! ( is_main_network() && is_main_site() && defined( 'MULTISITE' ) );
+}
+
+/**
+ * Swap the upload base URL at the front of an attachment URL.
+ *
+ * @param string $url       The attachment URL.
+ * @param string $from_base The base URL the URL currently carries.
+ * @param string $to_base   The base URL it should carry.
+ * @return string The rebased URL, or the original when it wasn't under `$from_base`.
+ */
+function rebase_url( string $url, string $from_base, string $to_base ): string {
+	$from_base = untrailingslashit( $from_base );
+
+	if ( '' === $from_base || ! str_starts_with( $url, $from_base ) ) {
+		return $url;
+	}
+
+	return untrailingslashit( $to_base ) . substr( $url, strlen( $from_base ) );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wporg/sponsors",
+	"version": "1.0.0",
+	"title": "Sponsors",
+	"category": "widgets",
+	"icon": "awards",
+	"description": "Displays the network's sponsors — logo, name, description and link — identically on every group site.",
+	"attributes": {
+		"limit": {
+			"type": "number",
+			"default": 4
+		},
+		"level": {
+			"type": "number",
+			"default": 2
+		}
+	},
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": { "margin": true }
+	},
+	"render": "file:./render.php",
+	"editorScript": "file:./index.js",
+	"viewScriptModule": "file:./view.js",
+	"style": "file:./style-index.css"
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/index.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/index.js
@@ -1,0 +1,46 @@
+/**
+ * Block registration + styles.
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import ServerSideRender from '@wordpress/server-side-render';
+import metadata from './block.json';
+import './style.css';
+
+registerBlockType( metadata.name, {
+	edit: ( { attributes, setAttributes } ) => {
+		const blockProps = useBlockProps();
+
+		return (
+			<div { ...blockProps }>
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings', 'wporg-groups-frontend' ) }>
+						<RangeControl
+							label={ __( 'Sponsors shown', 'wporg-groups-frontend' ) }
+							help={ __(
+								'The rest are revealed by a "Show all" button. Set to 0 to always show every sponsor.',
+								'wporg-groups-frontend'
+							) }
+							value={ attributes.limit }
+							onChange={ ( limit ) => setAttributes( { limit } ) }
+							min={ 0 }
+							max={ 20 }
+						/>
+						<RangeControl
+							label={ __( 'Heading level', 'wporg-groups-frontend' ) }
+							value={ attributes.level }
+							onChange={ ( level ) => setAttributes( { level } ) }
+							min={ 1 }
+							max={ 6 }
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<ServerSideRender block={ metadata.name } attributes={ attributes } />
+			</div>
+		);
+	},
+	save: () => null,
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/render.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Server-side rendering for the wporg/sponsors block.
+ *
+ * Renders the network's global sponsor list (see `inc/sponsors.php`). The
+ * same markup renders on every group site, since the data comes from one
+ * network-level store rather than from the current site.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+use function WordCamp\Groups\Frontend\Sponsors\get_sponsors;
+
+$wporg_sponsors = get_sponsors();
+
+// No sponsors — render nothing at all rather than an empty card. The block
+// sits in the theme's templates on every group site, so an empty state would
+// otherwise show up on sites that have simply never had a sponsor.
+if ( empty( $wporg_sponsors ) ) {
+	return;
+}
+
+$wporg_limit    = max( 0, (int) ( $attributes['limit'] ?? 4 ) );
+$wporg_level    = min( 6, max( 1, (int) ( $attributes['level'] ?? 2 ) ) );
+$wporg_heading  = 'h' . $wporg_level;
+$wporg_has_more = $wporg_limit > 0 && count( $wporg_sponsors ) > $wporg_limit;
+
+$wporg_wrapper_attributes = get_block_wrapper_attributes(
+	array( 'class' => 'wporg-sponsors' )
+);
+?>
+<div
+	<?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+	data-wp-interactive="wporg/sponsors"
+	<?php echo wp_interactivity_data_wp_context( array( 'isExpanded' => false ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+>
+	<div class="wporg-sponsors__header">
+		<<?php echo esc_html( $wporg_heading ); ?> class="wporg-sponsors__heading">
+			<?php esc_html_e( 'Sponsors', 'wporg-groups-frontend' ); ?>
+		</<?php echo esc_html( $wporg_heading ); ?>>
+
+		<?php if ( $wporg_has_more ) : ?>
+			<?php
+			/*
+			 * Rendered hidden and revealed by the Interactivity API on
+			 * hydration: without JavaScript the button couldn't expand
+			 * anything, so it shouldn't be offered.
+			 */
+			?>
+			<button
+				type="button"
+				class="wporg-sponsors__show-all"
+				hidden
+				data-wp-bind--hidden="context.isExpanded"
+				data-wp-on--click="actions.expand"
+			>
+				<?php esc_html_e( 'Show all', 'wporg-groups-frontend' ); ?>
+			</button>
+		<?php endif; ?>
+	</div>
+
+	<ul class="wporg-sponsors__list">
+		<?php foreach ( $wporg_sponsors as $wporg_index => $wporg_sponsor ) :
+			$wporg_is_overflow = $wporg_has_more && $wporg_index >= $wporg_limit;
+			$wporg_tag         = $wporg_sponsor['url'] ? 'a' : 'div';
+			?>
+			<li
+				class="wporg-sponsors__item"
+				<?php if ( $wporg_is_overflow ) : ?>
+					hidden data-wp-bind--hidden="!context.isExpanded"
+				<?php endif; ?>
+			>
+				<<?php echo esc_html( $wporg_tag ); ?>
+					class="wporg-sponsors__link"
+					<?php if ( $wporg_sponsor['url'] ) : ?>
+						href="<?php echo esc_url( $wporg_sponsor['url'] ); ?>"
+						target="_blank"
+						rel="noopener nofollow sponsor"
+					<?php endif; ?>
+				>
+					<span class="wporg-sponsors__logo">
+						<?php if ( $wporg_sponsor['logo'] ) : ?>
+							<img
+								src="<?php echo esc_url( $wporg_sponsor['logo'] ); ?>"
+								alt=""
+								<?php if ( $wporg_sponsor['logo_width'] && $wporg_sponsor['logo_height'] ) : ?>
+									width="<?php echo esc_attr( (string) $wporg_sponsor['logo_width'] ); ?>"
+									height="<?php echo esc_attr( (string) $wporg_sponsor['logo_height'] ); ?>"
+								<?php endif; ?>
+								loading="lazy"
+								decoding="async"
+							/>
+						<?php endif; ?>
+					</span>
+
+					<span class="wporg-sponsors__info">
+						<span class="wporg-sponsors__name"><?php echo esc_html( $wporg_sponsor['name'] ); ?></span>
+						<?php if ( $wporg_sponsor['description'] ) : ?>
+							<span class="wporg-sponsors__description"><?php echo esc_html( $wporg_sponsor['description'] ); ?></span>
+						<?php endif; ?>
+					</span>
+
+					<?php if ( $wporg_sponsor['url'] ) : ?>
+						<span class="screen-reader-text">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %s: sponsor name. */
+									__( 'Visit %s (opens in a new tab)', 'wporg-groups-frontend' ),
+									$wporg_sponsor['name']
+								)
+							);
+							?>
+						</span>
+						<span class="wporg-sponsors__external" aria-hidden="true">
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false">
+								<path d="M14 5h5v5M19 5l-8 8M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+						</span>
+					<?php endif; ?>
+				</<?php echo esc_html( $wporg_tag ); ?>>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
@@ -1,0 +1,121 @@
+/**
+ * Sponsors block styles.
+ */
+
+.wporg-sponsors {
+	padding: 24px;
+	border: 1px solid #d9d9d9;
+	border-radius: 8px;
+	background: #fff;
+}
+
+.wporg-sponsors__header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 16px;
+}
+
+.wporg-sponsors__heading {
+	font-size: 24px;
+	font-weight: 700;
+	margin: 0 !important;
+	padding: 0 !important;
+}
+
+.wporg-sponsors__show-all {
+	background: none;
+	border: 0;
+	padding: 0;
+	font-size: 14px;
+	font-weight: 500;
+	color: #3858e9;
+	cursor: pointer;
+}
+
+.wporg-sponsors__show-all:hover {
+	text-decoration: underline;
+}
+
+.wporg-sponsors__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+}
+
+.wporg-sponsors__item + .wporg-sponsors__item {
+	border-top: 1px solid #e0e0e0;
+}
+
+.wporg-sponsors__item[hidden] {
+	display: none;
+}
+
+.wporg-sponsors__link {
+	display: grid;
+	grid-template-columns: 96px 1fr auto;
+	align-items: center;
+	gap: 16px;
+	padding: 16px;
+	text-decoration: none;
+	color: inherit;
+}
+
+a.wporg-sponsors__link:hover {
+	text-decoration: none;
+	background: #f6f7f7;
+}
+
+.wporg-sponsors__logo {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 32px;
+}
+
+.wporg-sponsors__logo img {
+	max-width: 100%;
+	max-height: 40px;
+	width: auto;
+	height: auto;
+	object-fit: contain;
+}
+
+.wporg-sponsors__info {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+}
+
+.wporg-sponsors__name {
+	font-size: 16px;
+	font-weight: 600;
+	color: #1a1919;
+}
+
+.wporg-sponsors__description {
+	font-size: 14px;
+	line-height: 1.4;
+	color: #40464d;
+}
+
+.wporg-sponsors__external {
+	display: flex;
+	align-items: center;
+	color: #40464d;
+}
+
+a.wporg-sponsors__link:hover .wporg-sponsors__external {
+	color: #3858e9;
+}
+
+@media (max-width: 480px) {
+	.wporg-sponsors__link {
+		grid-template-columns: 64px 1fr auto;
+		gap: 12px;
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/view.js
@@ -1,0 +1,19 @@
+/**
+ * Sponsors block — Interactivity API store.
+ *
+ * The list renders capped at the block's `limit`; this expands it in place.
+ * The "Show all" button is server-rendered `hidden` and only revealed once
+ * this store hydrates, so it never appears without a working handler.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+import { store, getContext } from '@wordpress/interactivity';
+
+store( 'wporg/sponsors', {
+	actions: {
+		expand() {
+			getContext().isExpanded = true;
+		},
+	},
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -20,10 +20,11 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		'wporg/group-settings',
 		'wporg/my-events',
 		'wporg/page-content',
+		'wporg/sponsors',
 	);
 
 	/**
-	 * Exactly these 8 `wporg/*` blocks should be registered. The original
+	 * Exactly these 9 `wporg/*` blocks should be registered. The original
 	 * set of 10 also included `event-rsvp-count` and `event-venue-name`;
 	 * both were intentionally removed in favor of GatherPress core's own
 	 * `gatherpress/rsvp-count` and `gatherpress/venue` blocks (see #1793's

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-gatherpress-off-guard.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-gatherpress-off-guard.php
@@ -39,6 +39,29 @@ class Test_Groups_GatherPress_Off_Guard extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The sponsors store is the one piece that must run *without* GatherPress:
+	 * it's edited on the groups network root site, which doesn't run the
+	 * plugin. If someone moves `Sponsors\bootstrap()` below the guard, the
+	 * Sponsors admin screen silently disappears.
+	 */
+	public function test_sponsors_bootstrap_runs_before_the_gatherpress_guard() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- reading a local plugin file, not a remote URL.
+		$source = file_get_contents(
+			dirname( __DIR__ ) . '/wporg-groups-frontend.php'
+		);
+
+		$sponsors = strpos( $source, 'Sponsors\bootstrap();' );
+		$guard    = strpos( $source, 'class_exists( \'\GatherPress\Core\Event\Event\' )' );
+
+		$this->assertNotFalse( $sponsors, 'wporg-groups-frontend.php should still bootstrap the sponsors store.' );
+		$this->assertLessThan(
+			$guard,
+			$sponsors,
+			'Sponsors\bootstrap() should run before the GatherPress guard, since the network root site has no GatherPress.'
+		);
+	}
+
+	/**
 	 * `gatherpress-groups-tweaks.php` must stay guarded on its
 	 * GatherPress-dependent code path.
 	 */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-sponsors.php
@@ -1,0 +1,374 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WordCamp\Groups\Frontend\Sponsors;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * Covers the network-level sponsor store and the `wporg/sponsors` block.
+ *
+ * The point of the feature is that one list renders identically on every
+ * group site, so these tests create the sponsor on the store site
+ * (`EVENTS_ROOT_BLOG_ID`, which `Database_TestCase` sets up) and read it back
+ * from group sites, which sit on a different network entirely.
+ *
+ * @group groups
+ */
+class Test_Groups_Sponsors extends Groups_TestCase {
+	/**
+	 * A second group site, used to prove the data really is shared.
+	 *
+	 * @var int
+	 */
+	protected $other_group_id;
+
+	/**
+	 * Creates the second group site and clears the cached list, which would
+	 * otherwise leak sponsors between tests.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->other_group_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/testing-sponsors/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		Sponsors\flush_cache();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function tearDown(): void {
+		wp_delete_site( $this->other_group_id );
+		Sponsors\flush_cache();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Creates a published sponsor on the store site.
+	 *
+	 * @param array $args Overrides for the sponsor post.
+	 * @return int The new sponsor's post ID.
+	 */
+	protected function create_sponsor( array $args = array() ): int {
+		$url = $args['url'] ?? 'https://example.org/sponsor/';
+		unset( $args['url'] );
+
+		switch_to_blog( self::$events_root_site_id );
+
+		$post_id = self::factory()->post->create(
+			array_merge(
+				array(
+					'post_type'    => Sponsors\POST_TYPE,
+					'post_status'  => 'publish',
+					'post_title'   => 'Woo',
+					'post_excerpt' => 'Woo is the leading open-source ecommerce platform.',
+				),
+				$args
+			)
+		);
+
+		if ( $url ) {
+			update_post_meta( $post_id, Sponsors\URL_META_KEY, $url );
+		}
+
+		restore_current_blog();
+		Sponsors\flush_cache();
+
+		return $post_id;
+	}
+
+	/**
+	 * The sponsor post type has to exist on every group site, not just the
+	 * one that stores the posts, so the block can resolve it while reading.
+	 */
+	public function test_post_type_is_registered() {
+		$this->assertTrue( post_type_exists( Sponsors\POST_TYPE ) );
+	}
+
+	/**
+	 * The admin screens only exist on the store site. A group organiser
+	 * browsing their own wp-admin should never find a Sponsors menu, quite
+	 * apart from not having the capability to use one.
+	 *
+	 * Re-runs the registration in each blog's context, since `show_ui` is
+	 * decided once at `init` from whichever site is serving the request.
+	 */
+	public function test_admin_ui_is_only_registered_on_the_store_site() {
+		$show_ui = function () {
+			Sponsors\register_post_type();
+
+			return get_post_type_object( Sponsors\POST_TYPE )->show_ui;
+		};
+
+		switch_to_blog( $this->other_group_id );
+		$on_group_site = $show_ui();
+		restore_current_blog();
+
+		switch_to_blog( self::$events_root_site_id );
+		$on_store_site = $show_ui();
+		restore_current_blog();
+
+		// Leave the registration as this test found it.
+		Sponsors\register_post_type();
+
+		$this->assertFalse( $on_group_site );
+		$this->assertTrue( $on_store_site );
+	}
+
+	/**
+	 * A sponsor added once on the store site is readable from an unrelated
+	 * group site on another network — the whole point of the feature.
+	 */
+	public function test_sponsors_are_readable_from_another_group_site() {
+		$this->create_sponsor();
+
+		switch_to_blog( $this->other_group_id );
+		$sponsors = Sponsors\get_sponsors();
+		restore_current_blog();
+
+		$this->assertCount( 1, $sponsors );
+		$this->assertSame( 'Woo', $sponsors[0]['name'] );
+		$this->assertSame( 'https://example.org/sponsor/', $sponsors[0]['url'] );
+		$this->assertStringStartsWith( 'Woo is the leading', $sponsors[0]['description'] );
+	}
+
+	/**
+	 * Nothing is copied into the group sites — a group site that queries its
+	 * own tables for sponsors finds none, so there's no second copy to drift.
+	 */
+	public function test_sponsors_are_not_duplicated_into_group_sites() {
+		$this->create_sponsor();
+
+		switch_to_blog( $this->other_group_id );
+		$local = get_posts(
+			array(
+				'post_type'   => Sponsors\POST_TYPE,
+				'post_status' => 'any',
+				'numberposts' => -1,
+			)
+		);
+		restore_current_blog();
+
+		$this->assertSame( array(), $local );
+	}
+
+	/**
+	 * Drafted and trashed sponsors stay off the group sites.
+	 */
+	public function test_unpublished_sponsors_are_excluded() {
+		$this->create_sponsor( array( 'post_status' => 'draft' ) );
+
+		$this->assertSame( array(), Sponsors\get_sponsors() );
+	}
+
+	/**
+	 * Editing a sponsor has to show up on the group sites without waiting for
+	 * the cache to expire.
+	 */
+	public function test_cache_is_invalidated_when_a_sponsor_changes() {
+		$post_id = $this->create_sponsor();
+
+		// Prime the cache from the other site.
+		switch_to_blog( $this->other_group_id );
+		Sponsors\get_sponsors();
+		restore_current_blog();
+
+		switch_to_blog( self::$events_root_site_id );
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Woo Renamed',
+			)
+		);
+		restore_current_blog();
+
+		switch_to_blog( $this->other_group_id );
+		$sponsors = Sponsors\get_sponsors();
+		restore_current_blog();
+
+		$this->assertSame( 'Woo Renamed', $sponsors[0]['name'] );
+	}
+
+	/**
+	 * Trashing a sponsor removes it from the group sites immediately too.
+	 */
+	public function test_cache_is_invalidated_when_a_sponsor_is_trashed() {
+		$post_id = $this->create_sponsor();
+
+		Sponsors\get_sponsors();
+
+		switch_to_blog( self::$events_root_site_id );
+		wp_trash_post( $post_id );
+		restore_current_blog();
+
+		$this->assertSame( array(), Sponsors\get_sponsors() );
+	}
+
+	/**
+	 * Sponsors render in the order network admins put them in, not by date.
+	 */
+	public function test_sponsors_are_ordered_by_menu_order_then_title() {
+		$this->create_sponsor(
+			array(
+				'post_title' => 'Zeta',
+				'menu_order' => 1,
+			)
+		);
+		$this->create_sponsor(
+			array(
+				'post_title' => 'Beta',
+				'menu_order' => 2,
+			)
+		);
+		$this->create_sponsor(
+			array(
+				'post_title' => 'Alpha',
+				'menu_order' => 2,
+			)
+		);
+
+		$this->assertSame(
+			array( 'Zeta', 'Alpha', 'Beta' ),
+			wp_list_pluck( Sponsors\get_sponsors(), 'name' )
+		);
+	}
+
+	/**
+	 * A group organiser — an administrator on their own group site, but not a
+	 * network admin — must not be able to edit the shared sponsor list.
+	 */
+	public function test_group_organisers_cannot_edit_sponsors() {
+		$organiser = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		add_user_to_blog( $this->other_group_id, $organiser, 'administrator' );
+		wp_set_current_user( $organiser );
+
+		$post_id   = $this->create_sponsor();
+		$post_type = get_post_type_object( Sponsors\POST_TYPE );
+
+		switch_to_blog( $this->other_group_id );
+		$can_edit_any = current_user_can( $post_type->cap->edit_posts );
+		$can_create   = current_user_can( $post_type->cap->create_posts );
+		$can_delete   = current_user_can( $post_type->cap->delete_posts );
+		restore_current_blog();
+
+		switch_to_blog( self::$events_root_site_id );
+		$can_edit_one = current_user_can( 'edit_post', $post_id );
+		restore_current_blog();
+
+		$this->assertFalse( $can_edit_any, 'A site administrator should not be able to edit sponsors.' );
+		$this->assertFalse( $can_create, 'A site administrator should not be able to add sponsors.' );
+		$this->assertFalse( $can_delete, 'A site administrator should not be able to delete sponsors.' );
+		$this->assertFalse( $can_edit_one, 'A site administrator should not be able to edit a specific sponsor.' );
+	}
+
+	/**
+	 * Network admins are the ones who can.
+	 */
+	public function test_network_admins_can_edit_sponsors() {
+		$super_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		// `grant_super_admin()` reads `site_admins` out of `sitemeta`, which
+		// `Database_TestCase` truncates; setting the global that
+		// `get_super_admins()` checks first is the fixture-safe equivalent.
+		$GLOBALS['super_admins'] = array( get_userdata( $super_admin )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_set_current_user( $super_admin );
+
+		$post_id   = $this->create_sponsor();
+		$post_type = get_post_type_object( Sponsors\POST_TYPE );
+
+		switch_to_blog( self::$events_root_site_id );
+		$can_edit_any = current_user_can( $post_type->cap->edit_posts );
+		$can_edit_one = current_user_can( 'edit_post', $post_id );
+		restore_current_blog();
+
+		unset( $GLOBALS['super_admins'] );
+
+		$this->assertTrue( $can_edit_any );
+		$this->assertTrue( $can_edit_one );
+	}
+
+	/**
+	 * The block renders the sponsor's logo, name, description and link.
+	 */
+	public function test_block_renders_sponsor_details() {
+		$this->create_sponsor();
+
+		switch_to_blog( $this->other_group_id );
+		$output = do_blocks( '<!-- wp:wporg/sponsors /-->' );
+		restore_current_blog();
+
+		$this->assertStringContainsString( 'wporg-sponsors__list', $output );
+		$this->assertStringContainsString( 'Woo', $output );
+		$this->assertStringContainsString( 'Woo is the leading open-source ecommerce platform.', $output );
+		$this->assertStringContainsString( 'href="https://example.org/sponsor/"', $output );
+		$this->assertStringContainsString( 'rel="noopener nofollow sponsor"', $output );
+	}
+
+	/**
+	 * Zero sponsors must render nothing at all — the block sits in the theme
+	 * templates of every group site, so an empty card would show up on sites
+	 * that have never had a sponsor.
+	 */
+	public function test_block_renders_nothing_without_sponsors() {
+		switch_to_blog( $this->other_group_id );
+		$output = trim( do_blocks( '<!-- wp:wporg/sponsors /-->' ) );
+		restore_current_blog();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * A sponsor with no website URL still renders, just without a link.
+	 */
+	public function test_block_renders_sponsor_without_url() {
+		$this->create_sponsor( array( 'url' => '' ) );
+
+		switch_to_blog( $this->other_group_id );
+		$output = do_blocks( '<!-- wp:wporg/sponsors /-->' );
+		restore_current_blog();
+
+		$this->assertStringContainsString( 'Woo', $output );
+		$this->assertStringNotContainsString( '<a class="wporg-sponsors__link"', $output );
+	}
+
+	/**
+	 * Sponsors past the block's `limit` are rendered but hidden, with a
+	 * "Show all" button to reveal them.
+	 */
+	public function test_block_hides_sponsors_past_the_limit() {
+		$this->create_sponsor( array( 'post_title' => 'Alpha' ) );
+		$this->create_sponsor( array( 'post_title' => 'Beta' ) );
+		$this->create_sponsor( array( 'post_title' => 'Gamma' ) );
+
+		switch_to_blog( $this->other_group_id );
+		$output = do_blocks( '<!-- wp:wporg/sponsors {"limit":2} /-->' );
+		restore_current_blog();
+
+		$this->assertStringContainsString( 'wporg-sponsors__show-all', $output );
+		$this->assertSame( 1, substr_count( $output, 'data-wp-bind--hidden="!context.isExpanded"' ) );
+	}
+
+	/**
+	 * No "Show all" button when everything already fits.
+	 */
+	public function test_block_omits_show_all_when_everything_fits() {
+		$this->create_sponsor();
+
+		switch_to_blog( $this->other_group_id );
+		$output = do_blocks( '<!-- wp:wporg/sponsors {"limit":4} /-->' );
+		restore_current_blog();
+
+		$this->assertStringNotContainsString( 'wporg-sponsors__show-all', $output );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-sponsors.php
@@ -48,10 +48,30 @@ class Test_Groups_Sponsors extends Groups_TestCase {
 	 * @inheritDoc
 	 */
 	protected function tearDown(): void {
+		unset( $GLOBALS['super_admins'] );
 		wp_delete_site( $this->other_group_id );
 		Sponsors\flush_cache();
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Becomes a network admin for the rest of the test.
+	 *
+	 * `grant_super_admin()` reads `site_admins` out of `sitemeta`, which
+	 * `Database_TestCase` truncates; setting the global that
+	 * `get_super_admins()` checks first is the fixture-safe equivalent.
+	 * `tearDown()` clears it.
+	 *
+	 * @return int The new user's ID.
+	 */
+	protected function act_as_network_admin(): int {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		$GLOBALS['super_admins'] = array( get_userdata( $user_id )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_set_current_user( $user_id );
+
+		return $user_id;
 	}
 
 	/**
@@ -276,13 +296,7 @@ class Test_Groups_Sponsors extends Groups_TestCase {
 	 * Network admins are the ones who can.
 	 */
 	public function test_network_admins_can_edit_sponsors() {
-		$super_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
-
-		// `grant_super_admin()` reads `site_admins` out of `sitemeta`, which
-		// `Database_TestCase` truncates; setting the global that
-		// `get_super_admins()` checks first is the fixture-safe equivalent.
-		$GLOBALS['super_admins'] = array( get_userdata( $super_admin )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		wp_set_current_user( $super_admin );
+		$this->act_as_network_admin();
 
 		$post_id   = $this->create_sponsor();
 		$post_type = get_post_type_object( Sponsors\POST_TYPE );
@@ -291,8 +305,6 @@ class Test_Groups_Sponsors extends Groups_TestCase {
 		$can_edit_any = current_user_can( $post_type->cap->edit_posts );
 		$can_edit_one = current_user_can( 'edit_post', $post_id );
 		restore_current_blog();
-
-		unset( $GLOBALS['super_admins'] );
 
 		$this->assertTrue( $can_edit_any );
 		$this->assertTrue( $can_edit_one );
@@ -370,5 +382,220 @@ class Test_Groups_Sponsors extends Groups_TestCase {
 		restore_current_blog();
 
 		$this->assertStringNotContainsString( 'wporg-sponsors__show-all', $output );
+	}
+
+	/**
+	 * Submits the sponsor URL meta box for a post, as wp-admin would.
+	 *
+	 * @param int    $post_id The sponsor being saved.
+	 * @param string $url     The value typed into the field.
+	 * @param bool   $valid_nonce Whether to send a valid nonce.
+	 */
+	protected function submit_url_form( int $post_id, string $url, bool $valid_nonce = true ): void {
+		$_POST['wporg_sponsor_url']       = addslashes( $url );
+		$_POST['wporg_sponsor_url_nonce'] = $valid_nonce
+			? wp_create_nonce( 'wporg_sponsor_url' )
+			: 'not-a-nonce';
+
+		Sponsors\save_sponsor_url( $post_id );
+
+		unset( $_POST['wporg_sponsor_url'], $_POST['wporg_sponsor_url_nonce'] );
+	}
+
+	/**
+	 * The happy path: a valid URL is sanitised and stored.
+	 */
+	public function test_meta_box_saves_a_valid_url() {
+		$this->act_as_network_admin();
+
+		$post_id = $this->create_sponsor();
+
+		switch_to_blog( self::$events_root_site_id );
+		$this->submit_url_form( $post_id, 'https://example.org/new/' );
+		$saved = get_post_meta( $post_id, Sponsors\URL_META_KEY, true );
+		restore_current_blog();
+
+		$this->assertSame( 'https://example.org/new/', $saved );
+	}
+
+	/**
+	 * Clearing the field removes the link, as the field's own help text
+	 * promises.
+	 */
+	public function test_meta_box_clears_the_url_when_the_field_is_emptied() {
+		$this->act_as_network_admin();
+
+		$post_id = $this->create_sponsor();
+
+		switch_to_blog( self::$events_root_site_id );
+		$this->submit_url_form( $post_id, '   ' );
+		$saved = get_post_meta( $post_id, Sponsors\URL_META_KEY, true );
+		restore_current_blog();
+
+		$this->assertSame( '', $saved );
+	}
+
+	/**
+	 * Data provider for test_meta_box_keeps_the_url_when_input_is_unusable().
+	 */
+	public function data_unusable_urls(): array {
+		return array(
+			'mistyped scheme'     => array( 'htps://example.org/' ),
+			'disallowed protocol' => array( 'javascript:alert(1)' ),
+		);
+	}
+
+	/**
+	 * Input that `sanitize_url()` can't parse must not wipe a working link.
+	 *
+	 * `sanitize_url()` returns '' for these, which is indistinguishable from
+	 * the field having been cleared — so a single mistyped character used to
+	 * silently delete the sponsor's URL.
+	 *
+	 * @dataProvider data_unusable_urls
+	 */
+	public function test_meta_box_keeps_the_url_when_input_is_unusable( string $typed ) {
+		$this->act_as_network_admin();
+
+		$post_id = $this->create_sponsor();
+
+		switch_to_blog( self::$events_root_site_id );
+		$this->submit_url_form( $post_id, $typed );
+		$saved  = get_post_meta( $post_id, Sponsors\URL_META_KEY, true );
+		$notice = get_transient( Sponsors\invalid_url_notice_key( $post_id ) );
+		delete_transient( Sponsors\invalid_url_notice_key( $post_id ) );
+		restore_current_blog();
+
+		$this->assertSame( 'https://example.org/sponsor/', $saved, 'The existing URL should survive unusable input.' );
+		$this->assertSame( $typed, $notice, 'The editor should be told their input was rejected.' );
+	}
+
+	/**
+	 * A missing or forged nonce leaves the meta alone.
+	 */
+	public function test_meta_box_ignores_a_bad_nonce() {
+		$this->act_as_network_admin();
+
+		$post_id = $this->create_sponsor();
+
+		switch_to_blog( self::$events_root_site_id );
+		$this->submit_url_form( $post_id, 'https://evil.example/', false );
+		$saved = get_post_meta( $post_id, Sponsors\URL_META_KEY, true );
+		restore_current_blog();
+
+		$this->assertSame( 'https://example.org/sponsor/', $saved );
+	}
+
+	/**
+	 * A user without the capability can't write the field even with a valid
+	 * nonce — the nonce proves intent, not permission.
+	 */
+	public function test_meta_box_ignores_a_user_without_the_capability() {
+		$post_id = $this->create_sponsor();
+
+		$organiser = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $organiser );
+
+		switch_to_blog( self::$events_root_site_id );
+		$this->submit_url_form( $post_id, 'https://evil.example/' );
+		$saved = get_post_meta( $post_id, Sponsors\URL_META_KEY, true );
+		restore_current_blog();
+
+		$this->assertSame( 'https://example.org/sponsor/', $saved );
+	}
+
+	/**
+	 * Data provider for test_rebase_url().
+	 */
+	public function data_rebase_url(): array {
+		return array(
+			'ms-files rewrite'      => array(
+				'https://events.wordpress.test/wp-content/uploads/2026/08/logo.png',
+				'https://events.wordpress.test/wp-content/uploads',
+				'https://events.wordpress.test/files',
+				'https://events.wordpress.test/files/2026/08/logo.png',
+			),
+			'trailing slashes'      => array(
+				'https://events.wordpress.test/wp-content/uploads/logo.png',
+				'https://events.wordpress.test/wp-content/uploads/',
+				'https://events.wordpress.test/files/',
+				'https://events.wordpress.test/files/logo.png',
+			),
+			'url outside the base'  => array(
+				'https://cdn.example/logo.png',
+				'https://events.wordpress.test/wp-content/uploads',
+				'https://events.wordpress.test/files',
+				'https://cdn.example/logo.png',
+			),
+			'empty base is a no-op' => array(
+				'https://events.wordpress.test/wp-content/uploads/logo.png',
+				'',
+				'https://events.wordpress.test/files',
+				'https://events.wordpress.test/wp-content/uploads/logo.png',
+			),
+		);
+	}
+
+	/**
+	 * The rewriting half of the ms-files logo fix, in isolation — the
+	 * end-to-end behaviour is covered by
+	 * `test_sponsor_logo_url_is_loadable_from_a_group_site()`.
+	 *
+	 * @dataProvider data_rebase_url
+	 */
+	public function test_rebase_url( string $url, string $from, string $to, string $expected ) {
+		$this->assertSame( $expected, Sponsors\rebase_url( $url, $from, $to ) );
+	}
+
+	/**
+	 * The logo URL a group site renders has to be one a visitor can load.
+	 *
+	 * This is the regression guard for the ms-files fix. The fixture network
+	 * reproduces the real condition — ms-files rewriting on, `UPLOADS`
+	 * defined, the read happening while switched — so without
+	 * `correct_switched_upload_url()` the logo comes back as
+	 * `…/wp-content/blogs.dir/{id}/files/…`, which 404s in production.
+	 */
+	public function test_sponsor_logo_url_is_loadable_from_a_group_site() {
+		$post_id = $this->create_sponsor();
+
+		switch_to_blog( self::$events_root_site_id );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Logo',
+				'post_mime_type' => 'image/png',
+				'post_status'    => 'inherit',
+			),
+			'2026/08/logo.png',
+			$post_id
+		);
+		set_post_thumbnail( $post_id, $attachment_id );
+
+		$expected = trailingslashit( get_option( 'siteurl' ) ) . 'files/2026/08/logo.png';
+
+		restore_current_blog();
+		Sponsors\flush_cache();
+
+		switch_to_blog( $this->other_group_id );
+		$sponsors = Sponsors\get_sponsors();
+		$rendered = do_blocks( '<!-- wp:wporg/sponsors /-->' );
+		restore_current_blog();
+
+		$this->assertSame( $expected, $sponsors[0]['logo'] );
+		$this->assertStringContainsString( $expected, $rendered );
+		$this->assertStringNotContainsString(
+			'blogs.dir',
+			$sponsors[0]['logo'],
+			"The raw ms-files path isn't publicly servable — see correct_switched_upload_url()."
+		);
+	}
+
+	/**
+	 * An empty URL — a sponsor with no logo — is never rewritten.
+	 */
+	public function test_empty_upload_url_is_untouched() {
+		$this->assertSame( '', Sponsors\correct_switched_upload_url( '' ) );
+		$this->assertFalse( Sponsors\upload_url_needs_correcting( '' ) );
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/inc/blocks.php';
 require_once __DIR__ . '/inc/my-events.php';
 require_once __DIR__ . '/inc/class-members-controller.php';
 require_once __DIR__ . '/inc/notifications.php';
+require_once __DIR__ . '/inc/sponsors.php';
 
 /**
  * Bootstrap the plugin.
@@ -30,6 +31,11 @@ require_once __DIR__ . '/inc/notifications.php';
  * GatherPress there's no event post type and no work to do.
  */
 function bootstrap(): void {
+	// Sponsors are network-level data with no connection to events, and the
+	// network root site where they're edited doesn't run GatherPress at all,
+	// so this has to be registered before the guard below.
+	Sponsors\bootstrap();
+
 	if ( ! class_exists( '\GatherPress\Core\Event\Event' ) ) {
 		return;
 	}

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -89,10 +89,19 @@ iframe {
    ========================================================================== */
 
 @media (min-width: 1024px) {
-	/* Stick the event sidebar info card to the top while scrolling. */
-	.groups-site-event-sidebar .groups-site-event-info-card {
+	/*
+	 * Stick the event sidebar to the top while scrolling.
+	 *
+	 * Applied to the whole column rather than just the info card, because a
+	 * sticky card scrolls *over* anything after it in the same container —
+	 * with the sponsors block below it, the card would slide down and cover
+	 * it. `align-self` stops the column stretching to the row's full height,
+	 * which would leave `sticky` no room to travel in.
+	 */
+	.groups-site-event-sidebar {
 		position: sticky;
 		top: 96px;
 		z-index: 100;
+		align-self: flex-start;
 	}
 }

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -107,6 +107,12 @@
 	</div>
 	<!-- /wp:group -->
 
+	<!-- wp:group {"className":"groups-site-section","anchor":"sponsors","style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"constrained","contentSize":"768px","justifyContent":"left"}} -->
+	<div id="sponsors" class="wp-block-group groups-site-section" style="margin-top:var(--wp--preset--spacing--70)">
+		<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true}} /-->
+	</div>
+	<!-- /wp:group -->
+
 </main>
 <!-- /wp:group -->
 

--- a/public_html/wp-content/themes/groups-site/templates/single-event.html
+++ b/public_html/wp-content/themes/groups-site/templates/single-event.html
@@ -150,6 +150,8 @@
 					<!-- wp:gatherpress/add-to-calendar /-->
 			</div>
 			<!-- /wp:group -->
+
+			<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"limit":3,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>


### PR DESCRIPTION
Fixes #1784.

Adds a `wporg_sponsor` post type (logo, name, description, link) on the **events root site**, rendered by a new `wporg/sponsors` block on every group site via `switch_to_blog()` — one copy of the data, no per-site duplication. Network-admin-only: every capability maps to `manage_network`, and the admin UI is only registered on the store site.

The groups network root would have been the obvious home, but `sunrise-groups.php` redirects its `/group/files/…` uploads away, so logos 404 there. Full reasoning in the commit message.

## Testing

1. `wp --url=<events root> post create --post_type=wporg_sponsor --post_status=publish --post_title=Woo --post_excerpt="…"`, or add one via **Sponsors** in the events root wp-admin. Set a featured image (logo) and the Sponsor Website URL.
2. Visit any group site front page → the card lists sponsors, ordered by **Order** then title. The event single view shows the same list in the sidebar.
3. Add a 5th sponsor → **Show all** appears and expands the list in place.
4. Edit a sponsor and reload the group site → the change shows immediately (cache is invalidated on save/trash/delete).
5. As a group-site administrator (not a network admin), confirm there's no Sponsors menu and no way to edit one.
6. Trash all sponsors → the block disappears entirely instead of rendering an empty card.

Groups suite 65 green, full suite 454 green, `phpcs` clean.

## Screenshots

**Sponsors in wp-admin (events root)**
<img width="1440" height="840" alt="sponsors-admin-list" src="https://github.com/user-attachments/assets/71642e5e-4f98-43b2-9310-2f85a5d1556e" />

**Editing a sponsor — logo, description, link, order**
<img width="1440" height="840" alt="sponsors-admin-edit" src="https://github.com/user-attachments/assets/3592d043-a609-4057-ab6c-a0eac51b9992" />

**Group site front page**
<img width="1440" height="840" alt="sponsors-front-page" src="https://github.com/user-attachments/assets/b9646603-adb1-477e-a992-05c9fdd68a5d" />

**…after "Show all"**
<img width="1440" height="840" alt="sponsors-front-page-expanded" src="https://github.com/user-attachments/assets/df260f23-2412-4d48-87ba-57ce3825c572" />

**Event single view**
<img width="1440" height="840" alt="sponsors-event-sidebar" src="https://github.com/user-attachments/assets/9c06540a-47f7-4752-8815-7e514df894c3" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
