### PR TITLE
Groups: update GatherPress pin to 0.35.0

### DIFF
--- a/.claude/skills/groups-gatherpress-compat-test/SKILL.md
+++ b/.claude/skills/groups-gatherpress-compat-test/SKILL.md
@@ -44,7 +44,7 @@ docker compose ps   # expect wordcamp.test + wordcamp.db running
 docker compose exec wordcamp.test wp plugin list --url=events.wordpress.test/group/sunshine-coast-qld/ | grep gatherpress
 # If missing/inactive:
 docker compose exec wordcamp.test wp plugin install \
-  https://github.com/GatherPress/gatherpress/releases/download/0.34.0-alpha.2/gatherpress.0.34.0-alpha.2.zip \
+  https://github.com/GatherPress/gatherpress/releases/download/0.35.0/gatherpress.0.35.0.zip \
   --activate --url=events.wordpress.test/group/sunshine-coast-qld/
 ```
 

--- a/.claude/skills/groups-gatherpress-compat-test/SKILL.md
+++ b/.claude/skills/groups-gatherpress-compat-test/SKILL.md
@@ -48,6 +48,24 @@ docker compose exec wordcamp.test wp plugin install \
   --activate --url=events.wordpress.test/group/sunshine-coast-qld/
 ```
 
+**After bumping the pinned GatherPress version, also install/update
+[GatherPress Alpha](https://github.com/GatherPress/gatherpress-alpha)
+(version-locked to core) and run its one-time migration.** GatherPress ships
+breaking *content* migrations (old `gatherpress/icon` block usage, old
+`gatherpress/venue-map` width/height attributes, renamed RSVP settings
+values) through this companion plugin rather than an automatic upgrade
+routine. Skipping this step is exactly what it looks like when a venue's
+address/phone/website/map silently vanish from the front end after a version
+bump — it reads like a GatherPress regression but is actually just unmigrated
+data:
+
+```bash
+docker compose exec wordcamp.test wp plugin install \
+  https://github.com/GatherPress/gatherpress-alpha/releases/download/0.35.0/gatherpress-alpha.0.35.0.zip \
+  --activate --url=events.wordpress.test/group/sunshine-coast-qld/
+docker compose exec wordcamp.test wp gatherpress alpha fix --url=events.wordpress.test/group/sunshine-coast-qld/
+```
+
 Create one test user per role tier, with **both** a browser login password
 and a REST application password (the browser pass needs the former, the
 REST pass needs the latter):

--- a/.claude/skills/groups-gatherpress-compat-test/SKILL.md
+++ b/.claude/skills/groups-gatherpress-compat-test/SKILL.md
@@ -25,9 +25,50 @@ interaction, cross-plugin capability leaks, exploratory checks):
   `e2e-tests.yml` GitHub Action manually — it's `workflow_dispatch`-only).
   Covers anonymous front-page rendering, an author creating an event
   end-to-end through the real browser UI, and the member directory.
+  **If a spec times out waiting on a UI interaction (e.g. a sidebar
+  panel/button that should obviously be there), re-run with
+  `--workers=1` before concluding it's a regression.** `fullyParallel: true`
+  against a single local docker container is a real, repeatable source of
+  90s timeouts that have nothing to do with GatherPress — confirmed during
+  the 0.35.0 bump: 3 "failures" all passed in under 10s each serially.
 
 If either automated suite fails, stop and fix that before doing the manual
 pass below — don't duplicate debugging effort across layers.
