### PR TITLE
Identify which registration question is unanswered

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -228,23 +228,46 @@ function scheduleFocus( element ) {
  * the block so a page listing several events reads the right one.
  *
  * @param {Element} block The `.wp-block-wporg-event-rsvp` element.
- * @return {{answers: Object, missingRequired: boolean}} Collected answers.
+ * @return {{answers: Object, missingRequired: boolean, missingInputs: Element[]}} Collected answers.
  */
 function collectAnswers( block ) {
 	const answers = {};
-	let missingRequired = false;
+	const missingInputs = [];
 
 	block?.querySelectorAll( '.wporg-event-rsvp__question-input' ).forEach( ( input ) => {
 		const value = input.value.trim();
 		if ( ! value && input.required ) {
-			missingRequired = true;
+			missingInputs.push( input );
 		}
 		// Blanks are sent too, so the server can tell "cleared this answer"
 		// from "never rendered this question".
 		answers[ input.dataset.questionId ] = value;
 	} );
 
-	return { answers, missingRequired };
+	return { answers, missingRequired: 0 < missingInputs.length, missingInputs };
+}
+
+/**
+ * Marks the unanswered required inputs so assistive tech can find them.
+ *
+ * The error text itself is announced through the block's live region, but that
+ * only tells someone that an answer is missing. With several questions the
+ * field in error also has to be identifiable, which is the other half of
+ * WCAG 2.1 3.3.1, so flag them and move focus to the first.
+ *
+ * @param {Element}   block         The `.wp-block-wporg-event-rsvp` element.
+ * @param {Element[]} missingInputs Inputs that are required and still empty.
+ */
+function flagMissingAnswers( block, missingInputs ) {
+	block?.querySelectorAll( '.wporg-event-rsvp__question-input' ).forEach( ( input ) => {
+		if ( missingInputs.includes( input ) ) {
+			input.setAttribute( 'aria-invalid', 'true' );
+		} else {
+			input.removeAttribute( 'aria-invalid' );
+		}
+	} );
+
+	scheduleFocus( missingInputs[ 0 ] );
 }
 
 async function doToggleRsvp( ctx, actionElement ) {
@@ -300,9 +323,10 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		}
 	}
 
-	const { answers, missingRequired } = ctx.hasQuestions
-		? collectAnswers( actionElement?.closest( '.wp-block-wporg-event-rsvp' ) )
-		: { answers: {}, missingRequired: false };
+	const block = actionElement?.closest( '.wp-block-wporg-event-rsvp' );
+	const { answers, missingRequired, missingInputs } = ctx.hasQuestions
+		? collectAnswers( block )
+		: { answers: {}, missingRequired: false, missingInputs: [] };
 
 	// The server rejects this too — checking here just saves a round trip and
 	// keeps whatever the attendee already typed on screen.
@@ -311,7 +335,12 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		ctx.questionsError = message;
 		ctx.rsvpNotice = message;
 		openRsvpModal( ctx, actionElement );
+		flagMissingAnswers( block, missingInputs );
 		return;
+	}
+
+	if ( ctx.hasQuestions ) {
+		flagMissingAnswers( block, [] );
 	}
 
 	const oldStatus = ctx.currentUserStatus;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
@@ -394,6 +394,33 @@ describe( 'event RSVP custom registration questions', () => {
 		expect( mockContext.questionsError ).toBe( 'Please answer the required questions.' );
 	} );
 
+	test( 'identifies which required question is unanswered', async () => {
+		const { actions } = loadStore();
+		const { company, diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+
+		await actions.toggleRsvp();
+
+		// The generic error is announced via the live region, but the field in
+		// error also has to be identifiable. WCAG 2.1 3.3.1.
+		expect( diet.getAttribute( 'aria-invalid' ) ).toBe( 'true' );
+		expect( company.hasAttribute( 'aria-invalid' ) ).toBe( false );
+	} );
+
+	test( 'clears the invalid flag once the required question is answered', async () => {
+		const { actions } = loadStore();
+		const { diet, rsvp } = renderModalWithQuestions();
+		mockElement = rsvp;
+
+		await actions.toggleRsvp();
+		expect( diet.getAttribute( 'aria-invalid' ) ).toBe( 'true' );
+
+		diet.value = 'Vegetarian';
+		await actions.toggleRsvp();
+
+		expect( diet.hasAttribute( 'aria-invalid' ) ).toBe( false );
+	} );
+
 	test( 'sends the answers alongside the RSVP', async () => {
 		const { actions } = loadStore();
 		const { company, diet, rsvp } = renderModalWithQuestions();


### PR DESCRIPTION
Follows up my review comment on #1853 with the actual patch, since it is small enough that a branch is more use than a description. Targets `add/1813-rsvp-registration-questions` so it lands inside your PR rather than alongside it. Merge it, cherry-pick it, or ignore it entirely.

### What it does

`collectAnswers()` already knows which input is empty at the moment it decides `missingRequired`, it just throws that away. This returns the offending inputs, marks them `aria-invalid="true"`, and moves focus to the first via the `scheduleFocus()` helper already in the file. The flag is cleared on every submit so it never outlives the problem.

The change sits in `submitRsvp()`, which is the shared path for both the Attend toggle and the Save answers button, so both routes are covered by the one edit.

### Why

The message itself was never the gap. `ctx.rsvpNotice` is bound to the `role="status"` live region, so "Please answer the required questions" is announced properly. What was missing is the other half of WCAG 2.1 3.3.1: the error is described, but the item in error is not identified. With up to five questions, and every input sharing one `aria-describedby` pointing at the same generic paragraph, a screen reader user is told something is missing and then has to hunt for it.

### Tests

Two added to `tests-js/event-rsvp.test.js`, in the existing questions describe block:

- `identifies which required question is unanswered` asserts `aria-invalid` lands on the required empty input and not on the optional one
- `clears the invalid flag once the required question is answered`

I confirmed both fail against your branch without the source change and pass with it, and the file's full suite is green at 16 tests.

Nothing else in the PR is touched, and none of the #1852 accessibility work is affected.

Props motylanogha
