### PR TITLE
Groups: fix fatal error in event-cards patterns from wrong GatherPress class

### DIFF
--- a/public_html/wp-content/themes/groups-site/patterns/archive-past-events-cards.php
+++ b/public_html/wp-content/themes/groups-site/patterns/archive-past-events-cards.php
@@ -13,7 +13,7 @@
 
 namespace WordCamp\Groups\Site\Patterns\ArchivePastEventsCards;
 
-use GatherPress\Core\Blocks\Event_Query;
+use GatherPress\Core\Event\Query as Event_Query;
 use function WordCamp\Groups\Site\Event_Cards\render_event_cards;
 
 defined( 'ABSPATH' ) || exit;

--- a/public_html/wp-content/themes/groups-site/patterns/archive-upcoming-events-cards.php
+++ b/public_html/wp-content/themes/groups-site/patterns/archive-upcoming-events-cards.php
@@ -14,7 +14,7 @@
 
 namespace WordCamp\Groups\Site\Patterns\ArchiveUpcomingEventsCards;
 
-use GatherPress\Core\Blocks\Event_Query;
+use GatherPress\Core\Event\Query as Event_Query;
 use function WordCamp\Groups\Site\Event_Cards\render_event_cards;
 
 defined( 'ABSPATH' ) || exit;

--- a/public_html/wp-content/themes/groups-site/patterns/upcoming-events-cards.php
+++ b/public_html/wp-content/themes/groups-site/patterns/upcoming-events-cards.php
@@ -16,7 +16,7 @@
 
 namespace WordCamp\Groups\Site\Patterns\UpcomingEventsCards;
 
-use GatherPress\Core\Blocks\Event_Query;
+use GatherPress\Core\Event\Query as Event_Query;
 use function WordCamp\Groups\Site\Event_Cards\render_event_cards;
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Summary

Fixes a fatal error hit live on production (`events.wordpress.org`) while opening the block editor for a `gatherpress_event` post:

```
E_ERROR: Uncaught Error: Call to undefined method GatherPress\Core\Blocks\Event_Query::get_past_events()
in /home/wordcamp/public_html/wp-content/themes/groups-site/patterns/archive-past-events-cards.php:25
```

All three `groups-site` event-cards patterns (`archive-past-events-cards`, `archive-upcoming-events-cards`, `upcoming-events-cards`) import `GatherPress\Core\Blocks\Event_Query` and call `get_past_events()` / `get_upcoming_events()` on it — but those methods have **never** existed on that class, in any GatherPress version. They live on a different, confusingly-similarly-named class: `GatherPress\Core\Event\Query`. Confirmed both methods are byte-identical across GatherPress 0.34.1 and 0.35.0, so this is a pre-existing bug, not a regression from the 0.35.0 bump (#1873) — it just never got exercised in production until now.

Fix: correct the import in all three files, aliased so no other code in the files needs to change:
```diff
-use GatherPress\Core\Blocks\Event_Query;
+use GatherPress\Core\Event\Query as Event_Query;
```

## Why this wasn't caught earlier

These patterns are `Inserter: no` and aren't referenced by any template via `wp:pattern` — the actual events archive page (`archive-gatherpress_event.html`) queries events through a native Query Loop block with a `gatherpress_event_query` context var, a completely separate, working code path. So the front-end archive page was never affected.

The fatal instead surfaces because WordPress enumerates **every** registered block pattern (including `Inserter: no` ones) via `/wp/v2/block-patterns/patterns` whenever the block editor loads, executing each pattern's PHP to build that response — so simply opening the editor for any `gatherpress_event` post triggers it.

## Test plan

- [x] Reproduced locally: directly executing all three pattern files threw the same fatal before the fix.
- [x] After the fix, all three execute cleanly and return real rendered card markup (verified via `wp eval` including each file directly, matching the exact code path WordPress uses to build pattern content).
- [x] Confirm on production that opening the `gatherpress_event` block editor no longer errors, and that `/wp-json/wp/v2/block-patterns/patterns` returns successfully.
