### PR TITLE
Add JavaScript tests for group notification preferences

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-membership.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-membership.test.js
@@ -98,4 +98,42 @@ describe( 'group membership notification preference', () => {
 		expect( mockContext.preferenceNoticeError ).toBe( true );
 		expect( mockContext.preferenceSaving ).toBe( false );
 	} );
+
+	test( 'ignores preference changes while a save is pending', async () => {
+		let resolveResponse;
+		global.fetch.mockImplementation(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveResponse = resolve;
+				} )
+		);
+		const { actions } = loadStore();
+
+		const firstSave = actions.updateNotificationPreference( {
+			target: { checked: true },
+		} );
+
+		expect( mockContext.notificationOptIn ).toBe( true );
+		expect( mockContext.preferenceSaving ).toBe( true );
+
+		const secondSave = actions.updateNotificationPreference( {
+			target: { checked: false },
+		} );
+		await secondSave;
+		await Promise.resolve();
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+		expect( mockContext.notificationOptIn ).toBe( true );
+
+		resolveResponse( {
+			ok: true,
+			json: async () => ( { success: true, optIn: true } ),
+		} );
+		await firstSave;
+
+		expect( mockContext.notificationOptIn ).toBe( true );
+		expect( mockContext.preferenceNoticeSuccess ).toBe( true );
+		expect( mockContext.preferenceNoticeError ).toBe( false );
+		expect( mockContext.preferenceSaving ).toBe( false );
+	} );
 } );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-membership.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-membership.test.js
@@ -1,0 +1,101 @@
+/* eslint-disable id-length -- Fetch Response fixtures use the native `ok` property. */
+
+let mockContext;
+let mockStoreConfig;
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: jest.fn( ( namespace, config ) => {
+			mockStoreConfig = config;
+			return config;
+		} ),
+		getContext: jest.fn( () => mockContext ),
+	} ),
+	{ virtual: true }
+);
+
+function loadStore() {
+	jest.resetModules();
+	require( '../src/blocks/group-membership/view' );
+	return mockStoreConfig;
+}
+
+function createContext() {
+	return {
+		isMember: true,
+		notificationOptIn: false,
+		preferenceApi: '/wp-json/wporg-groups/v1/members/notification-preference',
+		preferenceErrorLabel: 'Your email preference could not be saved.',
+		preferenceMessage: '',
+		preferenceNoticeError: false,
+		preferenceNoticeSuccess: false,
+		preferenceSavedLabel: 'Your email preference has been saved.',
+		preferenceSaving: false,
+		restNonce: 'rest-nonce',
+	};
+}
+
+describe( 'group membership notification preference', () => {
+	beforeEach( () => {
+		mockContext = createContext();
+		mockStoreConfig = null;
+		global.fetch = jest.fn();
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'saves an opted-in member notification preference', async () => {
+		global.fetch.mockResolvedValue( {
+			ok: true,
+			json: async () => ( { success: true, optIn: true } ),
+		} );
+		const { actions } = loadStore();
+
+		await actions.updateNotificationPreference( {
+			target: { checked: true },
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledWith( mockContext.preferenceApi, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': 'rest-nonce',
+			},
+			body: JSON.stringify( { opt_in: true } ),
+		} );
+		expect( mockContext.notificationOptIn ).toBe( true );
+		expect( mockContext.preferenceMessage ).toBe( mockContext.preferenceSavedLabel );
+		expect( mockContext.preferenceNoticeSuccess ).toBe( true );
+		expect( mockContext.preferenceNoticeError ).toBe( false );
+		expect( mockContext.preferenceSaving ).toBe( false );
+	} );
+
+	test( 'rolls back the notification preference when saving fails', async () => {
+		mockContext.notificationOptIn = true;
+		global.fetch.mockResolvedValue( {
+			ok: false,
+			json: async () => ( { success: false } ),
+		} );
+		const { actions } = loadStore();
+
+		await actions.updateNotificationPreference( {
+			target: { checked: false },
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledWith(
+			mockContext.preferenceApi,
+			expect.objectContaining( {
+				body: JSON.stringify( { opt_in: false } ),
+			} )
+		);
+		expect( mockContext.notificationOptIn ).toBe( true );
+		expect( mockContext.preferenceMessage ).toBe( mockContext.preferenceErrorLabel );
+		expect( mockContext.preferenceNoticeSuccess ).toBe( false );
+		expect( mockContext.preferenceNoticeError ).toBe( true );
+		expect( mockContext.preferenceSaving ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Adds focused JavaScript coverage for the group membership notification preference flow identified during the GatherPress test coverage audit.

The tests cover:

- a successful opt-in request, including the nonce, JSON payload, and success state
- rollback and error state when the preference request fails
- suppression of additional changes while a save is pending, preventing duplicate requests and stale state

See #1863

### Screenshots

Not applicable. This is a test-only change.

### How to test the changes in this Pull Request:

1. Run `npm ci` from the repository root.
2. Run `npm run test --workspace=wporg-groups-frontend -- --runInBand`.
3. Confirm both JavaScript suites pass with 10 tests.
4. Run `npm exec -- eslint public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-membership.test.js`.
