### PR TITLE
Add group archiving controls

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -28,6 +28,7 @@ function manually_load_plugin() {
 	require_once $gatherpress_file;
 
 	require_once dirname( __DIR__ ) . '/gatherpress-groups-tweaks.php';
+	require_once dirname( __DIR__, 2 ) . '/wporg-groups-archive.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\Groups\Tests;
 
+use function WordCamp\Groups\Archive\current_user_can_archive_groups;
 use function WordCamp\Groups\Archive\get_group_sites;
 use function WordCamp\Groups\Archive\get_group_site_count;
 use function WordCamp\Groups\Archive\update_group_archive_status;
@@ -161,5 +162,36 @@ class Test_Group_Archive extends Groups_TestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_group_site', $result->get_error_code() );
+	}
+
+	/**
+	 * Administrators of a group site manage that group, not the network,
+	 * so archiving has to stay out of reach for them.
+	 */
+	public function test_group_administrators_cannot_archive_groups() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( current_user_can_archive_groups() );
+	}
+
+	/**
+	 * Network site managers can.
+	 */
+	public function test_network_admins_can_archive_groups() {
+		$user_id = self::factory()->user->create();
+
+		// `grant_super_admin()` reads `site_admins` off whichever network is
+		// current, which in this fixture isn't the groups network. Set the
+		// option `get_super_admins()` actually consults instead.
+		$original = get_site_option( 'site_admins' );
+
+		update_site_option( 'site_admins', array( get_userdata( $user_id )->user_login ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( current_user_can_archive_groups() );
+
+		update_site_option( 'site_admins', $original );
 	}
 }

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use function WordCamp\Groups\Archive\get_group_sites;
+use function WordCamp\Groups\Archive\update_group_archive_status;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Group_Archive extends Groups_TestCase {
+	/**
+	 * @var int
+	 */
+	private $group_site_id;
+
+	/**
+	 * Create a real group subsite for each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->group_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/archive-test/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		switch_to_blog( $this->group_site_id );
+		\GatherPress\Core\Setup::get_instance()->check_plugin_version();
+	}
+
+	/**
+	 * Remove the temporary group site and restore the parent fixture.
+	 */
+	protected function tearDown(): void {
+		restore_current_blog();
+		wp_delete_site( $this->group_site_id );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Active group queries omit both archived groups and the network root.
+	 */
+	public function test_active_group_query_excludes_archived_groups_and_network_root() {
+		$active_group_ids = array_map( 'intval', wp_list_pluck( get_group_sites(), 'blog_id' ) );
+		$all_group_ids    = array_map( 'intval', wp_list_pluck( get_group_sites( true ), 'blog_id' ) );
+
+		$this->assertContains( $this->group_site_id, $active_group_ids );
+		$this->assertNotContains( GROUPS_ROOT_BLOG_ID, $all_group_ids );
+
+		$this->assertTrue( update_group_archive_status( $this->group_site_id, true ) );
+
+		$active_group_ids = array_map( 'intval', wp_list_pluck( get_group_sites(), 'blog_id' ) );
+		$all_group_ids    = array_map( 'intval', wp_list_pluck( get_group_sites( true ), 'blog_id' ) );
+
+		$this->assertNotContains( $this->group_site_id, $active_group_ids );
+		$this->assertContains( $this->group_site_id, $all_group_ids );
+	}
+
+	/**
+	 * Archiving changes only site state; group records survive reactivation.
+	 */
+	public function test_archive_and_reactivate_preserve_group_records() {
+		global $wpdb;
+
+		$event_id  = self::factory()->post->create(
+			array(
+				'post_title'  => 'Preserved event',
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+		$member_id = self::factory()->user->create();
+		add_user_to_blog( $this->group_site_id, $member_id, 'subscriber' );
+
+		$rsvp_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $event_id,
+				'user_id'              => $member_id,
+				'comment_author'        => 'Group member',
+				'comment_author_email' => 'member@example.org',
+				'comment_content'       => 'RSVP',
+				'comment_type'          => 'gatherpress_rsvp',
+				'comment_approved'      => 1,
+			)
+		);
+
+		$this->assertTrue( update_group_archive_status( $this->group_site_id, true ) );
+		$this->assertSame( '1', get_site( $this->group_site_id )->archived );
+		$this->assertSame( 'Preserved event', get_post( $event_id )->post_title );
+		$this->assertSame( 'gatherpress_rsvp', get_comment( $rsvp_id )->comment_type );
+		$this->assertArrayHasKey(
+			'subscriber',
+			get_user_meta( $member_id, $wpdb->get_blog_prefix( $this->group_site_id ) . 'capabilities', true )
+		);
+
+		$this->assertTrue( update_group_archive_status( $this->group_site_id, false ) );
+		$this->assertSame( '0', get_site( $this->group_site_id )->archived );
+		$this->assertSame( 'Preserved event', get_post( $event_id )->post_title );
+		$this->assertSame( 'gatherpress_rsvp', get_comment( $rsvp_id )->comment_type );
+		$this->assertTrue( is_user_member_of_blog( $member_id, $this->group_site_id ) );
+	}
+
+	/**
+	 * Sites outside the Groups network cannot be changed through this tool.
+	 */
+	public function test_rejects_site_from_another_network() {
+		$other_site_id = self::factory()->blog->create();
+		$result        = update_group_archive_status( $other_site_id, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_group_site', $result->get_error_code() );
+
+		wp_delete_site( $other_site_id );
+	}
+
+	/**
+	 * The placeholder root site must remain available for network routing.
+	 */
+	public function test_rejects_groups_network_root() {
+		$result = update_group_archive_status( GROUPS_ROOT_BLOG_ID, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_group_site', $result->get_error_code() );
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
@@ -3,6 +3,7 @@
 namespace WordCamp\Groups\Tests;
 
 use function WordCamp\Groups\Archive\get_group_sites;
+use function WordCamp\Groups\Archive\get_group_site_count;
 use function WordCamp\Groups\Archive\update_group_archive_status;
 
 defined( 'WPINC' ) || die();
@@ -63,6 +64,31 @@ class Test_Group_Archive extends Groups_TestCase {
 
 		$this->assertNotContains( $this->group_site_id, $active_group_ids );
 		$this->assertContains( $this->group_site_id, $all_group_ids );
+	}
+
+	/**
+	 * Group queries can return stable pages and an accurate total.
+	 */
+	public function test_group_query_can_be_paginated() {
+		$second_group_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/archive-test-second/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		$all_group_ids = array_map( 'intval', wp_list_pluck( get_group_sites( true ), 'blog_id' ) );
+		$first_page    = get_group_sites( true, 1, 0 );
+		$second_page   = get_group_sites( true, 1, 1 );
+
+		$this->assertCount( count( $all_group_ids ), get_group_sites( true ) );
+		$this->assertSame( count( $all_group_ids ), get_group_site_count( true ) );
+		$this->assertCount( 1, $first_page );
+		$this->assertCount( 1, $second_page );
+		$this->assertNotSame( $first_page[0]->blog_id, $second_page[0]->blog_id );
+
+		wp_delete_site( $second_group_site_id );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-archive.php
@@ -78,17 +78,19 @@ class Test_Group_Archive extends Groups_TestCase {
 			)
 		);
 
-		$all_group_ids = array_map( 'intval', wp_list_pluck( get_group_sites( true ), 'blog_id' ) );
-		$first_page    = get_group_sites( true, 1, 0 );
-		$second_page   = get_group_sites( true, 1, 1 );
+		try {
+			$all_group_ids = array_map( 'intval', wp_list_pluck( get_group_sites( true ), 'blog_id' ) );
+			$first_page    = get_group_sites( true, 1, 0 );
+			$second_page   = get_group_sites( true, 1, 1 );
 
-		$this->assertCount( count( $all_group_ids ), get_group_sites( true ) );
-		$this->assertSame( count( $all_group_ids ), get_group_site_count( true ) );
-		$this->assertCount( 1, $first_page );
-		$this->assertCount( 1, $second_page );
-		$this->assertNotSame( $first_page[0]->blog_id, $second_page[0]->blog_id );
-
-		wp_delete_site( $second_group_site_id );
+			$this->assertCount( count( $all_group_ids ), get_group_sites( true ) );
+			$this->assertSame( count( $all_group_ids ), get_group_site_count( true ) );
+			$this->assertCount( 1, $first_page );
+			$this->assertCount( 1, $second_page );
+			$this->assertNotSame( $first_page[0]->blog_id, $second_page[0]->blog_id );
+		} finally {
+			wp_delete_site( $second_group_site_id );
+		}
 	}
 
 	/**
@@ -140,12 +142,15 @@ class Test_Group_Archive extends Groups_TestCase {
 	 */
 	public function test_rejects_site_from_another_network() {
 		$other_site_id = self::factory()->blog->create();
-		$result        = update_group_archive_status( $other_site_id, true );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'invalid_group_site', $result->get_error_code() );
+		try {
+			$result = update_group_archive_status( $other_site_id, true );
 
-		wp_delete_site( $other_site_id );
+			$this->assertWPError( $result );
+			$this->assertSame( 'invalid_group_site', $result->get_error_code() );
+		} finally {
+			wp_delete_site( $other_site_id );
+		}
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-archive.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-archive.php
@@ -89,7 +89,22 @@ function register_page(): void {
 }
 
 /**
+ * Whether the current user may archive or reactivate groups.
+ *
+ * Extracted so the capability is named in one place and can be asserted
+ * directly in tests, matching `Groups\Messaging\current_user_can_send_messages()`.
+ *
+ * @return bool
+ */
+function current_user_can_archive_groups(): bool {
+	return current_user_can( 'manage_sites' );
+}
+
+/**
  * Archive or reactivate a group using WordPress core's site status.
+ *
+ * Callers are responsible for the capability check; use
+ * `current_user_can_archive_groups()`. Both entry points in this file do.
  *
  * @param int  $site_id  Site ID to update.
  * @param bool $archived Whether the group should be archived.
@@ -127,7 +142,7 @@ function update_group_archive_status( int $site_id, bool $archived ) {
  * Process an archive/reactivate request from Network Admin.
  */
 function handle_update(): void {
-	if ( ! current_user_can( 'manage_sites' ) ) {
+	if ( ! current_user_can_archive_groups() ) {
 		wp_die(
 			esc_html__( 'Sorry, you are not allowed to manage groups.', 'wordcamporg' ),
 			'',
@@ -166,7 +181,7 @@ function handle_update(): void {
  * Render the Groups management screen.
  */
 function render_page(): void {
-	if ( ! current_user_can( 'manage_sites' ) ) {
+	if ( ! current_user_can_archive_groups() ) {
 		wp_die( esc_html__( 'Sorry, you are not allowed to manage groups.', 'wordcamporg' ) );
 	}
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-archive.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-archive.php
@@ -18,6 +18,7 @@ defined( 'WPINC' ) || die();
 
 const PAGE_SLUG     = 'wporg-groups';
 const UPDATE_ACTION = 'wporg_groups_update_archive_status';
+const PER_PAGE      = 50;
 
 add_action( 'network_admin_menu', __NAMESPACE__ . '\\register_page' );
 add_action( 'network_admin_edit_' . UPDATE_ACTION, __NAMESPACE__ . '\\handle_update' );
@@ -29,16 +30,19 @@ add_action( 'network_admin_edit_' . UPDATE_ACTION, __NAMESPACE__ . '\\handle_upd
  * The Groups network placeholder site is never a group and is always omitted.
  *
  * @param bool $include_archived Whether archived groups should be returned.
+ * @param int  $number           Maximum number of groups to return; 0 returns all.
+ * @param int  $offset           Number of groups to skip.
  * @return WP_Site[]
  */
-function get_group_sites( bool $include_archived = false ): array {
+function get_group_sites( bool $include_archived = false, int $number = 0, int $offset = 0 ): array {
 	$args = array(
 		'network_id'   => GROUPS_NETWORK_ID,
-		'number'       => 0,
+		'number'       => max( 0, $number ),
+		'offset'       => max( 0, $offset ),
 		'site__not_in' => array( GROUPS_ROOT_BLOG_ID ),
 		'deleted'      => 0,
 		'spam'         => 0,
-		'orderby'      => 'domain',
+		'orderby'      => 'id',
 		'order'        => 'ASC',
 	);
 
@@ -47,6 +51,27 @@ function get_group_sites( bool $include_archived = false ): array {
 	}
 
 	return get_sites( $args );
+}
+
+/**
+ * Count the group sites on the Groups network.
+ *
+ * @param bool $include_archived Whether archived groups should be counted.
+ */
+function get_group_site_count( bool $include_archived = false ): int {
+	$args = array(
+		'network_id'   => GROUPS_NETWORK_ID,
+		'site__not_in' => array( GROUPS_ROOT_BLOG_ID ),
+		'deleted'      => 0,
+		'spam'         => 0,
+		'count'        => true,
+	);
+
+	if ( ! $include_archived ) {
+		$args['archived'] = 0;
+	}
+
+	return (int) get_sites( $args );
 }
 
 /**
@@ -145,8 +170,12 @@ function render_page(): void {
 		wp_die( esc_html__( 'Sorry, you are not allowed to manage groups.', 'wordcamporg' ) );
 	}
 
-	$groups  = get_group_sites( true );
-	$updated = isset( $_GET['updated'] ) ? sanitize_key( wp_unslash( $_GET['updated'] ) ) : '';
+	$total_groups = get_group_site_count( true );
+	$total_pages  = max( 1, (int) ceil( $total_groups / PER_PAGE ) );
+	$current_page = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
+	$current_page = min( $current_page, $total_pages );
+	$groups       = get_group_sites( true, PER_PAGE, ( $current_page - 1 ) * PER_PAGE );
+	$updated      = isset( $_GET['updated'] ) ? sanitize_key( wp_unslash( $_GET['updated'] ) ) : '';
 	?>
 	<div class="wrap">
 		<h1><?php esc_html_e( 'Groups', 'wordcamporg' ); ?></h1>
@@ -218,6 +247,26 @@ function render_page(): void {
 				<?php endif; ?>
 			</tbody>
 		</table>
+
+		<?php if ( $total_pages > 1 ) : ?>
+			<div class="tablenav bottom">
+				<div class="tablenav-pages">
+					<?php
+					echo wp_kses_post(
+						paginate_links(
+							array(
+								'base'      => network_admin_url( 'sites.php?page=' . PAGE_SLUG . '&paged=%#%' ),
+								'current'   => $current_page,
+								'total'     => $total_pages,
+								'prev_text' => __( '&laquo; Previous', 'wordcamporg' ),
+								'next_text' => __( 'Next &raquo;', 'wordcamporg' ),
+							)
+						)
+					);
+					?>
+				</div>
+			</div>
+		<?php endif; ?>
 	</div>
 	<?php
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-archive.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-archive.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Network administration for archiving and reactivating group sites.
+ *
+ * Uses WordPress multisite's native archived-site flag so group content,
+ * RSVPs, and memberships remain intact. Organisers cannot request archival
+ * in v1; only users who can manage network sites can use this screen.
+ *
+ * @package WordCamp\Groups
+ */
+
+namespace WordCamp\Groups\Archive;
+
+use WP_Error;
+use WP_Site;
+
+defined( 'WPINC' ) || die();
+
+const PAGE_SLUG     = 'wporg-groups';
+const UPDATE_ACTION = 'wporg_groups_update_archive_status';
+
+add_action( 'network_admin_menu', __NAMESPACE__ . '\\register_page' );
+add_action( 'network_admin_edit_' . UPDATE_ACTION, __NAMESPACE__ . '\\handle_update' );
+
+/**
+ * Get the group sites on the Groups network.
+ *
+ * Active-only is the safe default for directories and other public listings.
+ * The Groups network placeholder site is never a group and is always omitted.
+ *
+ * @param bool $include_archived Whether archived groups should be returned.
+ * @return WP_Site[]
+ */
+function get_group_sites( bool $include_archived = false ): array {
+	$args = array(
+		'network_id'   => GROUPS_NETWORK_ID,
+		'number'       => 0,
+		'site__not_in' => array( GROUPS_ROOT_BLOG_ID ),
+		'deleted'      => 0,
+		'spam'         => 0,
+		'orderby'      => 'domain',
+		'order'        => 'ASC',
+	);
+
+	if ( ! $include_archived ) {
+		$args['archived'] = 0;
+	}
+
+	return get_sites( $args );
+}
+
+/**
+ * Register the Groups management screen in Network Admin.
+ */
+function register_page(): void {
+	add_submenu_page(
+		'sites.php',
+		__( 'Groups', 'wordcamporg' ),
+		__( 'Groups', 'wordcamporg' ),
+		'manage_sites',
+		PAGE_SLUG,
+		__NAMESPACE__ . '\\render_page'
+	);
+}
+
+/**
+ * Archive or reactivate a group using WordPress core's site status.
+ *
+ * @param int  $site_id  Site ID to update.
+ * @param bool $archived Whether the group should be archived.
+ * @return true|WP_Error
+ */
+function update_group_archive_status( int $site_id, bool $archived ) {
+	$site = get_site( $site_id );
+
+	if (
+		! $site ||
+		GROUPS_NETWORK_ID !== (int) $site->network_id ||
+		GROUPS_ROOT_BLOG_ID === (int) $site->blog_id ||
+		$site->deleted ||
+		$site->spam
+	) {
+		return new WP_Error(
+			'invalid_group_site',
+			__( 'That site is not an archivable group.', 'wordcamporg' )
+		);
+	}
+
+	$result = wp_update_site(
+		$site_id,
+		array( 'archived' => $archived ? 1 : 0 )
+	);
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	return true;
+}
+
+/**
+ * Process an archive/reactivate request from Network Admin.
+ */
+function handle_update(): void {
+	if ( ! current_user_can( 'manage_sites' ) ) {
+		wp_die(
+			esc_html__( 'Sorry, you are not allowed to manage groups.', 'wordcamporg' ),
+			'',
+			array( 'response' => 403 )
+		);
+	}
+
+	$site_id  = isset( $_POST['site_id'] ) ? absint( wp_unslash( $_POST['site_id'] ) ) : 0;
+	$archived = isset( $_POST['archived'] ) && '1' === wp_unslash( $_POST['archived'] );
+
+	check_admin_referer( UPDATE_ACTION . '_' . $site_id );
+
+	$result = update_group_archive_status( $site_id, $archived );
+
+	if ( is_wp_error( $result ) ) {
+		wp_die(
+			esc_html( $result->get_error_message() ),
+			esc_html__( 'Could not update group', 'wordcamporg' ),
+			array( 'response' => 400 )
+		);
+	}
+
+	$redirect_url = add_query_arg(
+		array(
+			'page'    => PAGE_SLUG,
+			'updated' => $archived ? 'archived' : 'reactivated',
+		),
+		network_admin_url( 'sites.php' )
+	);
+
+	wp_safe_redirect( $redirect_url );
+	exit;
+}
+
+/**
+ * Render the Groups management screen.
+ */
+function render_page(): void {
+	if ( ! current_user_can( 'manage_sites' ) ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to manage groups.', 'wordcamporg' ) );
+	}
+
+	$groups  = get_group_sites( true );
+	$updated = isset( $_GET['updated'] ) ? sanitize_key( wp_unslash( $_GET['updated'] ) ) : '';
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Groups', 'wordcamporg' ); ?></h1>
+
+		<?php if ( in_array( $updated, array( 'archived', 'reactivated' ), true ) ) : ?>
+			<div class="notice notice-success is-dismissible"><p>
+				<?php
+				echo esc_html(
+					'archived' === $updated
+						? __( 'Group archived.', 'wordcamporg' )
+						: __( 'Group reactivated.', 'wordcamporg' )
+				);
+				?>
+			</p></div>
+		<?php endif; ?>
+
+		<p>
+			<?php esc_html_e( 'Archive a group without deleting its events, RSVPs, or member records. Archived group sites are unavailable on the front end until reactivated.', 'wordcamporg' ); ?>
+		</p>
+		<p>
+			<?php esc_html_e( 'Only network site managers can perform this action. Already scheduled jobs are left unchanged.', 'wordcamporg' ); ?>
+		</p>
+
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Group', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'URL', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Status', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Action', 'wordcamporg' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( empty( $groups ) ) : ?>
+					<tr><td colspan="4"><?php esc_html_e( 'No groups found.', 'wordcamporg' ); ?></td></tr>
+				<?php else : ?>
+					<?php foreach ( $groups as $group ) : ?>
+						<?php
+						$group_id     = (int) $group->blog_id;
+						$is_archived  = (bool) $group->archived;
+						$group_name   = get_blog_option( $group_id, 'blogname' );
+						$group_url    = get_home_url( $group_id, '/' );
+						$confirmation = $is_archived
+							? ''
+							: __( 'Archive this group? The site will be unavailable until it is reactivated.', 'wordcamporg' );
+						?>
+						<tr>
+							<td><strong><?php echo esc_html( $group_name ?: $group->domain . $group->path ); ?></strong></td>
+							<td><a href="<?php echo esc_url( $group_url ); ?>"><?php echo esc_html( $group_url ); ?></a></td>
+							<td><?php echo esc_html( $is_archived ? __( 'Archived', 'wordcamporg' ) : __( 'Active', 'wordcamporg' ) ); ?></td>
+							<td>
+								<form method="post" action="<?php echo esc_url( network_admin_url( 'edit.php?action=' . UPDATE_ACTION ) ); ?>">
+									<input type="hidden" name="site_id" value="<?php echo esc_attr( $group_id ); ?>">
+									<input type="hidden" name="archived" value="<?php echo esc_attr( $is_archived ? '0' : '1' ); ?>">
+									<?php wp_nonce_field( UPDATE_ACTION . '_' . $group_id ); ?>
+									<button
+										type="submit"
+										class="button <?php echo esc_attr( $is_archived ? 'button-secondary' : 'button-link-delete' ); ?>"
+										<?php if ( $confirmation ) : ?>
+											onclick="return window.confirm( '<?php echo esc_js( $confirmation ); ?>' );"
+										<?php endif; ?>
+									>
+										<?php echo esc_html( $is_archived ? __( 'Reactivate', 'wordcamporg' ) : __( 'Archive', 'wordcamporg' ) ); ?>
+									</button>
+								</form>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	</div>
+	<?php
+}

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -199,7 +199,6 @@ function upgrade_database() {
 			due_date       int( 11 )        unsigned NOT NULL default '0',
 			amount         numeric( 10, 2 ) unsigned NOT NULL default '0',
 			last_modified  datetime                  NOT NULL default '0000-00-00 00:00:00',
-
 			PRIMARY KEY (blog_id, invoice_id),
 			KEY status (status),
 			KEY last_modified (last_modified)


### PR DESCRIPTION
## What

- Add a Network Admin **Groups** screen for archiving and reactivating group sites.
- Use WordPress multisite's native archived-site flag so events, RSVPs, and memberships are preserved.
- Exclude archived groups from active group queries and add regression coverage for archive safety and validation.

## Why

Inactive groups need to be removed from public access without deleting their historical data. Fixes #1783.

## Testing

1. Sign in as a network administrator and open https://wordcamp.test/wp-admin/network/sites.php?page=wporg-groups.
2. Find **Sunshine Coast, QLD**, confirm its status is **Active**, click **Archive**, accept the confirmation, and verify the success notice and **Archived** status.
3. Open https://events.wordpress.test/group/sunshine-coast-qld/ and confirm the archived group is unavailable.
4. Return to the Groups screen, click **Reactivate**, and confirm the group loads again with its existing events, RSVPs, and members intact.
5. Run `docker compose -f docker-compose.phpunit.yml run --rm --entrypoint phpunit phpunit_wp --testsuite 'WordCamp Groups'`.

## Screenshots

<!-- Add screenshots of the Network Admin Groups screen in Active and Archived states. Optionally include the archived group front-end response. -->

**[Network Admin Groups](https://wordcamp.test/wp-admin/network/sites.php?page=wporg-groups) — list of active and archived states**

<kbd><img width="1108" height="407" alt="image" src="https://github.com/user-attachments/assets/10494197-f1b9-4bfb-bedd-da96a6d49720" /></kbd>

**[Sunshine Coast group](https://events.wordpress.test/group/sunshine-coast-qld/) — archived group**

<kbd><img width="842" height="150" alt="image" src="https://github.com/user-attachments/assets/edd05bbc-2e73-40cc-93f8-7d8332e0672d" /></kbd>