+
+## 0. Before bumping the pinned version
+
+- **Confirm the target version is actually stable**, not a beta/RC:
+  `curl -s https://api.wordpress.org/plugins/info/1.0/gatherpress.json | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])"`.
+- **Diff GatherPress core itself** for breaking API changes before touching
+  any code here. Clone/pull `github.com/GatherPress/gatherpress` locally and
+  run `git diff <old-tag> <new-tag>` (and `git log <old-tag>..<new-tag>
+  --oneline` for the human-readable summary). Specifically check every class
+  this integration touches directly —
+  `GatherPress\Core\{Rsvp\Rsvp,Event\Event,Venue\Venue,Venue\Setup,User,Setup,Blocks\Setup,Blocks\Event_Query}`
+  (grep `GatherPress\\\\` across `mu-plugins/groups`,
+  `mu-plugins/wporg-groups-frontend`, and `themes/groups-site` to get the
+  current list) — for renamed/removed constants, changed return types
+  (`Rsvp::get()` went from always-`array` to `array|null` in 0.35.0 and broke
+  a test that indexed it directly), and classes marked `final` (harmless
+  unless something here extends one — check with
+  `grep -rn "extends.*GatherPress"`).
+- **Grep theme templates for GatherPress block usage**, not just PHP:
+  `grep -rn "wp:gatherpress" public_html/wp-content/themes/groups-site`.
+  GatherPress Alpha's migration (see below) only rewrites block content
+  *stored in the database* — it does not touch theme `.html` template
+  files. If a version bump removes/renames a block GatherPress itself used
+  to ship (e.g. `gatherpress/icon` → core `core/icon` in 0.35.0), any
+  in-repo template using it needs a manual, matching edit or it silently
+  renders blank.
+- **Find every place the version string is pinned** — there is no single
+  source of truth, so grep for the old version across the whole repo before
+  declaring the bump done:
+  `grep -rln "<old-version>" . --include="*.yml" --include="*.php" --include="*.md" --include="*.sh" | grep -v "plugins/gatherpress"`.
+  As of the 0.35.0 bump these were: `.github/workflows/e2e-tests.yml`,
+  `.github/workflows/unit-tests.yml`, `.docker/bin/install-test-suite.sh`
+  (which was *already* stale at a different, older version than the two
+  CI workflows — don't assume they're in sync), and this skill's own
+  install command below.
 
 ## 1. Environment setup
 
@@ -163,7 +204,12 @@ don't just check curl responses render correctly, click through:
   Organiser-only tabs are entirely absent (not just disabled) for lower
   roles.
 - **Member directory** (`/members/`) — role labels correct, join/leave
-  buttons behave.
+  buttons behave. If this 404s, check `wp post list --post_type=page` for a
+  page with slug `members` before assuming it's broken — the theme resolves
+  it via the `page-members.html` template, so it needs an actual WP page
+  with that slug to exist; a fresh/reset dev site may simply be missing it
+  (`wp post create --post_type=page --post_title=Members --post_name=members
+  --post_status=publish`).
 - **wp-admin, not just the front end** — capability leaks (like the fixed
   `promote_users` escalation) only show up here. Log in as each non-admin
   role and check: can they reach Users → a role-promotion UI beyond what

--- a/.docker/bin/install-test-suite.sh
+++ b/.docker/bin/install-test-suite.sh
@@ -16,7 +16,7 @@ TESTS_CONFIG="/tmp/wp/wordpress-tests-lib/wp-tests-config.php"
 # Same pinned release used by local dev (see the groups-gatherpress-compat-test
 # skill and PR #1793's test plan). GatherPress is gitignored/third-party, so the
 # `wporg-groups-frontend`/`groups` PHPUnit suites need it installed before they run.
