### PR TITLE
Groups: custom registration questions per event

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -15,6 +15,12 @@
  *   POST /event/{id}
  *        Updates an existing gatherpress_event.
  *
+ *   POST /event/{id}/rsvp
+ *        RSVPs the current user to an event, together with their answers to
+ *        the event's custom registration questions. Wraps GatherPress's own
+ *        RSVP save so the answers and the RSVP are written in one request and
+ *        required questions are enforced server-side.
+ *
  *   GET  /group-info
  *   POST /group-info
  *        Reads and writes the group's name and description. Exists because
@@ -47,6 +53,11 @@ use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group
 use function WordCamp\Groups\Frontend\Defaults\extract_description_blocks;
 use function WordCamp\Groups\Frontend\Defaults\get_default_event_data;
 use function WordCamp\Groups\Frontend\Defaults\get_event_venue_post_id;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_missing_required;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_questions;
+use function WordCamp\Groups\Frontend\RSVP_Questions\sanitize_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\save_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\save_questions;
 
 const NAMESPACE_V1 = 'wporg-groups/v1';
 
@@ -106,6 +117,36 @@ function register_routes(): void {
 					},
 				),
 			) + event_args_schema(),
+		)
+	);
+
+	register_rest_route(
+		NAMESPACE_V1,
+		'/event/(?P<id>\d+)/rsvp',
+		array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => __NAMESPACE__ . '\save_rsvp',
+			'permission_callback' => __NAMESPACE__ . '\rsvp_permissions_check',
+			'args'                => array(
+				'id'      => array(
+					'type'              => 'integer',
+					'required'          => true,
+					'sanitize_callback' => 'absint',
+				),
+				'status'  => array(
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_key',
+					'validate_callback' => static function ( $param ) {
+						return in_array( $param, array( 'attending', 'not_attending' ), true );
+					},
+				),
+				'answers' => array(
+					'type'     => 'object',
+					'required' => false,
+					'default'  => array(),
+				),
+			),
 		)
 	);
 
@@ -333,6 +374,92 @@ function publish_existing_event_permissions_check( WP_REST_Request $request ): b
 }
 
 /**
+ * Capability check for the RSVP route — any logged-in visitor may RSVP to a
+ * published event, exactly as with GatherPress's own RSVP endpoint.
+ */
+function rsvp_permissions_check(): bool {
+	return is_user_logged_in();
+}
+
+/**
+ * POST /event/{id}/rsvp
+ *
+ * RSVP the current user, storing their answers to the event's custom
+ * registration questions on the same request.
+ *
+ * This exists rather than posting answers to GatherPress's RSVP endpoint and
+ * then storing them in a follow-up call, because a required question has to be
+ * able to *block* the RSVP. Splitting it in two would leave an RSVP recorded
+ * with the answers rejected — exactly the "the RSVP data is wrong" failure the
+ * feature is meant to prevent.
+ *
+ * @return WP_Error|WP_REST_Response
+ */
+function save_rsvp( WP_REST_Request $request ) {
+	$event_id = (int) $request->get_param( 'id' );
+	$status   = (string) $request->get_param( 'status' );
+	$post     = get_post( $event_id );
+
+	if ( ! $post || Event::POST_TYPE !== $post->post_type || 'publish' !== $post->post_status ) {
+		return new WP_Error( 'wporg_groups_invalid_event', 'Invalid event ID', array( 'status' => 404 ) );
+	}
+
+	$event = new Event( $event_id );
+
+	if ( ! $event->rsvp ) {
+		return new WP_Error( 'wporg_groups_rsvp_unavailable', 'RSVP is not available for this event.', array( 'status' => 400 ) );
+	}
+
+	if ( $event->has_event_past() ) {
+		return new WP_Error( 'wporg_groups_event_past', 'This event has already happened.', array( 'status' => 400 ) );
+	}
+
+	$questions = get_questions( $event_id );
+	$answers   = sanitize_answers( $questions, $request->get_param( 'answers' ) );
+
+	if ( 'attending' === $status ) {
+		$missing = get_missing_required( $questions, $answers );
+
+		if ( $missing ) {
+			return new WP_Error(
+				'wporg_groups_missing_answers',
+				sprintf(
+					/* translators: %s: comma-separated list of question labels. */
+					__( 'Please answer: %s', 'wporg-groups-frontend' ),
+					implode( ', ', $missing )
+				),
+				array( 'status' => 400 )
+			);
+		}
+	}
+
+	// Group sites are open to join, and RSVPing is the point at which someone
+	// becomes a member — same as GatherPress's own endpoint and our
+	// /members/join route.
+	$user_id = get_current_user_id();
+	if ( ! is_user_member_of_blog( $user_id ) ) {
+		add_user_to_blog( get_current_blog_id(), $user_id, 'subscriber' );
+	}
+
+	$record     = $event->rsvp->save( $user_id, $status );
+	$comment_id = (int) ( $record['comment_id'] ?? 0 );
+
+	if ( $comment_id ) {
+		// Answers belong to an attendance, not to a declined invitation — a
+		// cancelled RSVP drops them.
+		save_answers( $comment_id, 'attending' === $record['status'] ? $answers : array() );
+	}
+
+	return new WP_REST_Response(
+		array(
+			'success'   => (bool) $comment_id,
+			'status'    => $record['status'] ?? 'no_status',
+			'responses' => $event->rsvp->responses(),
+		)
+	);
+}
+
+/**
  * Whether the current user can create a GatherPress event on this site.
  */
 function current_user_can_create_event(): bool {
@@ -470,7 +597,36 @@ function event_args_schema(): array {
 			'default'           => 0,
 			'sanitize_callback' => 'absint',
 		),
+		// Custom registration questions. Deliberately has no `default` — an
+		// absent parameter means "leave the existing questions alone", which
+		// an empty-array default would turn into "delete them all".
+		'rsvp_questions'    => array(
+			'type'     => 'array',
+			'required' => false,
+			'items'    => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'       => array( 'type' => 'string' ),
+					'label'    => array( 'type' => 'string' ),
+					'required' => array( 'type' => 'boolean' ),
+				),
+			),
+		),
 	);
