### PR TITLE
Groups: scope the event-updates email opt-in per group

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/notifications.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/notifications.php
@@ -49,14 +49,16 @@ function get_scoped_opt_in_meta_key( ?int $blog_id = null ): string {
  * lookup -- until a member makes an explicit choice on this group's site,
  * so existing opt-outs aren't silently reset to the default.
  *
- * @param mixed  $value    The filtered meta value. Untouched (null) unless a plugin upstream already set it.
+ * @param mixed  $value    The filtered meta value. A non-null value means an earlier
+ *                         `get_user_metadata` callback already short-circuited the read,
+ *                         which this filter must not override.
  * @param int    $object_id User ID.
  * @param string $meta_key  Meta key being read.
  * @param bool   $single    Whether to return a single value.
  * @return mixed
  */
 function scope_opt_in_read_to_current_group( $value, int $object_id, string $meta_key, bool $single ) {
-	if ( GATHERPRESS_OPT_IN_META_KEY !== $meta_key ) {
+	if ( GATHERPRESS_OPT_IN_META_KEY !== $meta_key || null !== $value ) {
 		return $value;
 	}
 
@@ -78,20 +80,20 @@ function scope_opt_in_read_to_current_group( $value, int $object_id, string $met
  * GatherPress's own network-wide meta key is never touched from a group
  * site -- each group keeps an independent value.
  *
- * @param mixed  $check     Whether to short-circuit the write. Untouched (null) unless a plugin upstream already handled it.
+ * @param mixed  $check     Whether to short-circuit the write. A non-null value means an
+ *                          earlier `update_user_metadata` callback already handled it, and
+ *                          this filter must not write again.
  * @param int    $object_id User ID.
  * @param string $meta_key  Meta key being written.
  * @param mixed  $meta_value New value.
  * @return mixed
  */
 function scope_opt_in_write_to_current_group( $check, int $object_id, string $meta_key, $meta_value ) {
-	if ( GATHERPRESS_OPT_IN_META_KEY !== $meta_key ) {
+	if ( GATHERPRESS_OPT_IN_META_KEY !== $meta_key || null !== $check ) {
 		return $check;
 	}
 
-	update_user_meta( $object_id, get_scoped_opt_in_meta_key(), $meta_value );
-
-	return true;
+	return update_user_meta( $object_id, get_scoped_opt_in_meta_key(), $meta_value );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/notifications.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/notifications.php
@@ -12,10 +12,86 @@ defined( 'WPINC' ) || die();
 const PUBLISH_NOTIFICATION_SCHEDULED_META = '_wporg_groups_event_publish_notification_scheduled';
 
 /**
+ * The GatherPress user meta key this file scopes per group.
+ *
+ * GatherPress stores event-update opt-in as a single, network-wide user
+ * meta value (`wp_usermeta` isn't per-site), so toggling it on one group's
+ * site changes it on every group the member belongs to. The filters below
+ * redirect reads/writes of this key to a key namespaced by blog ID instead,
+ * so the preference can differ per group.
+ */
+const GATHERPRESS_OPT_IN_META_KEY = 'gatherpress_event_updates_opt_in';
+
+/**
  * Register notification hooks.
  */
 function bootstrap(): void {
 	add_action( 'transition_post_status', __NAMESPACE__ . '\schedule_new_event_notification', 10, 3 );
+	add_filter( 'get_user_metadata', __NAMESPACE__ . '\scope_opt_in_read_to_current_group', 10, 4 );
+	add_filter( 'update_user_metadata', __NAMESPACE__ . '\scope_opt_in_write_to_current_group', 10, 4 );
+}
+
+/**
+ * The per-group user meta key for a given site.
+ *
+ * @param int|null $blog_id Site ID. Defaults to the current site.
+ * @return string
+ */
+function get_scoped_opt_in_meta_key( ?int $blog_id = null ): string {
+	return '_wporg_groups_event_updates_opt_in_' . ( $blog_id ?? get_current_blog_id() );
+}
+
+/**
+ * Read the event-updates opt-in from this group's own meta, when it's been set.
+ *
+ * Falls through to GatherPress's own (network-wide) value -- by returning
+ * the untouched `$value` so `get_metadata()` proceeds with its normal
+ * lookup -- until a member makes an explicit choice on this group's site,
+ * so existing opt-outs aren't silently reset to the default.
+ *
+ * @param mixed  $value    The filtered meta value. Untouched (null) unless a plugin upstream already set it.
+ * @param int    $object_id User ID.
+ * @param string $meta_key  Meta key being read.
+ * @param bool   $single    Whether to return a single value.
+ * @return mixed
+ */
+function scope_opt_in_read_to_current_group( $value, int $object_id, string $meta_key, bool $single ) {
+	if ( GATHERPRESS_OPT_IN_META_KEY !== $meta_key ) {
+		return $value;
+	}
+
+	$scoped_key = get_scoped_opt_in_meta_key();
+
+	if ( ! metadata_exists( 'user', $object_id, $scoped_key ) ) {
+		return $value;
+	}
+
+	$scoped_value = get_user_meta( $object_id, $scoped_key, true );
+
+	return $single ? $scoped_value : array( $scoped_value );
+}
+
+/**
+ * Redirect writes of the opt-in to this group's own meta key.
+ *
+ * Returning a non-null value here short-circuits `update_metadata()`, so
+ * GatherPress's own network-wide meta key is never touched from a group
+ * site -- each group keeps an independent value.
+ *
+ * @param mixed  $check     Whether to short-circuit the write. Untouched (null) unless a plugin upstream already handled it.
+ * @param int    $object_id User ID.
+ * @param string $meta_key  Meta key being written.
+ * @param mixed  $meta_value New value.
+ * @return mixed
+ */
+function scope_opt_in_write_to_current_group( $check, int $object_id, string $meta_key, $meta_value ) {
+	if ( GATHERPRESS_OPT_IN_META_KEY !== $meta_key ) {
+		return $check;
+	}
+
+	update_user_meta( $object_id, get_scoped_opt_in_meta_key(), $meta_value );
+
+	return true;
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -129,7 +129,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<span><?php esc_html_e( 'Email me updates and information about events from organisers.', 'wporg-groups-frontend' ); ?></span>
 			</label>
 			<span class="wporg-group-membership__preference-help">
-				<?php esc_html_e( 'This preference applies to all your groups.', 'wporg-groups-frontend' ); ?>
+				<?php esc_html_e( 'This preference applies to this group only. Set it separately for each group you belong to.', 'wporg-groups-frontend' ); ?>
 			</span>
 			<span
 				class="wporg-group-membership__preference-status"

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-notifications.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-notifications.php
@@ -4,6 +4,7 @@ namespace WordCamp\Groups\Tests;
 
 use function WordCamp\Groups\Frontend\Notifications\schedule_new_event_notification;
 use const WordCamp\Groups\Frontend\Notifications\PUBLISH_NOTIFICATION_SCHEDULED_META;
+use const WordCamp\Groups\Frontend\Notifications\GATHERPRESS_OPT_IN_META_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -199,5 +200,80 @@ class Test_Groups_Notifications extends Groups_TestCase {
 
 		$this->assertFalse( $this->is_notification_scheduled( $event_id ) );
 		$this->assertSame( '', get_post_meta( $event_id, PUBLISH_NOTIFICATION_SCHEDULED_META, true ) );
+	}
+
+	/**
+	 * Event-updates opt-in is scoped per group: each group site keeps an
+	 * independent value, because GatherPress's own
+	 * `gatherpress_event_updates_opt_in` user meta is network-wide (not
+	 * per-site) and would otherwise leak a member's choice on one group to
+	 * every other group they belong to.
+	 */
+	public function test_opt_in_preference_is_isolated_per_group() {
+		$user_id = self::factory()->user->create();
+
+		update_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, 1 );
+		$this->assertSame( '1', get_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, true ) );
+
+		$other_group_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/other-group/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		switch_to_blog( $other_group_id );
+		\GatherPress\Core\Setup::get_instance()->check_plugin_version();
+
+		update_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, 0 );
+		$this->assertSame(
+			'0',
+			get_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, true ),
+			"The other group must not inherit the first group's opt-in."
+		);
+
+		restore_current_blog();
+
+		$this->assertSame(
+			'1',
+			get_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, true ),
+			"Switching back must not have lost the first group's opt-in."
+		);
+
+		wp_delete_site( $other_group_id );
+	}
+
+	/**
+	 * Until a member makes an explicit choice on a given group's site, the
+	 * preference falls back to any pre-existing network-wide value, so
+	 * moving to per-group storage doesn't silently reset existing opt-outs.
+	 */
+	public function test_opt_in_falls_back_to_legacy_global_value_when_unset_for_this_group() {
+		$user_id = self::factory()->user->create();
+
+		// `add_user_meta()` bypasses the `update_user_metadata` redirect --
+		// it fires a different, unhooked filter -- so this seeds the real
+		// legacy network-wide meta key directly, as if it were written
+		// before per-group scoping existed.
+		add_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, '0' );
+
+		$this->assertSame( '0', get_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, true ) );
+		$this->assertFalse( \GatherPress\Core\User::get_instance()->has_event_updates_opt_in( $user_id ) );
+	}
+
+	/**
+	 * A group-specific override, once made, takes priority over the legacy
+	 * network-wide value for that group -- read through GatherPress's own
+	 * `has_event_updates_opt_in()`, the actual integration point that
+	 * decides whether an email goes out.
+	 */
+	public function test_opt_in_override_takes_priority_over_legacy_value_through_gatherpress_core() {
+		$user_id = self::factory()->user->create();
+
+		add_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, '1' );
+		update_user_meta( $user_id, GATHERPRESS_OPT_IN_META_KEY, 0 );
+
+		$this->assertFalse( \GatherPress\Core\User::get_instance()->has_event_updates_opt_in( $user_id ) );
 	}
 }