-GATHERPRESS_VERSION="0.34.0-alpha.2"
+GATHERPRESS_VERSION="0.35.0"
 GATHERPRESS_DIR="/app/public_html/wp-content/plugins/gatherpress"
 
 db_ready() {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Install GatherPress on the groups site
       run: |
         docker compose exec -T wordcamp.test wp plugin install \
-          https://github.com/GatherPress/gatherpress/releases/download/0.34.1/gatherpress.0.34.1.zip \
+          https://github.com/GatherPress/gatherpress/releases/download/0.35.0/gatherpress.0.35.0.zip \
           --activate --url=events.wordpress.test/group/sunshine-coast-qld/
 
     - name: Create role-tier test users

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -129,7 +129,7 @@ jobs:
       # groups-gatherpress-compat-test skill). GatherPress is gitignored/
       # third-party; the WordCamp Groups PHPUnit suite needs it present.
       run: |
-        curl -sL "https://github.com/GatherPress/gatherpress/releases/download/0.34.1/gatherpress.0.34.1.zip" -o /tmp/gatherpress.zip
+        curl -sL "https://github.com/GatherPress/gatherpress/releases/download/0.35.0/gatherpress.0.35.0.zip" -o /tmp/gatherpress.zip
         unzip -q -o /tmp/gatherpress.zip -d public_html/wp-content/plugins/
         rm -f /tmp/gatherpress.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ public_html/wp-content/plugins/custom-content-width
 public_html/wp-content/plugins/email-post-changes
 public_html/wp-content/plugins/edit-flow/
 public_html/wp-content/plugins/gatherpress/
+public_html/wp-content/plugins/gatherpress-alpha/
 public_html/wp-content/plugins/gutenberg/
 public_html/wp-content/plugins/hyperdb/
 public_html/wp-content/plugins/json-rest-api/

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-questions.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-questions.php
@@ -289,7 +289,7 @@ class Test_Groups_RSVP_Questions extends Groups_TestCase {
 		$this->assertSame( 'wporg_groups_missing_answers', $response->get_error_code() );
 
 		$rsvp = ( new \GatherPress\Core\Rsvp\Rsvp( $event_id ) )->get( $user_id );
-		$this->assertSame( 'no_status', $rsvp['status'] );
+		$this->assertSame( 'no_status', $rsvp['status'] ?? 'no_status' );
 	}
 
 	/**

--- a/public_html/wp-content/themes/groups-site/templates/single-event.html
+++ b/public_html/wp-content/themes/groups-site/templates/single-event.html
@@ -116,16 +116,16 @@
 					<!-- wp:gatherpress/venue {"lock":{"move":true,"remove":true}} -->
 					<!-- wp:post-title {"level":4,"isLink":false,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}}} /-->
 					<!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-address","style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-					<div class="wp-block-group gatherpress--has-venue-address" style="margin-top:0;margin-bottom:0"><!-- wp:gatherpress/icon {"icon":"location"} /-->
+					<div class="wp-block-group gatherpress--has-venue-address" style="margin-top:0;margin-bottom:0"><!-- wp:icon {"icon":"core/map-marker","style":{"dimensions":{"width":"24px"}}} /-->
 					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue address…","fieldType":"address"} /--></div>
 					<!-- /wp:group -->
 					<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
 					<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--30)"><!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-phone","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-					<div class="wp-block-group gatherpress--has-venue-phone"><!-- wp:gatherpress/icon {"icon":"phone"} /-->
+					<div class="wp-block-group gatherpress--has-venue-phone"><!-- wp:icon {"icon":"core/mobile","style":{"dimensions":{"width":"24px"}}} /-->
 					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue phone…","fieldType":"phone"} /--></div>
 					<!-- /wp:group -->
 					<!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-website","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-					<div class="wp-block-group gatherpress--has-venue-website"><!-- wp:gatherpress/icon {"icon":"admin-site-alt3"} /-->
+					<div class="wp-block-group gatherpress--has-venue-website"><!-- wp:icon {"icon":"core/external","style":{"dimensions":{"width":"24px"}}} /-->
 					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue website URL…","fieldType":"url"} /--></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->
@@ -138,7 +138,7 @@
 
 					<!-- wp:gatherpress/online-event -->
 					<div class="wp-block-gatherpress-online-event"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-					<div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:gatherpress/icon {"icon":"video-alt2"} /-->
+					<div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:icon {"icon":"core/capture-video","style":{"dimensions":{"width":"24px"}}} /-->
 					<!-- wp:gatherpress/online-event-link {"linkText":"\u003cspan class=\u0022gatherpress-tooltip\u0022 data-gatherpress-tooltip=\u0022Link available for attendees only.\u0022\u003eOnline event\u003c/span\u003e"} /--></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:gatherpress/online-event -->


### PR DESCRIPTION
Fixes #1843 

## Summary

Bumps the pinned GatherPress version from 0.34.1 to 0.35.0 and fixes the one breaking change that affects this repo.

- GatherPress 0.35.0 removes the `gatherpress/icon` block in favor of the new WP 7.0 core `Icon` block ([GatherPress#1931](https://github.com/GatherPress/gatherpress/commit/ae7ce4e3)). The `groups-site` theme's `single-event.html` template used `gatherpress/icon` for the venue address/phone/website and online-event indicators, so those are swapped for `core/icon` using GatherPress's own mapping (location → map-marker, phone → mobile, admin-site-alt3 → external, video-alt2 → capture-video) to avoid blank/broken blocks after the bump.
- Bumped every place that pins the GatherPress release zip for local dev and CI, since the plugin is gitignored/third-party and not tracked in this repo: `.github/workflows/e2e-tests.yml`, `.github/workflows/unit-tests.yml`, `.docker/bin/install-test-suite.sh` (was actually still on `0.34.0-alpha.2`), and the `groups-gatherpress-compat-test` skill's manual-install instructions.
- Fixed a `wporg-groups-frontend` PHPUnit test (`test_missing_required_answer_blocks_rsvp`) that assumed `Rsvp::get()` always returns an array — 0.35.0 changes it to return `null` when no identity resolves. Production code already handles this via `?? 'no_status'`; the test now does the same.

Everything else in the `Rsvp`, `Event`, `Venue`, and `Venue\Setup` APIs that `mu-plugins/groups`, `mu-plugins/wporg-groups-frontend`, and the `groups-site` theme depend on is unchanged or backward compatible between 0.34.1 and 0.35.0 (confirmed via a full diff of the two tags).

## ⚠️ Required rollout step: run GatherPress Alpha's migration after upgrading

GatherPress 0.35.0 ships breaking changes to **stored content**, not just code: the old `gatherpress/icon` block, old `gatherpress/venue-map` width/height attributes, and old RSVP settings option values (`rsvp_mode`: `all_on`/`per_event_on`/`per_event_off` → `enabled`/`per_event_enabled`/`per_event_disabled`) all need migrating in the database. GatherPress ships this as a **separate companion plugin, [GatherPress Alpha](https://github.com/GatherPress/gatherpress-alpha)**, version-locked to core.

After deploying this PR to any environment, install/update GatherPress Alpha to 0.35.0 and run its fixer once:
```
wp gatherpress alpha fix
```
(or via wp-admin: Events → Settings → Alpha → Apply Updates). I hit this directly in testing — a dev-seeded venue's address/phone/website/map data disappeared entirely after the bump, which looked like a GatherPress regression until I ran `wp gatherpress alpha fix` and it fully resolved (screenshots in the PR discussion). This only needs to run once per site; it does **not** touch this repo's own template file (`single-event.html`), which is why that still needed the manual fix above — Alpha only rewrites block content stored in the database, not theme template files.

We don't have a `rsvp_mode`/`all_on`/`per_event_on`/`per_event_off` reference anywhere in `mu-plugins/groups` or `mu-plugins/wporg-groups-frontend`, so the settings-value rename itself doesn't need any code change here — just the one-time Alpha run per site for any content/data already on disk.

## Notes for reviewers

- GatherPress 0.35.0 raises its minimum requirements to **PHP 8.1** and **WP 7.0**.
- `mu-plugins/groups/gatherpress-groups-tweaks.php`'s `render_block_gatherpress/venue` filter (hooked at priority 20) still works correctly, but its code comment explaining *why* priority 20 is needed is now stale — GatherPress's own competing priority-10 callback was removed in 0.35.0 (`Blocks\Venue::__construct()` is now empty). Not fixed here since it's a comment-only cleanup, not a behavior change.
- The `gatherpress/venue-map` block had a large rewrite (Google Maps provider, new REST API, Interactivity API port). Verified working end-to-end on a real venue (OSM/Leaflet provider) after running the Alpha migration above.

## Test plan

- [x] Run the `wporg-groups-frontend` and `groups` PHPUnit suites against GatherPress 0.35.0 — 137/137 passing after the one test fix above
- [x] Run the Playwright E2E suite (`npx playwright test`) — 9/9 passing. (The first parallel run threw 3 timeouts; they all passed in seconds when re-run serially, so that was resource contention from `fullyParallel: true` against a single local container, not a regression. The 4th failure, `/members/` 404ing, was this dev site never having a "Members" page provisioned — created one, unrelated to GatherPress.)
- [x] Run the `groups-gatherpress-compat-test` skill checklist (per-role browser pass, direct REST pass, GatherPress-off pass, security/perf sanity checks) — all green, including a no-fatals pass with GatherPress physically removed
- [x] Visually confirm the venue address/phone/website and online-event icons render correctly on a group's single-event page — confirmed via Claude in Chrome after running the GatherPress Alpha migration
- [x] Visually confirm the venue map block still renders correctly — confirmed (interactive Leaflet/OSM map with marker, zoom controls, attribution)
- [x] Verify venue creation end-to-end (RSVP/Venue Map rework in this release touches this path) — created a venue through the front-end editor as an Event Organiser; address geocoded correctly, static map pre-generated, structured address fields (state/postcode/country) populated, and the new venue was immediately selectable on the event
- [x] Confirm production PHP ≥ 8.1 and WP core ≥ 7.0 before merging
- [x] Confirm GatherPress 0.35.0 has gone stable on WordPress.org (not just beta) — confirmed via the plugin API, stable tag is 0.35.0 as of today

