### PR TITLE
Groups: improve front-page information hierarchy

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
@@ -207,8 +207,9 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( 'Now quarterly.', get_option( 'blogdescription' ) );
 	}
 
-	// phpcs:disable Squiz.Commenting.FunctionComment.Missing
-
+	/**
+	 * Physical locations are normalized before being saved.
+	 */
 	public function test_editor_can_save_physical_location() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
@@ -237,6 +238,9 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( 'TR', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
 	}
 
+	/**
+	 * Online locations discard stale physical metadata.
+	 */
 	public function test_editor_can_save_online_location() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
@@ -254,6 +258,9 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
 	}
 
+	/**
+	 * An explicit null location clears all location metadata.
+	 */
 	public function test_editor_can_clear_location() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
@@ -269,6 +276,9 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
 	}
 
+	/**
+	 * Invalid location data prevents every requested field from being written.
+	 */
 	public function test_incomplete_physical_location_is_rejected_without_partial_updates() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
@@ -290,6 +300,9 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertNull( $this->dispatch( 'GET' )->get_data()['location'] );
 	}
 
+	/**
+	 * Omitting location leaves existing location metadata untouched.
+	 */
 	public function test_omitted_location_is_not_clobbered() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'online' );
@@ -298,6 +311,4 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 
 		$this->assertSame( array( 'type' => 'online' ), $this->dispatch( 'GET' )->get_data()['location'] );
 	}
-
-	// phpcs:enable Squiz.Commenting.FunctionComment.Missing
 }

--- a/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
@@ -207,9 +207,8 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( 'Now quarterly.', get_option( 'blogdescription' ) );
 	}
 
-	/**
-	 * An Organiser can save a physical group location.
-	 */
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+
 	public function test_editor_can_save_physical_location() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
@@ -238,9 +237,6 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( 'TR', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
 	}
 
-	/**
-	 * Online is a complete group location without platform details.
-	 */
 	public function test_editor_can_save_online_location() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
@@ -258,9 +254,6 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
 	}
 
-	/**
-	 * Null clears all location metadata and restores the unspecified state.
-	 */
 	public function test_editor_can_clear_location() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
@@ -276,9 +269,6 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
 	}
 
-	/**
-	 * Physical locations require a city and a recognized country.
-	 */
 	public function test_incomplete_physical_location_is_rejected_without_partial_updates() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
@@ -300,9 +290,6 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$this->assertNull( $this->dispatch( 'GET' )->get_data()['location'] );
 	}
 
-	/**
-	 * Omitting location leaves existing location metadata untouched.
-	 */
 	public function test_omitted_location_is_not_clobbered() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'online' );
@@ -311,4 +298,6 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 
 		$this->assertSame( array( 'type' => 'online' ), $this->dispatch( 'GET' )->get_data()['location'] );
 	}
+
+	// phpcs:enable Squiz.Commenting.FunctionComment.Missing
 }

--- a/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
@@ -311,4 +311,63 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 
 		$this->assertSame( array( 'type' => 'online' ), $this->dispatch( 'GET' )->get_data()['location'] );
 	}
+
+	/**
+	 * A country code that no longer resolves (e.g. CLDR data changed since
+	 * it was saved) is still returned, not collapsed to null. Otherwise the
+	 * About tab's form loses the selection, and the next save of any field
+	 * — even just the group name — would post `location: null` and silently
+	 * wipe the stored location via `clear_location()`.
+	 */
+	public function test_stale_country_code_is_still_returned() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'ZZ' );
+
+		$this->assertSame(
+			array(
+				'type'        => 'physical',
+				'city'        => 'Warsaw',
+				'countryCode' => 'ZZ',
+			),
+			$this->dispatch( 'GET' )->get_data()['location']
+		);
+	}
+
+	/**
+	 * This is the actual failure mode: the About tab always resubmits the
+	 * location it read, so an unrelated field edit (here, the title) round-
+	 * trips the stale country code straight back to the server. Before the
+	 * fix, the GET had already nulled it out, so this same request posted
+	 * `location: null` and `clear_location()` wiped it. Now `normalize_location()`
+	 * rejects the stale code atomically — the title isn't saved either, but
+	 * the stored location survives, so the user can fix or clear it instead
+	 * of losing it outright.
+	 */
+	public function test_resubmitting_stale_country_code_is_rejected_without_wiping_stored_location() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'ZZ' );
+
+		$response = $this->dispatch(
+			'POST',
+			array(
+				'title'    => 'This should not be saved either',
+				'location' => array(
+					'type'        => 'physical',
+					'city'        => 'Warsaw',
+					'countryCode' => 'ZZ',
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'wporg_groups_invalid_country', $response->get_data()['code'] );
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+		$this->assertSame( 'physical', get_site_meta( get_current_blog_id(), 'wporg_group_location_type', true ) );
+		$this->assertSame( 'Warsaw', get_site_meta( get_current_blog_id(), 'wporg_group_location_city', true ) );
+		$this->assertSame( 'ZZ', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
+	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
@@ -11,6 +11,7 @@ use function WordCamp\Groups\Frontend\REST\register_routes;
 defined( 'WPINC' ) || die();
 
 require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/capabilities.php';
+require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/group-location.php';
 require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/rest.php';
 
 /**
@@ -18,9 +19,9 @@ require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/rest.php';
  *
  * These exist because core's `/wp/v2/settings` gates `blogname` and
  * `blogdescription` behind `manage_options`, which Organisers don't have.
- * The routes hand Organisers write access to two options that the group
- * cannot restore from anywhere else in this UI, so the interesting cases
- * are the ones where a write should be refused.
+ * The routes hand Organisers write access to those options and the site's
+ * location metadata, so the interesting cases are the ones where a write
+ * should be refused or existing data should be preserved.
  *
  * @group mu-plugins
  * @group groups-frontend
@@ -46,6 +47,9 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 
 		update_option( 'blogname', 'Warsaw WordPress Group' );
 		update_option( 'blogdescription', 'We meet monthly.' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_type' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_country' );
 	}
 
 	/**
@@ -73,13 +77,12 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET' );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				'title'       => 'Warsaw WordPress Group',
-				'description' => 'We meet monthly.',
-			),
-			$response->get_data()
-		);
+		$data = $response->get_data();
+		$this->assertSame( 'Warsaw WordPress Group', $data['title'] );
+		$this->assertSame( 'We meet monthly.', $data['description'] );
+		$this->assertNull( $data['location'] );
+		$this->assertNotEmpty( $data['countries'] );
+		$this->assertContains( 'TR', wp_list_pluck( $data['countries'], 'code' ) );
 	}
 
 	/**
@@ -202,5 +205,110 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 
 		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
 		$this->assertSame( 'Now quarterly.', get_option( 'blogdescription' ) );
+	}
+
+	/**
+	 * An Organiser can save a physical group location.
+	 */
+	public function test_editor_can_save_physical_location() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch(
+			'POST',
+			array(
+				'location' => array(
+					'type'        => 'physical',
+					'city'        => 'İstanbul',
+					'countryCode' => 'tr',
+				),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'type'        => 'physical',
+				'city'        => 'İstanbul',
+				'countryCode' => 'TR',
+			),
+			$response->get_data()['location']
+		);
+		$this->assertSame( 'physical', get_site_meta( get_current_blog_id(), 'wporg_group_location_type', true ) );
+		$this->assertSame( 'İstanbul', get_site_meta( get_current_blog_id(), 'wporg_group_location_city', true ) );
+		$this->assertSame( 'TR', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
+	}
+
+	/**
+	 * Online is a complete group location without platform details.
+	 */
+	public function test_editor_can_save_online_location() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'PL' );
+
+		$response = $this->dispatch(
+			'POST',
+			array( 'location' => array( 'type' => 'online' ) )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'type' => 'online' ), $response->get_data()['location'] );
+		$this->assertSame( 'online', get_site_meta( get_current_blog_id(), 'wporg_group_location_type', true ) );
+		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_city', true ) );
+		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
+	}
+
+	/**
+	 * Null clears all location metadata and restores the unspecified state.
+	 */
+	public function test_editor_can_clear_location() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'PL' );
+
+		$response = $this->dispatch( 'POST', array( 'location' => null ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $response->get_data()['location'] );
+		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_type', true ) );
+		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_city', true ) );
+		$this->assertSame( '', get_site_meta( get_current_blog_id(), 'wporg_group_location_country', true ) );
+	}
+
+	/**
+	 * Physical locations require a city and a recognized country.
+	 */
+	public function test_incomplete_physical_location_is_rejected_without_partial_updates() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->dispatch(
+			'POST',
+			array(
+				'title'    => 'This should not be saved',
+				'location' => array(
+					'type'        => 'physical',
+					'city'        => '',
+					'countryCode' => 'PL',
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'wporg_groups_incomplete_location', $response->get_data()['code'] );
+		$this->assertSame( 'Warsaw WordPress Group', get_option( 'blogname' ) );
+		$this->assertNull( $this->dispatch( 'GET' )->get_data()['location'] );
+	}
+
+	/**
+	 * Omitting location leaves existing location metadata untouched.
+	 */
+	public function test_omitted_location_is_not_clobbered() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'online' );
+
+		$this->dispatch( 'POST', array( 'description' => 'Now quarterly.' ) );
+
+		$this->assertSame( array( 'type' => 'online' ), $this->dispatch( 'GET' )->get_data()['location'] );
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/blocks.php
@@ -29,6 +29,7 @@ function register_blocks(): void {
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-settings' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-location' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-membership' );
+	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-news' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-members' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/event-speakers' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/my-events' );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/blocks.php
@@ -27,6 +27,7 @@ function register_blocks(): void {
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/event-rsvp' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/event-manage' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-settings' );
+	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-location' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-membership' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/group-members' );
 	register_block_type_from_metadata( dirname( __DIR__ ) . '/build/blocks/event-speakers' );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -65,26 +65,8 @@ function get_country_options(): array {
 	);
 }
 
