### PR TITLE
Groups: network-admin messaging for organisers and group segments

### DIFF
--- a/public_html/wp-content/mu-plugins/1-logger.php
+++ b/public_html/wp-content/mu-plugins/1-logger.php
@@ -167,7 +167,7 @@ function redact_url( string $raw_url ) : string {
  */
 function get_unique_request_id() {
 	if ( 'cli' === php_sapi_name() ) {
-		$caller = $_SERVER['USER'] . ( $_SERVER['SSH_CONNECTION'] ?? '' );
+		$caller = ( $_SERVER['USER'] ?? '' ) . ( $_SERVER['SSH_CONNECTION'] ?? '' );
 	} else {
 		$caller = $_SERVER['REMOTE_ADDR'] . $_SERVER['REMOTE_PORT'];
 	}

--- a/public_html/wp-content/mu-plugins/groups/network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/network-messaging.php
@@ -374,63 +374,98 @@ function process_batch(): void {
 	}
 
 	$processed = 0;
+	$crashed   = false;
 
-	while ( $processed < BATCH_SIZE ) {
-		if ( empty( $job['queue'] ) ) {
-			if ( empty( $job['pending_sites'] ) ) {
-				break;
+	/*
+	 * The job was already removed from `JOBS_OPTION` by the claim above, and
+	 * isn't written back until the commit below -- so a `Throwable` escaping
+	 * this loop (a rogue `pre_wp_mail`/`wp_mail` filter, a transport that
+	 * exhausts the request instead of returning cleanly) must not skip that
+	 * commit, or the job -- and every recipient still in it -- disappears
+	 * with nothing sent, re-queued, or recorded. `send_message()` already
+	 * turns an ordinary transport failure into `false`, so this is only
+	 * reached by something that couldn't be handled that way.
+	 */
+	try {
+		while ( $processed < BATCH_SIZE ) {
+			if ( empty( $job['queue'] ) ) {
+				if ( empty( $job['pending_sites'] ) ) {
+					break;
+				}
+
+				++$processed;
+
+				$site_id = (int) $job['pending_sites'][0];
+				$batch   = get_site_recipients( $site_id, $job['audience'], BATCH_SIZE, $job['site_offset'] );
+
+				if ( empty( $batch ) ) {
+					array_shift( $job['pending_sites'] );
+					$job['site_offset'] = 0;
+				} else {
+					$job['site_offset'] += count( $batch );
+					$job['queue']        = $batch;
+				}
+
+				continue;
 			}
+
+			$recipient = array_shift( $job['queue'] );
+			$key       = strtolower( $recipient['email'] );
 
 			++$processed;
 
-			$site_id = (int) $job['pending_sites'][0];
-			$batch   = get_site_recipients( $site_id, $job['audience'], BATCH_SIZE, $job['site_offset'] );
-
-			if ( empty( $batch ) ) {
-				array_shift( $job['pending_sites'] );
-				$job['site_offset'] = 0;
-			} else {
-				$job['site_offset'] += count( $batch );
-				$job['queue']        = $batch;
+			if ( isset( $job['sent'][ $key ] ) ) {
+				continue;
 			}
 
-			continue;
+			/*
+			 * Only mark the address done once the mail is actually away. Marking
+			 * first meant a transient transport failure retired the recipient for
+			 * good — no send, no retry, no trace. Left unmarked, the same person
+			 * gets another chance if they turn up again via another group, and
+			 * the failure is at least on the record either way.
+			 */
+			if ( send_message( $recipient, $job ) ) {
+				$job['sent'][ $key ] = true;
+
+				++$job['sent_count'];
+			} else {
+				$job['failed_count'] = ( $job['failed_count'] ?? 0 ) + 1;
+
+				Logger\log(
+					'groups_message_send_failed',
+					array(
+						'job'       => $job['id'],
+						'recipient' => $recipient['email'],
+					)
+				);
+			}
 		}
-
-		$recipient = array_shift( $job['queue'] );
-		$key       = strtolower( $recipient['email'] );
-
-		++$processed;
-
-		if ( isset( $job['sent'][ $key ] ) ) {
-			continue;
-		}
+	} catch ( \Throwable $error ) {
+		$crashed = true;
 
 		/*
-		 * Only mark the address done once the mail is actually away. Marking
-		 * first meant a transient transport failure retired the recipient for
-		 * good — no send, no retry, no trace. Left unmarked, the same person
-		 * gets another chance if they turn up again via another group, and
-		 * the failure is at least on the record either way.
+		 * Not just `compact( 'error' )`: `redact_keys()` only special-cases
+		 * `Exception`, not `Throwable` generally, so a plain `Error` (e.g. a
+		 * `TypeError`) would fall through to an `(array)` cast instead --
+		 * mangled keys for its private/protected properties that `wp_json_encode()`
+		 * silently drops, per that function's own docblock.
 		 */
-		if ( send_message( $recipient, $job ) ) {
-			$job['sent'][ $key ] = true;
-
-			++$job['sent_count'];
-		} else {
-			$job['failed_count'] = ( $job['failed_count'] ?? 0 ) + 1;
-
-			Logger\log(
-				'groups_message_send_failed',
-				array(
-					'job'       => $job['id'],
-					'recipient' => $recipient['email'],
-				)
-			);
-		}
+		Logger\log(
+			'groups_message_batch_crashed',
+			array(
+				'job'     => $job['id'],
+				'error'   => array(
+					'class'   => get_class( $error ),
+					'message' => $error->getMessage(),
+					'file'    => $error->getFile(),
+					'line'    => $error->getLine(),
+				),
+			)
+		);
 	}
 
-	$finished = empty( $job['queue'] ) && empty( $job['pending_sites'] );
+	$finished = ! $crashed && empty( $job['queue'] ) && empty( $job['pending_sites'] );
 
 	$jobs = with_jobs_lock(
 		function () use ( $job, $finished ) {

--- a/public_html/wp-content/mu-plugins/groups/network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/network-messaging.php
@@ -242,7 +242,15 @@ function schedule_next_batch(): void {
 }
 
 /**
- * Send up to `BATCH_SIZE` emails from the oldest queued job.
+ * Do up to `BATCH_SIZE` units of work on the oldest queued job.
+ *
+ * A unit is one recipient taken off the queue or one per-site recipient
+ * lookup — not one email sent. Bounding on emails instead would leave a run
+ * unbounded whenever the work doesn't produce mail: someone who organises a
+ * dozen groups is skipped as a duplicate, and a group with no members yields
+ * nothing, so a run could walk any number of sites and queries before hitting
+ * a send-based limit. Counting the work itself is what keeps a single cron
+ * run inside the time limit.
  *
  * Reschedules itself until the queue is empty. Core's `doing_cron` lock keeps
  * two runs from overlapping; the `sent` map means that even if a run were
@@ -255,14 +263,16 @@ function process_batch(): void {
 		return;
 	}
 
-	$job  = array_shift( $jobs );
-	$sent = 0;
+	$job       = array_shift( $jobs );
+	$processed = 0;
 
-	while ( $sent < BATCH_SIZE ) {
+	while ( $processed < BATCH_SIZE ) {
 		if ( empty( $job['queue'] ) ) {
 			if ( empty( $job['pending_sites'] ) ) {
 				break;
 			}
+
+			++$processed;
 
 			$site_id = (int) $job['pending_sites'][0];
 			$batch   = get_site_recipients( $site_id, $job['audience'], BATCH_SIZE, $job['site_offset'] );
@@ -281,6 +291,8 @@ function process_batch(): void {
 		$recipient = array_shift( $job['queue'] );
 		$key       = strtolower( $recipient['email'] );
 
+		++$processed;
+
 		if ( isset( $job['sent'][ $key ] ) ) {
 			continue;
 		}
@@ -290,8 +302,6 @@ function process_batch(): void {
 		if ( send_message( $recipient, $job ) ) {
 			++$job['sent_count'];
 		}
-
-		++$sent;
 	}
 
 	if ( empty( $job['queue'] ) && empty( $job['pending_sites'] ) ) {

--- a/public_html/wp-content/mu-plugins/groups/network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/network-messaging.php
@@ -1,0 +1,579 @@
+<?php
+/**
+ * Network-admin messaging for WordPress Group sites.
+ *
+ * Gives Program Managers (network admins) a single Network Admin screen for
+ * emailing group people, covering two audiences that were previously
+ * impossible to reach without hand-assembling address lists:
+ *
+ * - Every group organiser across the whole Groups network (#1775).
+ * - Every member of a hand-picked set of groups (#1776).
+ *
+ * Both are the same underlying tool: an audience filter (organisers only vs.
+ * all members) crossed with a group filter (all groups vs. selected ones).
+ *
+ * Delivery runs on cron in small batches rather than in the submit request,
+ * so a send to thousands of recipients can't time out the browser. The queue
+ * lives in a network option; recipients are resolved lazily, site by site,
+ * as the queue drains — a network-wide `get_users()` would be a single
+ * enormous query, and the row set would have to be held in the option too.
+ *
+ * Loaded on the groups network only (sits in the `groups/` mu-plugins folder).
+ *
+ * @package WordCamp\Groups
+ */
+
+namespace WordCamp\Groups\Messaging;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Capability required to compose and send. `manage_network` is what makes
+ * someone a Program Manager on this network; there's no narrower cap that
+ * fits, and this tool can reach every group at once.
+ */
+const CAPABILITY = 'manage_network';
+
+/** Network Admin page slug. */
+const MENU_SLUG = 'wporg-groups-messaging';
+
+/** `admin_post_` action the compose form submits to. */
+const FORM_ACTION = 'wporg_groups_send_message';
+
+/** Cron hook that drains the queue. */
+const CRON_HOOK = 'wporg_groups_message_batch';
+
+/** Network option holding queued jobs (a FIFO list). */
+const JOBS_OPTION = 'wporg_groups_message_jobs';
+
+/** Network option holding a summary of the last completed job. */
+const SUMMARY_OPTION = 'wporg_groups_message_last_send';
+
+/**
+ * Emails sent per cron run. Small enough that a single run stays well inside
+ * PHP's time limit even when the mail transport is slow.
+ */
+const BATCH_SIZE = 50;
+
+/** Audience: editors and administrators only ("Organisers"). */
+const AUDIENCE_ORGANIZERS = 'organizers';
+
+/** Audience: everyone on the site, whatever their role. */
+const AUDIENCE_MEMBERS = 'members';
+
+/**
+ * Roles that make someone a group organiser. Mirrors the "Organiser" tier in
+ * `Members_Controller::ROLE_LABELS` — authors are "Event Organisers" and are
+ * deliberately not included, since they only manage their own events.
+ */
+const ORGANIZER_ROLES = array( 'administrator', 'editor' );
+
+add_action( 'network_admin_menu', __NAMESPACE__ . '\add_page' );
+add_action( 'admin_post_' . FORM_ACTION, __NAMESPACE__ . '\handle_form_post' );
+add_action( CRON_HOOK, __NAMESPACE__ . '\process_batch' );
+
+/**
+ * Whether the current user may use this tool.
+ */
+function current_user_can_send_messages(): bool {
+	return current_user_can( CAPABILITY );
+}
+
+/**
+ * Register the Network Admin screen.
+ */
+function add_page(): void {
+	add_submenu_page(
+		'settings.php',
+		'Message Groups',
+		'Message Groups',
+		CAPABILITY,
+		MENU_SLUG,
+		__NAMESPACE__ . '\render_page'
+	);
+}
+
+/**
+ * Get the sites on the Groups network that represent an actual group.
+ *
+ * The network's root site is the `/group/` landing page rather than a group,
+ * so it has no members to message. Archived, deleted and spam sites are
+ * skipped for the same reason: nobody should be emailed on their behalf.
+ *
+ * @return int[] Site IDs.
+ */
+function get_group_site_ids(): array {
+	$sites = get_sites(
+		array(
+			'network_id'   => GROUPS_NETWORK_ID,
+			'site__not_in' => array( GROUPS_ROOT_BLOG_ID ),
+			'archived'     => 0,
+			'deleted'      => 0,
+			'spam'         => 0,
+			'number'       => 0,
+			'orderby'      => 'path',
+			'fields'       => 'ids',
+		)
+	);
+
+	return array_map( 'intval', $sites );
+}
+
+/**
+ * Get the group sites as `id => name` pairs, for the group selector.
+ *
+ * @return array<int, string>
+ */
+function get_group_choices(): array {
+	$choices = array();
+
+	foreach ( get_group_site_ids() as $site_id ) {
+		$name = get_blog_option( $site_id, 'blogname', '' );
+
+		$choices[ $site_id ] = $name ? $name : untrailingslashit( get_site( $site_id )->path );
+	}
+
+	return $choices;
+}
+
+/**
+ * Get one page of recipients from a single group.
+ *
+ * @param int    $site_id  Group site ID.
+ * @param string $audience One of the `AUDIENCE_*` constants.
+ * @param int    $number   Maximum users to return.
+ * @param int    $offset   Users to skip.
+ * @return array<int, array{email: string, name: string}>
+ */
+function get_site_recipients( int $site_id, string $audience, int $number, int $offset = 0 ): array {
+	$args = array(
+		'blog_id' => $site_id,
+		'number'  => $number,
+		'offset'  => $offset,
+		'orderby' => 'ID',
+		'order'   => 'ASC',
+		'fields'  => array( 'ID', 'user_email', 'display_name' ),
+	);
+
+	if ( AUDIENCE_ORGANIZERS === $audience ) {
+		$args['role__in'] = ORGANIZER_ROLES;
+	}
+
+	$recipients = array();
+
+	foreach ( get_users( $args ) as $user ) {
+		if ( ! is_email( $user->user_email ) ) {
+			continue;
+		}
+
+		$recipients[] = array(
+			'email' => $user->user_email,
+			'name'  => $user->display_name,
+		);
+	}
+
+	return $recipients;
+}
+
+/**
+ * Queue a message for background delivery.
+ *
+ * @param string $subject  Message subject.
+ * @param string $body     Message body (plain text).
+ * @param string $audience One of the `AUDIENCE_*` constants.
+ * @param int[]  $site_ids Group sites to message.
+ * @return string The queued job's ID.
+ */
+function queue_message( string $subject, string $body, string $audience, array $site_ids ): string {
+	$job = array(
+		'id'            => wp_generate_uuid4(),
+		'subject'       => $subject,
+		'body'          => $body,
+		'audience'      => $audience,
+		'sites'         => array_values( $site_ids ),
+		'pending_sites' => array_values( $site_ids ),
+		'site_offset'   => 0,
+		'queue'         => array(),
+		// Lowercased emails already mailed, used to dedupe people who belong
+		// to more than one of the selected groups.
+		'sent'          => array(),
+		'sent_count'    => 0,
+		'author'        => get_current_user_id(),
+		'created'       => time(),
+	);
+
+	$jobs   = get_jobs();
+	$jobs[] = $job;
+
+	update_site_option( JOBS_OPTION, $jobs );
+
+	schedule_next_batch();
+
+	return $job['id'];
+}
+
+/**
+ * Get the queued jobs.
+ *
+ * @return array[]
+ */
+function get_jobs(): array {
+	$jobs = get_site_option( JOBS_OPTION, array() );
+
+	return is_array( $jobs ) ? $jobs : array();
+}
+
+/**
+ * Schedule the next batch, unless one is already due.
+ */
+function schedule_next_batch(): void {
+	if ( wp_next_scheduled( CRON_HOOK ) ) {
+		return;
+	}
+
+	$scheduled = wp_schedule_single_event( time(), CRON_HOOK );
+
+	if ( false === $scheduled ) {
+		trigger_error(
+			'Failed to schedule the next group message batch -- `wp_schedule_single_event()` returned false. Queued messages will not be delivered.',
+			E_USER_WARNING
+		);
+	}
+}
+
+/**
+ * Send up to `BATCH_SIZE` emails from the oldest queued job.
+ *
+ * Reschedules itself until the queue is empty. Core's `doing_cron` lock keeps
+ * two runs from overlapping; the `sent` map means that even if a run were
+ * duplicated, an address already mailed wouldn't be mailed again.
+ */
+function process_batch(): void {
+	$jobs = get_jobs();
+
+	if ( empty( $jobs ) ) {
+		return;
+	}
+
+	$job  = array_shift( $jobs );
+	$sent = 0;
+
+	while ( $sent < BATCH_SIZE ) {
+		if ( empty( $job['queue'] ) ) {
+			if ( empty( $job['pending_sites'] ) ) {
+				break;
+			}
+
+			$site_id = (int) $job['pending_sites'][0];
+			$batch   = get_site_recipients( $site_id, $job['audience'], BATCH_SIZE, $job['site_offset'] );
+
+			if ( empty( $batch ) ) {
+				array_shift( $job['pending_sites'] );
+				$job['site_offset'] = 0;
+			} else {
+				$job['site_offset'] += count( $batch );
+				$job['queue']        = $batch;
+			}
+
+			continue;
+		}
+
+		$recipient = array_shift( $job['queue'] );
+		$key       = strtolower( $recipient['email'] );
+
+		if ( isset( $job['sent'][ $key ] ) ) {
+			continue;
+		}
+
+		$job['sent'][ $key ] = true;
+
+		if ( send_message( $recipient, $job ) ) {
+			++$job['sent_count'];
+		}
+
+		++$sent;
+	}
+
+	if ( empty( $job['queue'] ) && empty( $job['pending_sites'] ) ) {
+		record_summary( $job );
+	} else {
+		array_unshift( $jobs, $job );
+	}
+
+	update_site_option( JOBS_OPTION, $jobs );
+
+	if ( ! empty( $jobs ) ) {
+		schedule_next_batch();
+	}
+}
+
+/**
+ * Email a single recipient.
+ *
+ * @param array{email: string, name: string} $recipient Recipient.
+ * @param array                              $job       Job being processed.
+ * @return bool Whether the mail was handed off successfully.
+ */
+function send_message( array $recipient, array $job ): bool {
+	$to = $recipient['name']
+		? sprintf( '%s <%s>', $recipient['name'], $recipient['email'] )
+		: $recipient['email'];
+
+	return wp_mail(
+		$to,
+		$job['subject'],
+		$job['body'],
+		array( 'Content-Type: text/plain; charset=UTF-8' )
+	);
+}
+
+/**
+ * Store a summary of a finished job, so the screen can report what happened.
+ *
+ * @param array $job Completed job.
+ */
+function record_summary( array $job ): void {
+	update_site_option(
+		SUMMARY_OPTION,
+		array(
+			'subject'    => $job['subject'],
+			'audience'   => $job['audience'],
+			'site_count' => count( $job['sites'] ),
+			'sent_count' => (int) $job['sent_count'],
+			'author'     => (int) $job['author'],
+			'finished'   => time(),
+		)
+	);
+}
+
+/**
+ * Handle the compose form submission.
+ */
+function handle_form_post(): void {
+	if ( ! current_user_can_send_messages() ) {
+		wp_die( 'You do not have permission to send messages to groups.', 403 );
+	}
+
+	check_admin_referer( FORM_ACTION );
+
+	$subject  = sanitize_text_field( wp_unslash( $_POST['subject'] ?? '' ) );
+	$body     = sanitize_textarea_field( wp_unslash( $_POST['body'] ?? '' ) );
+	$audience = sanitize_key( wp_unslash( $_POST['audience'] ?? '' ) );
+	$scope    = sanitize_key( wp_unslash( $_POST['scope'] ?? '' ) );
+	$selected = array_map( 'absint', (array) ( $_POST['groups'] ?? array() ) );
+
+	if ( ! in_array( $audience, array( AUDIENCE_ORGANIZERS, AUDIENCE_MEMBERS ), true ) ) {
+		redirect_with_notice( 'invalid-audience' );
+	}
+
+	if ( '' === $subject || '' === $body ) {
+		redirect_with_notice( 'empty-message' );
+	}
+
+	$group_ids = get_group_site_ids();
+
+	if ( 'selected' === $scope ) {
+		$group_ids = array_values( array_intersect( $group_ids, $selected ) );
+
+		if ( empty( $group_ids ) ) {
+			redirect_with_notice( 'no-groups' );
+		}
+	}
+
+	if ( empty( $group_ids ) ) {
+		redirect_with_notice( 'no-groups' );
+	}
+
+	queue_message( $subject, $body, $audience, $group_ids );
+
+	redirect_with_notice( 'queued', count( $group_ids ) );
+}
+
+/**
+ * Redirect back to the compose screen with a notice, and exit.
+ *
+ * @param string $notice Notice slug.
+ * @param int    $groups Number of groups the message was queued for.
+ */
+function redirect_with_notice( string $notice, int $groups = 0 ): void {
+	$url = add_query_arg(
+		array(
+			'page'   => MENU_SLUG,
+			'notice' => $notice,
+			'groups' => $groups,
+		),
+		network_admin_url( 'settings.php' )
+	);
+
+	wp_safe_redirect( $url );
+	exit;
+}
+
+/**
+ * Render the notice for the current request, if any.
+ */
+function render_notice(): void {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only display of the result of an already-verified POST.
+	$notice = isset( $_GET['notice'] ) ? sanitize_key( wp_unslash( $_GET['notice'] ) ) : '';
+
+	if ( ! $notice ) {
+		return;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Ditto.
+	$groups = isset( $_GET['groups'] ) ? absint( $_GET['groups'] ) : 0;
+
+	$messages = array(
+		'queued'           => array(
+			'success',
+			sprintf(
+				/* translators: %s: number of groups. */
+				_n(
+					'Message queued for %s group. Delivery runs in the background.',
+					'Message queued for %s groups. Delivery runs in the background.',
+					$groups,
+					'wporg-groups-frontend'
+				),
+				number_format_i18n( $groups )
+			),
+		),
+		'empty-message'    => array( 'error', 'Please provide both a subject and a message.' ),
+		'no-groups'        => array( 'error', 'Please select at least one group.' ),
+		'invalid-audience' => array( 'error', 'Please choose who should receive the message.' ),
+	);
+
+	if ( ! isset( $messages[ $notice ] ) ) {
+		return;
+	}
+
+	list( $type, $text ) = $messages[ $notice ];
+
+	printf(
+		'<div class="notice notice-%s is-dismissible"><p>%s</p></div>',
+		esc_attr( $type ),
+		esc_html( $text )
+	);
+}
+
+/**
+ * Render the last-send summary, so an admin can confirm a message went out.
+ */
+function render_summary(): void {
+	$summary = get_site_option( SUMMARY_OPTION );
+
+	if ( ! is_array( $summary ) || empty( $summary['finished'] ) ) {
+		return;
+	}
+
+	$author = get_userdata( (int) $summary['author'] );
+
+	printf(
+		'<p class="description">%s</p>',
+		esc_html(
+			sprintf(
+				'Last send: "%1$s" reached %2$s recipient(s) across %3$s group(s), sent by %4$s on %5$s.',
+				$summary['subject'],
+				number_format_i18n( (int) $summary['sent_count'] ),
+				number_format_i18n( (int) $summary['site_count'] ),
+				$author ? $author->display_name : 'an unknown user',
+				wp_date( 'Y-m-d H:i', (int) $summary['finished'] )
+			)
+		)
+	);
+}
+
+/**
+ * Render the compose screen.
+ */
+function render_page(): void {
+	if ( ! current_user_can_send_messages() ) {
+		wp_die( 'You do not have permission to access this page.', 403 );
+	}
+
+	$groups = get_group_choices();
+
+	?>
+	<div class="wrap">
+		<h1>Message Groups</h1>
+
+		<?php render_notice(); ?>
+
+		<p>
+			Send an email to group organisers or members across the Groups network.
+			Messages are delivered in the background, in batches.
+		</p>
+
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="<?php echo esc_attr( FORM_ACTION ); ?>" />
+			<?php wp_nonce_field( FORM_ACTION ); ?>
+
+			<table class="form-table" role="presentation">
+				<tr>
+					<th scope="row">Recipients</th>
+					<td>
+						<fieldset>
+							<legend class="screen-reader-text">Who should receive this message?</legend>
+							<label>
+								<input type="radio" name="audience" value="<?php echo esc_attr( AUDIENCE_ORGANIZERS ); ?>" checked="checked" />
+								Organisers only (editors and administrators)
+							</label>
+							<br />
+							<label>
+								<input type="radio" name="audience" value="<?php echo esc_attr( AUDIENCE_MEMBERS ); ?>" />
+								All members, whatever their role
+							</label>
+						</fieldset>
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row">Groups</th>
+					<td>
+						<fieldset>
+							<legend class="screen-reader-text">Which groups should receive this message?</legend>
+							<label>
+								<input type="radio" name="scope" value="all" checked="checked" />
+								All groups on the network (<?php echo esc_html( number_format_i18n( count( $groups ) ) ); ?>)
+							</label>
+							<br />
+							<label>
+								<input type="radio" name="scope" value="selected" />
+								Only the groups selected below
+							</label>
+						</fieldset>
+
+						<p>
+							<label for="wporg-groups-message-groups" class="screen-reader-text">Groups</label>
+							<select name="groups[]" id="wporg-groups-message-groups" multiple="multiple" size="10" style="min-width: 20rem;">
+								<?php foreach ( $groups as $site_id => $name ) : ?>
+									<option value="<?php echo esc_attr( $site_id ); ?>"><?php echo esc_html( $name ); ?></option>
+								<?php endforeach; ?>
+							</select>
+						</p>
+						<p class="description">Hold <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> to select more than one group.</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row"><label for="wporg-groups-message-subject">Subject</label></th>
+					<td>
+						<input type="text" name="subject" id="wporg-groups-message-subject" class="regular-text" required="required" />
+					</td>
+				</tr>
+
+				<tr>
+					<th scope="row"><label for="wporg-groups-message-body">Message</label></th>
+					<td>
+						<textarea name="body" id="wporg-groups-message-body" rows="10" class="large-text" required="required"></textarea>
+						<p class="description">Plain text only.</p>
+					</td>
+				</tr>
+			</table>
+
+			<?php submit_button( 'Send message' ); ?>
+		</form>
+
+		<?php render_summary(); ?>
+	</div>
+	<?php
+}

--- a/public_html/wp-content/mu-plugins/groups/network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/network-messaging.php
@@ -25,6 +25,8 @@
 
 namespace WordCamp\Groups\Messaging;
 
+use WordCamp\Logger;
+
 defined( 'WPINC' ) || die();
 
 /**
@@ -49,6 +51,24 @@ const JOBS_OPTION = 'wporg_groups_message_jobs';
 /** Network option holding a summary of the last completed job. */
 const SUMMARY_OPTION = 'wporg_groups_message_last_send';
 
+/** Object-cache key serialising read-modify-write cycles on `JOBS_OPTION`. */
+const LOCK_KEY = 'jobs_lock';
+
+/** Object-cache group for `LOCK_KEY`. Registered global, see below. */
+const LOCK_GROUP = 'wporg-groups-messaging';
+
+/**
+ * Seconds before an abandoned lock expires on its own, so a process that dies
+ * mid-update can't wedge the queue permanently.
+ */
+const LOCK_TIMEOUT = 30;
+
+/** Lock acquisition attempts, `LOCK_RETRY_DELAY` apart. */
+const LOCK_ATTEMPTS = 20;
+
+/** Microseconds between lock acquisition attempts. */
+const LOCK_RETRY_DELAY = 50000;
+
 /**
  * Emails sent per cron run. Small enough that a single run stays well inside
  * PHP's time limit even when the mail transport is slow.
@@ -71,6 +91,17 @@ const ORGANIZER_ROLES = array( 'administrator', 'editor' );
 add_action( 'network_admin_menu', __NAMESPACE__ . '\add_page' );
 add_action( 'admin_post_' . FORM_ACTION, __NAMESPACE__ . '\handle_form_post' );
 add_action( CRON_HOOK, __NAMESPACE__ . '\process_batch' );
+
+/*
+ * `JOBS_OPTION` is a network option, but `process_batch()` runs under whatever
+ * blog happens to be current. Non-global cache groups are keyed per blog, so
+ * without this two runs on different blogs would take two different locks and
+ * not exclude each other at all.
+ *
+ * The object cache is started in `wp-settings.php` well before mu-plugins
+ * load, so this is safe at file scope.
+ */
+wp_cache_add_global_groups( array( LOCK_GROUP ) );
 
 /**
  * Whether the current user may use this tool.
@@ -182,7 +213,8 @@ function get_site_recipients( int $site_id, string $audience, int $number, int $
  * @param string $body     Message body (plain text).
  * @param string $audience One of the `AUDIENCE_*` constants.
  * @param int[]  $site_ids Group sites to message.
- * @return string The queued job's ID.
+ * @return string The queued job's ID, or an empty string if the queue was
+ *                locked by a concurrent update and the job wasn't stored.
  */
 function queue_message( string $subject, string $body, string $audience, array $site_ids ): string {
 	$job = array(
@@ -198,18 +230,74 @@ function queue_message( string $subject, string $body, string $audience, array $
 		// to more than one of the selected groups.
 		'sent'          => array(),
 		'sent_count'    => 0,
+		'failed_count'  => 0,
 		'author'        => get_current_user_id(),
 		'created'       => time(),
 	);
 
-	$jobs   = get_jobs();
-	$jobs[] = $job;
+	$queued = with_jobs_lock(
+		function () use ( $job ) {
+			$jobs   = get_jobs();
+			$jobs[] = $job;
 
-	update_site_option( JOBS_OPTION, $jobs );
+			update_site_option( JOBS_OPTION, $jobs );
+
+			return true;
+		}
+	);
+
+	if ( ! $queued ) {
+		return '';
+	}
 
 	schedule_next_batch();
 
 	return $job['id'];
+}
+
+/**
+ * Run `$callback` with exclusive access to `JOBS_OPTION`.
+ *
+ * Both the compose form and the cron batch read the whole job list, change
+ * one part of it, and write the whole thing back. Interleave two of those and
+ * one silently overwrites the other — cron reads `[A]`, an admin queues `B`
+ * and writes `[A, B]`, cron finishes `A` and writes back `[]`, and `B` is
+ * gone. Core's `doing_cron` lock only stops cron racing cron, not cron racing
+ * a form submission.
+ *
+ * `wp_cache_add()` is atomic on a shared backend (memcached in production),
+ * which makes it a usable cross-process mutex. Without a persistent object
+ * cache the lock is per-process and this degrades to the unsynchronised
+ * behaviour it replaces — no worse than not having it.
+ *
+ * @param callable $callback Runs while the lock is held.
+ * @param bool     $steal    Run the callback anyway if the lock can't be
+ *                           acquired. For updates where dropping the write
+ *                           loses more than a rare clobber would.
+ * @return mixed The callback's return value, or null if the lock wasn't
+ *               acquired and `$steal` is false.
+ */
+function with_jobs_lock( callable $callback, bool $steal = false ) {
+	$acquired = false;
+
+	for ( $attempt = 0; $attempt < LOCK_ATTEMPTS; $attempt++ ) {
+		if ( wp_cache_add( LOCK_KEY, 1, LOCK_GROUP, LOCK_TIMEOUT ) ) {
+			$acquired = true;
+			break;
+		}
+
+		usleep( LOCK_RETRY_DELAY );
+	}
+
+	if ( ! $acquired && ! $steal ) {
+		return null;
+	}
+
+	try {
+		return $callback();
+	} finally {
+		wp_cache_delete( LOCK_KEY, LOCK_GROUP );
+	}
 }
 
 /**
@@ -255,15 +343,36 @@ function schedule_next_batch(): void {
  * Reschedules itself until the queue is empty. Core's `doing_cron` lock keeps
  * two runs from overlapping; the `sent` map means that even if a run were
  * duplicated, an address already mailed wouldn't be mailed again.
+ *
+ * The job is claimed off `JOBS_OPTION` under `with_jobs_lock()` and written
+ * back the same way, but the sending in between runs unlocked — holding the
+ * lock across `BATCH_SIZE` `wp_mail()` calls would block the compose form for
+ * as long as the mail transport takes.
  */
 function process_batch(): void {
-	$jobs = get_jobs();
+	$job = with_jobs_lock(
+		function () {
+			$jobs = get_jobs();
 
-	if ( empty( $jobs ) ) {
+			if ( empty( $jobs ) ) {
+				return null;
+			}
+
+			$claimed = array_shift( $jobs );
+
+			// Claiming removes the job from the option for the duration of
+			// the batch, so a concurrent queue_message() appends to a list
+			// that no longer contains it and can't resurrect stale progress.
+			update_site_option( JOBS_OPTION, $jobs );
+
+			return $claimed;
+		}
+	);
+
+	if ( empty( $job ) ) {
 		return;
 	}
 
-	$job       = array_shift( $jobs );
 	$processed = 0;
 
 	while ( $processed < BATCH_SIZE ) {
@@ -297,20 +406,50 @@ function process_batch(): void {
 			continue;
 		}
 
-		$job['sent'][ $key ] = true;
-
+		/*
+		 * Only mark the address done once the mail is actually away. Marking
+		 * first meant a transient transport failure retired the recipient for
+		 * good — no send, no retry, no trace. Left unmarked, the same person
+		 * gets another chance if they turn up again via another group, and
+		 * the failure is at least on the record either way.
+		 */
 		if ( send_message( $recipient, $job ) ) {
+			$job['sent'][ $key ] = true;
+
 			++$job['sent_count'];
+		} else {
+			$job['failed_count'] = ( $job['failed_count'] ?? 0 ) + 1;
+
+			Logger\log(
+				'groups_message_send_failed',
+				array(
+					'job'       => $job['id'],
+					'recipient' => $recipient['email'],
+				)
+			);
 		}
 	}
 
-	if ( empty( $job['queue'] ) && empty( $job['pending_sites'] ) ) {
-		record_summary( $job );
-	} else {
-		array_unshift( $jobs, $job );
-	}
+	$finished = empty( $job['queue'] ) && empty( $job['pending_sites'] );
 
-	update_site_option( JOBS_OPTION, $jobs );
+	$jobs = with_jobs_lock(
+		function () use ( $job, $finished ) {
+			$jobs = get_jobs();
+
+			if ( $finished ) {
+				record_summary( $job );
+			} else {
+				array_unshift( $jobs, $job );
+
+				update_site_option( JOBS_OPTION, $jobs );
+			}
+
+			return $jobs;
+		},
+		// The batch's progress only exists in memory at this point, so
+		// abandoning the write would re-send everything this run just sent.
+		true
+	);
 
 	if ( ! empty( $jobs ) ) {
 		schedule_next_batch();
@@ -329,8 +468,15 @@ function send_message( array $recipient, array $job ): bool {
 		? sprintf( '%s <%s>', $recipient['name'], $recipient['email'] )
 		: $recipient['email'];
 
+	/*
+	 * Passed a string, `wp_mail()` splits it on commas to support multiple
+	 * recipients — so a display name containing one ("evil@example.test, Jane")
+	 * would smuggle an extra address into every message of a broadcast. Users
+	 * pick their own display name, so that's attacker-controlled. An array
+	 * skips the split entirely and this stays one address.
+	 */
 	return wp_mail(
-		$to,
+		array( $to ),
 		$job['subject'],
 		$job['body'],
 		array( 'Content-Type: text/plain; charset=UTF-8' )
@@ -346,12 +492,13 @@ function record_summary( array $job ): void {
 	update_site_option(
 		SUMMARY_OPTION,
 		array(
-			'subject'    => $job['subject'],
-			'audience'   => $job['audience'],
-			'site_count' => count( $job['sites'] ),
-			'sent_count' => (int) $job['sent_count'],
-			'author'     => (int) $job['author'],
-			'finished'   => time(),
+			'subject'      => $job['subject'],
+			'audience'     => $job['audience'],
+			'site_count'   => count( $job['sites'] ),
+			'sent_count'   => (int) $job['sent_count'],
+			'failed_count' => (int) ( $job['failed_count'] ?? 0 ),
+			'author'       => (int) $job['author'],
+			'finished'     => time(),
 		)
 	);
 }
@@ -394,7 +541,9 @@ function handle_form_post(): void {
 		redirect_with_notice( 'no-groups' );
 	}
 
-	queue_message( $subject, $body, $audience, $group_ids );
+	if ( ! queue_message( $subject, $body, $audience, $group_ids ) ) {
+		redirect_with_notice( 'queue-busy' );
+	}
 
 	redirect_with_notice( 'queued', count( $group_ids ) );
 }
@@ -450,6 +599,7 @@ function render_notice(): void {
 		'empty-message'    => array( 'error', 'Please provide both a subject and a message.' ),
 		'no-groups'        => array( 'error', 'Please select at least one group.' ),
 		'invalid-audience' => array( 'error', 'Please choose who should receive the message.' ),
+		'queue-busy'       => array( 'error', 'The message queue was busy and your message was not queued. Please try again.' ),
 	);
 
 	if ( ! isset( $messages[ $notice ] ) ) {
@@ -476,17 +626,25 @@ function render_summary(): void {
 	}
 
 	$author = get_userdata( (int) $summary['author'] );
+	$failed = (int) ( $summary['failed_count'] ?? 0 );
 
 	printf(
 		'<p class="description">%s</p>',
 		esc_html(
 			sprintf(
-				'Last send: "%1$s" reached %2$s recipient(s) across %3$s group(s), sent by %4$s on %5$s.',
+				'Last send: "%1$s" reached %2$s recipient(s) across %3$s group(s), sent by %4$s on %5$s.%6$s',
 				$summary['subject'],
 				number_format_i18n( (int) $summary['sent_count'] ),
 				number_format_i18n( (int) $summary['site_count'] ),
 				$author ? $author->display_name : 'an unknown user',
-				wp_date( 'Y-m-d H:i', (int) $summary['finished'] )
+				wp_date( 'Y-m-d H:i', (int) $summary['finished'] ),
+				$failed
+					? sprintf(
+						/* translators: %s: number of failed recipients. */
+						' %s message(s) could not be sent — see the error log.',
+						number_format_i18n( $failed )
+					)
+					: ''
 			)
 		)
 	);

--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -28,6 +28,7 @@ function manually_load_plugin() {
 	require_once $gatherpress_file;
 
 	require_once dirname( __DIR__ ) . '/gatherpress-groups-tweaks.php';
+	require_once dirname( __DIR__ ) . '/network-messaging.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
@@ -1,0 +1,419 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WordCamp\Groups\Messaging;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Groups_Network_Messaging extends Groups_TestCase {
+	/**
+	 * Group sites created for the current test.
+	 *
+	 * @var int[]
+	 */
+	protected $group_sites = array();
+
+	/**
+	 * Emails captured during the current test.
+	 *
+	 * @var array[]
+	 */
+	protected $sent_mail = array();
+
+	/**
+	 * Create two group sites and intercept outgoing mail.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->group_sites = array(
+			'brisbane' => $this->create_group_site( 'brisbane' ),
+			'hobart'   => $this->create_group_site( 'hobart' ),
+		);
+
+		$this->sent_mail = array();
+
+		add_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10, 2 );
+	}
+
+	/**
+	 * Clean up sites, queued jobs, and scheduled batches.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+
+		foreach ( $this->group_sites as $site_id ) {
+			wp_delete_site( $site_id );
+		}
+
+		$this->group_sites = array();
+
+		delete_site_option( Messaging\JOBS_OPTION );
+		delete_site_option( Messaging\SUMMARY_OPTION );
+		wp_clear_scheduled_hook( Messaging\CRON_HOOK );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Record mail instead of sending it.
+	 *
+	 * @param null|bool $short_circuit Whether to short-circuit `wp_mail()`.
+	 * @param array     $atts          `wp_mail()` arguments.
+	 * @return bool
+	 */
+	public function capture_mail( $short_circuit, $atts ) {
+		$this->sent_mail[] = $atts;
+
+		return true;
+	}
+
+	/**
+	 * Create a site on the groups network.
+	 *
+	 * @param string $slug Group slug.
+	 * @return int
+	 */
+	protected function create_group_site( string $slug ): int {
+		return self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => "/group/$slug/",
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+	}
+
+	/**
+	 * Add a user to a group site with a given role.
+	 *
+	 * @param int    $site_id Group site.
+	 * @param string $role    Role to assign.
+	 * @param string $email   Email address.
+	 * @return int User ID.
+	 */
+	protected function add_member( int $site_id, string $role, string $email ): int {
+		$user_id = self::factory()->user->create( array( 'user_email' => $email ) );
+
+		add_user_to_blog( $site_id, $user_id, $role );
+
+		return $user_id;
+	}
+
+	/**
+	 * Get the "to" address of every captured email, lowercased.
+	 *
+	 * @return string[]
+	 */
+	protected function get_sent_addresses(): array {
+		return array_map(
+			function ( $mail ) {
+				$to = is_array( $mail['to'] ) ? $mail['to'][0] : $mail['to'];
+
+				// `send_message()` sends to `Display Name <email>`.
+				if ( preg_match( '/<([^>]+)>/', $to, $matches ) ) {
+					$to = $matches[1];
+				}
+
+				return strtolower( trim( $to ) );
+			},
+			$this->sent_mail
+		);
+	}
+
+	/**
+	 * Drain the whole queue, however many batches it takes.
+	 */
+	protected function process_queue(): void {
+		$guard = 0;
+
+		while ( Messaging\get_jobs() && $guard < 50 ) {
+			Messaging\process_batch();
+			++$guard;
+		}
+	}
+
+	/**
+	 * Every group on the network is a candidate recipient site, but the
+	 * network's root site is the `/group/` landing page, not a group.
+	 */
+	public function test_group_site_ids_exclude_the_network_root() {
+		$site_ids = Messaging\get_group_site_ids();
+
+		$this->assertContains( $this->group_sites['brisbane'], $site_ids );
+		$this->assertContains( $this->group_sites['hobart'], $site_ids );
+		$this->assertNotContains( GROUPS_ROOT_BLOG_ID, $site_ids );
+	}
+
+	/**
+	 * Sites on other networks are never messaged, even though they share the
+	 * `events.wordpress.test` host.
+	 */
+	public function test_group_site_ids_exclude_other_networks() {
+		$events_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/othernetwork/2025/meetup/',
+				'network_id' => EVENTS_NETWORK_ID,
+			)
+		);
+
+		$this->assertNotContains( $events_site_id, Messaging\get_group_site_ids() );
+
+		wp_delete_site( $events_site_id );
+	}
+
+	/**
+	 * Archived groups are inactive, so their members shouldn't be emailed.
+	 */
+	public function test_group_site_ids_exclude_archived_groups() {
+		wp_update_site( $this->group_sites['hobart'], array( 'archived' => 1 ) );
+
+		$site_ids = Messaging\get_group_site_ids();
+
+		$this->assertContains( $this->group_sites['brisbane'], $site_ids );
+		$this->assertNotContains( $this->group_sites['hobart'], $site_ids );
+	}
+
+	/**
+	 * The organiser audience is the "Organiser" tier only — editors and
+	 * administrators. Authors ("Event Organisers") and members are excluded.
+	 */
+	public function test_organizer_audience_only_includes_editors_and_admins() {
+		$site_id = $this->group_sites['brisbane'];
+
+		$this->add_member( $site_id, 'editor', 'editor@example.test' );
+		$this->add_member( $site_id, 'administrator', 'admin@example.test' );
+		$this->add_member( $site_id, 'author', 'author@example.test' );
+		$this->add_member( $site_id, 'subscriber', 'subscriber@example.test' );
+
+		$emails = wp_list_pluck(
+			Messaging\get_site_recipients( $site_id, Messaging\AUDIENCE_ORGANIZERS, 100 ),
+			'email'
+		);
+
+		sort( $emails );
+
+		$this->assertSame( array( 'admin@example.test', 'editor@example.test' ), $emails );
+	}
+
+	/**
+	 * The member audience is everyone on the site, whatever their role.
+	 */
+	public function test_member_audience_includes_every_role() {
+		$site_id = $this->group_sites['brisbane'];
+
+		$this->add_member( $site_id, 'editor', 'editor@example.test' );
+		$this->add_member( $site_id, 'author', 'author@example.test' );
+		$this->add_member( $site_id, 'subscriber', 'subscriber@example.test' );
+
+		$emails = wp_list_pluck(
+			Messaging\get_site_recipients( $site_id, Messaging\AUDIENCE_MEMBERS, 100 ),
+			'email'
+		);
+
+		$this->assertContains( 'editor@example.test', $emails );
+		$this->assertContains( 'author@example.test', $emails );
+		$this->assertContains( 'subscriber@example.test', $emails );
+	}
+
+	/**
+	 * Queueing stores the job and schedules a batch, without sending anything
+	 * in the submit request itself.
+	 */
+	public function test_queue_message_stores_a_job_and_schedules_a_batch() {
+		Messaging\queue_message(
+			'Subject',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array_values( $this->group_sites )
+		);
+
+		$jobs = Messaging\get_jobs();
+
+		$this->assertCount( 1, $jobs );
+		$this->assertSame( 'Subject', $jobs[0]['subject'] );
+		$this->assertSame( Messaging\AUDIENCE_ORGANIZERS, $jobs[0]['audience'] );
+		$this->assertSame( array_values( $this->group_sites ), $jobs[0]['pending_sites'] );
+		$this->assertIsInt( wp_next_scheduled( Messaging\CRON_HOOK ) );
+		$this->assertSame( array(), $this->sent_mail );
+	}
+
+	/**
+	 * #1775: a broadcast reaches every organiser on every group, and nobody
+	 * else.
+	 */
+	public function test_broadcast_reaches_every_organizer_on_the_network() {
+		$this->add_member( $this->group_sites['brisbane'], 'editor', 'brisbane-organiser@example.test' );
+		$this->add_member( $this->group_sites['brisbane'], 'subscriber', 'brisbane-member@example.test' );
+		$this->add_member( $this->group_sites['hobart'], 'administrator', 'hobart-organiser@example.test' );
+		$this->add_member( $this->group_sites['hobart'], 'author', 'hobart-author@example.test' );
+
+		Messaging\queue_message( 'Hello', 'Body', Messaging\AUDIENCE_ORGANIZERS, Messaging\get_group_site_ids() );
+		$this->process_queue();
+
+		$addresses = $this->get_sent_addresses();
+
+		$this->assertContains( 'brisbane-organiser@example.test', $addresses );
+		$this->assertContains( 'hobart-organiser@example.test', $addresses );
+		$this->assertNotContains( 'brisbane-member@example.test', $addresses );
+		$this->assertNotContains( 'hobart-author@example.test', $addresses );
+	}
+
+	/**
+	 * #1776: a segmented message reaches every member of the selected groups,
+	 * and nobody from the groups that weren't selected.
+	 */
+	public function test_segmented_message_reaches_only_the_selected_groups() {
+		$this->add_member( $this->group_sites['brisbane'], 'subscriber', 'brisbane-member@example.test' );
+		$this->add_member( $this->group_sites['hobart'], 'subscriber', 'hobart-member@example.test' );
+
+		Messaging\queue_message(
+			'Hello',
+			'Body',
+			Messaging\AUDIENCE_MEMBERS,
+			array( $this->group_sites['brisbane'] )
+		);
+		$this->process_queue();
+
+		$addresses = $this->get_sent_addresses();
+
+		$this->assertContains( 'brisbane-member@example.test', $addresses );
+		$this->assertNotContains( 'hobart-member@example.test', $addresses );
+	}
+
+	/**
+	 * Someone who belongs to two selected groups is emailed once.
+	 */
+	public function test_recipients_in_overlapping_groups_are_emailed_once() {
+		$user_id = $this->add_member( $this->group_sites['brisbane'], 'editor', 'both@example.test' );
+
+		add_user_to_blog( $this->group_sites['hobart'], $user_id, 'editor' );
+
+		Messaging\queue_message(
+			'Hello',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array( $this->group_sites['brisbane'], $this->group_sites['hobart'] )
+		);
+		$this->process_queue();
+
+		$addresses = array_filter(
+			$this->get_sent_addresses(),
+			function ( $address ) {
+				return 'both@example.test' === $address;
+			}
+		);
+
+		$this->assertCount( 1, $addresses );
+	}
+
+	/**
+	 * A large send is spread over several cron runs rather than blocking one
+	 * request until it finishes.
+	 */
+	public function test_a_run_sends_at_most_one_batch() {
+		$queue = array();
+
+		for ( $i = 0; $i < Messaging\BATCH_SIZE + 10; $i++ ) {
+			$queue[] = array(
+				'email' => "recipient$i@example.test",
+				'name'  => "Recipient $i",
+			);
+		}
+
+		update_site_option(
+			Messaging\JOBS_OPTION,
+			array(
+				array(
+					'id'            => 'test-job',
+					'subject'       => 'Hello',
+					'body'          => 'Body',
+					'audience'      => Messaging\AUDIENCE_ORGANIZERS,
+					'sites'         => array_values( $this->group_sites ),
+					'pending_sites' => array(),
+					'site_offset'   => 0,
+					'queue'         => $queue,
+					'sent'          => array(),
+					'sent_count'    => 0,
+					'author'        => 0,
+					'created'       => time(),
+				),
+			)
+		);
+
+		Messaging\process_batch();
+
+		$this->assertCount( Messaging\BATCH_SIZE, $this->sent_mail );
+
+		$jobs = Messaging\get_jobs();
+
+		$this->assertCount( 1, $jobs, 'The unfinished job should stay queued.' );
+		$this->assertCount( 10, $jobs[0]['queue'] );
+		$this->assertIsInt( wp_next_scheduled( Messaging\CRON_HOOK ), 'Another batch should be scheduled.' );
+
+		$this->process_queue();
+
+		$this->assertCount( Messaging\BATCH_SIZE + 10, $this->sent_mail );
+		$this->assertSame( array(), Messaging\get_jobs() );
+	}
+
+	/**
+	 * A finished job leaves the queue and is summarised for the admin screen.
+	 */
+	public function test_completed_job_is_summarised() {
+		$this->add_member( $this->group_sites['brisbane'], 'editor', 'organiser@example.test' );
+
+		Messaging\queue_message(
+			'Newsletter',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array( $this->group_sites['brisbane'] )
+		);
+		$this->process_queue();
+
+		$summary = get_site_option( Messaging\SUMMARY_OPTION );
+
+		$this->assertSame( array(), Messaging\get_jobs() );
+		$this->assertSame( 'Newsletter', $summary['subject'] );
+		$this->assertSame( 1, $summary['sent_count'] );
+		$this->assertSame( 1, $summary['site_count'] );
+	}
+
+	/**
+	 * Group organisers — even administrators of their own group — can't reach
+	 * the whole network.
+	 */
+	public function test_group_administrators_cannot_send_messages() {
+		$user_id = $this->add_member( $this->group_sites['brisbane'], 'administrator', 'group-admin@example.test' );
+
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( Messaging\current_user_can_send_messages() );
+	}
+
+	/**
+	 * Network admins (Program Managers) can.
+	 */
+	public function test_network_admins_can_send_messages() {
+		$user_id = self::factory()->user->create();
+
+		// `grant_super_admin()` reads `site_admins` off whichever network is
+		// current, which in this fixture isn't the groups network. Set the
+		// option `get_super_admins()` actually consults instead.
+		$original = get_site_option( 'site_admins' );
+
+		update_site_option( 'site_admins', array( get_userdata( $user_id )->user_login ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( Messaging\current_user_can_send_messages() );
+
+		update_site_option( 'site_admins', $original );
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
@@ -497,6 +497,46 @@ class Test_Groups_Network_Messaging extends Groups_TestCase {
 	}
 
 	/**
+	 * A `Throwable` escaping the send loop -- a rogue mail filter, a `TypeError`,
+	 * anything `send_message()` doesn't turn into a clean `false` -- must not
+	 * lose the job. The claim step already removed it from `JOBS_OPTION` before
+	 * the loop runs, so without a `catch` around the loop, a crash skips the
+	 * commit and the job -- and everyone still in it -- vanishes: not sent,
+	 * not re-queued, not summarised, nothing in the log to explain why.
+	 */
+	public function test_a_crash_mid_batch_does_not_lose_the_job() {
+		$this->add_member( $this->group_sites['brisbane'], 'editor', 'organiser@example.test' );
+
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+
+		$throw = function () {
+			throw new \Error( 'Simulated fatal mid-batch' );
+		};
+
+		add_filter( 'pre_wp_mail', $throw );
+
+		Messaging\queue_message(
+			'Hello',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array( $this->group_sites['brisbane'] )
+		);
+		Messaging\process_batch();
+
+		remove_filter( 'pre_wp_mail', $throw );
+
+		$jobs = Messaging\get_jobs();
+
+		$this->assertCount( 1, $jobs, 'The job must still be queued for retry, not silently dropped.' );
+		$this->assertContains(
+			$this->group_sites['brisbane'],
+			$jobs[0]['pending_sites'],
+			'The recipient the crash was mid-send to must still be pending.'
+		);
+		$this->assertIsInt( wp_next_scheduled( Messaging\CRON_HOOK ), 'A retry must still be scheduled.' );
+	}
+
+	/**
 	 * A recipient who failed on one group is retried when they turn up again
 	 * through another — the `sent` map is a record of delivery, not of
 	 * attempts.

--- a/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
@@ -365,6 +365,53 @@ class Test_Groups_Network_Messaging extends Groups_TestCase {
 	}
 
 	/**
+	 * Duplicates are work too. A recipient who belongs to many selected groups
+	 * is skipped rather than mailed, and a run made entirely of such skips
+	 * must still stop at the batch limit instead of draining the whole queue.
+	 */
+	public function test_duplicate_recipients_still_count_against_the_batch() {
+		$queue = array();
+		$sent  = array();
+
+		for ( $i = 0; $i < Messaging\BATCH_SIZE + 10; $i++ ) {
+			$queue[] = array(
+				'email' => "recipient$i@example.test",
+				'name'  => "Recipient $i",
+			);
+
+			$sent[ "recipient$i@example.test" ] = true;
+		}
+
+		update_site_option(
+			Messaging\JOBS_OPTION,
+			array(
+				array(
+					'id'            => 'test-job',
+					'subject'       => 'Hello',
+					'body'          => 'Body',
+					'audience'      => Messaging\AUDIENCE_ORGANIZERS,
+					'sites'         => array_values( $this->group_sites ),
+					'pending_sites' => array(),
+					'site_offset'   => 0,
+					'queue'         => $queue,
+					'sent'          => $sent,
+					'sent_count'    => 0,
+					'author'        => 0,
+					'created'       => time(),
+				),
+			)
+		);
+
+		Messaging\process_batch();
+
+		$jobs = Messaging\get_jobs();
+
+		$this->assertSame( array(), $this->sent_mail, 'Already-mailed addresses should not be mailed again.' );
+		$this->assertCount( 1, $jobs, 'The job should not have drained in one run.' );
+		$this->assertCount( 10, $jobs[0]['queue'] );
+	}
+
+	/**
 	 * A finished job leaves the queue and is summarised for the admin screen.
 	 */
 	public function test_completed_job_is_summarised() {

--- a/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
@@ -434,6 +434,151 @@ class Test_Groups_Network_Messaging extends Groups_TestCase {
 	}
 
 	/**
+	 * A display name is user-controlled, and `wp_mail()` splits a string `to`
+	 * on commas — so one containing a comma must not be able to add a second
+	 * recipient to every message of a broadcast.
+	 */
+	public function test_display_name_cannot_smuggle_in_an_extra_recipient() {
+		$user_id = $this->add_member( $this->group_sites['brisbane'], 'editor', 'organiser@example.test' );
+
+		wp_update_user(
+			array(
+				'ID'           => $user_id,
+				'display_name' => 'evil@example.test, Jane',
+			)
+		);
+
+		Messaging\queue_message(
+			'Hello',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array( $this->group_sites['brisbane'] )
+		);
+		$this->process_queue();
+
+		$this->assertCount( 1, $this->sent_mail );
+
+		$to = $this->sent_mail[0]['to'];
+
+		// Mirror what core does with the value it was handed: a string `to` is
+		// split on commas, an array is taken as-is. Passing the string form
+		// here would yield two addresses.
+		$recipients = is_array( $to ) ? $to : explode( ',', $to );
+
+		$this->assertCount( 1, $recipients, 'The display name must not be split into a second recipient.' );
+		$this->assertStringContainsString( 'organiser@example.test', $recipients[0] );
+	}
+
+	/**
+	 * A transport failure must not retire the recipient. Marking the address
+	 * done before `wp_mail()` returned meant a transient failure dropped that
+	 * person from the send permanently, with nothing recorded.
+	 */
+	public function test_a_failed_send_is_not_marked_as_delivered() {
+		$this->add_member( $this->group_sites['brisbane'], 'editor', 'organiser@example.test' );
+
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+		add_filter( 'pre_wp_mail', '__return_false' );
+
+		Messaging\queue_message(
+			'Hello',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array( $this->group_sites['brisbane'] )
+		);
+		$this->process_queue();
+
+		remove_filter( 'pre_wp_mail', '__return_false' );
+
+		$summary = get_site_option( Messaging\SUMMARY_OPTION );
+
+		$this->assertSame( 0, $summary['sent_count'] );
+		$this->assertSame( 1, $summary['failed_count'], 'The failure should be counted, not silently swallowed.' );
+	}
+
+	/**
+	 * A recipient who failed on one group is retried when they turn up again
+	 * through another — the `sent` map is a record of delivery, not of
+	 * attempts.
+	 */
+	public function test_a_failed_recipient_is_retried_via_another_group() {
+		$user_id = $this->add_member( $this->group_sites['brisbane'], 'editor', 'both@example.test' );
+
+		add_user_to_blog( $this->group_sites['hobart'], $user_id, 'editor' );
+
+		$attempts = 0;
+
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+
+		$fail_first = function () use ( &$attempts ) {
+			++$attempts;
+
+			return 1 === $attempts ? false : true;
+		};
+
+		add_filter( 'pre_wp_mail', $fail_first );
+
+		Messaging\queue_message( 'Hello', 'Body', Messaging\AUDIENCE_ORGANIZERS, array_values( $this->group_sites ) );
+		$this->process_queue();
+
+		remove_filter( 'pre_wp_mail', $fail_first );
+
+		$this->assertSame( 2, $attempts, 'The second membership should give the failed address another attempt.' );
+
+		$summary = get_site_option( Messaging\SUMMARY_OPTION );
+
+		$this->assertSame( 1, $summary['sent_count'] );
+		$this->assertSame( 1, $summary['failed_count'] );
+	}
+
+	/**
+	 * A message queued while a batch is mid-flight must survive the batch
+	 * writing its own progress back. Both sides read-modify-write the same
+	 * option, so without the lock the batch's write would drop the new job.
+	 */
+	public function test_a_message_queued_during_a_batch_is_not_lost() {
+		$this->add_member( $this->group_sites['brisbane'], 'editor', 'organiser@example.test' );
+
+		Messaging\queue_message(
+			'First',
+			'Body',
+			Messaging\AUDIENCE_ORGANIZERS,
+			array( $this->group_sites['brisbane'] )
+		);
+
+		// Queue a second message from "another request" while the first job is
+		// claimed and mid-send, which is exactly the interleaving that used to
+		// lose it.
+		$queue_during_send = function ( $short_circuit, $atts ) {
+			static $queued = false;
+
+			if ( ! $queued ) {
+				$queued = true;
+
+				Messaging\queue_message(
+					'Second',
+					'Body',
+					Messaging\AUDIENCE_ORGANIZERS,
+					array( $this->group_sites['hobart'] )
+				);
+			}
+
+			return $this->capture_mail( $short_circuit, $atts );
+		};
+
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+		add_filter( 'pre_wp_mail', $queue_during_send, 10, 2 );
+
+		Messaging\process_batch();
+
+		remove_filter( 'pre_wp_mail', $queue_during_send, 10 );
+
+		$subjects = wp_list_pluck( Messaging\get_jobs(), 'subject' );
+
+		$this->assertContains( 'Second', $subjects, 'The concurrently queued job should still be in the queue.' );
+	}
+
+	/**
 	 * Group organisers — even administrators of their own group — can't reach
 	 * the whole network.
 	 */

--- a/public_html/wp-content/sunrise-groups.php
+++ b/public_html/wp-content/sunrise-groups.php
@@ -97,15 +97,43 @@ function set_network_and_site() {
 }
 
 /**
+ * Whether the current request is for one of core's own `wp-*.php` entry
+ * points (`wp-login.php`, `wp-signup.php`, `wp-activate.php`, …) rather than
+ * a front-end URL.
+ *
+ * Uses `REQUEST_URI` rather than `is_login()`, which can't run this early —
+ * it calls `wp_login_url()`, and that needs the blog's options, which don't
+ * exist until long after sunrise. `SCRIPT_NAME` would work on the current
+ * nginx config (`/group/wp-login.php` is rewritten to `/wp-login.php`) but
+ * would silently stop matching if the rewrites changed; `REQUEST_URI` is
+ * what the rest of this file already resolves the site from.
+ *
+ * @return bool
+ */
+function is_core_endpoint_request() {
+	$path = parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH );
+
+	return is_string( $path ) && 1 === preg_match( '~/wp-[\w-]+\.php$~', $path );
+}
+
+/**
  * Handle any redirects needed on the Groups network.
  */
 function do_redirects() {
 	global $blog_id, $site_id;
 
-	// The groups network root (`events.wordpress.org/group/`) is a placeholder
-	// that exists only because WordPress multisite requires every network to
-	// have a root site. Front-end requests bounce to the events root.
-	if ( GROUPS_ROOT_BLOG_ID === $blog_id && ! is_admin() && ! is_network_admin() ) {
+	/*
+	 * The groups network root (`events.wordpress.org/group/`) is a placeholder
+	 * that exists only because WordPress multisite requires every network to
+	 * have a root site. Front-end requests bounce to the events root.
+	 *
+	 * `wp-login.php` is exempt because it lives on that placeholder root and
+	 * is the only way to get a session on this network: `is_admin()` is false
+	 * for it, so bouncing it left every Network Admin screen here permanently
+	 * unreachable — you'd be redirected to the events root, whose login sets
+	 * an admin cookie scoped to `/wp-admin`, never `/group/wp-admin`.
+	 */
+	if ( GROUPS_ROOT_BLOG_ID === $blog_id && ! is_admin() && ! is_network_admin() && ! is_core_endpoint_request() ) {
 		header( 'X-Redirect-By: Groups/Sunrise::do_redirects' );
 		header( 'Location: https://events.wordpress.' . get_top_level_domain() . '/', true, 302 );
 		exit;

--- a/public_html/wp-content/sunrise-groups.php
+++ b/public_html/wp-content/sunrise-groups.php
@@ -97,23 +97,51 @@ function set_network_and_site() {
 }
 
 /**
- * Whether the current request is for one of core's own `wp-*.php` entry
- * points (`wp-login.php`, `wp-signup.php`, `wp-activate.php`, …) rather than
- * a front-end URL.
+ * Whether the current request targets a core entry point that must stay
+ * reachable on the groups network root, rather than being bounced to the
+ * events root by `do_redirects()`.
  *
- * Uses `REQUEST_URI` rather than `is_login()`, which can't run this early —
- * it calls `wp_login_url()`, and that needs the blog's options, which don't
- * exist until long after sunrise. `SCRIPT_NAME` would work on the current
- * nginx config (`/group/wp-login.php` is rewritten to `/wp-login.php`) but
- * would silently stop matching if the rewrites changed; `REQUEST_URI` is
- * what the rest of this file already resolves the site from.
+ * The allowlist is deliberately exact rather than a `wp-*.php` pattern. A
+ * pattern would also un-bounce `wp-signup.php`, `wp-mail.php`,
+ * `wp-trackback.php`, `wp-comments-post.php` and friends on what is only a
+ * placeholder site — none of which anything here needs, and all of which
+ * have been unreachable until now.
+ *
+ * - `wp-login.php` is the only way to get a session on this network, and
+ *   without one every Network Admin screen here is unreachable.
+ * - `wp-cron.php` is where `spawn_cron()` POSTs for this blog. Scheduled work
+ *   owned by the root site — the group messaging queue, for one — lives in
+ *   this blog's `cron` option, and the spawn is non-blocking, so a redirect
+ *   is never followed: the job simply never ran.
+ *
+ * The list is a local rather than a namespace constant on purpose: this file
+ * is `require`d from inside `load_network_sunrise()`, so a file-scope `const`
+ * here is evaluated in function scope and never actually declared. That's
+ * also why `sunrise.php` is where this namespace's constants live.
+ *
+ * Reads `REQUEST_URI` rather than using `is_login()`, which can't run this
+ * early — it calls `wp_login_url()`, needing blog options that don't exist
+ * until long after sunrise. `SCRIPT_NAME` would work under the current nginx
+ * config (`/group/wp-login.php` is rewritten to `/wp-login.php`) but would
+ * stop matching silently if those rewrites changed; `REQUEST_URI` is what the
+ * rest of this file already resolves the current site from.
+ *
+ * Anything that doesn't match falls through to the redirect, so an encoded or
+ * otherwise unrecognised spelling fails closed, back to today's behaviour.
  *
  * @return bool
  */
-function is_core_endpoint_request() {
+function is_reachable_root_endpoint() {
+	$reachable = array( 'wp-login.php', 'wp-cron.php' );
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- `wp_parse_url()` isn't available this early.
 	$path = parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH );
 
-	return is_string( $path ) && 1 === preg_match( '~/wp-[\w-]+\.php$~', $path );
+	if ( ! is_string( $path ) || '' === $path ) {
+		return false;
+	}
+
+	return in_array( basename( $path ), $reachable, true );
 }
 
 /**
@@ -127,13 +155,13 @@ function do_redirects() {
 	 * that exists only because WordPress multisite requires every network to
 	 * have a root site. Front-end requests bounce to the events root.
 	 *
-	 * `wp-login.php` is exempt because it lives on that placeholder root and
-	 * is the only way to get a session on this network: `is_admin()` is false
-	 * for it, so bouncing it left every Network Admin screen here permanently
-	 * unreachable — you'd be redirected to the events root, whose login sets
-	 * an admin cookie scoped to `/wp-admin`, never `/group/wp-admin`.
+	 * `REACHABLE_ROOT_ENDPOINTS` are exempt: `is_admin()` is false for them,
+	 * so bouncing `wp-login.php` left every Network Admin screen here
+	 * permanently unreachable — you'd be sent to the events root, whose login
+	 * sets an admin cookie scoped to `/wp-admin`, never `/group/wp-admin` —
+	 * and bouncing `wp-cron.php` silently dropped this blog's scheduled work.
 	 */
-	if ( GROUPS_ROOT_BLOG_ID === $blog_id && ! is_admin() && ! is_network_admin() && ! is_core_endpoint_request() ) {
+	if ( GROUPS_ROOT_BLOG_ID === $blog_id && ! is_admin() && ! is_network_admin() && ! is_reachable_root_endpoint() ) {
 		header( 'X-Redirect-By: Groups/Sunrise::do_redirects' );
 		header( 'Location: https://events.wordpress.' . get_top_level_domain() . '/', true, 302 );
 		exit;


### PR DESCRIPTION
Adds a Network Admin screen (Settings → Message Groups) for emailing group people network-wide: organisers only or all members, all groups or a selected few. Sends run on cron in batches of 50, deduped by email.

Fixes #1775
Fixes #1776

## Testing

https://events.wordpress.test/group/wp-admin/network/settings.php?page=wporg-groups-messaging

1. Groups network → Network Admin → Settings → **Message Groups**.

<img width="1440" height="840" alt="screenshot-1785924173223-1" src="https://github.com/user-attachments/assets/a13e10a3-5910-40b5-a11e-1cedc370f9ff" />

2. "Organisers only" + "All groups" → only editors/admins across every group site get it.
3. "All members" + one selected group → everyone on that site, nobody else.

<img width="1440" height="840" alt="screenshot-1785924205210-2" src="https://github.com/user-attachments/assets/7b7d68dc-85c6-4785-8e9f-5a13140bb681" />

4. Nothing sends on submit; run the batch with `wp cron event run wporg_groups_message_batch --url=<groups-network-url>`.

<img width="1440" height="840" alt="screenshot-1785924269843-3" src="https://github.com/user-attachments/assets/e86488ff-2915-4fbe-bafc-c4f318d93469" />

5. As a group organiser (not a network admin), the screen returns "Sorry, you are not allowed to access this page."
6. `phpunit --testsuite "WordCamp Groups"`