### PR DESCRIPTION
## Summary
- Anne's feedback on the group site: the "Email me updates and information about events from organisers" preference should be per group, like meetup.com's per-group notification settings, rather than one setting that silently applies to every group a member belongs to.
- GatherPress stores that opt-in as a single, network-wide user meta value (`wp_usermeta` isn't per-site), so toggling it on one group changed it everywhere. This redirects reads/writes of that meta key to a key namespaced by blog ID via `get_user_metadata`/`update_user_metadata` filters, so each group keeps its own value — without touching the (third-party, gitignored) GatherPress plugin itself.
- A member's pre-existing network-wide preference is used as the fallback until they make an explicit choice on a given group's site, so this doesn't silently reset anyone's existing opt-out.
- Updates the checkbox help text from "This preference applies to all your groups." to reflect the new per-group behavior.

(The "Move My upcoming events to the top" half of the feedback already landed on `production` in a separate commit.)

## Test plan
- [ ] `composer test -- --group=groups --filter=Test_Groups_Notifications` — 3 new tests cover per-group isolation, fallback to the legacy global value, and the override taking priority through GatherPress's own `has_event_updates_opt_in()`.
- [ ] Manual: as a member of two different group sites, join both, uncheck "Email me updates..." on group A only. Reload group B's page and confirm the checkbox there is still checked.
- [ ] Manual: publish an event on group B and confirm the member still receives the notification email (opted in there), then publish on group A and confirm they do not (opted out there).
- [ ] Manual: for a member who has an existing (pre-migration) global opt-out and has never touched the checkbox on either group site, confirm both groups still show it unchecked by default (legacy fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
