### PR TITLE
Fix Sponsor Invoices schema migration

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/sponsor-invoices-dashboard.php
@@ -10,7 +10,7 @@ use const WordCamp\Budgets\Sponsor_Invoices\POST_TYPE;
 
 defined( 'WPINC' ) || die();
 
-const LATEST_DATABASE_VERSION = 4;
+const LATEST_DATABASE_VERSION = 5;
 
 if ( defined( 'DOING_AJAX' ) ) {
 	add_action( 'wp_ajax_wcbdsi_approve_invoice', __NAMESPACE__ . '\handle_approve_invoice_request'       );
@@ -201,7 +201,7 @@ function upgrade_database() {
 			last_modified  datetime                  NOT NULL default '0000-00-00 00:00:00',
 
 			PRIMARY KEY (blog_id, invoice_id),
-			KEY status (status)
+			KEY status (status),
 			KEY last_modified (last_modified)
 		)
 		$charset_collate


### PR DESCRIPTION
## Issue

The Sponsor Invoices version 4 schema is missing a comma between indexes, causing `dbDelta()` to generate an invalid `ALTER TABLE` query. Installations may also be marked version 4 without the `last_modified` index.

https://wordcamp.test/wp-admin/network/sites.php?page=wporg-groups

```
Warning: Undefined array key "index_type" in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3101 Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3101 Warning: Undefined array key "index_name" in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3107 Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3107 Warning: Undefined array key "index_columns" in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3110 Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3110 Warning: Undefined array key "column_name" in /usr/src/public_html/mu/wp-admin/includes/upgrade.php on line 3139

WordPress database error: [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '(``)' at line 1] ALTER TABLE wc_wcbd_sponsor_invoice_index ADD `` (``)

```

## Changes

- Correct the schema definition.
- Bump the database version to 5 so affected installations rerun the migration.

## Testing

1. In a disposable local database, remove the `last_modified` index if present and set `wcbdsi_database_version` to `4`.
2. Check out this branch and load Network Admin.
3. Confirm there are no migration warnings, the database version becomes `5`, and `SHOW INDEX FROM wc_wcbd_sponsor_invoice_index` includes `last_modified`.

Static verification: PHP syntax and `git diff --check` pass.