+}
+
+/**
+ * Write the event's custom registration questions, if the request carried any.
+ *
+ * @param int             $event_id Saved event post ID.
+ * @param WP_REST_Request $request  The create/update/draft request.
+ */
+function maybe_save_rsvp_questions( int $event_id, WP_REST_Request $request ): void {
+	$questions = $request->get_param( 'rsvp_questions' );
+
+	if ( is_array( $questions ) ) {
+		save_questions( $event_id, $questions );
+	}
 }
 
 /**
@@ -535,6 +691,7 @@ function get_event_form_data( WP_REST_Request $request ): WP_REST_Response {
 	// `undefined` checks.
 	$fields['featured_image_id']  = $fields['featured_image_id'] ?? 0;
 	$fields['featured_image_url'] = $fields['featured_image_url'] ?? '';
+	$fields['rsvp_questions']     = $is_editing ? get_questions( $event_id ) : array();
 
 	$venues = array_map(
 		static function ( $post ) {
@@ -687,6 +844,8 @@ function save_draft( WP_REST_Request $request ): WP_REST_Response {
 		set_post_thumbnail( $saved_id, $featured_image_id );
 	}
 
+	maybe_save_rsvp_questions( $saved_id, $request );
+
 	return new WP_REST_Response(
 		array(
 			'id'           => $saved_id,
@@ -829,6 +988,8 @@ function persist_event( int $event_id, WP_REST_Request $request ) {
 		// Explicit clear on edit.
 		delete_post_thumbnail( $saved_id );
 	}
+
+	maybe_save_rsvp_questions( $saved_id, $request );
 
 	return new WP_REST_Response(
 		array(

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -55,6 +55,8 @@ use function WordCamp\Groups\Frontend\Defaults\get_default_event_data;
 use function WordCamp\Groups\Frontend\Defaults\get_event_venue_post_id;
 use function WordCamp\Groups\Frontend\RSVP_Questions\get_missing_required;
 use function WordCamp\Groups\Frontend\RSVP_Questions\get_questions;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_user_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\merge_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\sanitize_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\save_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\save_questions;
@@ -406,7 +408,11 @@ function save_rsvp( WP_REST_Request $request ) {
 
 	$event = new Event( $event_id );
 
-	if ( ! $event->rsvp ) {
+	// `$event->rsvp` is set for anything supporting `gatherpress-event-date`,
+	// which the post-type check above already guarantees. The meaningful gate
+	// is whether RSVP is switched on for this event — without it
+	// `Rsvp::save()` is a no-op that would otherwise look like success.
+	if ( ! $event->rsvp || ! $event->rsvp->is_enabled() ) {
 		return new WP_Error( 'wporg_groups_rsvp_unavailable', 'RSVP is not available for this event.', array( 'status' => 400 ) );
 	}
 
@@ -414,8 +420,14 @@ function save_rsvp( WP_REST_Request $request ) {
 		return new WP_Error( 'wporg_groups_event_past', 'This event has already happened.', array( 'status' => 400 ) );
 	}
 
+	$user_id   = get_current_user_id();
 	$questions = get_questions( $event_id );
-	$answers   = sanitize_answers( $questions, $request->get_param( 'answers' ) );
+
+	// Only the questions this request actually submitted are applied on top of
+	// what's already stored, so a stale form can't blank out answers it never
+	// rendered. Required questions are checked against that merged result.
+	$submitted = sanitize_answers( $questions, $request->get_param( 'answers' ) );
+	$answers   = merge_answers( get_user_answers( $event_id, $user_id ), $submitted );
 
 	if ( 'attending' === $status ) {
 		$missing = get_missing_required( $questions, $answers );
@@ -436,7 +448,6 @@ function save_rsvp( WP_REST_Request $request ) {
 	// Group sites are open to join, and RSVPing is the point at which someone
 	// becomes a member — same as GatherPress's own endpoint and our
 	// /members/join route.
-	$user_id = get_current_user_id();
 	if ( ! is_user_member_of_blog( $user_id ) ) {
 		add_user_to_blog( get_current_blog_id(), $user_id, 'subscriber' );
 	}
@@ -444,15 +455,24 @@ function save_rsvp( WP_REST_Request $request ) {
 	$record     = $event->rsvp->save( $user_id, $status );
 	$comment_id = (int) ( $record['comment_id'] ?? 0 );
 
-	if ( $comment_id ) {
-		// Answers belong to an attendance, not to a declined invitation — a
-		// cancelled RSVP drops them.
-		save_answers( $comment_id, 'attending' === $record['status'] ? $answers : array() );
+	if ( ! $comment_id ) {
+		return new WP_Error(
+			'wporg_groups_rsvp_failed',
+			'Your RSVP could not be saved.',
+			array( 'status' => 500 )
+		);
 	}
+
+	// Answers belong to an attendance, not to a declined invitation — a
+	// cancelled RSVP drops them. Keyed off the *requested* status, not the
+	// saved one: a full event downgrades `attending` to `waiting_list`, and
+	// `check_waiting_list()` later promotes the RSVP without ever restoring
+	// answers deleted here.
+	save_answers( $comment_id, 'attending' === $status ? $answers : array() );
 
 	return new WP_REST_Response(
 		array(
-			'success'   => (bool) $comment_id,
+			'success'   => true,
 			'status'    => $record['status'] ?? 'no_status',
 			'responses' => $event->rsvp->responses(),
 		)

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-questions.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-questions.php
@@ -42,6 +42,95 @@ const MAX_QUESTIONS = 5;
 const MAX_ANSWER_LENGTH = 500;
 
 /**
+ * Hook the guard on GatherPress's own RSVP route.
+ */
+function bootstrap(): void {
+	add_filter( 'rest_endpoints', __NAMESPACE__ . '\guard_gatherpress_rsvp_route' );
+}
+
+/**
+ * Stop GatherPress's `/gatherpress/v1/event/rsvp` route being used to attend an
+ * event while skipping its required questions.
+ *
+ * Our own `wporg-groups/v1/event/{id}/rsvp` validates the answers, but
+ * GatherPress's route stays registered and accepts any logged-in member, so
+ * without this the "required" flag is only a front-end suggestion.
+ *
+ * The permission callback is wrapped rather than replaced, so GatherPress's own
+ * token/membership checks still run. Only the case that can produce bad data is
+ * refused — attending an event with unanswered required questions. Cancelling,
+ * events without questions, and members whose stored answers already satisfy
+ * the questions all pass through untouched.
+ *
+ * @param array $endpoints Registered REST endpoints.
+ * @return array Filtered endpoints.
+ */
+function guard_gatherpress_rsvp_route( array $endpoints ): array {
+	$route = '/gatherpress/v1/event/rsvp';
+
+	if ( empty( $endpoints[ $route ] ) ) {
+		return $endpoints;
+	}
+
+	foreach ( $endpoints[ $route ] as $index => $handler ) {
+		if ( ! isset( $handler['permission_callback'] ) ) {
+			continue;
+		}
+
+		$original = $handler['permission_callback'];
+
+		$endpoints[ $route ][ $index ]['permission_callback'] = static function ( $request ) use ( $original ) {
+			$allowed = call_user_func( $original, $request );
+
+			if ( true !== $allowed ) {
+				return $allowed;
+			}
+
+			return rsvp_answers_satisfied( $request );
+		};
+	}
+
+	return $endpoints;
+}
+
+/**
+ * Whether a GatherPress RSVP request would leave required questions unanswered.
+ *
+ * @param \WP_REST_Request $request The RSVP request.
+ * @return true|\WP_Error True when the request is fine to proceed.
+ */
+function rsvp_answers_satisfied( $request ) {
+	if ( 'attending' !== sanitize_key( (string) $request->get_param( 'status' ) ) ) {
+		return true;
+	}
+
+	$post_id   = (int) $request->get_param( 'post_id' );
+	$questions = $post_id ? get_questions( $post_id ) : array();
+
+	if ( ! $questions ) {
+		return true;
+	}
+
+	$user_id = (int) $request->get_param( 'user_id' );
+	$user_id = $user_id ? $user_id : get_current_user_id();
+	$missing = get_missing_required( $questions, get_user_answers( $post_id, $user_id ) );
+
+	if ( ! $missing ) {
+		return true;
+	}
+
+	return new \WP_Error(
+		'wporg_groups_missing_answers',
+		sprintf(
+			/* translators: %s: comma-separated list of question labels. */
+			__( 'Please answer: %s', 'wporg-groups-frontend' ),
+			implode( ', ', $missing )
+		),
+		array( 'status' => 400 )
+	);
+}
+
+/**
  * The questions defined on an event, in display order.
  *
  * @param int $event_id Event post ID.
@@ -136,9 +225,14 @@ function next_question_id( array $used_ids ): string {
 /**
  * Filter a raw answer map down to the questions the event actually asks.
  *
+ * A key that is **present but blank** is kept as `''` — that's how the caller
+ * tells "the attendee cleared this answer" apart from "this question wasn't
+ * submitted at all", which `merge_answers()` then treats differently. Keys the
+ * request didn't mention are dropped entirely.
+ *
  * @param array $questions Sanitized question list.
  * @param mixed $raw       Raw `question id => answer` map from the request.
- * @return array Sanitized `question id => answer` map, blanks omitted.
+ * @return array Sanitized `question id => answer` map of submitted keys only.
  */
 function sanitize_answers( array $questions, $raw ): array {
 	if ( ! is_array( $raw ) ) {
@@ -148,17 +242,55 @@ function sanitize_answers( array $questions, $raw ): array {
 	$answers = array();
 
 	foreach ( $questions as $question ) {
-		$value = sanitize_text_field( (string) ( $raw[ $question['id'] ] ?? '' ) );
-		$value = trim( $value );
-
-		if ( '' === $value ) {
+		if ( ! array_key_exists( $question['id'], $raw ) ) {
 			continue;
 		}
+
+		$value = trim( sanitize_text_field( (string) $raw[ $question['id'] ] ) );
 
 		$answers[ $question['id'] ] = mb_substr( $value, 0, MAX_ANSWER_LENGTH );
 	}
 
 	return $answers;
+}
+
+/**
+ * Apply a submitted answer map on top of what's already stored.
+ *
+ * Only the questions the request actually mentioned are touched, so a client
+ * that renders a stale form — or any caller that omits the field — can't wipe
+ * answers it never showed. A submitted blank is an explicit clear.
+ *
+ * @param array $stored    Currently stored `question id => answer` map.
+ * @param array $submitted Sanitized submitted map (blanks preserved).
+ * @return array The resulting map.
+ */
+function merge_answers( array $stored, array $submitted ): array {
+	foreach ( $submitted as $id => $value ) {
+		if ( '' === $value ) {
+			unset( $stored[ $id ] );
+			continue;
+		}
+
+		$stored[ $id ] = $value;
+	}
+
+	return $stored;
+}
+
+/**
+ * Whether a question has an answer.
+ *
+ * Deliberately not `empty()`: an answer of `"0"` is a real answer (a count, a
+ * guest number, a size), and `empty( '0' )` is true in PHP while the browser
+ * treats the same string as filled in — so the two ends would disagree about
+ * whether a required question had been answered.
+ *
+ * @param array  $answers Answer map.
+ * @param string $id      Question ID.
+ */
+function has_answer( array $answers, string $id ): bool {
+	return isset( $answers[ $id ] ) && '' !== $answers[ $id ];
 }
 
 /**
@@ -172,7 +304,7 @@ function get_missing_required( array $questions, array $answers ): array {
 	$missing = array();
 
 	foreach ( $questions as $question ) {
-		if ( $question['required'] && empty( $answers[ $question['id'] ] ) ) {
+		if ( $question['required'] && ! has_answer( $answers, $question['id'] ) ) {
 			$missing[] = $question['label'];
 		}
 	}
@@ -187,7 +319,7 @@ function get_missing_required( array $questions, array $answers ): array {
  * @param array $answers    Sanitized answer map.
  */
 function save_answers( int $comment_id, array $answers ): void {
-	if ( empty( $answers ) ) {
+	if ( ! $answers ) {
 		delete_comment_meta( $comment_id, ANSWERS_META );
 		return;
 	}
@@ -222,7 +354,7 @@ function get_labelled_answers( int $comment_id, array $questions ): array {
 	$labelled = array();
 
 	foreach ( $questions as $question ) {
-		if ( empty( $answers[ $question['id'] ] ) ) {
+		if ( ! has_answer( $answers, $question['id'] ) ) {
 			continue;
 		}
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-questions.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-questions.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Per-event custom registration questions.
+ *
+ * Organizers define a short list of questions on an event; attendees answer
+ * them when they RSVP. Deliberately minimal for a first pass — every question
+ * is a single-line text field, and the count is capped so this stays a couple
+ * of extra questions at signup rather than a form builder.
+ *
+ * Storage:
+ *
+ *   - **Questions** live in one `wporg_groups_rsvp_questions` post meta on the
+ *     event: a list of `array( 'id', 'label', 'required' )`.
+ *   - **Answers** live in one `wporg_groups_rsvp_answers` comment meta on the
+ *     GatherPress RSVP comment, keyed by question id. Keeping them on the
+ *     comment means cancelling an RSVP takes the answers with it, and no
+ *     orphaned answers survive the RSVP they belong to.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+namespace WordCamp\Groups\Frontend\RSVP_Questions;
+
+defined( 'WPINC' ) || die();
+
+use GatherPress\Core\Rsvp\Rsvp;
+
+const QUESTIONS_META = 'wporg_groups_rsvp_questions';
+const ANSWERS_META   = 'wporg_groups_rsvp_answers';
+
+/**
+ * Hard cap on questions per event. Meetup.com's own profile questions cap at
+ * three; five leaves room for the common set (company, dietary needs, t-shirt
+ * size) without turning the RSVP into a form.
+ */
+const MAX_QUESTIONS = 5;
+
+/**
+ * Cap on a single answer's length. Long enough for a sentence or two, short
+ * enough that the attendee list stays readable.
+ */
+const MAX_ANSWER_LENGTH = 500;
+
+/**
+ * The questions defined on an event, in display order.
+ *
+ * @param int $event_id Event post ID.
+ * @return array List of `array{id:string, label:string, required:bool}`.
+ */
+function get_questions( int $event_id ): array {
+	$stored = get_post_meta( $event_id, QUESTIONS_META, true );
+
+	return is_array( $stored ) ? sanitize_questions( $stored ) : array();
+}
+
+/**
+ * Persist an event's questions, replacing whatever was there before.
+ *
+ * @param int   $event_id Event post ID.
+ * @param mixed $raw      Raw question list from the request.
+ */
+function save_questions( int $event_id, $raw ): void {
+	$questions = sanitize_questions( $raw );
+
+	if ( empty( $questions ) ) {
+		delete_post_meta( $event_id, QUESTIONS_META );
+		return;
+	}
+
+	update_post_meta( $event_id, QUESTIONS_META, $questions );
+}
+
+/**
+ * Normalise a raw question list: drop unlabelled entries, assign ids to new
+ * ones, and enforce `MAX_QUESTIONS`.
+ *
+ * @param mixed $raw Raw question list.
+ * @return array Sanitized questions.
+ */
+function sanitize_questions( $raw ): array {
+	if ( ! is_array( $raw ) ) {
+		return array();
+	}
+
+	$questions = array();
+	$used_ids  = array();
+
+	foreach ( $raw as $question ) {
+		if ( ! is_array( $question ) ) {
+			continue;
+		}
+
+		$label = sanitize_text_field( (string) ( $question['label'] ?? '' ) );
+		if ( '' === trim( $label ) ) {
+			continue;
+		}
+
+		$id = sanitize_key( (string) ( $question['id'] ?? '' ) );
+		if ( '' === $id || isset( $used_ids[ $id ] ) ) {
+			$id = next_question_id( $used_ids );
+		}
+		$used_ids[ $id ] = true;
+
+		$questions[] = array(
+			'id'       => $id,
+			'label'    => $label,
+			'required' => ! empty( $question['required'] ),
+		);
+
+		if ( count( $questions ) >= MAX_QUESTIONS ) {
+			break;
+		}
+	}
+
+	return $questions;
+}
+
+/**
+ * Mint an id for a question the organizer just added.
+ *
+ * Random rather than sequential on purpose: answers are stored against the
+ * question id, so an id must never be reused. A counter would hand `q1` back
+ * out after the first question was deleted, and the previous attendees'
+ * answers to the old `q1` would resurface under the new question's label.
+ *
+ * @param array $used_ids Map of ids already taken in this set.
+ */
+function next_question_id( array $used_ids ): string {
+	do {
+		$id = 'q' . substr( md5( uniqid( '', true ) ), 0, 8 );
+	} while ( isset( $used_ids[ $id ] ) );
+
+	return $id;
+}
+
+/**
+ * Filter a raw answer map down to the questions the event actually asks.
+ *
+ * @param array $questions Sanitized question list.
+ * @param mixed $raw       Raw `question id => answer` map from the request.
+ * @return array Sanitized `question id => answer` map, blanks omitted.
+ */
+function sanitize_answers( array $questions, $raw ): array {
+	if ( ! is_array( $raw ) ) {
+		return array();
+	}
+
+	$answers = array();
+
+	foreach ( $questions as $question ) {
+		$value = sanitize_text_field( (string) ( $raw[ $question['id'] ] ?? '' ) );
+		$value = trim( $value );
+
+		if ( '' === $value ) {
+			continue;
+		}
+
+		$answers[ $question['id'] ] = mb_substr( $value, 0, MAX_ANSWER_LENGTH );
+	}
+
+	return $answers;
+}
+
+/**
+ * Labels of the required questions left unanswered.
+ *
+ * @param array $questions Sanitized question list.
+ * @param array $answers   Sanitized answer map.
+ * @return string[] Labels of the missing answers, in question order.
+ */
+function get_missing_required( array $questions, array $answers ): array {
+	$missing = array();
+
+	foreach ( $questions as $question ) {
+		if ( $question['required'] && empty( $answers[ $question['id'] ] ) ) {
+			$missing[] = $question['label'];
+		}
+	}
+
+	return $missing;
+}
+
+/**
+ * Store the answers on an RSVP, or clear them when there are none.
+ *
+ * @param int   $comment_id RSVP comment ID.
+ * @param array $answers    Sanitized answer map.
+ */
+function save_answers( int $comment_id, array $answers ): void {
+	if ( empty( $answers ) ) {
+		delete_comment_meta( $comment_id, ANSWERS_META );
+		return;
+	}
+
+	update_comment_meta( $comment_id, ANSWERS_META, $answers );
+}
+
+/**
+ * The answers stored on a single RSVP.
+ *
+ * @param int $comment_id RSVP comment ID.
+ * @return array `question id => answer` map.
+ */
+function get_answers( int $comment_id ): array {
+	$stored = get_comment_meta( $comment_id, ANSWERS_META, true );
+
+	return is_array( $stored ) ? $stored : array();
+}
+
+/**
+ * An RSVP's answers paired with the question labels, ready to display.
+ *
+ * Questions the attendee skipped, and answers to questions the organizer has
+ * since deleted, are both left out.
+ *
+ * @param int   $comment_id RSVP comment ID.
+ * @param array $questions  Sanitized question list for the event.
+ * @return array List of `array{label:string, answer:string}`.
+ */
+function get_labelled_answers( int $comment_id, array $questions ): array {
+	$answers  = get_answers( $comment_id );
+	$labelled = array();
+
+	foreach ( $questions as $question ) {
+		if ( empty( $answers[ $question['id'] ] ) ) {
+			continue;
+		}
+
+		$labelled[] = array(
+			'label'  => $question['label'],
+			'answer' => (string) $answers[ $question['id'] ],
+		);
+	}
+
+	return $labelled;
+}
+
+/**
+ * Whether the current user may see other attendees' answers.
+ *
+ * Answers can hold things attendees would not post publicly (dietary needs,
+ * accessibility requirements), so they're limited to the people who need them
+ * to run the event: whoever can edit it.
+ *
+ * @param int $event_id Event post ID.
+ */
+function current_user_can_view_answers( int $event_id ): bool {
+	return current_user_can( 'edit_post', $event_id );
+}
+
+/**
+ * The current user's own answers for an event, for prefilling the RSVP form.
+ *
+ * @param int $event_id Event post ID.
+ * @param int $user_id  User ID.
+ * @return array `question id => answer` map.
+ */
+function get_user_answers( int $event_id, int $user_id ): array {
+	if ( ! $user_id || ! class_exists( Rsvp::class ) ) {
+		return array();
+	}
+
+	$rsvp       = ( new Rsvp( $event_id ) )->get( $user_id );
+	$comment_id = (int) ( $rsvp['comment_id'] ?? 0 );
+
+	return $comment_id ? get_answers( $comment_id ) : array();
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -47,6 +47,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import VenueEditor from './venue-editor';
 import MessageMembersModal from './message-members-modal';
+import RsvpQuestionsEditor from './rsvp-questions-editor';
 
 const NS =
 	( window.wporgGroupsEventModal &&
@@ -328,6 +329,7 @@ const NS =
 		online_event_link: '',
 		new_venue_name: '',
 		new_venue_address: '',
+		rsvp_questions: [],
 	};
 
 	function EventModal( { mode, eventId, onClose } ) {
@@ -403,6 +405,7 @@ const NS =
 						online_event_link: res.fields.online_event_link || '',
 						new_venue_name: '',
 						new_venue_address: '',
+						rsvp_questions: res.fields.rsvp_questions || [],
 					} );
 					setEditorKey( ( k ) => k + 1 );
 					setDirty( false );
@@ -451,6 +454,11 @@ const NS =
 				new_venue_name: isAddingNewVenue ? form.new_venue_name : '',
 				new_venue_address: isAddingNewVenue ? form.new_venue_address : '',
 				featured_image_id: featuredImage.id,
+				// Blank-labelled rows are just an empty slot the organizer
+				// added and never filled in; the server drops them too.
+				rsvp_questions: ( form.rsvp_questions || [] ).filter(
+					( q ) => q.label.trim() !== ''
+				),
 			};
 		};
 
@@ -745,6 +753,11 @@ const NS =
 							__nextHasNoMarginBottom: true,
 						} )
 					),
+
+					h( RsvpQuestionsEditor, {
+						questions: form.rsvp_questions,
+						onChange: ( value ) => updateField( 'rsvp_questions', value ),
+					} ),
 
 					h(
 						'div',

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/rsvp-questions-editor.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/rsvp-questions-editor.js
@@ -1,0 +1,125 @@
+/**
+ * WPorg Groups Frontend — RSVP questions editor.
+ *
+ * The "Registration questions" section of the create/edit event modal. Lets an
+ * organizer ask a handful of extra questions at RSVP time (company name,
+ * dietary requirements, t-shirt size…) instead of moving registration off to
+ * an external form.
+ *
+ * Kept deliberately small: every question is a single-line text field, and the
+ * list is capped at `MAX_QUESTIONS`. New questions are saved with an empty
+ * `id` — the server mints one, and it comes back on the next load.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+import { createElement as h } from '@wordpress/element';
+import { Button, CheckboxControl, TextControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Must match `WordCamp\Groups\Frontend\RSVP_Questions\MAX_QUESTIONS`.
+ */
+const MAX_QUESTIONS = 5;
+
+export default function RsvpQuestionsEditor( { questions, onChange } ) {
+	const list = questions || [];
+
+	const updateAt = ( index, changes ) => {
+		onChange(
+			list.map( ( question, i ) =>
+				i === index ? { ...question, ...changes } : question
+			)
+		);
+	};
+
+	const removeAt = ( index ) => {
+		onChange( list.filter( ( question, i ) => i !== index ) );
+	};
+
+	const addQuestion = () => {
+		onChange( [ ...list, { id: '', label: '', required: false } ] );
+	};
+
+	return h(
+		'div',
+		{ className: 'wporg-groups-event-modal__field wporg-groups-rsvp-questions' },
+		h(
+			'label',
+			{ className: 'components-base-control__label' },
+			__( 'Registration questions', 'wporg-groups-frontend' )
+		),
+		h(
+			'p',
+			{ className: 'wporg-groups-rsvp-questions__help' },
+			__(
+				'Optional. Attendees answer these when they RSVP. Only organizers can see the answers.',
+				'wporg-groups-frontend'
+			)
+		),
+		list.map( ( question, index ) =>
+			h(
+				'div',
+				{
+					className: 'wporg-groups-rsvp-questions__row',
+					key: question.id || `new-${ index }`,
+				},
+				h( TextControl, {
+					label: sprintf(
+						/* translators: %d: question number. */
+						__( 'Question %d', 'wporg-groups-frontend' ),
+						index + 1
+					),
+					value: question.label,
+					onChange: ( value ) => updateAt( index, { label: value } ),
+					placeholder: __(
+						'e.g. Dietary requirements',
+						'wporg-groups-frontend'
+					),
+					__nextHasNoMarginBottom: true,
+				} ),
+				h(
+					'div',
+					{ className: 'wporg-groups-rsvp-questions__row-actions' },
+					h( CheckboxControl, {
+						label: __( 'Required', 'wporg-groups-frontend' ),
+						checked: !! question.required,
+						onChange: ( value ) =>
+							updateAt( index, { required: value } ),
+						__nextHasNoMarginBottom: true,
+					} ),
+					h(
+						Button,
+						{
+							variant: 'tertiary',
+							isDestructive: true,
+							onClick: () => removeAt( index ),
+						},
+						__( 'Remove', 'wporg-groups-frontend' )
+					)
+				)
+			)
+		),
+		list.length < MAX_QUESTIONS
+			? h(
+				Button,
+				{
+					variant: 'secondary',
+					onClick: addQuestion,
+					className: 'wporg-groups-rsvp-questions__add',
+				},
+				__( '+ Add a question', 'wporg-groups-frontend' )
+			)
+			: h(
+				'p',
+				{ className: 'wporg-groups-rsvp-questions__help' },
+				sprintf(
+					/* translators: %d: maximum number of questions. */
+					__(
+						'You can ask up to %d questions.',
+						'wporg-groups-frontend'
+					),
+					MAX_QUESTIONS
+				)
+			)
+	);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -421,3 +421,30 @@
 	font-size: 12px;
 	margin-top: 4px;
 }
+
+/* === Registration questions === */
+
+.wporg-groups-rsvp-questions__help {
+	font-size: 12px;
+	color: #757575;
+	margin: 0 0 8px;
+}
+
+.wporg-groups-rsvp-questions__row {
+	display: flex;
+	align-items: flex-end;
+	gap: 12px;
+	margin-bottom: 12px;
+}
+
+.wporg-groups-rsvp-questions__row > .components-base-control {
+	flex: 1 1 auto;
+}
+
+.wporg-groups-rsvp-questions__row-actions {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-shrink: 0;
+	padding-bottom: 4px;
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -8,6 +8,13 @@
 use GatherPress\Core\Event\Event;
 use GatherPress\Core\Rsvp\Rsvp;
 
+use function WordCamp\Groups\Frontend\RSVP_Questions\current_user_can_view_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_labelled_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_questions;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_user_answers;
+
+use const WordCamp\Groups\Frontend\RSVP_Questions\MAX_ANSWER_LENGTH;
+
 $event_post_id = ! empty( $block->context['postId'] )
 	? (int) $block->context['postId']
 	: ( get_the_ID() ?: get_queried_object_id() );
@@ -48,6 +55,13 @@ if ( $attendee_user_ids ) {
 	update_meta_cache( 'user', $attendee_user_ids );
 }
 
+// Custom registration questions. Answers hold things attendees wouldn't post
+// publicly (dietary needs, accessibility requirements), so they're only
+// rendered for organizers.
+$questions        = get_questions( $event_post_id );
+$can_view_answers = $questions && current_user_can_view_answers( $event_post_id );
+$own_answers      = ( $questions && $is_login ) ? get_user_answers( $event_post_id, get_current_user_id() ) : array();
+
 $attendees = array();
 foreach ( $records as $record ) {
 	$bio = '';
@@ -62,6 +76,9 @@ foreach ( $records as $record ) {
 		'photo'   => $record['photo'] ?? '',
 		'profile' => $record['profile'] ?? '',
 		'bio'     => $bio,
+		'answers' => $can_view_answers
+			? get_labelled_answers( (int) ( $record['commentId'] ?? 0 ), $questions )
+			: array(),
 	);
 }
 
@@ -93,6 +110,8 @@ $rsvp_labels    = array(
 	'cancelRsvp'         => __( 'Cancel RSVP', 'wporg-groups-frontend' ),
 	'attend'             => __( 'Attend', 'wporg-groups-frontend' ),
 	'emptyAttendees'     => __( 'No attendees yet. Be the first to RSVP!', 'wporg-groups-frontend' ),
+	'missingAnswers'     => __( 'Please answer the required questions.', 'wporg-groups-frontend' ),
+	'rsvpFailed'         => __( 'Sorry, your RSVP could not be saved. Please try again.', 'wporg-groups-frontend' ),
 );
 
 $context = array(
@@ -106,8 +125,12 @@ $context = array(
 	'loginUrl'          => wp_login_url( get_permalink( $event_post_id ) ),
 	'apiBase'           => rest_url( 'gatherpress/v1/event' ),
 	'joinApi'           => rest_url( 'wporg-groups/v1/members/join' ),
+	'rsvpApi'           => rest_url( sprintf( 'wporg-groups/v1/event/%d/rsvp', $event_post_id ) ),
+	'hasQuestions'      => ! empty( $questions ),
+	'canViewAnswers'    => $can_view_answers,
 	'modalOpen'         => false,
 	'rsvpLoading'       => false,
+	'rsvpError'         => '',
 	'labels'            => $rsvp_labels,
 );
 
@@ -239,6 +262,34 @@ $wrapper_attributes = get_block_wrapper_attributes(
 							}
 							?>
 						</p>
+
+						<?php if ( $questions ) : ?>
+							<div class="wporg-event-rsvp__questions" data-wp-class--is-hidden="state.isAttending">
+								<?php foreach ( $questions as $question ) : ?>
+									<?php $field_id = 'wporg-event-rsvp-question-' . $event_post_id . '-' . $question['id']; ?>
+									<div class="wporg-event-rsvp__question">
+										<label class="wporg-event-rsvp__question-label" for="<?php echo esc_attr( $field_id ); ?>">
+											<?php echo esc_html( $question['label'] ); ?>
+											<?php if ( $question['required'] ) : ?>
+												<span class="wporg-event-rsvp__question-required" aria-hidden="true">*</span>
+											<?php endif; ?>
+										</label>
+										<input
+											type="text"
+											id="<?php echo esc_attr( $field_id ); ?>"
+											class="wporg-event-rsvp__question-input"
+											data-question-id="<?php echo esc_attr( $question['id'] ); ?>"
+											maxlength="<?php echo (int) MAX_ANSWER_LENGTH; ?>"
+											value="<?php echo esc_attr( $own_answers[ $question['id'] ] ?? '' ); ?>"
+											<?php echo $question['required'] ? 'required' : ''; ?>
+										/>
+									</div>
+								<?php endforeach; ?>
+							</div>
+						<?php endif; ?>
+
+						<p class="wporg-event-rsvp__error" role="alert" data-wp-text="context.rsvpError"></p>
+
 						<button
 							class="wporg-event-rsvp__modal-rsvp-btn wp-element-button<?php echo $is_attending ? ' is-attending' : ''; ?>"
 							data-wp-on--click="actions.toggleRsvp"
@@ -287,6 +338,12 @@ $wrapper_attributes = get_block_wrapper_attributes(
 							<?php if ( ! empty( $attendee['bio'] ) ) : ?>
 								<span class="wporg-event-rsvp__attendee-bio"><?php echo esc_html( $attendee['bio'] ); ?></span>
 							<?php endif; ?>
+							<?php foreach ( $attendee['answers'] as $answer ) : ?>
+								<span class="wporg-event-rsvp__attendee-answer">
+									<strong><?php echo esc_html( $answer['label'] ); ?>:</strong>
+									<?php echo esc_html( $answer['answer'] ); ?>
+								</span>
+							<?php endforeach; ?>
 						</div>
 					</a>
 				<?php endforeach; ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -126,6 +126,7 @@ $rsvp_labels    = array(
 	'rsvpSuccessWaitingList'  => __( 'You have joined the event waiting list.', 'wporg-groups-frontend' ),
 	'rsvpError'               => __( 'Your RSVP could not be updated. Please try again.', 'wporg-groups-frontend' ),
 	'missingAnswers'          => __( 'Please answer the required questions.', 'wporg-groups-frontend' ),
+	'answersSaved'            => __( 'Your answers have been saved.', 'wporg-groups-frontend' ),
 );
 
 $context = array(
@@ -155,6 +156,7 @@ wp_interactivity_state(
 	'wporg/event-rsvp',
 	array(
 		'isAttending'    => $is_attending,
+		'isNotAttending' => ! $is_attending,
 		'countLabel'     => sprintf(
 			/* translators: %s: attendee count. */
 			_n( '%s going', '%s going', $count, 'wporg-groups-frontend' ),
@@ -290,7 +292,8 @@ $wrapper_attributes = get_block_wrapper_attributes(
 
 						<?php if ( $questions ) : ?>
 							<?php $error_id = 'wporg-event-rsvp-questions-error-' . $event_post_id; ?>
-							<fieldset class="wporg-event-rsvp__questions" data-wp-class--is-hidden="state.isAttending">
+							<?php // Stays visible while attending: an organizer can add a required question after people have signed up, and correcting an answer shouldn't mean cancelling the RSVP. ?>
+							<fieldset class="wporg-event-rsvp__questions">
 								<legend class="screen-reader-text">
 									<?php esc_html_e( 'Registration questions', 'wporg-groups-frontend' ); ?>
 								</legend>
@@ -320,6 +323,15 @@ $wrapper_attributes = get_block_wrapper_attributes(
 									id="<?php echo esc_attr( $error_id ); ?>"
 									data-wp-text="context.questionsError"
 								></p>
+								<button
+									type="button"
+									class="wporg-event-rsvp__save-answers wp-element-button<?php echo $is_attending ? '' : ' is-hidden'; ?>"
+									data-wp-on--click="actions.saveAnswers"
+									data-wp-class--is-hidden="state.isNotAttending"
+									data-wp-bind--disabled="context.rsvpLoading"
+								>
+									<?php esc_html_e( 'Save answers', 'wporg-groups-frontend' ); ?>
+								</button>
 							</fieldset>
 						<?php endif; ?>
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -62,6 +62,17 @@ $questions        = get_questions( $event_post_id );
 $can_view_answers = $questions && current_user_can_view_answers( $event_post_id );
 $own_answers      = ( $questions && $is_login ) ? get_user_answers( $event_post_id, get_current_user_id() ) : array();
 
+// Same treatment for the answers, which live in commentmeta on each RSVP.
+// GatherPress primes this incidentally while *building* `responses()`, but
+// that result is object-cached for 15 minutes — on a cache hit the loop never
+// runs and the reads below would be one query per attendee.
+if ( $can_view_answers ) {
+	$attendee_comment_ids = array_filter( wp_list_pluck( $records, 'commentId' ) );
+	if ( $attendee_comment_ids ) {
+		update_meta_cache( 'comment', $attendee_comment_ids );
+	}
+}
+
 $attendees = array();
 foreach ( $records as $record ) {
 	$bio = '';

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
@@ -152,6 +152,55 @@
 	justify-content: space-between;
 	gap: 16px;
 	flex-shrink: 0;
+	flex-wrap: wrap;
+}
+
+/* === Custom registration questions === */
+
+.wporg-event-rsvp__questions {
+	flex: 1 0 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.wporg-event-rsvp__questions.is-hidden {
+	display: none;
+}
+
+.wporg-event-rsvp__question {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.wporg-event-rsvp__question-label {
+	font-size: 14px;
+	font-weight: 600;
+	color: #1a1919;
+}
+
+.wporg-event-rsvp__question-required {
+	color: #cc1818;
+}
+
+.wporg-event-rsvp__question-input {
+	width: 100%;
+	padding: 8px 12px;
+	font-size: 14px;
+	border: 1px solid #d9d9d9;
+	border-radius: 2px;
+}
+
+.wporg-event-rsvp__error {
+	flex: 1 0 100%;
+	margin: 0;
+	font-size: 14px;
+	color: #cc1818;
+}
+
+.wporg-event-rsvp__error:empty {
+	display: none;
 }
 
 .wporg-event-rsvp__modal-status {
@@ -233,6 +282,12 @@
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
+}
+
+.wporg-event-rsvp__attendee-answer {
+	font-size: 13px;
+	color: #40464d;
+	line-height: 1.4;
 }
 
 .wporg-event-rsvp__empty {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
@@ -184,6 +184,16 @@
 	display: none;
 }
 
+.wporg-event-rsvp__save-answers {
+	align-self: flex-start;
+	font-size: 13px;
+	padding: 6px 12px;
+}
+
+.wporg-event-rsvp__save-answers.is-hidden {
+	display: none;
+}
+
 .wporg-event-rsvp__question {
 	display: flex;
 	flex-direction: column;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -228,23 +228,46 @@ function scheduleFocus( element ) {
  * the block so a page listing several events reads the right one.
  *
  * @param {Element} block The `.wp-block-wporg-event-rsvp` element.
- * @return {{answers: Object, missingRequired: boolean}} Collected answers.
+ * @return {{answers: Object, missingRequired: boolean, missingInputs: Element[]}} Collected answers.
  */
 function collectAnswers( block ) {
 	const answers = {};
-	let missingRequired = false;
+	const missingInputs = [];
 
 	block?.querySelectorAll( '.wporg-event-rsvp__question-input' ).forEach( ( input ) => {
 		const value = input.value.trim();
 		if ( ! value && input.required ) {
-			missingRequired = true;
+			missingInputs.push( input );
 		}
 		// Blanks are sent too, so the server can tell "cleared this answer"
 		// from "never rendered this question".
 		answers[ input.dataset.questionId ] = value;
 	} );
 
-	return { answers, missingRequired };
+	return { answers, missingRequired: 0 < missingInputs.length, missingInputs };
+}
+
+/**
+ * Marks the unanswered required inputs so assistive tech can find them.
+ *
+ * The error text itself is announced through the block's live region, but that
+ * only tells someone that an answer is missing. With several questions the
+ * field in error also has to be identifiable, which is the other half of
+ * WCAG 2.1 3.3.1, so flag them and move focus to the first.
+ *
+ * @param {Element}   block         The `.wp-block-wporg-event-rsvp` element.
+ * @param {Element[]} missingInputs Inputs that are required and still empty.
+ */
+function flagMissingAnswers( block, missingInputs ) {
+	block?.querySelectorAll( '.wporg-event-rsvp__question-input' ).forEach( ( input ) => {
+		if ( missingInputs.includes( input ) ) {
+			input.setAttribute( 'aria-invalid', 'true' );
+		} else {
+			input.removeAttribute( 'aria-invalid' );
+		}
+	} );
+
+	scheduleFocus( missingInputs[ 0 ] );
 }
 
 async function doToggleRsvp( ctx, actionElement ) {
@@ -300,9 +323,10 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		}
 	}
 
-	const { answers, missingRequired } = ctx.hasQuestions
-		? collectAnswers( actionElement?.closest( '.wp-block-wporg-event-rsvp' ) )
-		: { answers: {}, missingRequired: false };
+	const block = actionElement?.closest( '.wp-block-wporg-event-rsvp' );
+	const { answers, missingRequired, missingInputs } = ctx.hasQuestions
+		? collectAnswers( block )
+		: { answers: {}, missingRequired: false, missingInputs: [] };
 
 	// The server rejects this too — checking here just saves a round trip and
 	// keeps whatever the attendee already typed on screen.
@@ -311,7 +335,12 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		ctx.questionsError = message;
 		ctx.rsvpNotice = message;
 		openRsvpModal( ctx, actionElement );
+		flagMissingAnswers( block, missingInputs );
 		return;
+	}
+
+	if ( ctx.hasQuestions ) {
+		flagMissingAnswers( block, [] );
 	}
 
 	const oldStatus = ctx.currentUserStatus;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -25,6 +25,10 @@ store( 'wporg/event-rsvp', {
 			return getContext().currentUserStatus === 'attending';
 		},
 
+		get isNotAttending() {
+			return getContext().currentUserStatus !== 'attending';
+		},
+
 		get countLabel() {
 			const count = getContext().attendingCount;
 			return formatLabel( label( 1 === count ? 'countSingular' : 'countPlural' ), [
@@ -149,6 +153,11 @@ store( 'wporg/event-rsvp', {
 			const ctx = getContext();
 			return doToggleRsvp( ctx, getElement().ref );
 		},
+
+		async saveAnswers() {
+			const ctx = getContext();
+			return doSaveAnswers( ctx, getElement().ref );
+		},
 	},
 } );
 
@@ -227,12 +236,11 @@ function collectAnswers( block ) {
 
 	block?.querySelectorAll( '.wporg-event-rsvp__question-input' ).forEach( ( input ) => {
 		const value = input.value.trim();
-		if ( ! value ) {
-			if ( input.required ) {
-				missingRequired = true;
-			}
-			return;
+		if ( ! value && input.required ) {
+			missingRequired = true;
 		}
+		// Blanks are sent too, so the server can tell "cleared this answer"
+		// from "never rendered this question".
 		answers[ input.dataset.questionId ] = value;
 	} );
 
@@ -240,6 +248,24 @@ function collectAnswers( block ) {
 }
 
 async function doToggleRsvp( ctx, actionElement ) {
+	const newStatus = ctx.currentUserStatus === 'attending' ? 'not_attending' : 'attending';
+
+	return submitRsvp( ctx, actionElement, newStatus );
+}
+
+/**
+ * Save edited answers without changing the attendance itself.
+ *
+ * Re-sending `attending` is idempotent in `Rsvp::save()`, so this updates the
+ * answers on the existing RSVP rather than requiring a cancel/re-RSVP round
+ * trip — which would delete the answers and, on a capped event, surrender the
+ * seat to the waiting list.
+ */
+async function doSaveAnswers( ctx, actionElement ) {
+	return submitRsvp( ctx, actionElement, 'attending' );
+}
+
+async function submitRsvp( ctx, actionElement, newStatus ) {
 	if ( ! ctx.isLoggedIn ) {
 		window.location.href = ctx.loginUrl;
 		return;
@@ -274,8 +300,6 @@ async function doToggleRsvp( ctx, actionElement ) {
 		}
 	}
 
-	const newStatus = ctx.currentUserStatus === 'attending' ? 'not_attending' : 'attending';
-
 	const { answers, missingRequired } = ctx.hasQuestions
 		? collectAnswers( actionElement?.closest( '.wp-block-wporg-event-rsvp' ) )
 		: { answers: {}, missingRequired: false };
@@ -292,8 +316,11 @@ async function doToggleRsvp( ctx, actionElement ) {
 
 	const oldStatus = ctx.currentUserStatus;
 	const oldCount = ctx.attendingCount;
+	const statusChanged = newStatus !== oldStatus;
 	ctx.currentUserStatus = newStatus;
-	ctx.attendingCount += newStatus === 'attending' ? 1 : -1;
+	if ( statusChanged ) {
+		ctx.attendingCount += newStatus === 'attending' ? 1 : -1;
+	}
 	ctx.rsvpLoading = true;
 
 	try {
@@ -301,7 +328,9 @@ async function doToggleRsvp( ctx, actionElement ) {
 
 		ctx.currentUserStatus = data.status;
 		ctx.attendingCount = data.responses.attending.count;
-		ctx.rsvpNotice = getRsvpSuccessNotice( ctx, data.status );
+		ctx.rsvpNotice = statusChanged
+			? getRsvpSuccessNotice( ctx, data.status )
+			: labelFromContext( ctx, 'answersSaved' );
 
 		// Organizers see the answers inline in the attendee list, which the
 		// client-side refresh can't rebuild — reload so their view stays
@@ -312,10 +341,19 @@ async function doToggleRsvp( ctx, actionElement ) {
 		}
 
 		refreshAttendees( ctx, actionElement );
-	} catch {
+	} catch ( error ) {
 		ctx.currentUserStatus = oldStatus;
 		ctx.attendingCount = oldCount;
-		ctx.rsvpNotice = labelFromContext( ctx, 'rsvpError' );
+
+		// Our own validation failures carry a message the attendee can act on
+		// ("Please answer: Dietary requirements"). Anything else — a network
+		// blip, a 500 — gets the generic retry wording.
+		const ours = error?.code?.startsWith?.( 'wporg_groups_' ) && error.message;
+		ctx.rsvpNotice = ours ? error.message : labelFromContext( ctx, 'rsvpError' );
+		if ( ours ) {
+			ctx.questionsError = error.message;
+			openRsvpModal( ctx, actionElement );
+		}
 	} finally {
 		ctx.rsvpLoading = false;
 	}
@@ -357,7 +395,11 @@ async function sendRsvp( ctx, status, answers, retry = false ) {
 
 	const data = await resp.json();
 	if ( ! resp.ok || ! data?.success ) {
-		throw new Error( data?.message || resp.statusText );
+		const error = new Error( data?.message || resp.statusText );
+		// Keep the code so the caller can tell a message meant for the
+		// attendee ("Please answer: …") from an opaque transport failure.
+		error.code = data?.code || '';
+		throw error;
 	}
 
 	return data;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -74,23 +74,17 @@ const { state } = store( 'wporg/event-rsvp', {
 
 	actions: {
 		openModal() {
-			const ctx = getContext();
-			ctx.modalOpen = true;
-			document.body.style.overflow = 'hidden';
+			openModal( getContext() );
 		},
 
 		closeModal() {
-			const ctx = getContext();
-			ctx.modalOpen = false;
-			document.body.style.overflow = '';
+			closeModal( getContext() );
 		},
 
 		handleBackdropClick( event ) {
 			const { ref } = getElement();
 			if ( event.target === ref ) {
-				const ctx = getContext();
-				ctx.modalOpen = false;
-				document.body.style.overflow = '';
+				closeModal( getContext() );
 			}
 		},
 
@@ -98,8 +92,7 @@ const { state } = store( 'wporg/event-rsvp', {
 			if ( event.key === 'Escape' ) {
 				const ctx = getContext();
 				if ( ctx.modalOpen ) {
-					ctx.modalOpen = false;
-					document.body.style.overflow = '';
+					closeModal( ctx );
 				}
 			}
 		},
@@ -110,9 +103,10 @@ const { state } = store( 'wporg/event-rsvp', {
 				window.location.href = ctx.loginUrl;
 				return;
 			}
-			if ( ctx.currentUserStatus === 'attending' ) {
-				ctx.modalOpen = true;
-				document.body.style.overflow = 'hidden';
+			// Attending already, or there are questions to answer first —
+			// either way the modal is where the next step lives.
+			if ( ctx.currentUserStatus === 'attending' || ctx.hasQuestions ) {
+				openModal( ctx );
 				return;
 			}
 			doToggleRsvp( ctx );
@@ -121,9 +115,7 @@ const { state } = store( 'wporg/event-rsvp', {
 		handleSummaryKeydown( event ) {
 			if ( event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
-				const ctx = getContext();
-				ctx.modalOpen = true;
-				document.body.style.overflow = 'hidden';
+				openModal( getContext() );
 			}
 		},
 
@@ -134,6 +126,45 @@ const { state } = store( 'wporg/event-rsvp', {
 	},
 } );
 
+function openModal( ctx ) {
+	ctx.modalOpen = true;
+	document.body.style.overflow = 'hidden';
+}
+
+function closeModal( ctx ) {
+	ctx.modalOpen = false;
+	ctx.rsvpError = '';
+	document.body.style.overflow = '';
+}
+
+/**
+ * Read the custom registration questions out of the modal.
+ *
+ * The inputs are server-rendered from the event's stored questions, so they're
+ * read straight from the DOM rather than mirrored into interactivity state.
+ *
+ * @return {{answers: Object, missingRequired: boolean}} Collected answers.
+ */
+function collectAnswers() {
+	const answers = {};
+	let missingRequired = false;
+
+	document
+		.querySelectorAll( '.wporg-event-rsvp__question-input' )
+		.forEach( ( input ) => {
+			const value = input.value.trim();
+			if ( ! value ) {
+				if ( input.required ) {
+					missingRequired = true;
+				}
+				return;
+			}
+			answers[ input.dataset.questionId ] = value;
+		} );
+
+	return { answers, missingRequired };
+}
+
 async function doToggleRsvp( ctx ) {
 	if ( ! ctx.isLoggedIn ) {
 		window.location.href = ctx.loginUrl;
@@ -143,6 +174,8 @@ async function doToggleRsvp( ctx ) {
 	if ( ctx.isPastEvent || ctx.rsvpLoading ) {
 		return;
 	}
+
+	ctx.rsvpError = '';
 
 	// Join group first if not a member.
 	if ( ! ctx.isMember && ctx.joinApi ) {
@@ -170,6 +203,18 @@ async function doToggleRsvp( ctx ) {
 	const newStatus =
 		ctx.currentUserStatus === 'attending' ? 'not_attending' : 'attending';
 
+	const { answers, missingRequired } = ctx.hasQuestions
+		? collectAnswers()
+		: { answers: {}, missingRequired: false };
+
+	// The server rejects this too — checking here just saves a round trip and
+	// keeps whatever the attendee already typed on screen.
+	if ( newStatus === 'attending' && missingRequired ) {
+		ctx.rsvpError = labelFromContext( ctx, 'missingAnswers' );
+		openModal( ctx );
+		return;
+	}
+
 	const oldStatus = ctx.currentUserStatus;
 	const oldCount = ctx.attendingCount;
 	ctx.currentUserStatus = newStatus;
@@ -177,19 +222,34 @@ async function doToggleRsvp( ctx ) {
 	ctx.rsvpLoading = true;
 
 	try {
-		const data = await sendRsvp( ctx, newStatus );
+		const data = await sendRsvp( ctx, newStatus, answers );
 
 		if ( data && data.success ) {
 			ctx.currentUserStatus = data.status;
 			ctx.attendingCount = data.responses.attending.count;
+
+			// Organizers see the answers inline in the attendee list, which
+			// the client-side refresh below can't rebuild — reload instead so
+			// their view stays complete.
+			if ( ctx.canViewAnswers ) {
+				window.location.reload();
+				return;
+			}
+
 			refreshAttendees( ctx );
 		} else {
 			ctx.currentUserStatus = oldStatus;
 			ctx.attendingCount = oldCount;
+			ctx.rsvpError =
+				( data && data.message ) ||
+				labelFromContext( ctx, 'rsvpFailed' );
+			openModal( ctx );
 		}
 	} catch {
 		ctx.currentUserStatus = oldStatus;
 		ctx.attendingCount = oldCount;
+		ctx.rsvpError = labelFromContext( ctx, 'rsvpFailed' );
+		openModal( ctx );
 	} finally {
 		ctx.rsvpLoading = false;
 	}
@@ -207,26 +267,26 @@ async function getNonce( apiBase ) {
 	return cachedNonce;
 }
 
-async function sendRsvp( ctx, status, retry = false ) {
+/**
+ * Save the RSVP through our own endpoint rather than GatherPress's, so the
+ * status and the answers to the event's custom registration questions are
+ * written in one request and required questions can block the RSVP.
+ */
+async function sendRsvp( ctx, status, answers, retry = false ) {
 	const nonce = await getNonce( ctx.apiBase );
-	const resp = await fetch( ctx.apiBase + '/rsvp', {
+	const resp = await fetch( ctx.rsvpApi, {
 		method: 'POST',
 		credentials: 'same-origin',
 		headers: {
 			'Content-Type': 'application/json',
 			'X-WP-Nonce': nonce,
 		},
-		body: JSON.stringify( {
-			post_id: ctx.postId,
-			status,
-			guests: 0,
-			anonymous: 0,
-		} ),
+		body: JSON.stringify( { status, answers: answers || {} } ),
 	} );
 
 	if ( resp.status === 403 && ! retry ) {
 		cachedNonce = null;
-		return sendRsvp( ctx, status, true );
+		return sendRsvp( ctx, status, answers, true );
 	}
 
 	return resp.json();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
@@ -35,6 +35,7 @@ import { parse, serialize } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import VenueEditor from '../../event-manage/venue-editor';
+import RsvpQuestionsEditor from '../../event-manage/rsvp-questions-editor';
 
 const NS =
 	( window.wporgGroupsEventModal &&
@@ -186,6 +187,7 @@ function EventForm( { eventId, onDone, onCancel } ) {
 		venue_select: '',
 		is_online: false,
 		online_event_link: '',
+		rsvp_questions: [],
 	} );
 	const [ initialDescription, setInitialDescription ] = useState( '' );
 	const [ featuredImage, setFeaturedImage ] = useState( { id: 0, url: '' } );
@@ -210,6 +212,7 @@ function EventForm( { eventId, onDone, onCancel } ) {
 					venue_select: res.fields.venue_id ? String( res.fields.venue_id ) : '',
 					is_online: !! res.fields.is_online,
 					online_event_link: res.fields.online_event_link || '',
+					rsvp_questions: res.fields.rsvp_questions || [],
 				} );
 				setInitialDescription( res.fields.description || '' );
 				setFeaturedImage( { id: res.fields.featured_image_id || 0, url: res.fields.featured_image_url || '' } );
@@ -269,6 +272,9 @@ function EventForm( { eventId, onDone, onCancel } ) {
 					is_online: form.is_online,
 					online_event_link: form.is_online ? form.online_event_link : '',
 					featured_image_id: featuredImage.id,
+					// Blank-labelled rows are an empty slot the organizer added
+					// and never filled in; the server drops them too.
+					rsvp_questions: ( form.rsvp_questions || [] ).filter( ( question ) => question.label.trim() !== '' ),
 				},
 			} );
 
@@ -330,6 +336,10 @@ function EventForm( { eventId, onDone, onCancel } ) {
 				__nextHasNoMarginBottom: true,
 			} )
 		),
+		h( RsvpQuestionsEditor, {
+			questions: form.rsvp_questions,
+			onChange: ( value ) => updateField( 'rsvp_questions', value ),
+		} ),
 		h( 'div', { className: 'wporg-event-form__field' },
 			h( FormTokenField, {
 				label: __( 'Speakers', 'wporg-groups-frontend' ),

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -460,3 +460,37 @@
 		color: #656a71;
 	}
 }
+
+/* === Registration questions ===
+   The editor component is shared with the event-manage modal, so these mirror
+   the rules in `event-manage/style.css` — the two blocks load separate
+   stylesheets and this one isn't on the page in the settings context. */
+
+.wporg-groups-rsvp-questions {
+	margin-bottom: 16px;
+
+	&__help {
+		font-size: 12px;
+		color: #757575;
+		margin: 0 0 8px;
+	}
+
+	&__row {
+		display: flex;
+		align-items: flex-end;
+		gap: 12px;
+		margin-bottom: 12px;
+
+		> .components-base-control {
+			flex: 1 1 auto;
+		}
+	}
+
+	&__row-actions {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		flex-shrink: 0;
+		padding-bottom: 4px;
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
@@ -329,6 +329,27 @@ describe( 'event RSVP custom registration questions', () => {
 		} );
 	} );
 
+	function mockRsvpSuccess() {
+		global.fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: async () => ( { nonce: 'nonce' } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				status: 200,
+				json: async () => ( {
+					success: true,
+					status: 'attending',
+					responses: { attending: { count: 1 } },
+				} ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: async () => ( { success: false } ),
+			} );
+	}
+
 	function renderModalWithQuestions() {
 		document.body.innerHTML = `
 			<div class="wp-block-wporg-event-rsvp">
@@ -410,11 +431,47 @@ describe( 'event RSVP custom registration questions', () => {
 		expect( mockContext.currentUserStatus ).toBe( 'attending' );
 	} );
 
-	test( 'omits blank optional answers', async () => {
+	test( 'sends blank optional answers so the server can tell cleared from absent', async () => {
 		const { actions } = loadStore();
 		const { diet, rsvp } = renderModalWithQuestions();
 		mockElement = rsvp;
 		diet.value = '  Vegetarian  ';
+
+		mockRsvpSuccess();
+
+		await actions.toggleRsvp();
+
+		expect( JSON.parse( global.fetch.mock.calls[ 1 ][ 1 ].body ).answers ).toEqual( {
+			company: '',
+			diet: 'Vegetarian',
+		} );
+	} );
+
+	test( 'saves edited answers without changing attendance', async () => {
+		const { actions } = loadStore();
+		const { diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+		mockContext.currentUserStatus = 'attending';
+		mockContext.attendingCount = 1;
+		mockContext.labels.answersSaved = 'Your answers have been saved.';
+		diet.value = 'Vegan';
+
+		mockRsvpSuccess();
+
+		await actions.saveAnswers();
+
+		expect( JSON.parse( global.fetch.mock.calls[ 1 ][ 1 ].body ).status ).toBe( 'attending' );
+		expect( mockContext.currentUserStatus ).toBe( 'attending' );
+		expect( mockContext.attendingCount ).toBe( 1 );
+		expect( mockContext.rsvpNotice ).toBe( 'Your answers have been saved.' );
+	} );
+
+	test( 'surfaces the server validation message instead of the generic error', async () => {
+		const { actions } = loadStore();
+		const { diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+		// Passes the client check — "0" is a filled-in field in the browser.
+		diet.value = '0';
 
 		global.fetch
 			.mockResolvedValueOnce( {
@@ -422,23 +479,43 @@ describe( 'event RSVP custom registration questions', () => {
 				json: async () => ( { nonce: 'nonce' } ),
 			} )
 			.mockResolvedValueOnce( {
-				ok: true,
-				status: 200,
+				ok: false,
+				status: 400,
+				statusText: 'Bad Request',
 				json: async () => ( {
-					success: true,
-					status: 'attending',
-					responses: { attending: { count: 1 } },
+					code: 'wporg_groups_missing_answers',
+					message: 'Please answer: Dietary requirements',
 				} ),
-			} )
-			.mockResolvedValueOnce( {
-				ok: true,
-				json: async () => ( { success: false } ),
 			} );
 
 		await actions.toggleRsvp();
 
-		expect( JSON.parse( global.fetch.mock.calls[ 1 ][ 1 ].body ).answers ).toEqual( {
-			diet: 'Vegetarian',
-		} );
+		expect( mockContext.rsvpNotice ).toBe( 'Please answer: Dietary requirements' );
+		expect( mockContext.questionsError ).toBe( 'Please answer: Dietary requirements' );
+		expect( mockContext.currentUserStatus ).toBe( 'no_status' );
+	} );
+
+	test( 'keeps the generic wording for failures that are not ours', async () => {
+		const { actions } = loadStore();
+		const { diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+		diet.value = 'Vegetarian';
+
+		global.fetch
+			.mockResolvedValueOnce( {
+				ok: true,
+				json: async () => ( { nonce: 'nonce' } ),
+			} )
+			.mockResolvedValueOnce( {
+				ok: false,
+				status: 500,
+				statusText: 'Internal Server Error',
+				json: async () => ( {} ),
+			} );
+
+		await actions.toggleRsvp();
+
+		expect( mockContext.rsvpNotice ).toBe( 'Your RSVP could not be updated. Please try again.' );
+		expect( mockContext.questionsError ).toBe( '' );
 	} );
 } );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
@@ -394,6 +394,33 @@ describe( 'event RSVP custom registration questions', () => {
 		expect( mockContext.questionsError ).toBe( 'Please answer the required questions.' );
 	} );
 
+	test( 'identifies which required question is unanswered', async () => {
+		const { actions } = loadStore();
+		const { company, diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+
+		await actions.toggleRsvp();
+
+		// The generic error is announced via the live region, but the field in
+		// error also has to be identifiable. WCAG 2.1 3.3.1.
+		expect( diet.getAttribute( 'aria-invalid' ) ).toBe( 'true' );
+		expect( company.hasAttribute( 'aria-invalid' ) ).toBe( false );
+	} );
+
+	test( 'clears the invalid flag once the required question is answered', async () => {
+		const { actions } = loadStore();
+		const { diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+
+		await actions.toggleRsvp();
+		expect( diet.getAttribute( 'aria-invalid' ) ).toBe( 'true' );
+
+		diet.value = 'Vegetarian';
+		await actions.toggleRsvp();
+
+		expect( diet.hasAttribute( 'aria-invalid' ) ).toBe( false );
+	} );
+
 	test( 'sends the answers alongside the RSVP', async () => {
 		const { actions } = loadStore();
 		const { company, diet, rsvp } = renderModalWithQuestions();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-questions.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-questions.php
@@ -1,0 +1,493 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_REST_Request;
+
+use function WordCamp\Groups\Frontend\REST\create_event;
+use function WordCamp\Groups\Frontend\REST\save_rsvp;
+use function WordCamp\Groups\Frontend\REST\update_event;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_labelled_answers;
+use function WordCamp\Groups\Frontend\RSVP_Questions\get_questions;
+use function WordCamp\Groups\Frontend\RSVP_Questions\sanitize_questions;
+use function WordCamp\Groups\Frontend\RSVP_Questions\save_questions;
+
+use const WordCamp\Groups\Frontend\RSVP_Questions\MAX_QUESTIONS;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * Custom per-event registration questions, and the answers attendees give at
+ * RSVP time.
+ *
+ * @group groups
+ */
+class Test_Groups_RSVP_Questions extends Groups_TestCase {
+
+	/**
+	 * Create a published event, owned by an editor.
+	 */
+	private function create_event( array $questions = array() ): int {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Far enough out that `has_event_past()` is false.
+		( new \GatherPress\Core\Event\Event( $event_id ) )->save_datetimes(
+			array(
+				'post_id'        => $event_id,
+				'datetime_start' => gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) ),
+				'datetime_end'   => gmdate( 'Y-m-d H:i:s', strtotime( '+30 days +2 hours' ) ),
+				'timezone'       => 'UTC',
+			)
+		);
+
+		if ( $questions ) {
+			save_questions( $event_id, $questions );
+		}
+
+		return $event_id;
+	}
+
+	/**
+	 * Build a POST /event/{id}/rsvp request.
+	 */
+	private function rsvp_request( int $event_id, string $status, array $answers = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', "/wporg-groups/v1/event/{$event_id}/rsvp" );
+		$request->set_param( 'id', $event_id );
+		$request->set_param( 'status', $status );
+		$request->set_param( 'answers', $answers );
+
+		return $request;
+	}
+
+	/**
+	 * Unlabelled rows are dropped, `required` is normalised to a boolean, and
+	 * new questions (empty id) are given one.
+	 */
+	public function test_sanitize_questions_drops_blanks_and_assigns_ids() {
+		$questions = sanitize_questions(
+			array(
+				array(
+					'id'       => '',
+					'label'    => 'Company name',
+					'required' => 1,
+				),
+				array(
+					'id'    => '',
+					'label' => '   ',
+				),
+				array(
+					'id'    => '',
+					'label' => 'Dietary requirements',
+				),
+			)
+		);
+
+		$this->assertCount( 2, $questions );
+		$this->assertSame( 'Company name', $questions[0]['label'] );
+		$this->assertTrue( $questions[0]['required'] );
+		$this->assertSame( 'Dietary requirements', $questions[1]['label'] );
+		$this->assertFalse( $questions[1]['required'] );
+		$this->assertNotEmpty( $questions[0]['id'] );
+		$this->assertNotSame( $questions[0]['id'], $questions[1]['id'] );
+	}
+
+	/**
+	 * The question count is capped, so this stays a couple of extra questions
+	 * rather than a form builder.
+	 */
+	public function test_question_count_is_capped() {
+		$raw = array();
+		for ( $i = 0; $i < MAX_QUESTIONS + 3; $i++ ) {
+			$raw[] = array(
+				'id'    => '',
+				'label' => "Question {$i}",
+			);
+		}
+
+		$this->assertCount( MAX_QUESTIONS, sanitize_questions( $raw ) );
+	}
+
+	/**
+	 * Ids assigned on the first save survive later edits, so answers already
+	 * given stay attached to the question that was asked.
+	 */
+	public function test_question_ids_are_stable_across_saves() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => '',
+					'label' => 'T-shirt size',
+				),
+			)
+		);
+
+		$original = get_questions( $event_id );
+
+		save_questions(
+			$event_id,
+			array(
+				array(
+					'id'       => $original[0]['id'],
+					'label'    => 'T-shirt size (EU)',
+					'required' => true,
+				),
+			)
+		);
+
+		$updated = get_questions( $event_id );
+
+		$this->assertSame( $original[0]['id'], $updated[0]['id'] );
+		$this->assertSame( 'T-shirt size (EU)', $updated[0]['label'] );
+	}
+
+	/**
+	 * A deleted question's id is never handed back out — otherwise the answers
+	 * previous attendees gave would resurface under a new question's label.
+	 */
+	public function test_deleted_question_ids_are_not_reused() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => '',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$deleted_id = get_questions( $event_id )[0]['id'];
+
+		save_questions(
+			$event_id,
+			array(
+				array(
+					'id'    => '',
+					'label' => 'Dietary requirements',
+				),
+			)
+		);
+
+		$this->assertNotSame( $deleted_id, get_questions( $event_id )[0]['id'] );
+	}
+
+	/**
+	 * Questions round-trip through the event create endpoint.
+	 */
+	public function test_questions_saved_with_new_event() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wporg-groups/v1/event' );
+		$request->set_param( 'title', 'Test Event' );
+		$request->set_param( 'date', gmdate( 'Y-m-d', strtotime( '+30 days' ) ) );
+		$request->set_param( 'time_start', '18:00' );
+		$request->set_param( 'time_end', '20:00' );
+		$request->set_param(
+			'rsvp_questions',
+			array(
+				array(
+					'id'       => '',
+					'label'    => 'Dietary requirements',
+					'required' => true,
+				),
+			)
+		);
+
+		$response  = create_event( $request );
+		$questions = get_questions( $response->get_data()['id'] );
+
+		$this->assertCount( 1, $questions );
+		$this->assertSame( 'Dietary requirements', $questions[0]['label'] );
+		$this->assertTrue( $questions[0]['required'] );
+	}
+
+	/**
+	 * An update that doesn't mention `rsvp_questions` leaves the existing ones
+	 * alone, rather than reading the absent parameter as "delete them all".
+	 */
+	public function test_update_without_questions_param_keeps_them() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => '',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wporg-groups/v1/event/{$event_id}" );
+		$request->set_param( 'id', $event_id );
+		$request->set_param( 'title', 'Renamed Event' );
+		$request->set_param( 'date', gmdate( 'Y-m-d', strtotime( '+30 days' ) ) );
+		$request->set_param( 'time_start', '18:00' );
+		$request->set_param( 'time_end', '20:00' );
+
+		update_event( $request );
+
+		$this->assertCount( 1, get_questions( $event_id ) );
+	}
+
+	/**
+	 * Answers are stored against the RSVP when an attendee submits them.
+	 */
+	public function test_rsvp_stores_answers() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$response = save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => 'Automattic' ) ) );
+
+		$this->assertNotWPError( $response );
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'attending', $data['status'] );
+
+		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+		$this->assertSame( array( 'company' => 'Automattic' ), get_answers( (int) $rsvp['comment_id'] ) );
+	}
+
+	/**
+	 * A required question with no answer blocks the RSVP outright — a recorded
+	 * RSVP without the organizer's required detail is exactly the wrong-data
+	 * problem this feature exists to avoid.
+	 */
+	public function test_missing_required_answer_blocks_rsvp() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'       => 'diet',
+					'label'    => 'Dietary requirements',
+					'required' => true,
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$response = save_rsvp( $this->rsvp_request( $event_id, 'attending' ) );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'wporg_groups_missing_answers', $response->get_error_code() );
+
+		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+		$this->assertSame( 'no_status', $rsvp['status'] );
+	}
+
+	/**
+	 * Answers to questions the event doesn't ask are discarded.
+	 */
+	public function test_unknown_answers_are_discarded() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		save_rsvp(
+			$this->rsvp_request(
+				$event_id,
+				'attending',
+				array(
+					'company' => 'Automattic',
+					'sneaky'  => 'not asked',
+				)
+			)
+		);
+
+		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+
+		$this->assertSame( array( 'company' => 'Automattic' ), get_answers( (int) $rsvp['comment_id'] ) );
+	}
+
+	/**
+	 * Cancelling an RSVP takes the answers with it.
+	 */
+	public function test_cancelling_rsvp_clears_answers() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => 'Automattic' ) ) );
+
+		$rsvp       = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+		$comment_id = (int) $rsvp['comment_id'];
+		$this->assertNotEmpty( get_answers( $comment_id ) );
+
+		save_rsvp( $this->rsvp_request( $event_id, 'not_attending' ) );
+
+		$this->assertSame( array(), get_answers( $comment_id ) );
+	}
+
+	/**
+	 * Displayed answers are paired with the current question labels, and
+	 * answers to since-deleted questions are left out.
+	 */
+	public function test_labelled_answers_follow_the_current_questions() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+				array(
+					'id'    => 'diet',
+					'label' => 'Dietary requirements',
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		save_rsvp(
+			$this->rsvp_request(
+				$event_id,
+				'attending',
+				array(
+					'company' => 'Automattic',
+					'diet'    => 'Vegetarian',
+				)
+			)
+		);
+
+		$rsvp       = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+		$comment_id = (int) $rsvp['comment_id'];
+
+		// The organizer drops the dietary question afterwards.
+		save_questions(
+			$event_id,
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company or organization',
+				),
+			)
+		);
+
+		$labelled = get_labelled_answers( $comment_id, get_questions( $event_id ) );
+
+		$this->assertSame(
+			array(
+				array(
+					'label'  => 'Company or organization',
+					'answer' => 'Automattic',
+				),
+			),
+			$labelled
+		);
+	}
+
+	/**
+	 * Render the `wporg/event-rsvp` block in the context of an event.
+	 */
+	private function render_rsvp_block( int $event_id ): string {
+		global $post;
+
+		$post = get_post( $event_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		setup_postdata( $post );
+
+		$output = (string) do_blocks( '<!-- wp:wporg/event-rsvp /-->' );
+
+		wp_reset_postdata();
+
+		return $output;
+	}
+
+	/**
+	 * The RSVP modal renders an input per question, so attendees answer them
+	 * on the event page rather than on an external form.
+	 */
+	public function test_questions_render_in_the_rsvp_modal() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$output = $this->render_rsvp_block( $event_id );
+
+		$this->assertStringContainsString( 'wporg-event-rsvp__question-input', $output );
+		$this->assertStringContainsString( 'Company name', $output );
+	}
+
+	/**
+	 * Answers show up in the attendee list for organizers, and for nobody else.
+	 */
+	public function test_answers_render_only_for_organizers() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'diet',
+					'label' => 'Dietary requirements',
+				),
+			)
+		);
+
+		$attendee_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $attendee_id );
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'diet' => 'Vegetarian' ) ) );
+
+		// A fellow attendee sees the attendee, but not what they answered.
+		$other_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $other_id );
+		$this->assertStringNotContainsString( 'Vegetarian', $this->render_rsvp_block( $event_id ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		$this->assertStringContainsString( 'Vegetarian', $this->render_rsvp_block( $event_id ) );
+	}
+
+	/**
+	 * Answers are for the people running the event: visible to whoever can
+	 * edit it, not to other attendees.
+	 */
+	public function test_only_event_editors_can_view_answers() {
+		$event_id = $this->create_event();
+
+		$editor_id     = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $subscriber_id );
+		$this->assertFalse( \WordCamp\Groups\Frontend\RSVP_Questions\current_user_can_view_answers( $event_id ) );
+
+		wp_set_current_user( $editor_id );
+		$this->assertTrue( \WordCamp\Groups\Frontend\RSVP_Questions\current_user_can_view_answers( $event_id ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-questions.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-questions.php
@@ -411,6 +411,230 @@ class Test_Groups_RSVP_Questions extends Groups_TestCase {
 	}
 
 	/**
+	 * An answer of "0" is a real answer — `empty()` would call it missing,
+	 * while the browser treats the same string as filled in.
+	 */
+	public function test_zero_is_a_valid_answer() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'       => 'guests',
+					'label'    => 'How many guests?',
+					'required' => true,
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$response = save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'guests' => '0' ) ) );
+
+		$this->assertNotWPError( $response );
+		$this->assertTrue( $response->get_data()['success'] );
+
+		$rsvp       = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+		$comment_id = (int) $rsvp['comment_id'];
+
+		$this->assertSame( array( 'guests' => '0' ), get_answers( $comment_id ) );
+		$this->assertSame(
+			array(
+				array(
+					'label'  => 'How many guests?',
+					'answer' => '0',
+				),
+			),
+			get_labelled_answers( $comment_id, get_questions( $event_id ) )
+		);
+	}
+
+	/**
+	 * A request that doesn't mention a question leaves its stored answer
+	 * alone — a stale form can't blank out answers it never rendered.
+	 */
+	public function test_omitted_questions_keep_their_stored_answers() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => 'Automattic' ) ) );
+
+		// A second, stale tab re-sends "attending" with nothing filled in.
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array() ) );
+
+		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+
+		$this->assertSame( array( 'company' => 'Automattic' ), get_answers( (int) $rsvp['comment_id'] ) );
+	}
+
+	/**
+	 * Submitting a question with a blank value does clear it, which is how an
+	 * attendee removes an answer they'd rather not share.
+	 */
+	public function test_submitted_blank_clears_the_answer() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => 'Automattic' ) ) );
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => '' ) ) );
+
+		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
+
+		$this->assertSame( array(), get_answers( (int) $rsvp['comment_id'] ) );
+	}
+
+	/**
+	 * A full event downgrades the RSVP to the waiting list. The answers have
+	 * to survive that, because the later promotion to attending never
+	 * restores them.
+	 */
+	public function test_waiting_list_rsvp_keeps_its_answers() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'    => 'company',
+					'label' => 'Company name',
+				),
+			)
+		);
+
+		// One seat, already taken, so the next RSVP lands on the waiting list.
+		update_post_meta( $event_id, 'gatherpress_max_attendance_limit', 1 );
+
+		$first = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $first );
+		save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => 'First' ) ) );
+
+		$second = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $second );
+		$response = save_rsvp( $this->rsvp_request( $event_id, 'attending', array( 'company' => 'Second' ) ) );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( 'waiting_list', $response->get_data()['status'] );
+
+		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $second );
+
+		$this->assertSame( array( 'company' => 'Second' ), get_answers( (int) $rsvp['comment_id'] ) );
+	}
+
+	/**
+	 * An event with RSVP switched off reports the failure instead of
+	 * returning a 200 that the client can only read as "OK".
+	 */
+	public function test_rsvp_disabled_event_returns_an_error() {
+		$event_id = $this->create_event();
+
+		// The groups tweaks plugin short-circuits `gatherpress_settings` via
+		// `pre_option_*`, so the stored option is never read — the mode has to
+		// be injected through the same filter. `disabled` makes
+		// `Rsvp::is_enabled()` false regardless of the per-event meta.
+		$disable_rsvp = static function ( $value ) {
+			$value = is_array( $value ) ? $value : array();
+
+			$value['rsvp_mode'] = 'disabled';
+
+			return $value;
+		};
+		add_filter( 'pre_option_gatherpress_settings', $disable_rsvp, 20 );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = save_rsvp( $this->rsvp_request( $event_id, 'attending' ) );
+
+		remove_filter( 'pre_option_gatherpress_settings', $disable_rsvp, 20 );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'wporg_groups_rsvp_unavailable', $response->get_error_code() );
+	}
+
+	/**
+	 * GatherPress's own RSVP route can't be used to attend while skipping the
+	 * required questions our endpoint enforces.
+	 */
+	public function test_gatherpress_route_is_guarded() {
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'       => 'diet',
+					'label'    => 'Dietary requirements',
+					'required' => true,
+				),
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$request = new WP_REST_Request( 'POST', '/gatherpress/v1/event/rsvp' );
+		$request->set_param( 'post_id', $event_id );
+		$request->set_param( 'status', 'attending' );
+
+		$result = \WordCamp\Groups\Frontend\RSVP_Questions\rsvp_answers_satisfied( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wporg_groups_missing_answers', $result->get_error_code() );
+
+		// Cancelling is never blocked.
+		$cancel = new WP_REST_Request( 'POST', '/gatherpress/v1/event/rsvp' );
+		$cancel->set_param( 'post_id', $event_id );
+		$cancel->set_param( 'status', 'not_attending' );
+
+		$this->assertTrue( \WordCamp\Groups\Frontend\RSVP_Questions\rsvp_answers_satisfied( $cancel ) );
+	}
+
+	/**
+	 * The guard is wired onto the real route, not just callable in isolation.
+	 */
+	public function test_gatherpress_route_guard_is_registered() {
+		$endpoints = apply_filters(
+			'rest_endpoints',
+			array(
+				'/gatherpress/v1/event/rsvp' => array(
+					array( 'permission_callback' => '__return_true' ),
+				),
+			)
+		);
+
+		$callback = $endpoints['/gatherpress/v1/event/rsvp'][0]['permission_callback'];
+
+		$this->assertNotSame( '__return_true', $callback );
+
+		$event_id = $this->create_event(
+			array(
+				array(
+					'id'       => 'diet',
+					'label'    => 'Dietary requirements',
+					'required' => true,
+				),
+			)
+		);
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$request = new WP_REST_Request( 'POST', '/gatherpress/v1/event/rsvp' );
+		$request->set_param( 'post_id', $event_id );
+		$request->set_param( 'status', 'attending' );
+
+		$this->assertWPError( call_user_func( $callback, $request ) );
+	}
+
+	/**
 	 * Render the `wporg/event-rsvp` block in the context of an event.
 	 */
 	private function render_rsvp_block( int $event_id ): string {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
@@ -16,6 +16,7 @@ const VERSION = '0.2.0';
 
 require_once __DIR__ . '/inc/capabilities.php';
 require_once __DIR__ . '/inc/defaults.php';
+require_once __DIR__ . '/inc/rsvp-questions.php';
 require_once __DIR__ . '/inc/rest.php';
 require_once __DIR__ . '/inc/modal.php';
 require_once __DIR__ . '/inc/blocks.php';

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
@@ -43,6 +43,7 @@ function bootstrap(): void {
 
 	Blocks\bootstrap();
 	REST\bootstrap();
+	RSVP_Questions\bootstrap();
 	Modal\bootstrap();
 	Notifications\bootstrap();
 


### PR DESCRIPTION
Fixes #1813.

Organizers can add up to 5 text questions to an event. Attendees answer them at RSVP time; only people who can edit the event see the answers. Required questions block the RSVP, client- and server-side.

RSVP posts to a new `wporg-groups/v1` endpoint instead of GatherPress's, so the status and the answers are saved in one request. Questions are stored in post meta on the event, answers in comment meta on the RSVP comment — cancelling an RSVP drops them.

Not included: non-text field types, per-field visibility, group-level defaults, export (#1780).

## Testing instructions

1. As an organizer, open an event and click **Edit this event**. Under **Registration questions**, add "Dietary requirements" (tick Required) and "Company or organization". Save.

<img width="1309" height="1026" alt="Screenshot 2026-08-04 at 20 14 43" src="https://github.com/user-attachments/assets/a894f38b-8953-4c03-883c-cea120f512dc" />

2. Reopen the edit modal — both questions and the Required flag come back.
3. As a different member, open the event and click **RSVP**. The modal opens with both questions instead of RSVPing immediately.
4. Click **Attend** with the required field empty → "Please answer the required questions.", no RSVP recorded.

<img width="1478" height="866" alt="Screenshot 2026-08-04 at 20 15 54" src="https://github.com/user-attachments/assets/7ff9c82e-6008-46c5-b96a-efe1ad08e00e" />

5. Fill both in, click **Attend** → RSVP goes through, count increments, questions hide.
6. As the organizer, reload and open the attendee list → the answers show under the attendee's name.

<img width="943" height="784" alt="Screenshot 2026-08-04 at 20 19 12" src="https://github.com/user-attachments/assets/d39758b8-7ea2-4fe8-9adb-e03e28aeef14" />

7. As another non-organizer member, open the attendee list → no answers visible.
8. As the attendee, **Cancel RSVP**, reload → the stored answers are gone.
9. Regression: on an event with no questions, RSVP is still one click with no modal.

Server-side guard (should return 400 `wporg_groups_missing_answers`):

```js
const n = await fetch('/wp-json/gatherpress/v1/event/nonce').then(r=>r.json());
await fetch('/wp-json/wporg-groups/v1/event/<EVENT_ID>/rsvp', {method:'POST', credentials:'same-origin',
  headers:{'Content-Type':'application/json','X-WP-Nonce':n.nonce},
  body: JSON.stringify({status:'attending', answers:{}})}).then(r=>r.json());
```

Unit tests: `phpunit --group=groups` (14 new tests).

## Screenshots

<!-- screenshots -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)