-/**
- * Normalize and validate a location supplied by an organizer.
- *
- * Null explicitly means that the existing location should be cleared.
- *
- * @return array|WP_Error|null
- */
-function normalize_location( $location ) {
-	if ( null === $location ) {
-		return null;
-	}
-
-	if ( ! is_array( $location ) ) {
-		return new WP_Error(
-			'wporg_groups_invalid_location',
-			__( 'Location must be an object or null.', 'wporg-groups-frontend' ),
-			array( 'status' => 400 )
-		);
-	}
-
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function normalize_location( array $location ): array|WP_Error {
 	$type = sanitize_key( $location['type'] ?? '' );
 
 	if ( TYPE_ONLINE === $type ) {
@@ -124,28 +106,9 @@ function normalize_location( $location ) {
 		'countryCode' => $country_code,
 	);
 }
-
-/**
- * Save or clear the current group's location.
- *
- * @return array|WP_Error|null The normalized saved value.
- */
-function save_location( $location ) {
-	$location = normalize_location( $location );
-
-	if ( is_wp_error( $location ) ) {
-		return $location;
-	}
-
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function save_location( array $location ): void {
 	$site_id = get_current_blog_id();
-
-	if ( null === $location ) {
-		delete_site_meta( $site_id, TYPE_META_KEY );
-		delete_site_meta( $site_id, CITY_META_KEY );
-		delete_site_meta( $site_id, COUNTRY_META_KEY );
-
-		return null;
-	}
 
 	update_site_meta( $site_id, TYPE_META_KEY, $location['type'] );
 
@@ -153,13 +116,20 @@ function save_location( $location ) {
 		delete_site_meta( $site_id, CITY_META_KEY );
 		delete_site_meta( $site_id, COUNTRY_META_KEY );
 
-		return $location;
+		return;
 	}
 
 	update_site_meta( $site_id, CITY_META_KEY, $location['city'] );
 	update_site_meta( $site_id, COUNTRY_META_KEY, $location['countryCode'] );
+}
 
-	return $location;
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function clear_location(): void {
+	$site_id = get_current_blog_id();
+
+	delete_site_meta( $site_id, TYPE_META_KEY );
+	delete_site_meta( $site_id, CITY_META_KEY );
+	delete_site_meta( $site_id, COUNTRY_META_KEY );
 }
 
 // phpcs:ignore Squiz.Commenting.FunctionComment.Missing

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -112,6 +112,7 @@ function normalize_location( array $location ): array|WP_Error {
 		'countryCode' => $country_code,
 	);
 }
+
 /**
  * Persist a normalized location for the current group.
  *

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -22,12 +22,7 @@ const TYPE_PHYSICAL = 'physical';
 const TYPE_ONLINE   = 'online';
 
 /**
- * Get the current group's location.
- *
  * Missing or incomplete metadata is treated as an unspecified location.
- *
- * @param int $site_id Site ID. Defaults to the current site.
- * @return array|null Normalized location, or null when it is not specified.
  */
 function get_location( int $site_id = 0 ): ?array {
 	$site_id = $site_id ?: get_current_blog_id();
@@ -55,11 +50,7 @@ function get_location( int $site_id = 0 ): ?array {
 	);
 }
 
-/**
- * Get the country options used by the organizer settings form.
- *
- * @return array[] Each option has a `code` and localized `name`.
- */
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 function get_country_options(): array {
 	return array_values(
 		array_map(
@@ -79,7 +70,6 @@ function get_country_options(): array {
  *
  * Null explicitly means that the existing location should be cleared.
  *
- * @param mixed $location Submitted location.
  * @return array|WP_Error|null
  */
 function normalize_location( $location ) {
@@ -138,7 +128,6 @@ function normalize_location( $location ) {
 /**
  * Save or clear the current group's location.
  *
- * @param mixed $location Submitted location.
  * @return array|WP_Error|null The normalized saved value.
  */
 function save_location( $location ) {
@@ -173,9 +162,7 @@ function save_location( $location ) {
 	return $location;
 }
 
-/**
- * Get the public label shown in the group header.
- */
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 function get_location_label(): string {
 	$location = get_location();
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Group-level location data.
+ *
+ * A location belongs to the group site, rather than to any particular event.
+ * Event venues and online access details remain in GatherPress.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+namespace WordCamp\Groups\Frontend\Group_Location;
+
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+const TYPE_META_KEY    = 'wporg_group_location_type';
+const CITY_META_KEY    = 'wporg_group_location_city';
+const COUNTRY_META_KEY = 'wporg_group_location_country';
+
+const TYPE_PHYSICAL = 'physical';
+const TYPE_ONLINE   = 'online';
+
+/**
+ * Get the current group's location.
+ *
+ * Missing or incomplete metadata is treated as an unspecified location.
+ *
+ * @param int $site_id Site ID. Defaults to the current site.
+ * @return array|null Normalized location, or null when it is not specified.
+ */
+function get_location( int $site_id = 0 ): ?array {
+	$site_id = $site_id ?: get_current_blog_id();
+	$type    = (string) get_site_meta( $site_id, TYPE_META_KEY, true );
+
+	if ( TYPE_ONLINE === $type ) {
+		return array( 'type' => TYPE_ONLINE );
+	}
+
+	if ( TYPE_PHYSICAL !== $type ) {
+		return null;
+	}
+
+	$city         = trim( (string) get_site_meta( $site_id, CITY_META_KEY, true ) );
+	$country_code = strtoupper( (string) get_site_meta( $site_id, COUNTRY_META_KEY, true ) );
+
+	if ( '' === $city || '' === $country_code || ! wcorg_get_country_name_from_code( $country_code ) ) {
+		return null;
+	}
+
+	return array(
+		'type'        => TYPE_PHYSICAL,
+		'city'        => $city,
+		'countryCode' => $country_code,
+	);
+}
+
+/**
+ * Get the country options used by the organizer settings form.
+ *
+ * @return array[] Each option has a `code` and localized `name`.
+ */
+function get_country_options(): array {
+	return array_values(
+		array_map(
+			static function ( array $country ): array {
+				return array(
+					'code' => $country['alpha2'],
+					'name' => $country['name'],
+				);
+			},
+			wcorg_get_countries()
+		)
+	);
+}
+
+/**
+ * Normalize and validate a location supplied by an organizer.
+ *
+ * Null explicitly means that the existing location should be cleared.
+ *
+ * @param mixed $location Submitted location.
+ * @return array|WP_Error|null
+ */
+function normalize_location( $location ) {
+	if ( null === $location ) {
+		return null;
+	}
+
+	if ( ! is_array( $location ) ) {
+		return new WP_Error(
+			'wporg_groups_invalid_location',
+			__( 'Location must be an object or null.', 'wporg-groups-frontend' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$type = sanitize_key( $location['type'] ?? '' );
+
+	if ( TYPE_ONLINE === $type ) {
+		return array( 'type' => TYPE_ONLINE );
+	}
+
+	if ( TYPE_PHYSICAL !== $type ) {
+		return new WP_Error(
+			'wporg_groups_invalid_location_type',
+			__( 'Choose an in-person or online location.', 'wporg-groups-frontend' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$city         = trim( sanitize_text_field( $location['city'] ?? '' ) );
+	$country_code = strtoupper( sanitize_text_field( $location['countryCode'] ?? '' ) );
+
+	if ( '' === $city || '' === $country_code ) {
+		return new WP_Error(
+			'wporg_groups_incomplete_location',
+			__( 'City and country are required for an in-person group.', 'wporg-groups-frontend' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( ! wcorg_get_country_name_from_code( $country_code ) ) {
+		return new WP_Error(
+			'wporg_groups_invalid_country',
+			__( 'Choose a valid country.', 'wporg-groups-frontend' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	return array(
+		'type'        => TYPE_PHYSICAL,
+		'city'        => $city,
+		'countryCode' => $country_code,
+	);
+}
+
+/**
+ * Save or clear the current group's location.
+ *
+ * @param mixed $location Submitted location.
+ * @return array|WP_Error|null The normalized saved value.
+ */
+function save_location( $location ) {
+	$location = normalize_location( $location );
+
+	if ( is_wp_error( $location ) ) {
+		return $location;
+	}
+
+	$site_id = get_current_blog_id();
+
+	if ( null === $location ) {
+		delete_site_meta( $site_id, TYPE_META_KEY );
+		delete_site_meta( $site_id, CITY_META_KEY );
+		delete_site_meta( $site_id, COUNTRY_META_KEY );
+
+		return null;
+	}
+
+	update_site_meta( $site_id, TYPE_META_KEY, $location['type'] );
+
+	if ( TYPE_ONLINE === $location['type'] ) {
+		delete_site_meta( $site_id, CITY_META_KEY );
+		delete_site_meta( $site_id, COUNTRY_META_KEY );
+
+		return $location;
+	}
+
+	update_site_meta( $site_id, CITY_META_KEY, $location['city'] );
+	update_site_meta( $site_id, COUNTRY_META_KEY, $location['countryCode'] );
+
+	return $location;
+}
+
+/**
+ * Get the public label shown in the group header.
+ */
+function get_location_label(): string {
+	$location = get_location();
+
+	if ( null === $location ) {
+		return '';
+	}
+
+	if ( TYPE_ONLINE === $location['type'] ) {
+		return __( 'Online', 'wporg-groups-frontend' );
+	}
+
+	$country_name = wcorg_get_country_name_from_code( $location['countryCode'] );
+
+	return sprintf(
+		/* translators: 1: city name, 2: country name. */
+		__( '%1$s, %2$s', 'wporg-groups-frontend' ),
+		$location['city'],
+		$country_name
+	);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -22,7 +22,13 @@ const TYPE_PHYSICAL = 'physical';
 const TYPE_ONLINE   = 'online';
 
 /**
- * Missing or incomplete metadata is treated as an unspecified location.
+ * Missing metadata is treated as an unspecified location.
+ *
+ * A stored country code that no longer resolves to a name (e.g. CLDR data
+ * changed) is still returned rather than collapsed to null here: the About
+ * tab builds its form from this response, and a null location would make
+ * the next save of any field — even just the group name — post
+ * `location: null` and silently wipe the type, city, and country.
  */
 function get_location( int $site_id = 0 ): ?array {
 	$site_id = $site_id ?: get_current_blog_id();
@@ -39,7 +45,7 @@ function get_location( int $site_id = 0 ): ?array {
 	$city         = trim( (string) get_site_meta( $site_id, CITY_META_KEY, true ) );
 	$country_code = strtoupper( (string) get_site_meta( $site_id, COUNTRY_META_KEY, true ) );
 
-	if ( '' === $city || '' === $country_code || ! wcorg_get_country_name_from_code( $country_code ) ) {
+	if ( '' === $city || '' === $country_code ) {
 		return null;
 	}
 
@@ -160,6 +166,10 @@ function get_location_label(): string {
 	}
 
 	$country_name = wcorg_get_country_name_from_code( $location['countryCode'] );
+
+	if ( '' === $country_name ) {
+		return $location['city'];
+	}
 
 	return sprintf(
 		/* translators: 1: city name, 2: country name. */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -50,7 +50,9 @@ function get_location( int $site_id = 0 ): ?array {
 	);
 }
 
-// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+/**
+ * Build localized country options for the group settings form.
+ */
 function get_country_options(): array {
 	return array_values(
 		array_map(
@@ -65,7 +67,11 @@ function get_country_options(): array {
 	);
 }
 
-// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+/**
+ * Normalize and validate a submitted location.
+ *
+ * Online locations contain only their type; physical locations require a city and recognized country.
+ */
 function normalize_location( array $location ): array|WP_Error {
 	$type = sanitize_key( $location['type'] ?? '' );
 
@@ -106,7 +112,11 @@ function normalize_location( array $location ): array|WP_Error {
 		'countryCode' => $country_code,
 	);
 }
-// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+/**
+ * Persist a normalized location for the current group.
+ *
+ * Saving an online location removes any stale city and country metadata.
+ */
 function save_location( array $location ): void {
 	$site_id = get_current_blog_id();
 
@@ -123,7 +133,9 @@ function save_location( array $location ): void {
 	update_site_meta( $site_id, COUNTRY_META_KEY, $location['countryCode'] );
 }
 
-// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+/**
+ * Remove all location metadata for the current group.
+ */
 function clear_location(): void {
 	$site_id = get_current_blog_id();
 
@@ -132,7 +144,9 @@ function clear_location(): void {
 	delete_site_meta( $site_id, COUNTRY_META_KEY );
 }
 
-// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+/**
+ * Build the public location label, or an empty string when unspecified.
+ */
 function get_location_label(): string {
 	$location = get_location();
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -17,9 +17,9 @@
  *
  *   GET  /group-info
  *   POST /group-info
- *        Reads and writes the group's name and description. Exists because
- *        core's /wp/v2/settings requires `manage_options`, which Organisers
- *        (editors) do not have.
+ *        Reads and writes the group's name, description, and location.
+ *        Exists because core's /wp/v2/settings requires `manage_options`,
+ *        which Organisers (editors) do not have.
  *
  * The event routes require the `current_user_can_manage_events()` capability,
  * plus post-specific capabilities when operating on an existing event. The
@@ -47,6 +47,10 @@ use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group
 use function WordCamp\Groups\Frontend\Defaults\extract_description_blocks;
 use function WordCamp\Groups\Frontend\Defaults\get_default_event_data;
 use function WordCamp\Groups\Frontend\Defaults\get_event_venue_post_id;
+use function WordCamp\Groups\Frontend\Group_Location\get_country_options;
+use function WordCamp\Groups\Frontend\Group_Location\get_location;
+use function WordCamp\Groups\Frontend\Group_Location\normalize_location;
+use function WordCamp\Groups\Frontend\Group_Location\save_location;
 
 const NAMESPACE_V1 = 'wporg-groups/v1';
 
@@ -182,10 +186,11 @@ function register_routes(): void {
 
 	// ----- Group info -----------------------------------------------------
 	//
-	// The Settings > About tab edits `blogname` and `blogdescription`. Core's
+	// The Settings > About tab edits `blogname`, `blogdescription`, and the
+	// group-level location. Core's
 	// /wp/v2/settings gates both behind `manage_options`, which only network
 	// administrators have, so Organisers got a 403 on every read and write.
-	// These routes expose just those two fields, behind the same capability
+	// These routes expose just those group fields, behind the same capability
 	// check that gates the settings UI itself.
 
 	register_rest_route(
@@ -212,6 +217,12 @@ function register_routes(): void {
 						'required'          => false,
 						'sanitize_callback' => 'sanitize_text_field',
 					),
+					'location'    => array(
+						'required'          => false,
+						'validate_callback' => static function ( $location ) {
+							return null === $location || is_array( $location );
+						},
+					),
 				),
 			),
 		)
@@ -226,19 +237,21 @@ function manage_group_settings_permissions_check(): bool {
 }
 
 /**
- * Return the group's name and description.
+ * Return the group's name, description, location, and location form options.
  */
 function get_group_info(): WP_REST_Response {
 	return new WP_REST_Response(
 		array(
 			'title'       => get_option( 'blogname', '' ),
 			'description' => get_option( 'blogdescription', '' ),
+			'location'    => get_location(),
+			'countries'   => get_country_options(),
 		)
 	);
 }
 
 /**
- * Update the group's name and description.
+ * Update the group's name, description, and location.
  *
  * Only the fields present in the request are written, so a client can send
  * one without clobbering the other.
@@ -246,8 +259,10 @@ function get_group_info(): WP_REST_Response {
  * @return WP_Error|WP_REST_Response
  */
 function update_group_info( WP_REST_Request $request ) {
-	$title       = $request->get_param( 'title' );
-	$description = $request->get_param( 'description' );
+	$title        = $request->get_param( 'title' );
+	$description  = $request->get_param( 'description' );
+	$has_location = $request->has_param( 'location' );
+	$location     = null;
 
 	// An empty group name is not recoverable from this UI: the next load
 	// returns the blank value, so there is nothing left to restore it from.
@@ -257,12 +272,24 @@ function update_group_info( WP_REST_Request $request ) {
 		return new WP_Error( 'wporg_groups_empty_group_name', 'Group name is required.', array( 'status' => 400 ) );
 	}
 
+	if ( $has_location ) {
+		$location = normalize_location( $request->get_param( 'location' ) );
+
+		if ( is_wp_error( $location ) ) {
+			return $location;
+		}
+	}
+
 	if ( null !== $title ) {
 		update_option( 'blogname', $title );
 	}
 
 	if ( null !== $description ) {
 		update_option( 'blogdescription', $description );
+	}
+
+	if ( $has_location ) {
+		save_location( $location );
 	}
 
 	return get_group_info();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -185,13 +185,6 @@ function register_routes(): void {
 	);
 
 	// ----- Group info -----------------------------------------------------
-	//
-	// The Settings > About tab edits `blogname`, `blogdescription`, and the
-	// group-level location. Core's
-	// /wp/v2/settings gates both behind `manage_options`, which only network
-	// administrators have, so Organisers got a 403 on every read and write.
-	// These routes expose just those group fields, behind the same capability
-	// check that gates the settings UI itself.
 
 	register_rest_route(
 		NAMESPACE_V1,
@@ -236,9 +229,7 @@ function manage_group_settings_permissions_check(): bool {
 	return current_user_can_manage_group_settings();
 }
 
-/**
- * Return the group's name, description, location, and location form options.
- */
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 function get_group_info(): WP_REST_Response {
 	return new WP_REST_Response(
 		array(
@@ -251,10 +242,7 @@ function get_group_info(): WP_REST_Response {
 }
 
 /**
- * Update the group's name, description, and location.
- *
- * Only the fields present in the request are written, so a client can send
- * one without clobbering the other.
+ * Only fields present in the request are written.
  *
  * @return WP_Error|WP_REST_Response
  */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -230,7 +230,9 @@ function manage_group_settings_permissions_check(): bool {
 	return current_user_can_manage_group_settings();
 }
 
-// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+/**
+ * Return the editable group details and location options.
+ */
 function get_group_info(): WP_REST_Response {
 	return new WP_REST_Response(
 		array(

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -18,8 +18,6 @@
  *   GET  /group-info
  *   POST /group-info
  *        Reads and writes the group's name, description, and location.
- *        Exists because core's /wp/v2/settings requires `manage_options`,
- *        which Organisers (editors) do not have.
  *
  * The event routes require the `current_user_can_manage_events()` capability,
  * plus post-specific capabilities when operating on an existing event. The
@@ -186,6 +184,10 @@ function register_routes(): void {
 	);
 
 	// ----- Group info -----------------------------------------------------
+	//
+	// Organisers cannot use core's /wp/v2/settings endpoint because it requires
+	// `manage_options`. Expose only the fields managed by this UI behind the
+	// group-settings capability instead.
 
 	register_rest_route(
 		NAMESPACE_V1,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -47,6 +47,7 @@ use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group
 use function WordCamp\Groups\Frontend\Defaults\extract_description_blocks;
 use function WordCamp\Groups\Frontend\Defaults\get_default_event_data;
 use function WordCamp\Groups\Frontend\Defaults\get_event_venue_post_id;
+use function WordCamp\Groups\Frontend\Group_Location\clear_location;
 use function WordCamp\Groups\Frontend\Group_Location\get_country_options;
 use function WordCamp\Groups\Frontend\Group_Location\get_location;
 use function WordCamp\Groups\Frontend\Group_Location\normalize_location;
@@ -261,10 +262,14 @@ function update_group_info( WP_REST_Request $request ) {
 	}
 
 	if ( $has_location ) {
-		$location = normalize_location( $request->get_param( 'location' ) );
+		$location = $request->get_param( 'location' );
 
-		if ( is_wp_error( $location ) ) {
-			return $location;
+		if ( null !== $location ) {
+			$location = normalize_location( $location );
+
+			if ( is_wp_error( $location ) ) {
+				return $location;
+			}
 		}
 	}
 
@@ -277,7 +282,11 @@ function update_group_info( WP_REST_Request $request ) {
 	}
 
 	if ( $has_location ) {
-		save_location( $location );
+		if ( null === $location ) {
+			clear_location();
+		} else {
+			save_location( $location );
+		}
 	}
 
 	return get_group_info();

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/block.json
@@ -13,6 +13,10 @@
 			"type": "string",
 			"default": "auto",
 			"enum": [ "auto", "create", "edit" ]
+		},
+		"showHeading": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/block.json
@@ -13,10 +13,6 @@
 			"type": "string",
 			"default": "auto",
 			"enum": [ "auto", "create", "edit" ]
-		},
-		"showHeading": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"supports": {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
@@ -54,6 +54,12 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php if ( ! empty( $attributes['showHeading'] ) ) : ?>
+		<h2 class="wporg-event-manage__heading">
+			<?php esc_html_e( 'Organiser tools', 'wporg-groups-frontend' ); ?>
+		</h2>
+	<?php endif; ?>
+
 	<?php if ( $show_edit_button && $event_post_id ) : ?>
 		<button
 			type="button"

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/render.php
@@ -50,47 +50,49 @@ if ( ! $show_edit && ! $show_create ) {
 }
 
 $wrapper_attributes = get_block_wrapper_attributes(
-	array( 'class' => 'wporg-event-manage' )
+	array( 'class' => 'wp-block-buttons wporg-event-manage' )
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<?php if ( ! empty( $attributes['showHeading'] ) ) : ?>
-		<h2 class="wporg-event-manage__heading">
-			<?php esc_html_e( 'Organiser tools', 'wporg-groups-frontend' ); ?>
-		</h2>
-	<?php endif; ?>
-
 	<?php if ( $show_edit_button && $event_post_id ) : ?>
-		<button
-			type="button"
-			class="wporg-event-manage__button wporg-event-manage__button--edit wp-element-button"
-			data-wporg-groups-modal="edit"
-			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
-		>&#9998; <?php esc_html_e( 'Edit this event', 'wporg-groups-frontend' ); ?></button>
+		<div class="wp-block-button is-style-outline">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button"
+				data-wporg-groups-modal="edit"
+				data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
+			>&#9998; <?php esc_html_e( 'Edit this event', 'wporg-groups-frontend' ); ?></button>
+		</div>
 	<?php endif; ?>
 
 	<?php if ( $show_edit && $event_post_id ) : ?>
-		<button
-			type="button"
-			class="wporg-event-manage__button wporg-event-manage__button--message wp-element-button"
-			data-wporg-groups-modal="message-all"
-			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
-		><?php esc_html_e( 'Message all members', 'wporg-groups-frontend' ); ?></button>
+		<div class="wp-block-button is-style-outline">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button"
+				data-wporg-groups-modal="message-all"
+				data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
+			><?php esc_html_e( 'Message all members', 'wporg-groups-frontend' ); ?></button>
+		</div>
 
-		<button
-			type="button"
-			class="wporg-event-manage__button wporg-event-manage__button--message wp-element-button"
-			data-wporg-groups-modal="message-attendees"
-			data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
-		><?php esc_html_e( 'Message attendees', 'wporg-groups-frontend' ); ?></button>
+		<div class="wp-block-button is-style-outline">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button"
+				data-wporg-groups-modal="message-attendees"
+				data-wporg-groups-event-id="<?php echo (int) $event_post_id; ?>"
+			><?php esc_html_e( 'Message attendees', 'wporg-groups-frontend' ); ?></button>
+		</div>
 	<?php endif; ?>
 
 	<?php if ( $show_create ) : ?>
-		<button
-			type="button"
-			class="wporg-event-manage__button wporg-event-manage__button--create wp-element-button"
-			data-wporg-groups-modal="create"
-		>+ <?php esc_html_e( 'Create event', 'wporg-groups-frontend' ); ?></button>
+		<div class="wp-block-button">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button"
+				data-wporg-groups-modal="create"
+			>+ <?php esc_html_e( 'Create event', 'wporg-groups-frontend' ); ?></button>
+		</div>
 	<?php endif; ?>
 
 	<div id="wporg-groups-event-modal-root"></div>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -21,10 +21,6 @@
 	cursor: pointer;
 }
 
-/* The primary CTA — same shape as every secondary button here, but filled
-   with the theme's default button color (theme.json's blueberry-1/white/
-   deep-blueberry-hover) made explicit so it doesn't depend on `wp-element-
-   button` load order. */
 .wporg-event-manage__button--create {
 	background: var(--wp--preset--color--blueberry-1, #3858e9);
 	border-color: var(--wp--preset--color--blueberry-1, #3858e9);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -2,60 +2,6 @@
  * WPorg Groups Frontend — event manage block + modal styles.
  */
 
-/* === Trigger buttons === */
-
-.wporg-event-manage {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-
-.wporg-event-manage__button {
-	box-sizing: border-box;
-	padding: 10px 22px;
-	border: 1px solid transparent;
-	border-radius: 2px;
-	font-size: 14px;
-	font-weight: 600;
-	line-height: 1.3;
-	cursor: pointer;
-}
-
-.wporg-event-manage__button--create {
-	background: var(--wp--preset--color--blueberry-1, #3858e9);
-	border-color: var(--wp--preset--color--blueberry-1, #3858e9);
-	color: var(--wp--preset--color--white, #fff);
-}
-
-.wporg-event-manage__button--create:hover {
-	background: var(--wp--preset--color--deep-blueberry, #213fd4);
-	border-color: var(--wp--preset--color--deep-blueberry, #213fd4);
-}
-
-.wporg-event-manage__button--edit {
-	background: transparent !important;
-	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9) !important;
-	color: var(--wp--preset--color--charcoal-3, #40464d) !important;
-}
-
-.wporg-event-manage__button--edit:hover {
-	border-color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
-	color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
-	background: var(--wp--preset--color--blueberry-4, #eff2ff) !important;
-}
-
-.wporg-event-manage__button--message {
-	background: transparent !important;
-	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9) !important;
-	color: var(--wp--preset--color--charcoal-3, #40464d) !important;
-}
-
-.wporg-event-manage__button--message:hover {
-	border-color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
-	color: var(--wp--preset--color--blueberry-1, #3858e9) !important;
-	background: var(--wp--preset--color--blueberry-4, #eff2ff) !important;
-}
-
 /* === Message members modal === */
 
 .wporg-groups-message-modal .components-modal__content {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -11,8 +11,29 @@
 }
 
 .wporg-event-manage__button {
+	box-sizing: border-box;
+	padding: 10px 22px;
+	border: 1px solid transparent;
+	border-radius: 2px;
 	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.3;
 	cursor: pointer;
+}
+
+/* The primary CTA — same shape as every secondary button here, but filled
+   with the theme's default button color (theme.json's blueberry-1/white/
+   deep-blueberry-hover) made explicit so it doesn't depend on `wp-element-
+   button` load order. */
+.wporg-event-manage__button--create {
+	background: var(--wp--preset--color--blueberry-1, #3858e9);
+	border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+	color: var(--wp--preset--color--white, #fff);
+}
+
+.wporg-event-manage__button--create:hover {
+	background: var(--wp--preset--color--deep-blueberry, #213fd4);
+	border-color: var(--wp--preset--color--deep-blueberry, #213fd4);
 }
 
 .wporg-event-manage__button--edit {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -185,28 +185,35 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	</button>
 
 	<?php if ( ! $is_past ) : ?>
-		<button
-			type="button"
-			class="wporg-event-rsvp__button wp-element-button<?php echo $is_attending ? ' is-attending' : ''; ?>"
-			data-wp-on--click="actions.handleRsvpButton"
-			data-wp-text="state.rsvpButtonLabel"
-			data-wp-class--is-attending="state.isAttending"
-			data-wp-bind--disabled="context.rsvpLoading"
+		<div
+			class="wp-block-button<?php echo $is_attending ? ' is-style-outline' : ''; ?>"
+			data-wp-class--is-style-outline="state.isAttending"
 		>
-			<?php
-			if ( $is_attending ) {
-				echo "\u{2713} " . esc_html__( 'Attending', 'wporg-groups-frontend' );
-			} elseif ( $is_member ) {
-				esc_html_e( 'RSVP', 'wporg-groups-frontend' );
-			} else {
-				esc_html_e( 'Join & RSVP', 'wporg-groups-frontend' );
-			}
-			?>
-		</button>
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button<?php echo $is_attending ? ' is-attending' : ''; ?>"
+				data-wp-on--click="actions.handleRsvpButton"
+				data-wp-text="state.rsvpButtonLabel"
+				data-wp-class--is-attending="state.isAttending"
+				data-wp-bind--disabled="context.rsvpLoading"
+			>
+				<?php
+				if ( $is_attending ) {
+					echo "\u{2713} " . esc_html__( 'Attending', 'wporg-groups-frontend' );
+				} elseif ( $is_member ) {
+					esc_html_e( 'RSVP', 'wporg-groups-frontend' );
+				} else {
+					esc_html_e( 'Join & RSVP', 'wporg-groups-frontend' );
+				}
+				?>
+			</button>
+		</div>
 	<?php else : ?>
-		<button type="button" class="wporg-event-rsvp__button wp-element-button is-past" disabled>
-			<?php esc_html_e( 'Past Event', 'wporg-groups-frontend' ); ?>
-		</button>
+		<div class="wp-block-button is-style-outline">
+			<button type="button" class="wp-block-button__link wp-element-button is-past" disabled>
+				<?php esc_html_e( 'Past Event', 'wporg-groups-frontend' ); ?>
+			</button>
+		</div>
 	<?php endif; ?>
 
 	<p

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
@@ -67,23 +67,27 @@
 }
 
 /* === RSVP button === */
-.wporg-event-rsvp__button {
+.wp-block-wporg-event-rsvp .wp-block-button {
 	width: 100%;
+}
+
+.wp-block-wporg-event-rsvp .wp-block-button__link {
+	width: 100%;
+	text-align: center;
 	justify-content: center;
-	margin-bottom: 0;
 }
 
-.wporg-event-rsvp__button.is-attending {
-	background: #e2ffed;
-	color: #1a1919;
-	border: 1px solid #33f078;
+.wp-block-wporg-event-rsvp .wp-block-button__link.is-attending {
+	background: var(--wp--preset--color--acid-green-3, #e2ffed);
+	color: var(--wp--preset--color--charcoal-0, #1a1919);
+	border: 1px solid var(--wp--preset--color--acid-green-1, #33f078);
 }
 
-.wporg-event-rsvp__button.is-attending:hover {
+.wp-block-wporg-event-rsvp .wp-block-button__link.is-attending:hover {
 	background: #c8f5d9;
 }
 
-.wporg-event-rsvp__button.is-past {
+.wp-block-wporg-event-rsvp .wp-block-button__link.is-past {
 	opacity: 0.5;
 	cursor: not-allowed;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wporg/group-location",
+	"version": "1.0.0",
+	"title": "Group Location",
+	"category": "widgets",
+	"icon": "location",
+	"description": "Displays the group's location when one has been specified.",
+	"supports": {
+		"html": false,
+		"inserter": false,
+		"color": {
+			"text": true,
+			"background": false
+		},
+		"typography": {
+			"fontSize": true
+		},
+		"spacing": {
+			"margin": true
+		}
+	},
+	"render": "file:./render.php",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/index.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/index.js
@@ -1,0 +1,20 @@
+import { registerBlockType } from '@wordpress/blocks';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+import metadata from './block.json';
+import './style.css';
+
+function Edit( { attributes } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender block={ metadata.name } attributes={ attributes } />
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/render.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Server-side rendering for the wporg/group-location block.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+use function WordCamp\Groups\Frontend\Group_Location\get_location_label;
+
+$location_label = get_location_label();
+
+if ( '' === $location_label ) {
+	return;
+}
+?>
+<p <?php echo get_block_wrapper_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by core. ?>>
+	<svg class="wporg-group-location__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+		<path d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7Zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5Z"/>
+	</svg>
+	<?php echo esc_html( $location_label ); ?>
+</p>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/style.css
@@ -1,0 +1,12 @@
+.wp-block-wporg-group-location {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.wporg-group-location__icon {
+	width: 1em;
+	height: 1em;
+	flex: 0 0 auto;
+	fill: currentColor;
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/block.json
@@ -19,6 +19,10 @@
 		"showPreference": {
 			"type": "boolean",
 			"default": true
+		},
+		"showHeadings": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/block.json
@@ -7,6 +7,20 @@
 	"category": "widgets",
 	"icon": "groups",
 	"description": "Displays a join/leave button for group membership.",
+	"attributes": {
+		"showIdentity": {
+			"type": "boolean",
+			"default": true
+		},
+		"showLeave": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPreference": {
+			"type": "boolean",
+			"default": true
+		}
+	},
 	"supports": {
 		"html": false,
 		"interactivity": true,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/block.json
@@ -6,23 +6,12 @@
 	"title": "Group Membership",
 	"category": "widgets",
 	"icon": "groups",
-	"description": "Displays a join/leave button for group membership.",
+	"description": "Displays group membership controls or event email preferences.",
 	"attributes": {
-		"showIdentity": {
-			"type": "boolean",
-			"default": true
-		},
-		"showLeave": {
-			"type": "boolean",
-			"default": true
-		},
-		"showPreference": {
-			"type": "boolean",
-			"default": true
-		},
-		"showHeadings": {
-			"type": "boolean",
-			"default": false
+		"variant": {
+			"type": "string",
+			"enum": [ "combined", "membership", "preference" ],
+			"default": "combined"
 		}
 	},
 	"supports": {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -2,8 +2,29 @@
 /**
  * Server-side rendering for the wporg/group-membership block.
  *
+ * The block renders a set of independently toggleable parts, so the same
+ * interactivity store and REST wiring can back placements that answer quite
+ * different questions:
+ *
+ *   - `showIdentity` (default true) — the join button for visitors, or the
+ *     role badge plus member count for members. Answers "what is this group
+ *     and am I in it?", which is what earns hero placement.
+ *   - `showLeave` — the "Leave group" action. Destructive account management,
+ *     not identity, so it sits with the member directory rather than the hero.
+ *   - `showPreference` — the GatherPress event-email opt-in. Stored as
+ *     `gatherpress_event_updates_opt_in` usermeta, which on multisite is
+ *     shared across the whole install: this toggle is not scoped to the group
+ *     rendering it. It therefore belongs with the member's own content
+ *     (alongside `wporg/my-events`, which is gated on the same
+ *     logged-in-and-a-member condition) rather than anywhere that reads as a
+ *     property of this particular group.
+ *
  * @package WordCamp\Groups\Frontend
  */
+
+$show_identity   = ! isset( $attributes['showIdentity'] ) || ! empty( $attributes['showIdentity'] );
+$show_leave      = ! isset( $attributes['showLeave'] ) || ! empty( $attributes['showLeave'] );
+$show_preference = ! isset( $attributes['showPreference'] ) || ! empty( $attributes['showPreference'] );
 
 $is_logged_in = is_user_logged_in();
 $is_member    = $is_logged_in && is_user_member_of_blog();
@@ -26,7 +47,22 @@ if ( $is_member ) {
 // Only logged-in visitors can join or leave, and only their markup should carry a nonce.
 $rest_nonce = $is_logged_in ? wp_create_nonce( 'wp_rest' ) : '';
 
-$is_organiser        = in_array( $user_role, array( 'administrator', 'editor' ), true );
+$is_organiser = in_array( $user_role, array( 'administrator', 'editor' ), true );
+
+/*
+ * Bail before rendering a wrapper that would hold nothing. Every part except
+ * the identity row is member-only, so a placement that asks for the leave
+ * action or the email preference alone has nothing to show a logged-out
+ * visitor. Returning here also skips the `count_users()` call below, which is
+ * only needed for the member count in the identity row.
+ */
+$renders_leave      = $show_leave && $is_member && ! $is_organiser;
+$renders_preference = $show_preference && $is_member;
+
+if ( ! $show_identity && ! $renders_leave && ! $renders_preference ) {
+	return;
+}
+
 $user_count          = count_users( 'time', get_current_blog_id() );
 $member_count        = $user_count['total_users'] ?? 0;
 $join_api            = rest_url( 'wporg-groups/v1/members/join' );
@@ -85,38 +121,41 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<?php if ( $is_member ) : ?>
-		<span class="wporg-group-membership__badge" data-wp-text="state.buttonLabel">
-			<?php echo esc_html( $role_label ); ?>
-		</span>
-		<?php if ( ! $is_organiser ) : ?>
+	<?php if ( $show_identity ) : ?>
+		<?php if ( $is_member ) : ?>
+			<span class="wporg-group-membership__badge" data-wp-text="state.buttonLabel">
+				<?php echo esc_html( $role_label ); ?>
+			</span>
+		<?php else : ?>
 			<button
-				class="wporg-group-membership__leave"
-				data-wp-on--click="actions.leave"
+				class="wporg-group-membership__join wp-element-button"
+				data-wp-on--click="actions.join"
+				data-wp-text="state.buttonLabel"
 				data-wp-bind--disabled="context.loading"
-			><?php esc_html_e( 'Leave group', 'wporg-groups-frontend' ); ?></button>
+			><?php esc_html_e( 'Join this group', 'wporg-groups-frontend' ); ?></button>
 		<?php endif; ?>
-	<?php else : ?>
-		<button
-			class="wporg-group-membership__join wp-element-button"
-			data-wp-on--click="actions.join"
-			data-wp-text="state.buttonLabel"
-			data-wp-bind--disabled="context.loading"
-		><?php esc_html_e( 'Join this group', 'wporg-groups-frontend' ); ?></button>
+
+		<span class="wporg-group-membership__count" data-wp-text="state.countLabel">
+			<?php
+			echo esc_html(
+				sprintf(
+					_n( '%s member', '%s members', $member_count, 'wporg-groups-frontend' ),
+					number_format_i18n( $member_count )
+				)
+			);
+			?>
+		</span>
 	<?php endif; ?>
 
-	<span class="wporg-group-membership__count" data-wp-text="state.countLabel">
-		<?php
-		echo esc_html(
-			sprintf(
-				_n( '%s member', '%s members', $member_count, 'wporg-groups-frontend' ),
-				number_format_i18n( $member_count )
-			)
-		);
-		?>
-	</span>
+	<?php if ( $renders_leave ) : ?>
+		<button
+			class="wporg-group-membership__leave"
+			data-wp-on--click="actions.leave"
+			data-wp-bind--disabled="context.loading"
+		><?php esc_html_e( 'Leave group', 'wporg-groups-frontend' ); ?></button>
+	<?php endif; ?>
 
-	<?php if ( $is_member ) : ?>
+	<?php if ( $renders_preference ) : ?>
 		<div class="wporg-group-membership__preference">
 			<label>
 				<input

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -5,17 +5,20 @@
  * @package WordCamp\Groups\Frontend
  */
 
-$show_identity   = ! isset( $attributes['showIdentity'] ) || ! empty( $attributes['showIdentity'] );
-$show_leave      = ! isset( $attributes['showLeave'] ) || ! empty( $attributes['showLeave'] );
-$show_preference = ! isset( $attributes['showPreference'] ) || ! empty( $attributes['showPreference'] );
-$show_headings   = ! empty( $attributes['showHeadings'] );
+$variant = $attributes['variant'] ?? 'combined';
+if ( ! in_array( $variant, array( 'combined', 'membership', 'preference' ), true ) ) {
+	$variant = 'combined';
+}
+
+$shows_membership = in_array( $variant, array( 'combined', 'membership' ), true );
+$shows_preference = in_array( $variant, array( 'combined', 'preference' ), true );
 
 $is_logged_in = is_user_logged_in();
 $is_member    = $is_logged_in && is_user_member_of_blog();
 $user_role    = '';
 $role_label   = '';
 
-if ( $is_member ) {
+if ( $shows_membership && $is_member ) {
 	$user      = wp_get_current_user();
 	$user_role = reset( $user->roles ) ?: 'subscriber';
 
@@ -28,67 +31,82 @@ if ( $is_member ) {
 	$role_label = $labels[ $user_role ] ?? __( 'Member', 'wporg-groups-frontend' );
 }
 
-// Only logged-in visitors can join or leave, and only their markup should carry a nonce.
-$rest_nonce = $is_logged_in ? wp_create_nonce( 'wp_rest' ) : '';
+$is_organiser       = in_array( $user_role, array( 'administrator', 'editor' ), true );
+$renders_leave      = $shows_membership && $is_member && ! $is_organiser;
+$renders_preference = $shows_preference && $is_member;
 
-$is_organiser = in_array( $user_role, array( 'administrator', 'editor' ), true );
-
-$renders_leave      = $show_leave && $is_member && ! $is_organiser;
-$renders_preference = $show_preference && $is_member;
-
-// Avoid count_users() when this block placement has nothing to render.
-if ( ! $show_identity && ! $renders_leave && ! $renders_preference ) {
+if ( ! $shows_membership && ! $renders_preference ) {
 	return;
 }
 
-$user_count          = count_users( 'time', get_current_blog_id() );
-$member_count        = $user_count['total_users'] ?? 0;
-$join_api            = rest_url( 'wporg-groups/v1/members/join' );
-$leave_api           = rest_url( 'wporg-groups/v1/members/leave' );
-$preference_api      = rest_url( 'wporg-groups/v1/members/notification-preference' );
-$login_url           = wp_login_url( get_permalink() ?: home_url() );
-$notification_opt_in = $is_member
+// Only logged-in visitors can mutate membership or preferences, and only their markup should carry a nonce.
+$rest_nonce = $is_logged_in ? wp_create_nonce( 'wp_rest' ) : '';
+
+$member_count = 0;
+$count_label  = '';
+
+if ( $shows_membership ) {
+	$user_count   = count_users( 'time', get_current_blog_id() );
+	$member_count = $user_count['total_users'] ?? 0;
+	$count_label  = sprintf(
+		_n( '%s member', '%s members', $member_count, 'wporg-groups-frontend' ),
+		number_format_i18n( $member_count )
+	);
+}
+
+$notification_opt_in = $renders_preference
 	? \GatherPress\Core\User::get_instance()->has_event_updates_opt_in( get_current_user_id() )
 	: false;
-$count_label         = sprintf(
-	_n( '%s member', '%s members', $member_count, 'wporg-groups-frontend' ),
-	number_format_i18n( $member_count )
-);
 
 $context = array(
-	'isLoggedIn'    => $is_logged_in,
-	'isMember'      => $is_member,
-	'isOrganiser'   => $is_organiser,
-	'roleLabel'     => $role_label,
-	'memberCount'   => $member_count,
-	'memberLabel'   => __( 'Member', 'wporg-groups-frontend' ),
-	'joinLabel'     => __( 'Join this group', 'wporg-groups-frontend' ),
-	'countLabel'    => $count_label,
-	'leaveConfirm' => __( 'Leave this group?', 'wporg-groups-frontend' ),
-	'joinApi'       => $join_api,
-	'leaveApi'      => $leave_api,
-	'preferenceApi' => $preference_api,
-	'restNonce'     => $rest_nonce,
-	'loginUrl'      => $login_url,
-	'loading'       => false,
-	'notificationOptIn'     => $notification_opt_in,
-	'preferenceSaving'      => false,
-	'preferenceMessage'     => '',
-	'preferenceNoticeSuccess' => false,
-	'preferenceNoticeError'   => false,
-	'preferenceSavedLabel'  => __( 'Email preference saved.', 'wporg-groups-frontend' ),
-	'preferenceErrorLabel'  => __( 'The email preference could not be saved. Please try again.', 'wporg-groups-frontend' ),
+	'isLoggedIn' => $is_logged_in,
+	'isMember'   => $is_member,
+	'restNonce'  => $rest_nonce,
 );
 
-wp_interactivity_state(
-	'wporg/group-membership',
-	array(
-		'buttonLabel'  => $is_member ? $role_label : __( 'Join this group', 'wporg-groups-frontend' ),
-		'isMember'     => $is_member,
-		'memberCount'  => $member_count,
-		'countLabel'   => $count_label,
-	)
-);
+if ( $shows_membership ) {
+	$context = array_merge(
+		$context,
+		array(
+			'roleLabel'    => $role_label,
+			'memberCount'  => $member_count,
+			'memberLabel'  => __( 'Member', 'wporg-groups-frontend' ),
+			'joinLabel'    => __( 'Join this group', 'wporg-groups-frontend' ),
+			'countLabel'   => $count_label,
+			'leaveConfirm' => __( 'Leave this group?', 'wporg-groups-frontend' ),
+			'joinApi'      => rest_url( 'wporg-groups/v1/members/join' ),
+			'leaveApi'     => rest_url( 'wporg-groups/v1/members/leave' ),
+			'loginUrl'     => wp_login_url( get_permalink() ?: home_url() ),
+			'loading'      => false,
+		)
+	);
+
+	wp_interactivity_state(
+		'wporg/group-membership',
+		array(
+			'buttonLabel' => $is_member ? $role_label : __( 'Join this group', 'wporg-groups-frontend' ),
+			'isMember'    => $is_member,
+			'memberCount' => $member_count,
+			'countLabel'  => $count_label,
+		)
+	);
+}
+
+if ( $renders_preference ) {
+	$context = array_merge(
+		$context,
+		array(
+			'preferenceApi'           => rest_url( 'wporg-groups/v1/members/notification-preference' ),
+			'notificationOptIn'       => $notification_opt_in,
+			'preferenceSaving'        => false,
+			'preferenceMessage'       => '',
+			'preferenceNoticeSuccess' => false,
+			'preferenceNoticeError'   => false,
+			'preferenceSavedLabel'    => __( 'Email preference saved.', 'wporg-groups-frontend' ),
+			'preferenceErrorLabel'    => __( 'The email preference could not be saved. Please try again.', 'wporg-groups-frontend' ),
+		)
+	);
+}
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
@@ -99,8 +117,8 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<?php if ( $show_identity ) : ?>
-		<?php if ( $show_headings ) : ?>
+	<?php if ( $shows_membership ) : ?>
+		<?php if ( 'membership' === $variant ) : ?>
 			<h2 class="wporg-group-membership__heading">
 				<?php esc_html_e( 'Membership', 'wporg-groups-frontend' ); ?>
 			</h2>
@@ -143,16 +161,10 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	<?php endif; ?>
 
 	<?php if ( $renders_preference ) : ?>
-		<?php if ( $show_headings ) : ?>
-			<?php if ( $show_identity ) : ?>
-				<h3 class="wporg-group-membership__preference-heading">
-					<?php esc_html_e( 'Email preferences', 'wporg-groups-frontend' ); ?>
-				</h3>
-			<?php else : ?>
-				<h2 class="wporg-group-membership__preference-heading wporg-group-membership__preference-heading--standalone">
-					<?php esc_html_e( 'Email preferences', 'wporg-groups-frontend' ); ?>
-				</h2>
-			<?php endif; ?>
+		<?php if ( 'preference' === $variant ) : ?>
+			<h2 class="wporg-group-membership__preference-heading">
+				<?php esc_html_e( 'Email preferences', 'wporg-groups-frontend' ); ?>
+			</h2>
 		<?php endif; ?>
 
 		<div class="wporg-group-membership__preference">

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -8,16 +8,17 @@
  *
  *   - `showIdentity` (default true) — the join button for visitors, or the
  *     role badge plus member count for members. Answers "what is this group
- *     and am I in it?", which is what earns hero placement.
+ *     and am I in it?", which belongs with the group's supporting details.
  *   - `showLeave` — the "Leave group" action. Destructive account management,
  *     not identity, so it sits with the member directory rather than the hero.
  *   - `showPreference` — the GatherPress event-email opt-in. Stored as
  *     `gatherpress_event_updates_opt_in` usermeta, which on multisite is
  *     shared across the whole install: this toggle is not scoped to the group
- *     rendering it. It therefore belongs with the member's own content
- *     (alongside `wporg/my-events`, which is gated on the same
- *     logged-in-and-a-member condition) rather than anywhere that reads as a
- *     property of this particular group.
+ *     rendering it. It therefore belongs with the member controls rather
+ *     than anywhere that reads as a property of this particular group.
+ *   - `showHeadings` (default false) — labels the rendered membership and
+ *     preference sections. When identity is hidden, the preference receives
+ *     a standalone section heading instead of a subordinate heading.
  *
  * @package WordCamp\Groups\Frontend
  */
@@ -25,6 +26,7 @@
 $show_identity   = ! isset( $attributes['showIdentity'] ) || ! empty( $attributes['showIdentity'] );
 $show_leave      = ! isset( $attributes['showLeave'] ) || ! empty( $attributes['showLeave'] );
 $show_preference = ! isset( $attributes['showPreference'] ) || ! empty( $attributes['showPreference'] );
+$show_headings   = ! empty( $attributes['showHeadings'] );
 
 $is_logged_in = is_user_logged_in();
 $is_member    = $is_logged_in && is_user_member_of_blog();
@@ -122,6 +124,12 @@ $wrapper_attributes = get_block_wrapper_attributes(
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<?php if ( $show_identity ) : ?>
+		<?php if ( $show_headings ) : ?>
+			<h2 class="wporg-group-membership__heading">
+				<?php esc_html_e( 'Membership', 'wporg-groups-frontend' ); ?>
+			</h2>
+		<?php endif; ?>
+
 		<?php if ( $is_member ) : ?>
 			<span class="wporg-group-membership__badge" data-wp-text="state.buttonLabel">
 				<?php echo esc_html( $role_label ); ?>
@@ -156,6 +164,18 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	<?php endif; ?>
 
 	<?php if ( $renders_preference ) : ?>
+		<?php if ( $show_headings ) : ?>
+			<?php if ( $show_identity ) : ?>
+				<h3 class="wporg-group-membership__preference-heading">
+					<?php esc_html_e( 'Email preferences', 'wporg-groups-frontend' ); ?>
+				</h3>
+			<?php else : ?>
+				<h2 class="wporg-group-membership__preference-heading wporg-group-membership__preference-heading--standalone">
+					<?php esc_html_e( 'Email preferences', 'wporg-groups-frontend' ); ?>
+				</h2>
+			<?php endif; ?>
+		<?php endif; ?>
+
 		<div class="wporg-group-membership__preference">
 			<label>
 				<input

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -2,24 +2,6 @@
 /**
  * Server-side rendering for the wporg/group-membership block.
  *
- * The block renders a set of independently toggleable parts, so the same
- * interactivity store and REST wiring can back placements that answer quite
- * different questions:
- *
- *   - `showIdentity` (default true) — the join button for visitors, or the
- *     role badge plus member count for members. Answers "what is this group
- *     and am I in it?", which belongs with the group's supporting details.
- *   - `showLeave` — the "Leave group" action. Destructive account management,
- *     not identity, so it sits with the member directory rather than the hero.
- *   - `showPreference` — the GatherPress event-email opt-in. Stored as
- *     `gatherpress_event_updates_opt_in` usermeta, which on multisite is
- *     shared across the whole install: this toggle is not scoped to the group
- *     rendering it. It therefore belongs with the member controls rather
- *     than anywhere that reads as a property of this particular group.
- *   - `showHeadings` (default false) — labels the rendered membership and
- *     preference sections. When identity is hidden, the preference receives
- *     a standalone section heading instead of a subordinate heading.
- *
  * @package WordCamp\Groups\Frontend
  */
 
@@ -51,16 +33,10 @@ $rest_nonce = $is_logged_in ? wp_create_nonce( 'wp_rest' ) : '';
 
 $is_organiser = in_array( $user_role, array( 'administrator', 'editor' ), true );
 
-/*
- * Bail before rendering a wrapper that would hold nothing. Every part except
- * the identity row is member-only, so a placement that asks for the leave
- * action or the email preference alone has nothing to show a logged-out
- * visitor. Returning here also skips the `count_users()` call below, which is
- * only needed for the member count in the identity row.
- */
 $renders_leave      = $show_leave && $is_member && ! $is_organiser;
 $renders_preference = $show_preference && $is_member;
 
+// Avoid count_users() when this block placement has nothing to render.
 if ( ! $show_identity && ! $renders_leave && ! $renders_preference ) {
 	return;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -111,12 +111,15 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<?php echo esc_html( $role_label ); ?>
 			</span>
 		<?php else : ?>
-			<button
-				class="wporg-group-membership__join wp-element-button"
-				data-wp-on--click="actions.join"
-				data-wp-text="state.buttonLabel"
-				data-wp-bind--disabled="context.loading"
-			><?php esc_html_e( 'Join this group', 'wporg-groups-frontend' ); ?></button>
+			<div class="wp-block-button">
+				<button
+					type="button"
+					class="wp-block-button__link wp-element-button"
+					data-wp-on--click="actions.join"
+					data-wp-text="state.buttonLabel"
+					data-wp-bind--disabled="context.loading"
+				><?php esc_html_e( 'Join this group', 'wporg-groups-frontend' ); ?></button>
+			</div>
 		<?php endif; ?>
 
 		<span class="wporg-group-membership__count" data-wp-text="state.countLabel">

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/style.css
@@ -22,10 +22,6 @@
 	border-radius: 100px;
 }
 
-.wporg-group-membership__join {
-	font-size: 14px;
-}
-
 .wporg-group-membership__leave {
 	background: none;
 	border: none;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wporg/group-news",
+	"version": "1.0.0",
+	"title": "Group News",
+	"category": "widgets",
+	"icon": "admin-post",
+	"description": "Displays recent group posts and hides itself when there are none.",
+	"attributes": {
+		"limit": {
+			"type": "number",
+			"default": 3
+		}
+	},
+	"supports": {
+		"html": false,
+		"inserter": false
+	},
+	"render": "file:./render.php",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/index.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/index.js
@@ -1,0 +1,20 @@
+import { registerBlockType } from '@wordpress/blocks';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+import metadata from './block.json';
+import './style.css';
+
+function Edit( { attributes } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender block={ metadata.name } attributes={ attributes } />
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Server-side rendering for the wporg/group-news block.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+$wporg_limit = max( 1, min( 10, (int) ( $attributes['limit'] ?? 3 ) ) );
+$wporg_posts = get_posts(
+	array(
+		'post_type'           => 'post',
+		'post_status'         => 'publish',
+		'posts_per_page'      => $wporg_limit,
+		'orderby'             => 'date',
+		'order'               => 'DESC',
+		'ignore_sticky_posts' => true,
+	)
+);
+
+// A heading with no posts would advertise an empty section, so the entire
+// block disappears until the group publishes its first update.
+if ( empty( $wporg_posts ) ) {
+	return;
+}
+
+$wporg_wrapper_attributes = get_block_wrapper_attributes(
+	array( 'class' => 'wporg-group-news' )
+);
+?>
+<section <?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by core. ?>>
+	<h2 class="wporg-group-news__heading"><?php esc_html_e( 'News', 'wporg-groups-frontend' ); ?></h2>
+
+	<div class="wporg-group-news__list">
+		<?php foreach ( $wporg_posts as $wporg_post ) : ?>
+			<article class="wporg-group-news__item">
+				<time
+					class="wporg-group-news__date"
+					datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $wporg_post ) ); ?>"
+				>
+					<?php echo esc_html( get_the_date( '', $wporg_post ) ); ?>
+				</time>
+				<h3 class="wporg-group-news__title">
+					<a href="<?php echo esc_url( get_permalink( $wporg_post ) ); ?>">
+						<?php echo esc_html( get_the_title( $wporg_post ) ); ?>
+					</a>
+				</h3>
+				<?php if ( has_excerpt( $wporg_post ) ) : ?>
+					<p class="wporg-group-news__excerpt">
+						<?php echo esc_html( wp_trim_words( get_the_excerpt( $wporg_post ), 28 ) ); ?>
+					</p>
+				<?php endif; ?>
+			</article>
+		<?php endforeach; ?>
+	</div>
+</section>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
@@ -39,7 +39,10 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 				</time>
 				<h3 class="wporg-group-news__title">
 					<a href="<?php echo esc_url( get_permalink( $wporg_post ) ); ?>">
-						<?php echo esc_html( get_the_title( $wporg_post ) ); ?>
+						<?php
+						$wporg_title = get_the_title( $wporg_post );
+						echo esc_html( '' !== $wporg_title ? $wporg_title : __( '(Untitled)', 'wporg-groups-frontend' ) );
+						?>
 					</a>
 				</h3>
 				<?php if ( has_excerpt( $wporg_post ) ) : ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
@@ -17,8 +17,6 @@ $wporg_posts = get_posts(
 	)
 );
 
-// A heading with no posts would advertise an empty section, so the entire
-// block disappears until the group publishes its first update.
 if ( empty( $wporg_posts ) ) {
 	return;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
@@ -1,0 +1,45 @@
+.wporg-group-news__heading {
+	margin: 0 0 16px !important;
+	padding: 0 !important;
+	font-size: 24px;
+	font-weight: 700;
+}
+
+.wporg-group-news__list {
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.wporg-group-news__item {
+	padding: 20px 0;
+	border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.wporg-group-news__date {
+	display: block;
+	margin-bottom: 4px;
+	color: var(--wp--preset--color--charcoal-4);
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.wporg-group-news__title {
+	margin: 0 !important;
+	padding: 0 !important;
+	font-size: 20px;
+	line-height: 1.3;
+}
+
+.wporg-group-news__title a {
+	text-decoration: none;
+}
+
+.wporg-group-news__title a:hover {
+	text-decoration: underline;
+}
+
+.wporg-group-news__excerpt {
+	margin: 8px 0 0;
+	color: var(--wp--preset--color--charcoal-3);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
@@ -13,6 +13,8 @@ import {
 } from '@wordpress/element';
 import {
 	TextControl,
+	RadioControl,
+	SelectControl,
 	Button,
 	Notice,
 	Spinner,
@@ -26,18 +28,27 @@ export default function AboutTab() {
 	const [ saving, setSaving ] = useState( false );
 	const [ notice, setNotice ] = useState( '' );
 	const [ noticeType, setNoticeType ] = useState( 'success' );
+	const [ countries, setCountries ] = useState( [] );
 	const [ form, setForm ] = useState( {
 		blogname: '',
 		blogdescription: '',
+		locationType: '',
+		city: '',
+		countryCode: '',
 	} );
 
 	useEffect( () => {
 		apiFetch( { path: '/wporg-groups/v1/group-info' } )
 			.then( ( data ) => {
+				const location = data.location || {};
 				setForm( {
 					blogname: data.title || '',
 					blogdescription: data.description || '',
+					locationType: location.type || '',
+					city: location.city || '',
+					countryCode: location.countryCode || '',
 				} );
+				setCountries( data.countries || [] );
 				setLoading( false );
 			} )
 			.catch( ( err ) => {
@@ -60,12 +71,24 @@ export default function AboutTab() {
 		setSaving( true );
 		setNotice( '' );
 		try {
+			let location = null;
+			if ( 'online' === form.locationType ) {
+				location = { type: 'online' };
+			} else if ( 'physical' === form.locationType ) {
+				location = {
+					type: 'physical',
+					city: form.city,
+					countryCode: form.countryCode,
+				};
+			}
+
 			await apiFetch( {
 				path: '/wporg-groups/v1/group-info',
 				method: 'POST',
 				data: {
 					title: form.blogname,
 					description: form.blogdescription,
+					location,
 				},
 			} );
 			setNoticeType( 'success' );
@@ -77,6 +100,10 @@ export default function AboutTab() {
 			setSaving( false );
 		}
 	};
+
+	const physicalLocationIsIncomplete =
+		'physical' === form.locationType &&
+		( '' === form.city.trim() || '' === form.countryCode );
 
 	if ( loading ) {
 		return h( 'div', { className: 'wporg-settings-tab__loading' }, h( Spinner ) );
@@ -115,6 +142,73 @@ export default function AboutTab() {
 		} ),
 		h(
 			'div',
+			{ className: 'wporg-settings-tab__location' },
+			h( 'h3', { className: 'wporg-settings-tab__section-title' }, __( 'Location', 'wporg-groups-frontend' ) ),
+			h( RadioControl, {
+				label: __( 'Where is this group based?', 'wporg-groups-frontend' ),
+				help: __( 'This appears in the group header. Individual event venues and online access details are managed with each event.', 'wporg-groups-frontend' ),
+				selected: form.locationType,
+				disabled: loadFailed,
+				options: [
+					{ label: __( 'In person', 'wporg-groups-frontend' ), value: 'physical' },
+					{ label: __( 'Online', 'wporg-groups-frontend' ), value: 'online' },
+				],
+				onChange: ( v ) => setForm( { ...form, locationType: v } ),
+			} ),
+			'physical' === form.locationType &&
+				h(
+					'div',
+					{ className: 'wporg-settings-tab__location-fields' },
+					h( TextControl, {
+						label: __( 'City', 'wporg-groups-frontend' ),
+						value: form.city,
+						onChange: ( v ) => setForm( { ...form, city: v } ),
+						disabled: loadFailed,
+						required: true,
+						__nextHasNoMarginBottom: true,
+					} ),
+					h( SelectControl, {
+						label: __( 'Country', 'wporg-groups-frontend' ),
+						value: form.countryCode,
+						options: [
+							{ label: __( 'Select a country', 'wporg-groups-frontend' ), value: '' },
+						].concat(
+							countries.map( ( country ) => ( {
+								label: country.name,
+								value: country.code,
+							} ) )
+						),
+						onChange: ( v ) => setForm( { ...form, countryCode: v } ),
+						disabled: loadFailed,
+						required: true,
+						__nextHasNoMarginBottom: true,
+					} )
+				),
+			'' === form.locationType &&
+				h(
+					'p',
+					{ className: 'wporg-settings-tab__empty' },
+					__( 'No location specified.', 'wporg-groups-frontend' )
+				),
+			'' !== form.locationType &&
+				h(
+					Button,
+					{
+						variant: 'link',
+						isDestructive: true,
+						disabled: loadFailed,
+						onClick: () => setForm( {
+							...form,
+							locationType: '',
+							city: '',
+							countryCode: '',
+						} ),
+					},
+					__( 'Clear location', 'wporg-groups-frontend' )
+				)
+		),
+		h(
+			'div',
 			{ className: 'wporg-settings-tab__actions' },
 			h(
 				Button,
@@ -122,7 +216,7 @@ export default function AboutTab() {
 					variant: 'primary',
 					onClick: handleSave,
 					isBusy: saving,
-					disabled: saving || loadFailed || '' === form.blogname.trim(),
+					disabled: saving || loadFailed || '' === form.blogname.trim() || physicalLocationIsIncomplete,
 				},
 				__( 'Save', 'wporg-groups-frontend' )
 			)

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
@@ -52,11 +52,7 @@ export default function AboutTab() {
 				setLoading( false );
 			} )
 			.catch( ( err ) => {
-				// Don't leave the fields silently blank: a failed load looks
-				// identical to an empty group name otherwise. Lock the form as
-				// well, so a save can't write those blanks back over the real
-				// values — a failed read followed by a successful write is all
-				// it takes to wipe the group's name and description.
+				// Prevent a failed read from being saved back as blank values.
 				setLoadFailed( true );
 				setNoticeType( 'error' );
 				setNotice(
@@ -129,9 +125,7 @@ export default function AboutTab() {
 			disabled: loadFailed,
 			__nextHasNoMarginBottom: true,
 		} ),
-		// Single-line on purpose: the value is stored in `blogdescription`
-		// and sanitized with `sanitize_text_field()`, which silently flattens
-		// line breaks, so a textarea would invite input it can't keep.
+		// blogdescription is sanitized as a single line.
 		h( TextControl, {
 			label: __( 'Description', 'wporg-groups-frontend' ),
 			value: form.blogdescription,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/render.php
@@ -39,30 +39,34 @@ $needs_setup          = '' === $description || in_array( $description, $default_
 $can_manage_roles = current_user_can_manage_group_settings();
 
 $wrapper_attributes = get_block_wrapper_attributes(
-	array( 'class' => 'wporg-group-settings-block' )
+	array( 'class' => 'wp-block-buttons wporg-group-settings-block' )
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<?php if ( $is_single_event ) : ?>
-		<button
-			type="button"
-			class="wporg-group-settings-block__edit wp-element-button"
-			data-wporg-settings-open="events"
-			data-wporg-settings-event-id="<?php echo (int) $event_post_id; ?>"
-		>&#9998; <?php esc_html_e( 'Edit this event', 'wporg-groups-frontend' ); ?></button>
+		<div class="wp-block-button is-style-outline">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button"
+				data-wporg-settings-open="events"
+				data-wporg-settings-event-id="<?php echo (int) $event_post_id; ?>"
+			>&#9998; <?php esc_html_e( 'Edit this event', 'wporg-groups-frontend' ); ?></button>
+		</div>
 	<?php else : ?>
-		<button
-			type="button"
-			class="wporg-group-settings-block__trigger<?php echo $needs_setup ? ' wporg-group-settings-block__trigger--setup' : ''; ?>"
-			data-wporg-settings-open="<?php echo $needs_setup ? 'about' : ''; ?>"
-		>
-			<?php if ( $needs_setup ) : ?>
-				<?php esc_html_e( 'Set up your group', 'wporg-groups-frontend' ); ?>
-			<?php else : ?>
-				<span class="dashicons dashicons-admin-generic"></span>
-				<?php esc_html_e( 'Settings', 'wporg-groups-frontend' ); ?>
-			<?php endif; ?>
-		</button>
+		<div class="wp-block-button<?php echo $needs_setup ? '' : ' is-style-outline'; ?>">
+			<button
+				type="button"
+				class="wp-block-button__link wp-element-button"
+				data-wporg-settings-open="<?php echo $needs_setup ? 'about' : ''; ?>"
+			>
+				<?php if ( $needs_setup ) : ?>
+					<?php esc_html_e( 'Set up your group', 'wporg-groups-frontend' ); ?>
+				<?php else : ?>
+					<span class="dashicons dashicons-admin-generic"></span>
+					<?php esc_html_e( 'Settings', 'wporg-groups-frontend' ); ?>
+				<?php endif; ?>
+			</button>
+		</div>
 	<?php endif; ?>
 
 	<div

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -12,16 +12,22 @@
 	gap: 8px;
 	flex-wrap: wrap;
 
+	// Secondary button — same size/shape as the primary "Create event" CTA
+	// in the event-manage block, just outlined instead of filled, so the
+	// two read as one hierarchy rather than two unrelated buttons.
 	&__trigger {
+		box-sizing: border-box;
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;
-		padding: 6px 14px;
+		padding: 10px 22px;
 		background: none;
-		border: 1px solid #d9d9d9;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
 		border-radius: 2px;
-		font-size: 13px;
-		color: #656a71;
+		font-size: 14px;
+		font-weight: 600;
+		line-height: 1.3;
+		color: var(--wp--preset--color--charcoal-3, #40464d);
 		cursor: pointer;
 
 		.dashicons {
@@ -31,21 +37,21 @@
 		}
 
 		&:hover {
-			border-color: #3858e9;
-			color: #3858e9;
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--blueberry-1, #3858e9);
 		}
 
+		// Incomplete setup promotes this to a filled primary CTA in its own
+		// right, since finishing setup outranks creating an event.
 		&--setup {
-			background: #3858e9;
-			border-color: #3858e9;
-			color: #fff;
-			font-weight: 600;
-			padding: 10px 20px;
+			background: var(--wp--preset--color--blueberry-1, #3858e9);
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--white, #fff);
 
 			&:hover {
-				background: #213fd4;
-				border-color: #213fd4;
-				color: #fff;
+				background: var(--wp--preset--color--deep-blueberry, #213fd4);
+				border-color: var(--wp--preset--color--deep-blueberry, #213fd4);
+				color: var(--wp--preset--color--white, #fff);
 			}
 		}
 	}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -133,6 +133,22 @@
 		font-style: italic;
 	}
 
+	&__location {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	&__location-fields {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 16px;
+
+		@media (max-width: 600px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
 	&__section-title {
 		font-size: 14px;
 		font-weight: 600;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -7,61 +7,10 @@
 // === Trigger button ===
 
 .wporg-group-settings-block {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	flex-wrap: wrap;
-
-	&__trigger {
-		box-sizing: border-box;
-		display: inline-flex;
-		align-items: center;
-		gap: 6px;
-		padding: 10px 22px;
-		background: none;
-		border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
-		border-radius: 2px;
-		font-size: 14px;
-		font-weight: 600;
-		line-height: 1.3;
-		color: var(--wp--preset--color--charcoal-3, #40464d);
-		cursor: pointer;
-
-		.dashicons {
-			font-size: 16px;
-			width: 16px;
-			height: 16px;
-		}
-
-		&:hover {
-			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
-			color: var(--wp--preset--color--blueberry-1, #3858e9);
-		}
-
-		&--setup {
-			background: var(--wp--preset--color--blueberry-1, #3858e9);
-			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
-			color: var(--wp--preset--color--white, #fff);
-
-			&:hover {
-				background: var(--wp--preset--color--deep-blueberry, #213fd4);
-				border-color: var(--wp--preset--color--deep-blueberry, #213fd4);
-				color: var(--wp--preset--color--white, #fff);
-			}
-		}
-	}
-
-	&__edit {
-		background: transparent !important;
-		border: 1px solid #d9d9d9 !important;
-		color: #40464d !important;
-		font-size: 14px;
-
-		&:hover {
-			border-color: #3858e9 !important;
-			color: #3858e9 !important;
-			background: #eff2ff !important;
-		}
+	.dashicons {
+		font-size: 16px;
+		width: 16px;
+		height: 16px;
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -12,9 +12,6 @@
 	gap: 8px;
 	flex-wrap: wrap;
 
-	// Secondary button — same size/shape as the primary "Create event" CTA
-	// in the event-manage block, just outlined instead of filled, so the
-	// two read as one hierarchy rather than two unrelated buttons.
 	&__trigger {
 		box-sizing: border-box;
 		display: inline-flex;
@@ -41,8 +38,6 @@
 			color: var(--wp--preset--color--blueberry-1, #3858e9);
 		}
 
-		// Incomplete setup promotes this to a filled primary CTA in its own
-		// right, since finishing setup outranks creating an event.
 		&--setup {
 			background: var(--wp--preset--color--blueberry-1, #3858e9);
 			border-color: var(--wp--preset--color--blueberry-1, #3858e9);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
@@ -40,9 +40,9 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<h3 class="wporg-my-events__heading">
+	<h2 class="wporg-my-events__heading">
 		<?php esc_html_e( 'My upcoming events', 'wporg-groups-frontend' ); ?>
-	</h3>
+	</h2>
 	<?php if ( empty( $wporg_upcoming_events ) ) : ?>
 		<p class="wporg-my-events__empty">
 			<?php esc_html_e( 'Nothing on your calendar yet. Events you RSVP to, and events you organise, will show up here.', 'wporg-groups-frontend' ); ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/block.json
@@ -11,10 +11,19 @@
 		"slug": {
 			"type": "string",
 			"default": ""
+		},
+		"heading": {
+			"type": "string",
+			"default": ""
+		},
+		"headingLevel": {
+			"type": "number",
+			"default": 2
 		}
 	},
 	"supports": {
-		"html": false
+		"html": false,
+		"anchor": true
 	},
 	"render": "file:./render.php",
 	"editorScript": "file:./index.js"

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
@@ -4,10 +4,40 @@
  *
  * Renders a page's content by slug, with an edit link for organisers.
  *
+ * The optional `heading` attribute renders a section heading *inside* the
+ * block rather than beside it in the template. The block renders nothing at
+ * all when the target page is missing and the viewer can't create it, so a
+ * heading placed in the template would be left stranded above empty space —
+ * which is what happened on the front page's "About this group" section for
+ * every group that hadn't written an about page yet.
+ *
  * @package WordCamp\Groups\Frontend
  */
 
-$slug = $attributes['slug'] ?? '';
+$slug          = $attributes['slug'] ?? '';
+$heading       = trim( (string) ( $attributes['heading'] ?? '' ) );
+$heading_level = (int) ( $attributes['headingLevel'] ?? 2 );
+$heading_level = min( 6, max( 1, $heading_level ) );
+
+/**
+ * Build the optional section heading.
+ *
+ * Called only from branches that are about to emit content, so the heading
+ * never appears on its own.
+ *
+ * @return string Escaped heading HTML, or an empty string when unset.
+ */
+$wporg_get_heading = static function () use ( $heading, $heading_level ): string {
+	if ( '' === $heading ) {
+		return '';
+	}
+
+	return sprintf(
+		'<h%1$d class="wp-block-heading has-heading-3-font-size" style="margin-bottom:var(--wp--preset--spacing--30)">%2$s</h%1$d>',
+		$heading_level,
+		esc_html( $heading )
+	);
+};
 
 if ( empty( $slug ) ) {
 	return;
@@ -16,11 +46,17 @@ if ( empty( $slug ) ) {
 $target_page = get_page_by_path( $slug );
 
 if ( ! $target_page || 'publish' !== $target_page->post_status ) {
-	// If the page doesn't exist yet, show a prompt for organisers.
+	// If the page doesn't exist yet, show a prompt for organisers. Rendered
+	// inside the block wrapper so the section keeps the layout classes the
+	// template gave it — without it the prompt loses the front page's section
+	// spacing and collides with whatever precedes it.
 	if ( current_user_can( 'edit_pages' ) ) {
 		$create_url = admin_url( 'post-new.php?post_type=page&post_title=' . urlencode( ucfirst( $slug ) ) );
+
 		printf(
-			'<p><a href="%s" class="wp-element-button">%s</a></p>',
+			'<div %1$s>%2$s<p><a href="%3$s" class="wp-element-button">%4$s</a></p></div>',
+			get_block_wrapper_attributes(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by core.
+			$wporg_get_heading(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the callback.
 			esc_url( $create_url ),
 			esc_html(
 				sprintf(
@@ -34,15 +70,26 @@ if ( ! $target_page || 'publish' !== $target_page->post_status ) {
 	return;
 }
 
+$can_edit = current_user_can( 'edit_page', $target_page->ID );
+
+// A published-but-empty page is the same dead end as a missing one for a
+// visitor: render nothing rather than a heading over blank space. Organisers
+// still get the block so they have somewhere to click through and write it.
+if ( '' === trim( (string) $target_page->post_content ) && ! $can_edit ) {
+	return;
+}
+
 $content = apply_filters( 'the_content', $target_page->post_content );
 $content = str_replace( ']]>', ']]&gt;', $content );
 
 $wrapper_attributes = get_block_wrapper_attributes();
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php echo $wporg_get_heading(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the callback. ?>
+
 	<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Filtered by the_content. ?>
 
-	<?php if ( current_user_can( 'edit_page', $target_page->ID ) ) : ?>
+	<?php if ( $can_edit ) : ?>
 		<p class="wporg-page-content__edit">
 			<a href="<?php echo esc_url( get_edit_post_link( $target_page->ID ) ); ?>">
 				&#9998; <?php esc_html_e( 'Edit this content', 'wporg-groups-frontend' ); ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
@@ -4,13 +4,6 @@
  *
  * Renders a page's content by slug, with an edit link for organisers.
  *
- * The optional `heading` attribute renders a section heading *inside* the
- * block rather than beside it in the template. The block renders nothing at
- * all when the target page is missing and the viewer can't create it, so a
- * heading placed in the template would be left stranded above empty space —
- * which is what happened on the front page's "About this group" section for
- * every group that hadn't written an about page yet.
- *
  * @package WordCamp\Groups\Frontend
  */
 
@@ -19,14 +12,6 @@ $heading       = trim( (string) ( $attributes['heading'] ?? '' ) );
 $heading_level = (int) ( $attributes['headingLevel'] ?? 2 );
 $heading_level = min( 6, max( 1, $heading_level ) );
 
-/**
- * Build the optional section heading.
- *
- * Called only from branches that are about to emit content, so the heading
- * never appears on its own.
- *
- * @return string Escaped heading HTML, or an empty string when unset.
- */
 $wporg_get_heading = static function () use ( $heading, $heading_level ): string {
 	if ( '' === $heading ) {
 		return '';
@@ -46,10 +31,6 @@ if ( empty( $slug ) ) {
 $target_page = get_page_by_path( $slug );
 
 if ( ! $target_page || 'publish' !== $target_page->post_status ) {
-	// If the page doesn't exist yet, show a prompt for organisers. Rendered
-	// inside the block wrapper so the section keeps the layout classes the
-	// template gave it — without it the prompt loses the front page's section
-	// spacing and collides with whatever precedes it.
 	if ( current_user_can( 'edit_pages' ) ) {
 		$create_url = admin_url( 'post-new.php?post_type=page&post_title=' . urlencode( ucfirst( $slug ) ) );
 
@@ -72,9 +53,6 @@ if ( ! $target_page || 'publish' !== $target_page->post_status ) {
 
 $can_edit = current_user_can( 'edit_page', $target_page->ID );
 
-// A published-but-empty page is the same dead end as a missing one for a
-// visitor: render nothing rather than a heading over blank space. Organisers
-// still get the block so they have somewhere to click through and write it.
 if ( '' === trim( (string) $target_page->post_content ) && ! $can_edit ) {
 	return;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
@@ -69,7 +69,9 @@ function renderTwoModals() {
 				<span class="wporg-event-rsvp__avatars">First avatars untouched</span>
 				View first attendees
 			</button>
-			<button class="wporg-event-rsvp__button" type="button">RSVP first</button>
+			<div class="wp-block-button">
+				<button class="wp-block-button__link wp-element-button" type="button">RSVP first</button>
+			</div>
 			<div class="wporg-event-rsvp__modal">
 				<button class="wporg-event-rsvp__modal-close" type="button">Close first</button>
 				<div class="wporg-event-rsvp__attendee-list">First list untouched</div>
@@ -80,7 +82,9 @@ function renderTwoModals() {
 				<span class="wporg-event-rsvp__avatars">Second avatars pending</span>
 				View second attendees
 			</button>
-			<button class="wporg-event-rsvp__button" type="button">RSVP second</button>
+			<div class="wp-block-button">
+				<button class="wp-block-button__link wp-element-button" type="button">RSVP second</button>
+			</div>
 			<div class="wporg-event-rsvp__modal">
 				<button class="wporg-event-rsvp__modal-close" type="button">Close second</button>
 				<div class="wporg-event-rsvp__attendee-list">Second list pending</div>
@@ -92,7 +96,7 @@ function renderTwoModals() {
 		avatars: block.querySelector( '.wporg-event-rsvp__avatars' ),
 		close: block.querySelector( '.wporg-event-rsvp__modal-close' ),
 		list: block.querySelector( '.wporg-event-rsvp__attendee-list' ),
-		rsvp: block.querySelector( '.wporg-event-rsvp__button' ),
+		rsvp: block.querySelector( '.wp-block-button button' ),
 		summary: block.querySelector( '.wporg-event-rsvp__summary' ),
 	} ) );
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -136,8 +136,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'data-wp-text="context.rsvpNotice"', $output );
 	}
 
-	// phpcs:disable Squiz.Commenting.FunctionComment.Missing
-
+	/**
+	 * Unspecified locations leave no empty header markup.
+	 */
 	public function test_group_location_block_is_hidden_when_unspecified() {
 		delete_site_meta( get_current_blog_id(), 'wporg_group_location_type' );
 		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
@@ -146,6 +147,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertSame( '', trim( do_blocks( '<!-- wp:wporg/group-location /-->' ) ) );
 	}
 
+	/**
+	 * Physical locations render their city and localized country.
+	 */
 	public function test_group_location_block_renders_physical_location() {
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'İstanbul' );
@@ -159,6 +163,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'aria-hidden="true"', $output );
 	}
 
+	/**
+	 * The online label depends only on the group location type.
+	 */
 	public function test_group_location_block_renders_online_location() {
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'online' );
 		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
@@ -169,6 +176,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'Online', $output );
 	}
 
+	/**
+	 * Combined identity and preference sections use an h2/h3 heading hierarchy.
+	 */
 	public function test_group_membership_block_renders_optional_sidebar_headings() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $member_id );
@@ -183,6 +193,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'Email preferences', $output );
 	}
 
+	/**
+	 * Preference-only placements use an h2 and omit identity markup.
+	 */
 	public function test_group_membership_block_renders_standalone_preference_heading() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $member_id );
@@ -200,6 +213,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringNotContainsString( 'wporg-group-membership__count', $output );
 	}
 
+	/**
+	 * Empty news blocks leave no heading or wrapper markup.
+	 */
 	public function test_group_news_block_is_hidden_without_posts() {
 		$existing_posts = get_posts(
 			array(
@@ -216,6 +232,9 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertSame( '', trim( do_blocks( '<!-- wp:wporg/group-news /-->' ) ) );
 	}
 
+	/**
+	 * Published posts render their title and excerpt in the News section.
+	 */
 	public function test_group_news_block_renders_published_posts() {
 		self::factory()->post->create(
 			array(
@@ -232,6 +251,4 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'A group update', $output );
 		$this->assertStringContainsString( 'What the group has been working on.', $output );
 	}
-
-	// phpcs:enable Squiz.Commenting.FunctionComment.Missing
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -19,13 +19,14 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		'wporg/group-membership',
 		'wporg/group-location',
 		'wporg/group-settings',
+		'wporg/group-news',
 		'wporg/my-events',
 		'wporg/page-content',
 		'wporg/sponsors',
 	);
 
 	/**
-	 * Exactly these 10 `wporg/*` blocks should be registered. An earlier
+	 * Exactly these 11 `wporg/*` blocks should be registered. An earlier
 	 * set also included `event-rsvp-count` and `event-venue-name`;
 	 * both were intentionally removed in favor of GatherPress core's own
 	 * `gatherpress/rsvp-count` and `gatherpress/venue` blocks (see #1793's
@@ -173,5 +174,83 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$output = do_blocks( '<!-- wp:wporg/group-location /-->' );
 
 		$this->assertStringContainsString( 'Online', $output );
+	}
+
+	/**
+	 * The front-page sidebar can opt into labels for its membership and email
+	 * preference sections without adding headings to other block placements.
+	 */
+	public function test_group_membership_block_renders_optional_sidebar_headings() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$output = do_blocks(
+			'<!-- wp:wporg/group-membership {"showLeave":false,"showPreference":true,"showHeadings":true} /-->'
+		);
+
+		$this->assertStringContainsString( '<h2 class="wporg-group-membership__heading">', $output );
+		$this->assertStringContainsString( 'Membership', $output );
+		$this->assertStringContainsString( '<h3 class="wporg-group-membership__preference-heading">', $output );
+		$this->assertStringContainsString( 'Email preferences', $output );
+	}
+
+	/**
+	 * A preference-only placement promotes its label to a standalone section
+	 * heading and leaves the identity markup to another block placement.
+	 */
+	public function test_group_membership_block_renders_standalone_preference_heading() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$output = do_blocks(
+			'<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"showHeadings":true} /-->'
+		);
+
+		$this->assertStringContainsString(
+			'<h2 class="wporg-group-membership__preference-heading wporg-group-membership__preference-heading--standalone">',
+			$output
+		);
+		$this->assertStringNotContainsString( 'wporg-group-membership__heading', $output );
+		$this->assertStringNotContainsString( 'wporg-group-membership__badge', $output );
+		$this->assertStringNotContainsString( 'wporg-group-membership__count', $output );
+	}
+
+	/**
+	 * News leaves no heading or wrapper behind until a post is published.
+	 */
+	public function test_group_news_block_is_hidden_without_posts() {
+		$existing_posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		foreach ( $existing_posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		$this->assertSame( '', trim( do_blocks( '<!-- wp:wporg/group-news /-->' ) ) );
+	}
+
+	/**
+	 * Published group posts render as a conditional News section.
+	 */
+	public function test_group_news_block_renders_published_posts() {
+		self::factory()->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'A group update',
+				'post_excerpt' => 'What the group has been working on.',
+			)
+		);
+
+		$output = do_blocks( '<!-- wp:wporg/group-news /-->' );
+
+		$this->assertStringContainsString( '<h2 class="wporg-group-news__heading">News</h2>', $output );
+		$this->assertStringContainsString( 'A group update', $output );
+		$this->assertStringContainsString( 'What the group has been working on.', $output );
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -88,7 +88,7 @@ class Test_Groups_Blocks extends Groups_TestCase {
 				'post_title'  => 'Accessible RSVP Event',
 			)
 		);
-		$user_id = self::factory()->user->create(
+		$user_id  = self::factory()->user->create(
 			array(
 				'display_name' => 'Avatar Name Must Stay Decorative',
 			)
@@ -177,40 +177,59 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	}
 
 	/**
-	 * Combined identity and preference sections use an h2/h3 heading hierarchy.
+	 * The default combined variant preserves the original unheaded output.
 	 */
-	public function test_group_membership_block_renders_optional_sidebar_headings() {
+	public function test_group_membership_block_defaults_to_combined_variant() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$output = do_blocks( '<!-- wp:wporg/group-membership /-->' );
+
+		$this->assertStringContainsString( 'wporg-group-membership__badge', $output );
+		$this->assertStringContainsString( 'wporg-group-membership__count', $output );
+		$this->assertStringContainsString( 'wporg-group-membership__leave', $output );
+		$this->assertStringContainsString( 'class="wporg-group-membership__preference"', $output );
+		$this->assertStringNotContainsString( 'wporg-group-membership__heading', $output );
+		$this->assertStringNotContainsString( 'wporg-group-membership__preference-heading', $output );
+	}
+
+	/**
+	 * Membership placements include their heading and omit the preference.
+	 */
+	public function test_group_membership_block_renders_membership_variant() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $member_id );
 
 		$output = do_blocks(
-			'<!-- wp:wporg/group-membership {"showLeave":false,"showPreference":true,"showHeadings":true} /-->'
+			'<!-- wp:wporg/group-membership {"variant":"membership"} /-->'
 		);
 
 		$this->assertStringContainsString( '<h2 class="wporg-group-membership__heading">', $output );
 		$this->assertStringContainsString( 'Membership', $output );
-		$this->assertStringContainsString( '<h3 class="wporg-group-membership__preference-heading">', $output );
-		$this->assertStringContainsString( 'Email preferences', $output );
+		$this->assertStringContainsString( 'wporg-group-membership__badge', $output );
+		$this->assertStringContainsString( 'wporg-group-membership__count', $output );
+		$this->assertStringContainsString( 'wporg-group-membership__leave', $output );
+		$this->assertStringNotContainsString( 'wporg-group-membership__preference', $output );
 	}
 
 	/**
-	 * Preference-only placements use an h2 and omit identity markup.
+	 * Preference placements include their heading and omit membership controls.
 	 */
-	public function test_group_membership_block_renders_standalone_preference_heading() {
+	public function test_group_membership_block_renders_preference_variant() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $member_id );
 
 		$output = do_blocks(
-			'<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"showHeadings":true} /-->'
+			'<!-- wp:wporg/group-membership {"variant":"preference"} /-->'
 		);
 
-		$this->assertStringContainsString(
-			'<h2 class="wporg-group-membership__preference-heading wporg-group-membership__preference-heading--standalone">',
-			$output
-		);
+		$this->assertStringContainsString( '<h2 class="wporg-group-membership__preference-heading">', $output );
+		$this->assertStringContainsString( 'Email preferences', $output );
+		$this->assertStringContainsString( 'class="wporg-group-membership__preference"', $output );
 		$this->assertStringNotContainsString( 'wporg-group-membership__heading', $output );
 		$this->assertStringNotContainsString( 'wporg-group-membership__badge', $output );
 		$this->assertStringNotContainsString( 'wporg-group-membership__count', $output );
+		$this->assertStringNotContainsString( 'wporg-group-membership__leave', $output );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -17,6 +17,7 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		'wporg/event-speakers',
 		'wporg/group-members',
 		'wporg/group-membership',
+		'wporg/group-location',
 		'wporg/group-settings',
 		'wporg/my-events',
 		'wporg/page-content',
@@ -24,8 +25,8 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	);
 
 	/**
-	 * Exactly these 9 `wporg/*` blocks should be registered. The original
-	 * set of 10 also included `event-rsvp-count` and `event-venue-name`;
+	 * Exactly these 10 `wporg/*` blocks should be registered. An earlier
+	 * set also included `event-rsvp-count` and `event-venue-name`;
 	 * both were intentionally removed in favor of GatherPress core's own
 	 * `gatherpress/rsvp-count` and `gatherpress/venue` blocks (see #1793's
 	 * "Review fixes" for why) — if either reappears, or a new custom block
@@ -132,5 +133,45 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'aria-live="polite"', $output );
 		$this->assertStringContainsString( 'aria-atomic="true"', $output );
 		$this->assertStringContainsString( 'data-wp-text="context.rsvpNotice"', $output );
+	}
+
+	/**
+	 * An unspecified group location leaves no empty header element behind.
+	 */
+	public function test_group_location_block_is_hidden_when_unspecified() {
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_type' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_country' );
+
+		$this->assertSame( '', trim( do_blocks( '<!-- wp:wporg/group-location /-->' ) ) );
+	}
+
+	/**
+	 * A physical group location is rendered as its city and localized country.
+	 */
+	public function test_group_location_block_renders_physical_location() {
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'İstanbul' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'TR' );
+
+		$output = do_blocks( '<!-- wp:wporg/group-location /-->' );
+
+		$this->assertStringContainsString( 'İstanbul', $output );
+		$this->assertStringContainsString( wcorg_get_country_name_from_code( 'TR' ), $output );
+		$this->assertStringContainsString( '<svg', $output );
+		$this->assertStringContainsString( 'aria-hidden="true"', $output );
+	}
+
+	/**
+	 * Online is derived from the location type; no event platform is needed.
+	 */
+	public function test_group_location_block_renders_online_location() {
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'online' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
+		delete_site_meta( get_current_blog_id(), 'wporg_group_location_country' );
+
+		$output = do_blocks( '<!-- wp:wporg/group-location /-->' );
+
+		$this->assertStringContainsString( 'Online', $output );
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -177,6 +177,22 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	}
 
 	/**
+	 * A city with a country code that no longer resolves to a name (e.g.
+	 * CLDR data changed since it was saved) still renders — with just the
+	 * city — rather than disappearing or printing a dangling "City, ".
+	 */
+	public function test_group_location_block_renders_city_when_country_code_is_stale() {
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'Warsaw' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'ZZ' );
+
+		$output = do_blocks( '<!-- wp:wporg/group-location /-->' );
+
+		$this->assertStringContainsString( 'Warsaw', $output );
+		$this->assertStringNotContainsString( 'Warsaw,', $output );
+	}
+
+	/**
 	 * The default combined variant preserves the original unheaded output.
 	 */
 	public function test_group_membership_block_defaults_to_combined_variant() {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -136,9 +136,8 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'data-wp-text="context.rsvpNotice"', $output );
 	}
 
-	/**
-	 * An unspecified group location leaves no empty header element behind.
-	 */
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+
 	public function test_group_location_block_is_hidden_when_unspecified() {
 		delete_site_meta( get_current_blog_id(), 'wporg_group_location_type' );
 		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
@@ -147,9 +146,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertSame( '', trim( do_blocks( '<!-- wp:wporg/group-location /-->' ) ) );
 	}
 
-	/**
-	 * A physical group location is rendered as its city and localized country.
-	 */
 	public function test_group_location_block_renders_physical_location() {
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'İstanbul' );
@@ -163,9 +159,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'aria-hidden="true"', $output );
 	}
 
-	/**
-	 * Online is derived from the location type; no event platform is needed.
-	 */
 	public function test_group_location_block_renders_online_location() {
 		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'online' );
 		delete_site_meta( get_current_blog_id(), 'wporg_group_location_city' );
@@ -176,10 +169,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'Online', $output );
 	}
 
-	/**
-	 * The front-page sidebar can opt into labels for its membership and email
-	 * preference sections without adding headings to other block placements.
-	 */
 	public function test_group_membership_block_renders_optional_sidebar_headings() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $member_id );
@@ -194,10 +183,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'Email preferences', $output );
 	}
 
-	/**
-	 * A preference-only placement promotes its label to a standalone section
-	 * heading and leaves the identity markup to another block placement.
-	 */
 	public function test_group_membership_block_renders_standalone_preference_heading() {
 		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $member_id );
@@ -215,9 +200,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringNotContainsString( 'wporg-group-membership__count', $output );
 	}
 
-	/**
-	 * News leaves no heading or wrapper behind until a post is published.
-	 */
 	public function test_group_news_block_is_hidden_without_posts() {
 		$existing_posts = get_posts(
 			array(
@@ -234,9 +216,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertSame( '', trim( do_blocks( '<!-- wp:wporg/group-news /-->' ) ) );
 	}
 
-	/**
-	 * Published group posts render as a conditional News section.
-	 */
 	public function test_group_news_block_renders_published_posts() {
 		self::factory()->post->create(
 			array(
@@ -253,4 +232,6 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( 'A group update', $output );
 		$this->assertStringContainsString( 'What the group has been working on.', $output );
 	}
+
+	// phpcs:enable Squiz.Commenting.FunctionComment.Missing
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -58,19 +58,6 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 	}
 
 	/**
-	 * Create-event placements can opt into an Organiser tools heading.
-	 */
-	public function test_optional_organiser_tools_heading_is_rendered() {
-		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
-		wp_set_current_user( $editor_id );
-
-		$output = do_blocks( '<!-- wp:wporg/event-manage {"mode":"create","showHeading":true} /-->' );
-
-		$this->assertStringContainsString( '<h2 class="wporg-event-manage__heading">', $output );
-		$this->assertStringContainsString( 'Organiser tools', $output );
-	}
-
-	/**
 	 * An Event Organiser (author) viewing their own event sees both
 	 * messaging buttons.
 	 */
@@ -101,11 +88,10 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 		$other_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $other_author_id );
 
-		$output = do_blocks( '<!-- wp:wporg/event-manage {"showHeading":true} /-->' );
+		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
 
 		$this->assertStringNotContainsString( 'data-wporg-groups-modal="message-all"', $output );
 		$this->assertStringNotContainsString( 'data-wporg-groups-modal="message-attendees"', $output );
-		$this->assertStringNotContainsString( 'Organiser tools', $output );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -57,7 +57,9 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 		$this->assertStringContainsString( (string) $event_id, $output );
 	}
 
-	// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+	/**
+	 * Create-event placements can opt into an Organiser tools heading.
+	 */
 	public function test_optional_organiser_tools_heading_is_rendered() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -57,10 +57,7 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 		$this->assertStringContainsString( (string) $event_id, $output );
 	}
 
-	/**
-	 * A placement can opt into a section heading without changing the
-	 * unlabelled event-management controls used elsewhere.
-	 */
+	// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 	public function test_optional_organiser_tools_heading_is_rendered() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -58,6 +58,20 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 	}
 
 	/**
+	 * A placement can opt into a section heading without changing the
+	 * unlabelled event-management controls used elsewhere.
+	 */
+	public function test_optional_organiser_tools_heading_is_rendered() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$output = do_blocks( '<!-- wp:wporg/event-manage {"mode":"create","showHeading":true} /-->' );
+
+		$this->assertStringContainsString( '<h2 class="wporg-event-manage__heading">', $output );
+		$this->assertStringContainsString( 'Organiser tools', $output );
+	}
+
+	/**
 	 * An Event Organiser (author) viewing their own event sees both
 	 * messaging buttons.
 	 */
@@ -88,10 +102,11 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 		$other_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $other_author_id );
 
-		$output = do_blocks( '<!-- wp:wporg/event-manage /-->' );
+		$output = do_blocks( '<!-- wp:wporg/event-manage {"showHeading":true} /-->' );
 
 		$this->assertStringNotContainsString( 'data-wporg-groups-modal="message-all"', $output );
 		$this->assertStringNotContainsString( 'data-wporg-groups-modal="message-attendees"', $output );
+		$this->assertStringNotContainsString( 'Organiser tools', $output );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
@@ -16,6 +16,7 @@ const VERSION = '0.2.0';
 
 require_once __DIR__ . '/inc/capabilities.php';
 require_once __DIR__ . '/inc/defaults.php';
+require_once __DIR__ . '/inc/group-location.php';
 require_once __DIR__ . '/inc/rest.php';
 require_once __DIR__ . '/inc/modal.php';
 require_once __DIR__ . '/inc/blocks.php';

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -56,13 +56,6 @@
    Front-page hero
    ========================================================================== */
 
-/* The hero carries the group's own description (`blogdescription`), which is
-   often a single short line. Cap its measure so it stays readable rather than
-   stretching the full 720px content width.
-
-   When it's unset the hero simply omits it — no placeholder. Organisers are
-   already prompted by `wporg/group-settings`, whose trigger button switches to
-   "Set up your group" on exactly this condition and opens the About tab. */
 .groups-site-hero .wp-block-site-tagline {
 	max-width: 52ch;
 	text-wrap: pretty;
@@ -140,10 +133,6 @@
 	margin: 0 !important;
 	font-size: var(--wp--preset--font-size--normal);
 }
-
-/* The separator is only needed when organiser controls render above the
-   preference. Ordinary members see the preference as the sidebar's first
-   and only section. */
 
 .groups-site-sidebar:has(.wporg-event-manage) .groups-site-sidebar-preference {
 	margin-top: var(--wp--preset--spacing--10) !important;

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -68,31 +68,96 @@
 	text-wrap: pretty;
 }
 
-/* Page-level spacing for the email preference in the member's own section. */
-.groups-site-my-preference {
-	margin-top: var(--wp--preset--spacing--20);
+.groups-site-hero .wp-block-wporg-group-location,
+.groups-site-hero .wp-block-wporg-group-membership {
+	padding-top: var(--wp--preset--spacing--10);
+}
+
+.groups-site-hero .wp-block-wporg-group-membership {
+	margin-block-start: 0;
 }
 
 /* ==========================================================================
-   Front-page lower sections ("About this group", sponsors)
-
-   Constrained and spaced here rather than by wrapper groups in the template.
-   Both blocks render nothing when they have no content, and a wrapper would
-   leave its top margin behind as a gap on every group site that hasn't
-   written an About page or been given a sponsor.
+   Front-page content and sidebar
    ========================================================================== */
 
-.groups-site-about,
-.groups-site-sponsors {
-	max-width: 768px;
-	margin-top: var(--wp--preset--spacing--70);
+.groups-site-home-layout {
+	align-items: flex-start !important;
 }
 
-/* The rule between the events sections and About/Sponsors has nothing to
-   separate when both of those render empty, which is the common case for a
-   brand-new group. Drop it when it ends up last in the main column. */
-main > .groups-site-content-separator:last-child {
-	display: none;
+.groups-site-sidebar-column {
+	order: 2;
+}
+
+.groups-site-main-column-wrapper {
+	order: 1;
+}
+
+.groups-site-sidebar {
+	box-sizing: border-box;
+	width: 100%;
+	padding-left: var(--wp--preset--spacing--40);
+	border-left: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.groups-site-sidebar .wporg-event-manage,
+.groups-site-sidebar .wporg-group-settings-block,
+.groups-site-sidebar .wporg-group-membership {
+	width: 100%;
+}
+
+.groups-site-sidebar .wporg-event-manage,
+.groups-site-sidebar .wporg-group-membership {
+	flex-direction: column;
+	align-items: flex-start;
+}
+
+.groups-site-sidebar .wporg-event-manage {
+	gap: 12px;
+}
+
+.groups-site-sidebar .wporg-event-manage__heading,
+.groups-site-sidebar .wporg-group-membership__heading,
+.groups-site-sidebar .wporg-group-membership__preference-heading {
+	box-sizing: border-box;
+	width: 100%;
+	padding: 0;
+	font-family: var(--wp--preset--font-family--inter);
+	color: var(--wp--preset--color--charcoal-1);
+}
+
+.groups-site-sidebar .wporg-event-manage__heading,
+.groups-site-sidebar .wporg-group-membership__heading {
+	margin: 0 !important;
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+.groups-site-sidebar .wporg-group-membership__preference-heading {
+	margin: var(--wp--preset--spacing--10) 0 0 !important;
+	font-size: var(--wp--preset--font-size--small);
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+.groups-site-sidebar .wporg-group-membership__preference-heading--standalone {
+	margin: 0 !important;
+	font-size: var(--wp--preset--font-size--normal);
+}
+
+/* The separator is only needed when organiser controls render above the
+   preference. Ordinary members see the preference as the sidebar's first
+   and only section. */
+
+.groups-site-sidebar:has(.wporg-event-manage) .groups-site-sidebar-preference {
+	margin-top: var(--wp--preset--spacing--10) !important;
+	padding-top: var(--wp--preset--spacing--20);
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.groups-site-main-column {
+	min-width: 0;
 }
 
 /* ==========================================================================

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -68,6 +68,11 @@
 	text-wrap: pretty;
 }
 
+/* Page-level spacing for the email preference in the member's own section. */
+.groups-site-my-preference {
+	margin-top: var(--wp--preset--spacing--20);
+}
+
 /* ==========================================================================
    Query Loop event cards — make the entire card clickable via the
    post-title link and add hover state.

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -74,6 +74,28 @@
 }
 
 /* ==========================================================================
+   Front-page lower sections ("About this group", sponsors)
+
+   Constrained and spaced here rather than by wrapper groups in the template.
+   Both blocks render nothing when they have no content, and a wrapper would
+   leave its top margin behind as a gap on every group site that hasn't
+   written an About page or been given a sponsor.
+   ========================================================================== */
+
+.groups-site-about,
+.groups-site-sponsors {
+	max-width: 768px;
+	margin-top: var(--wp--preset--spacing--70);
+}
+
+/* The rule between the events sections and About/Sponsors has nothing to
+   separate when both of those render empty, which is the common case for a
+   brand-new group. Drop it when it ends up last in the main column. */
+main > .groups-site-content-separator:last-child {
+	display: none;
+}
+
+/* ==========================================================================
    Query Loop event cards — make the entire card clickable via the
    post-title link and add hover state.
    ========================================================================== */

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -68,13 +68,8 @@
 	text-wrap: pretty;
 }
 
-.groups-site-hero .wp-block-wporg-group-location,
-.groups-site-hero .wp-block-wporg-group-membership {
+.groups-site-hero .wp-block-wporg-group-location {
 	padding-top: var(--wp--preset--spacing--10);
-}
-
-.groups-site-hero .wp-block-wporg-group-membership {
-	margin-block-start: 0;
 }
 
 /* ==========================================================================

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -104,7 +104,6 @@
 	gap: 12px;
 }
 
-.groups-site-sidebar .wporg-event-manage__heading,
 .groups-site-sidebar .wporg-group-membership__heading,
 .groups-site-sidebar .wporg-group-membership__preference-heading {
 	box-sizing: border-box;
@@ -114,7 +113,6 @@
 	color: var(--wp--preset--color--charcoal-1);
 }
 
-.groups-site-sidebar .wporg-event-manage__heading,
 .groups-site-sidebar .wporg-group-membership__heading {
 	margin: 0 !important;
 	font-size: var(--wp--preset--font-size--normal);

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -53,6 +53,22 @@
 
 
 /* ==========================================================================
+   Front-page hero
+   ========================================================================== */
+
+/* The hero carries the group's own description (`blogdescription`), which is
+   often a single short line. Cap its measure so it stays readable rather than
+   stretching the full 720px content width.
+
+   When it's unset the hero simply omits it — no placeholder. Organisers are
+   already prompted by `wporg/group-settings`, whose trigger button switches to
+   "Set up your group" on exactly this condition and opens the About tab. */
+.groups-site-hero .wp-block-site-tagline {
+	max-width: 52ch;
+	text-wrap: pretty;
+}
+
+/* ==========================================================================
    Query Loop event cards — make the entire card clickable via the
    post-title link and add hover state.
    ========================================================================== */

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -109,27 +109,12 @@
 	box-sizing: border-box;
 	width: 100%;
 	padding: 0;
+	margin: 0 !important;
 	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: 600;
+	line-height: 1.4;
 	color: var(--wp--preset--color--charcoal-1);
-}
-
-.groups-site-sidebar .wporg-group-membership__heading {
-	margin: 0 !important;
-	font-size: var(--wp--preset--font-size--normal);
-	font-weight: 600;
-	line-height: 1.4;
-}
-
-.groups-site-sidebar .wporg-group-membership__preference-heading {
-	margin: var(--wp--preset--spacing--10) 0 0 !important;
-	font-size: var(--wp--preset--font-size--small);
-	font-weight: 600;
-	line-height: 1.4;
-}
-
-.groups-site-sidebar .wporg-group-membership__preference-heading--standalone {
-	margin: 0 !important;
-	font-size: var(--wp--preset--font-size--normal);
 }
 
 .groups-site-sidebar:has(.wporg-event-manage) .groups-site-sidebar-preference {

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -11,6 +11,34 @@ iframe {
 	height: auto;
 }
 
+/* Give the home-page columns enough room before switching to a stacked
+   information hierarchy. The sidebar stays first when stacked so membership
+   and organiser actions do not fall below the entire event feed. */
+@media (max-width: 960px) {
+	.groups-site-home-layout {
+		flex-wrap: wrap !important;
+	}
+
+	.groups-site-home-layout > .wp-block-column {
+		flex-basis: 100% !important;
+	}
+
+	.groups-site-sidebar-column {
+		order: 1;
+	}
+
+	.groups-site-main-column-wrapper {
+		order: 2;
+	}
+
+	.groups-site-sidebar {
+		padding-left: 0;
+		padding-bottom: var(--wp--preset--spacing--50);
+		border-left: 0;
+		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+	}
+}
+
 /* ==========================================================================
    Mobile (up to 781px)
    ========================================================================== */

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -11,9 +11,6 @@ iframe {
 	height: auto;
 }
 
-/* Give the home-page columns enough room before switching to a stacked
-   information hierarchy. The sidebar stays first when stacked so membership
-   and organiser actions do not fall below the entire event feed. */
 @media (max-width: 960px) {
 	.groups-site-home-layout {
 		flex-wrap: wrap !important;

--- a/public_html/wp-content/themes/groups-site/templates/archive-gatherpress_event.html
+++ b/public_html/wp-content/themes/groups-site/templates/archive-gatherpress_event.html
@@ -61,8 +61,10 @@
 						<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M j, Y","showTimezone":"no","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.04em"}}} /-->
 						<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.3"}}} /-->
 						<!-- wp:post-excerpt {"moreText":"","excerptLength":25,"fontSize":"small","textColor":"charcoal-3"} /-->
-						<!-- wp:wporg/event-rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
-						<!-- wp:wporg/event-venue-name {"fontSize":"small","textColor":"charcoal-4"} /-->
+						<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
+						<!-- wp:gatherpress/venue -->
+							<!-- wp:post-title {"level":4,"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
+						<!-- /wp:gatherpress/venue -->
 					</div>
 					<!-- /wp:group -->
 				</div>

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -28,81 +28,83 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
 <main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"className":"groups-site-section","anchor":"upcoming","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained","contentSize":"1160px","justifyContent":"left"}} -->
-	<div id="upcoming" class="wp-block-group groups-site-section" style="margin-bottom:var(--wp--preset--spacing--70)">
-		<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"}} -->
-		<div class="wp-block-group alignwide" style="margin-bottom:var(--wp--preset--spacing--40)">
-			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"center"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
-			<div class="wp-block-group">
-				<!-- wp:heading {"level":2,"fontSize":"heading-3","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
-				<h2 class="wp-block-heading has-heading-3-font-size" style="margin-bottom:0">Upcoming events</h2>
-				<!-- /wp:heading -->
+	<!-- The sidebar contains group-level actions and member utilities. Each
+	     dynamic block renders nothing when it does not apply to the current
+	     visitor, so public visitors never see empty organiser controls. -->
+	<!-- wp:columns {"align":"wide","className":"groups-site-home-layout","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
+	<div class="wp-block-columns alignwide groups-site-home-layout">
+		<!-- wp:column {"width":"26%","className":"groups-site-sidebar-column"} -->
+		<div class="wp-block-column groups-site-sidebar-column" style="flex-basis:26%">
+			<!-- wp:group {"tagName":"aside","className":"groups-site-sidebar","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+			<aside class="wp-block-group groups-site-sidebar">
+				<!-- wp:wporg/event-manage {"mode":"create","showHeading":true,"lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
-			</div>
+
+				<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"showHeadings":true,"className":"groups-site-sidebar-preference","lock":{"move":true,"remove":true}} /-->
+			</aside>
 			<!-- /wp:group -->
-
-			<!-- wp:pattern {"slug":"groups-site/view-all-events-link"} /-->
 		</div>
-		<!-- /wp:group -->
+		<!-- /wp:column -->
 
-		<!-- wp:query {"query":{"postType":"gatherpress_event","perPage":3,"offset":0,"order":"asc","orderBy":"datetime","gatherpress_event_query":"upcoming","include_unfinished":1,"inherit":false},"namespace":"gatherpress-event-query","className":"gatherpress-event-query","align":"wide"} -->
-		<div class="wp-block-query alignwide gatherpress-event-query">
-			<!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
-				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"}},"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group has-border-color" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px">
-					<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9","style":{"border":{"radius":{"topLeft":"3px","topRight":"3px","bottomLeft":"0px","bottomRight":"0px"}}}} /-->
-					<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
-					<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
-						<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M j, Y","showTimezone":"no","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.04em"}}} /-->
-						<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.3"}}} /-->
-						<!-- wp:post-excerpt {"moreText":"","excerptLength":18,"fontSize":"small","textColor":"charcoal-3"} /-->
-						<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
-						<!-- wp:gatherpress/venue -->
-							<!-- wp:post-title {"level":4,"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
-						<!-- /wp:gatherpress/venue -->
+		<!-- wp:column {"width":"74%","className":"groups-site-main-column-wrapper"} -->
+		<div class="wp-block-column groups-site-main-column-wrapper" style="flex-basis:74%">
+			<!-- wp:group {"className":"groups-site-main-column","style":{"spacing":{"blockGap":"var:preset|spacing|70"}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group groups-site-main-column">
+				<!-- wp:group {"className":"groups-site-section","anchor":"upcoming","layout":{"type":"constrained","justifyContent":"left"}} -->
+				<div id="upcoming" class="wp-block-group groups-site-section">
+					<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"}} -->
+					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+						<!-- wp:heading {"level":2,"fontSize":"heading-3","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
+						<h2 class="wp-block-heading has-heading-3-font-size" style="margin-bottom:0">Upcoming events</h2>
+						<!-- /wp:heading -->
+
+						<!-- wp:pattern {"slug":"groups-site/view-all-events-link"} /-->
 					</div>
 					<!-- /wp:group -->
+
+					<!-- wp:query {"query":{"postType":"gatherpress_event","perPage":3,"offset":0,"order":"asc","orderBy":"datetime","gatherpress_event_query":"upcoming","include_unfinished":1,"inherit":false},"namespace":"gatherpress-event-query","className":"gatherpress-event-query"} -->
+					<div class="wp-block-query gatherpress-event-query">
+						<!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
+							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"}},"layout":{"type":"constrained"}} -->
+							<div class="wp-block-group has-border-color" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px">
+								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9","style":{"border":{"radius":{"topLeft":"3px","topRight":"3px","bottomLeft":"0px","bottomRight":"0px"}}}} /-->
+								<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
+								<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+									<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M j, Y","showTimezone":"no","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.04em"}}} /-->
+									<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.3"}}} /-->
+									<!-- wp:post-excerpt {"moreText":"","excerptLength":18,"fontSize":"small","textColor":"charcoal-3"} /-->
+									<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
+									<!-- wp:gatherpress/venue -->
+										<!-- wp:post-title {"level":4,"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
+									<!-- /wp:gatherpress/venue -->
+								</div>
+								<!-- /wp:group -->
+							</div>
+							<!-- /wp:group -->
+						<!-- /wp:post-template -->
+
+						<!-- wp:query-no-results -->
+							<!-- wp:paragraph {"textColor":"charcoal-4"} -->
+							<p class="has-charcoal-4-color has-text-color">No upcoming events yet. Check back soon!</p>
+							<!-- /wp:paragraph -->
+						<!-- /wp:query-no-results -->
+					</div>
+					<!-- /wp:query -->
 				</div>
 				<!-- /wp:group -->
-			<!-- /wp:post-template -->
 
-			<!-- wp:query-no-results -->
-				<!-- wp:paragraph {"textColor":"charcoal-4"} -->
-				<p class="has-charcoal-4-color has-text-color">No upcoming events yet. Check back soon!</p>
-				<!-- /wp:paragraph -->
-			<!-- /wp:query-no-results -->
+				<!-- wp:wporg/my-events {"lock":{"move":true,"remove":true}} /-->
+
+				<!-- wp:wporg/group-news {"limit":3,"lock":{"move":true,"remove":true}} /-->
+
+				<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"className":"groups-site-sponsors"} /-->
+			</div>
+			<!-- /wp:group -->
 		</div>
-		<!-- /wp:query -->
+		<!-- /wp:column -->
 	</div>
-	<!-- /wp:group -->
-
-	<!-- The member's own corner of the page. The event-email opt-in sits here
-	     rather than in the hero or on the Members page: it's a per-user
-	     setting that spans every group, so it belongs with the member's own
-	     content, not anywhere that reads as a property of this group. Both
-	     blocks are gated on the same logged-in-and-a-member condition, so
-	     they appear and disappear together — and neither is wrapped, so a
-	     logged-out visitor is left with no empty container holding margin. -->
-	<!-- wp:wporg/my-events {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
-
-	<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"className":"groups-site-my-preference","lock":{"move":true,"remove":true}} /-->
-
-	<!-- wp:separator {"className":"is-style-wide groups-site-content-separator","backgroundColor":"light-grey-1"} -->
-	<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide groups-site-content-separator"/>
-	<!-- /wp:separator -->
-
-	<!-- The heading is an attribute of the block rather than a sibling in the
-	     template: `wporg/page-content` renders nothing when the About page is
-	     missing or empty and the viewer can't edit it, and a heading out here
-	     would be stranded above that empty space. -->
-	<!-- wp:wporg/page-content {"slug":"about","heading":"About this group","anchor":"about","className":"groups-site-about"} /-->
-
-	<!-- Same reasoning as the About block above: `wporg/sponsors` renders
-	     nothing when the network has no sponsors, so it carries its own
-	     spacing rather than sitting in a wrapper that would leave a 100px
-	     gap behind on every group site without one. -->
-	<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"className":"groups-site-sponsors"} /-->
+	<!-- /wp:columns -->
 
 </main>
 <!-- /wp:group -->

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -55,8 +55,10 @@
 						<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M j, Y","showTimezone":"no","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.04em"}}} /-->
 						<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.3"}}} /-->
 						<!-- wp:post-excerpt {"moreText":"","excerptLength":18,"fontSize":"small","textColor":"charcoal-3"} /-->
-						<!-- wp:wporg/event-rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
-						<!-- wp:wporg/event-venue-name {"fontSize":"small","textColor":"charcoal-4"} /-->
+						<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
+						<!-- wp:gatherpress/venue -->
+							<!-- wp:post-title {"level":4,"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
+						<!-- /wp:gatherpress/venue -->
 					</div>
 					<!-- /wp:group -->
 				</div>

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -26,9 +26,6 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
 <main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- The sidebar contains group-level actions and member utilities. Each
-	     dynamic block renders nothing when it does not apply to the current
-	     visitor, so public visitors never see empty organiser controls. -->
 	<!-- wp:columns {"align":"wide","className":"groups-site-home-layout","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
 	<div class="wp-block-columns alignwide groups-site-home-layout">
 		<!-- wp:column {"width":"26%","className":"groups-site-sidebar-column"} -->

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -23,8 +23,8 @@
 </div></div>
 <!-- /wp:cover -->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:group {"className":"groups-site-section","anchor":"upcoming","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained","contentSize":"1160px","justifyContent":"left"}} -->
 	<div id="upcoming" class="wp-block-group groups-site-section" style="margin-bottom:var(--wp--preset--spacing--70)">
@@ -86,25 +86,21 @@
 
 	<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"className":"groups-site-my-preference","lock":{"move":true,"remove":true}} /-->
 
-	<!-- wp:separator {"className":"is-style-wide","backgroundColor":"light-grey-1"} -->
-	<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide"/>
+	<!-- wp:separator {"className":"is-style-wide groups-site-content-separator","backgroundColor":"light-grey-1"} -->
+	<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide groups-site-content-separator"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:group {"className":"groups-site-section","anchor":"about","style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"constrained","contentSize":"768px","justifyContent":"left"}} -->
-	<div id="about" class="wp-block-group groups-site-section" style="margin-top:var(--wp--preset--spacing--70)">
-		<!-- wp:heading {"level":2,"fontSize":"heading-3","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-		<h2 class="wp-block-heading has-heading-3-font-size" style="margin-bottom:var(--wp--preset--spacing--30)">About this group</h2>
-		<!-- /wp:heading -->
+	<!-- The heading is an attribute of the block rather than a sibling in the
+	     template: `wporg/page-content` renders nothing when the About page is
+	     missing or empty and the viewer can't edit it, and a heading out here
+	     would be stranded above that empty space. -->
+	<!-- wp:wporg/page-content {"slug":"about","heading":"About this group","anchor":"about","className":"groups-site-about"} /-->
 
-		<!-- wp:wporg/page-content {"slug":"about"} /-->
-	</div>
-	<!-- /wp:group -->
-
-	<!-- wp:group {"className":"groups-site-section","anchor":"sponsors","style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"constrained","contentSize":"768px","justifyContent":"left"}} -->
-	<div id="sponsors" class="wp-block-group groups-site-section" style="margin-top:var(--wp--preset--spacing--70)">
-		<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true}} /-->
-	</div>
-	<!-- /wp:group -->
+	<!-- Same reasoning as the About block above: `wporg/sponsors` renders
+	     nothing when the network has no sponsors, so it carries its own
+	     spacing rather than sitting in a wrapper that would leave a 100px
+	     gap behind on every group site without one. -->
+	<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"className":"groups-site-sponsors"} /-->
 
 </main>
 <!-- /wp:group -->

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -7,8 +7,8 @@
 	<!-- /wp:navigation -->
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:cover {"overlayColor":"blueberry-4","isUserOverlayColor":true,"align":"full","lock":{"move":true,"remove":true},"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
-<div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-4-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
+<!-- wp:cover {"overlayColor":"blueberry-4","isUserOverlayColor":true,"align":"full","lock":{"move":true,"remove":true},"style":{"dimensions":{"minHeight":"0"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
+<div class="wp-block-cover alignfull" style="min-height:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-4-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
 
 	<!-- wp:group {"className":"groups-site-hero","style":{"dimensions":{"minHeight":"0"},"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained","contentSize":"720px","justifyContent":"left"}} -->
 	<div class="wp-block-group groups-site-hero" style="min-height:0">

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -32,13 +32,13 @@
 		<div class="wp-block-column groups-site-sidebar-column" style="flex-basis:26%">
 			<!-- wp:group {"tagName":"aside","className":"groups-site-sidebar","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 			<aside class="wp-block-group groups-site-sidebar">
-				<!-- wp:wporg/group-membership {"showPreference":false,"showHeadings":true,"lock":{"move":true,"remove":true}} /-->
+				<!-- wp:wporg/group-membership {"variant":"membership","lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:wporg/event-manage {"mode":"create","lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
 
-				<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"showHeadings":true,"className":"groups-site-sidebar-preference","lock":{"move":true,"remove":true}} /-->
+				<!-- wp:wporg/group-membership {"variant":"preference","className":"groups-site-sidebar-preference","lock":{"move":true,"remove":true}} /-->
 			</aside>
 			<!-- /wp:group -->
 		</div>

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -17,8 +17,6 @@
 		<!-- wp:site-tagline {"fontSize":"large","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
 
 		<!-- wp:wporg/group-location {"fontSize":"small","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"lock":{"move":true,"remove":true}} /-->
-
-		<!-- wp:wporg/group-membership {"showLeave":false,"showPreference":false,"lock":{"move":true,"remove":true}} /-->
 	</div>
 	<!-- /wp:group -->
 
@@ -37,6 +35,8 @@
 		<div class="wp-block-column groups-site-sidebar-column" style="flex-basis:26%">
 			<!-- wp:group {"tagName":"aside","className":"groups-site-sidebar","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 			<aside class="wp-block-group groups-site-sidebar">
+				<!-- wp:wporg/group-membership {"showPreference":false,"showHeadings":true,"lock":{"move":true,"remove":true}} /-->
+
 				<!-- wp:wporg/event-manage {"mode":"create","showHeading":true,"lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -75,7 +75,16 @@
 	</div>
 	<!-- /wp:group -->
 
+	<!-- The member's own corner of the page. The event-email opt-in sits here
+	     rather than in the hero or on the Members page: it's a per-user
+	     setting that spans every group, so it belongs with the member's own
+	     content, not anywhere that reads as a property of this group. Both
+	     blocks are gated on the same logged-in-and-a-member condition, so
+	     they appear and disappear together — and neither is wrapped, so a
+	     logged-out visitor is left with no empty container holding margin. -->
 	<!-- wp:wporg/my-events {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
+
+	<!-- wp:wporg/group-membership {"showIdentity":false,"showLeave":false,"showPreference":true,"className":"groups-site-my-preference","lock":{"move":true,"remove":true}} /-->
 
 	<!-- wp:separator {"className":"is-style-wide","backgroundColor":"light-grey-1"} -->
 	<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide"/>

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -34,7 +34,7 @@
 			<aside class="wp-block-group groups-site-sidebar">
 				<!-- wp:wporg/group-membership {"showPreference":false,"showHeadings":true,"lock":{"move":true,"remove":true}} /-->
 
-				<!-- wp:wporg/event-manage {"mode":"create","showHeading":true,"lock":{"move":true,"remove":true}} /-->
+				<!-- wp:wporg/event-manage {"mode":"create","lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
 

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -16,6 +16,8 @@
 
 		<!-- wp:site-tagline {"fontSize":"large","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
 
+		<!-- wp:wporg/group-location {"fontSize":"small","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"lock":{"move":true,"remove":true}} /-->
+
 		<!-- wp:wporg/group-membership {"showLeave":false,"showPreference":false,"lock":{"move":true,"remove":true}} /-->
 	</div>
 	<!-- /wp:group -->

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -7,34 +7,16 @@
 	<!-- /wp:navigation -->
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:cover {"overlayColor":"blueberry-4","isUserOverlayColor":true,"minHeight":300,"align":"full","lock":{"move":true,"remove":true},"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
-<div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space);min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-4-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
+<!-- wp:cover {"overlayColor":"blueberry-4","isUserOverlayColor":true,"align":"full","lock":{"move":true,"remove":true},"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
+<div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-4-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
 
-	<!-- wp:group {"style":{"dimensions":{"minHeight":"0"}},"layout":{"type":"constrained","contentSize":"600px","justifyContent":"left"}} -->
-	<div class="wp-block-group" style="min-height:0">
-		<!-- wp:paragraph {"fontSize":"small","textColor":"blueberry-1","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08em","fontWeight":"600"},"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
-		<p class="has-blueberry-1-color has-text-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--20);font-weight:600;letter-spacing:0.08em;text-transform:uppercase">A WordPress Group</p>
-		<!-- /wp:paragraph -->
+	<!-- wp:group {"className":"groups-site-hero","style":{"dimensions":{"minHeight":"0"},"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained","contentSize":"720px","justifyContent":"left"}} -->
+	<div class="wp-block-group groups-site-hero" style="min-height:0">
+		<!-- wp:site-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":"1.05"}}} /-->
 
-		<!-- wp:site-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}},"typography":{"lineHeight":"1.05"}}} /-->
+		<!-- wp:site-tagline {"fontSize":"large","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
 
-		<!-- wp:paragraph {"fontSize":"large","textColor":"charcoal-3","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
-		<p class="has-charcoal-3-color has-text-color has-large-font-size" style="margin-bottom:var(--wp--preset--spacing--40)">Connect with fellow WordPress enthusiasts. Join us for local meetups, workshops, and hands-on learning — all skill levels welcome.</p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:buttons {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-		<div class="wp-block-buttons">
-			<!-- wp:button -->
-			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#upcoming">Browse events</a></div>
-			<!-- /wp:button -->
-
-			<!-- wp:button {"className":"is-style-outline","style":{"border":{"color":"var:preset|color|blueberry-1","width":"1px"},"color":{"text":"var:preset|color|blueberry-1"}}} -->
-			<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color has-border-color wp-element-button" href="#about" style="border-color:var(--wp--preset--color--blueberry-1);border-width:1px;color:var(--wp--preset--color--blueberry-1)">About this group</a></div>
-			<!-- /wp:button -->
-		</div>
-		<!-- /wp:buttons -->
-
-		<!-- wp:wporg/group-membership {"lock":{"move":true,"remove":true}} /-->
+		<!-- wp:wporg/group-membership {"showLeave":false,"showPreference":false,"lock":{"move":true,"remove":true}} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/public_html/wp-content/themes/groups-site/templates/page-members.html
+++ b/public_html/wp-content/themes/groups-site/templates/page-members.html
@@ -10,8 +10,6 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
 <main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:wporg/group-membership {"showPreference":false,"lock":{"move":true,"remove":true}} /-->
-
 	<!-- wp:wporg/group-members {"lock":{"move":true,"remove":true}} /-->
 
 </main>

--- a/public_html/wp-content/themes/groups-site/templates/page-members.html
+++ b/public_html/wp-content/themes/groups-site/templates/page-members.html
@@ -10,7 +10,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
 <main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:wporg/group-membership {"lock":{"move":true,"remove":true}} /-->
+	<!-- wp:wporg/group-membership {"showPreference":false,"lock":{"move":true,"remove":true}} /-->
 
 	<!-- wp:wporg/group-members {"lock":{"move":true,"remove":true}} /-->
 

--- a/public_html/wp-content/themes/groups-site/templates/single-event.html
+++ b/public_html/wp-content/themes/groups-site/templates/single-event.html
@@ -51,9 +51,13 @@
 
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
 
-			<!-- wp:wporg/event-manage {"lock":{"move":true,"remove":true},"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+			<div class="wp-block-group">
+				<!-- wp:wporg/event-manage {"lock":{"move":true,"remove":true}} /-->
 
-			<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
+				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
+			</div>
+			<!-- /wp:group -->
 
 			<!-- wp:wporg/event-speakers {"lock":{"move":true,"remove":true},"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /-->
 

--- a/tests/e2e/anonymous.spec.js
+++ b/tests/e2e/anonymous.spec.js
@@ -10,6 +10,11 @@ test.describe( 'anonymous visitor', () => {
 	test( 'front page renders', async ( { page } ) => {
 		const response = await page.goto( '' );
 		expect( response.status() ).toBe( 200 );
+
+		const sidebar = page.locator( '.groups-site-sidebar' );
+		await expect( sidebar.getByRole( 'button', { name: 'Join this group' } ) ).toBeVisible();
+		await expect( sidebar.locator( '.wporg-group-membership__count' ) ).toHaveText( /\d+ members?/ );
+		await expect( page.locator( '.groups-site-hero .wporg-group-membership' ) ).toHaveCount( 0 );
 	} );
 
 	test( 'no management UI is rendered on the front page', async ( { page } ) => {

--- a/tests/e2e/member-directory.spec.js
+++ b/tests/e2e/member-directory.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
+const { login } = require( './utils/login' );
 
 /**
  * The public member directory (`wporg/group-members` block, rendered on
@@ -16,5 +17,17 @@ test.describe( 'member directory', () => {
 		await expect( grid.locator( '.wporg-group-members__role--editor' ).first() ).toHaveText( /Organiser/ );
 		await expect( grid.locator( '.wporg-group-members__role--author' ).first() ).toHaveText( /Event Organiser/ );
 		await expect( grid.locator( '.wporg-group-members__role--subscriber' ).first() ).toHaveText( /Member/ );
+	} );
+
+	test( 'keeps the leave action in the homepage sidebar', async ( { page } ) => {
+		await login( page, 'grouptestmember', 'password' );
+		await page.goto( '' );
+
+		const sidebar = page.locator( '.groups-site-sidebar' );
+		await expect( sidebar.getByRole( 'button', { name: 'Leave group' } ) ).toBeVisible();
+
+		await page.goto( 'members/' );
+		await expect( page.locator( '.groups-site-sidebar' ) ).toHaveCount( 0 );
+		await expect( page.locator( '.wporg-group-membership' ) ).toHaveCount( 0 );
 	} );
 } );

--- a/tests/e2e/member-directory.spec.js
+++ b/tests/e2e/member-directory.spec.js
@@ -20,7 +20,7 @@ test.describe( 'member directory', () => {
 	} );
 
 	test( 'keeps the leave action in the homepage sidebar', async ( { page } ) => {
-		await login( page, 'grouptestmember', 'password' );
+		await login( page, 'member1', 'password' );
 		await page.goto( '' );
 
 		const sidebar = page.locator( '.groups-site-sidebar' );


### PR DESCRIPTION
## What changed

Refreshes Groups pages with a compact location-aware hero, responsive member/organizer sidebar, news/event/sponsor sections, and consistent event action buttons.

## Test

1. View a group home logged out, as a member, and as an organizer on desktop/mobile; verify the hero location, sections, and sidebar states.
2. In **Group settings → About**, save online and in-person locations; verify each appears in the hero.
3. Join/leave the group, toggle email preferences, create/edit an event, and RSVP/un-RSVP; verify the buttons, modals, and states.

Part of #1858