### PR TITLE
Improve group site 404 page

### DIFF
--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -50,6 +50,11 @@
 	height: auto;
 }
 
+/* Keep the parent theme's 404 heading readable over its dark background. */
+body.error404 .site-content-container h1 {
+	color: inherit;
+}
+
 
 
 /* ==========================================================================

--- a/public_html/wp-content/themes/groups-site/templates/404.html
+++ b/public_html/wp-content/themes/groups-site/templates/404.html
@@ -7,23 +7,6 @@
 	<!-- /wp:navigation -->
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"680px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--edge-space)">
-
-	<!-- wp:paragraph {"align":"center","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08em","fontWeight":"600"},"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->
-	<p class="has-text-align-center has-blueberry-1-color has-text-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--10);font-weight:600;letter-spacing:0.08em;text-transform:uppercase">404</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:heading {"level":1,"textAlign":"center","fontSize":"heading-1"} -->
-	<h1 class="wp-block-heading has-text-align-center has-heading-1-font-size">Page not found</h1>
-	<!-- /wp:heading -->
-
-	<!-- wp:paragraph {"align":"center","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|40"}}}} -->
-	<p class="has-text-align-center has-charcoal-3-color has-text-color" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--40)">The page you are looking for does not exist. It may have been moved or deleted.</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search this group\u2026","buttonText":"Search","align":"center"} /-->
-
-</main>
+<!-- wp:pattern {"slug":"wporg-parent-2021/404-page"} /-->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","lock":{"move":true,"remove":true}} /-->


### PR DESCRIPTION
## Description

Improves the 404 page for individual group sites by reusing the established WordPress.org parent-theme 404 pattern.

The group template previously rendered custom markup that did not match the parent theme's 404 CSS, leaving the heading and supporting copy with insufficient contrast on the dark background.

## Changes

- Replace the custom group-site 404 content with the parent theme's 404 pattern.
- Preserve the group header, navigation, footer, homepage link, and group-scoped search.
- Inherit the 404 heading color from the dark content container so it remains readable.

## Screenshots

https://events.wordpress.test/group/sunshine-coast-qld/404.

| before | after |
| -- | -- |
| <kbd><img width="1265" height="712" alt="image" src="https://github.com/user-attachments/assets/08e09e0e-1327-46b5-ae15-5014c7704dc4" /></kbd> | <kbd><img width="1253" height="705" alt="image" src="https://github.com/user-attachments/assets/0a6591a6-6219-4dc9-9201-c18e69397b13" /></kbd> 


## Testing

- Confirmed the 404 renders at `https://events.wordpress.test/group/sunshine-coast-qld/404`.
- Confirmed the heading is white and readable.
- Confirmed “the homepage” links to `/group/sunshine-coast-qld/`.
- Confirmed the search field remains visible.
- Confirmed the layout has no horizontal overflow at a 390px viewport.
- `git diff --check` passes.
- Stylelint reports the same six pre-existing errors as `production`; this change adds none.

Fixes #1867.
