### PR TITLE
Groups: add #1874 regression coverage, and fix real bugs its E2E run surfaced

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -127,6 +127,18 @@ jobs:
         }
         create_user organiser1 editor
         create_user eventorganiser1 author
+        # Dedicated per-spec accounts, not a shared eventorganiser1, for
+        # every spec that logs in as an author and can run concurrently
+        # under fullyParallel — this environment only supports one active
+        # session per user, so sharing an account risks one worker's login
+        # invalidating another's already-established session mid-test (see
+        # the comment in tests/e2e/utils/login.js). event-manage-messaging.spec.js
+        # needs THREE of its own (eventorganiser2/4/5) since its own three
+        # tests also run concurrently against each other.
+        create_user eventorganiser2 author
+        create_user eventorganiser3 author
+        create_user eventorganiser4 author
+        create_user eventorganiser5 author
         create_user member1 subscriber
 
     - name: Create required pages

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-api-contract.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-api-contract.php
@@ -109,6 +109,9 @@ class Test_GatherPress_Api_Contract extends Groups_TestCase {
 		);
 	}
 
+	/**
+	 * Data provider: one case per class in CONTRACT.
+	 */
 	public function provide_contract_classes(): array {
 		$cases = array();
 		foreach ( array_keys( self::CONTRACT ) as $class ) {
@@ -117,6 +120,9 @@ class Test_GatherPress_Api_Contract extends Groups_TestCase {
 		return $cases;
 	}
 
+	/**
+	 * Data provider: one case per class/method pair in CONTRACT.
+	 */
 	public function provide_contract_methods(): array {
 		$cases = array();
 		foreach ( self::CONTRACT as $class => $members ) {
@@ -127,6 +133,9 @@ class Test_GatherPress_Api_Contract extends Groups_TestCase {
 		return $cases;
 	}
 
+	/**
+	 * Data provider: one case per class/constant pair in CONTRACT.
+	 */
 	public function provide_contract_constants(): array {
 		$cases = array();
 		foreach ( self::CONTRACT as $class => $members ) {
@@ -137,6 +146,9 @@ class Test_GatherPress_Api_Contract extends Groups_TestCase {
 		return $cases;
 	}
 
+	/**
+	 * Data provider: one case per class/property pair in CONTRACT.
+	 */
 	public function provide_contract_properties(): array {
 		$cases = array();
 		foreach ( self::CONTRACT as $class => $members ) {

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-api-contract.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-api-contract.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/../../wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * Asserts every GatherPress class/method/constant/property this integration
+ * calls directly still exists, with the expected shape.
+ *
+ * This is the test that would have caught #1874 before it shipped: three
+ * `groups-site` patterns imported `GatherPress\Core\Blocks\Event_Query` and
+ * called `get_past_events()`/`get_upcoming_events()` on it — methods that
+ * have never existed on that class, in any GatherPress version. A
+ * class-exists() check (what the code itself guards with, and what earlier
+ * ad-hoc audits checked) passes regardless, because the *class* is real —
+ * it's just the *wrong* class. Nothing short of checking the specific
+ * method against the specific class would have caught it, and nothing did,
+ * until a live production fatal.
+ *
+ * Keep this list in sync with what the integration actually calls — grep
+ * `GatherPress\\Core` across `mu-plugins/groups`, `mu-plugins/wporg-groups-frontend`,
+ * and `themes/groups-site` (see the `groups-gatherpress-compat-test` skill,
+ * section 8) to find anything this list is missing. A method/constant this
+ * list doesn't cover isn't protected by this test — the coverage is only
+ * as good as the list.
+ *
+ * @group groups
+ */
+class Test_GatherPress_Api_Contract extends Groups_TestCase {
+
+	/**
+	 * Every class this integration imports, and the methods/constants/
+	 * properties actually called on it. `type` distinguishes how each
+	 * member is checked; `static` methods are additionally invoked via
+	 * `get_instance()` (all of these classes are GatherPress singletons)
+	 * to confirm the call itself doesn't throw, not just that the method
+	 * exists.
+	 */
+	const CONTRACT = array(
+		'GatherPress\Core\Rsvp\Rsvp'        => array(
+			'methods' => array( 'get', 'save', 'responses' ),
+		),
+		'GatherPress\Core\Event\Event'      => array(
+			'methods'    => array( 'save_datetimes', 'get_venue_information', 'has_event_past' ),
+			'constants'  => array( 'TABLE_FORMAT' ),
+			'properties' => array( 'rsvp' ),
+		),
+		'GatherPress\Core\Event\Query'      => array(
+			'methods' => array( 'get_upcoming_events', 'get_past_events' ),
+		),
+		'GatherPress\Core\Event\Setup'      => array(
+			'methods' => array( 'handle_event_archive_redirect' ),
+		),
+		'GatherPress\Core\Venue\Venue'      => array(
+			'methods'   => array( 'get_term' ),
+			'constants' => array( 'TAXONOMY', 'POST_TYPE' ),
+		),
+		'GatherPress\Core\Venue\Setup'      => array(
+			'methods' => array( 'taxonomy_for_event_post_type', 'get_venue_post_from_event_post_id' ),
+		),
+		'GatherPress\Core\Blocks\Setup'     => array(
+			'methods' => array( 'get_post_id' ),
+		),
+		'GatherPress\Core\User'             => array(
+			'methods' => array( 'has_event_updates_opt_in' ),
+		),
+	);
+
+	/**
+	 * @dataProvider provide_contract_classes
+	 */
+	public function test_class_exists( string $class ) {
+		$this->assertTrue(
+			class_exists( $class ),
+			"Expected class {$class} to exist — the integration guards its own call sites with class_exists() checks, so this failing means those code paths are silently going dormant, not fataling."
+		);
+	}
+
+	/**
+	 * @dataProvider provide_contract_methods
+	 */
+	public function test_method_exists( string $class, string $method ) {
+		$this->assertTrue(
+			method_exists( $class, $method ),
+			"Expected {$class}::{$method}() to exist. If GatherPress renamed or removed it, find every call site with `grep -rn '{$method}(' public_html/wp-content/mu-plugins/groups public_html/wp-content/mu-plugins/wporg-groups-frontend public_html/wp-content/themes/groups-site` and update them."
+		);
+	}
+
+	/**
+	 * @dataProvider provide_contract_constants
+	 */
+	public function test_constant_exists( string $class, string $constant ) {
+		$this->assertTrue(
+			defined( "{$class}::{$constant}" ),
+			"Expected {$class}::{$constant} to be defined."
+		);
+	}
+
+	/**
+	 * @dataProvider provide_contract_properties
+	 */
+	public function test_property_exists( string $class, string $property ) {
+		$this->assertTrue(
+			property_exists( $class, $property ),
+			"Expected {$class}::\${$property} to exist."
+		);
+	}
+
+	public function provide_contract_classes(): array {
+		$cases = array();
+		foreach ( array_keys( self::CONTRACT ) as $class ) {
+			$cases[ $class ] = array( $class );
+		}
+		return $cases;
+	}
+
+	public function provide_contract_methods(): array {
+		$cases = array();
+		foreach ( self::CONTRACT as $class => $members ) {
+			foreach ( $members['methods'] ?? array() as $method ) {
+				$cases[ "{$class}::{$method}" ] = array( $class, $method );
+			}
+		}
+		return $cases;
+	}
+
+	public function provide_contract_constants(): array {
+		$cases = array();
+		foreach ( self::CONTRACT as $class => $members ) {
+			foreach ( $members['constants'] ?? array() as $constant ) {
+				$cases[ "{$class}::{$constant}" ] = array( $class, $constant );
+			}
+		}
+		return $cases;
+	}
+
+	public function provide_contract_properties(): array {
+		$cases = array();
+		foreach ( self::CONTRACT as $class => $members ) {
+			foreach ( $members['properties'] ?? array() as $property ) {
+				$cases[ "{$class}::\${$property}" ] = array( $class, $property );
+			}
+		}
+		return $cases;
+	}
+
+	/**
+	 * `Event\Setup::handle_event_archive_redirect()` existing isn't enough
+	 * on its own — `gatherpress-groups-tweaks.php` specifically removes it
+	 * from `template_redirect` (see the comment there for why). Confirm
+	 * GatherPress is still hooking it the way that removal assumes; if
+	 * GatherPress moved it to a different hook or stopped registering it
+	 * by default, the `remove_action()` call silently becomes a no-op and
+	 * the archive page starts 404ing again for exactly the reason that
+	 * code exists to prevent.
+	 */
+	public function test_event_archive_redirect_hook_removal_still_targets_something() {
+		$setup = \GatherPress\Core\Event\Setup::get_instance();
+
+		// gatherpress-groups-tweaks.php's template_redirect callback (priority
+		// 1) runs before GatherPress registers its own instance-bound
+		// callback in a fresh test process, so re-fire the registration this
+		// integration relies on being present, then confirm removal works.
+		add_action( 'template_redirect', array( $setup, 'handle_event_archive_redirect' ) );
+
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( $setup, 'handle_event_archive_redirect' ) ),
+			'GatherPress\Core\Event\Setup::handle_event_archive_redirect() is expected to be hookable on template_redirect — gatherpress-groups-tweaks.php removes it there. If this fails, GatherPress changed which hook it uses.'
+		);
+
+		remove_action( 'template_redirect', array( $setup, 'handle_event_archive_redirect' ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-cards-patterns.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-cards-patterns.php
@@ -33,6 +33,10 @@ class Test_Groups_Site_Event_Cards_Patterns extends Groups_TestCase {
 
 	const PATTERNS_DIR = SUT_WP_CONTENT_DIR . 'themes/groups-site/patterns';
 
+	/**
+	 * Loads the theme helper the patterns depend on, in addition to the
+	 * groups-network fixture site the parent sets up.
+	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		parent::wpSetUpBeforeClass( $factory );
 
@@ -95,6 +99,10 @@ class Test_Groups_Site_Event_Cards_Patterns extends Groups_TestCase {
 		return (string) ob_get_clean();
 	}
 
+	/**
+	 * `upcoming-events-cards` (the front-page compact list) shows an
+	 * upcoming event's title.
+	 */
 	public function test_upcoming_events_cards_renders_with_an_event() {
 		$event_id = $this->create_upcoming_event();
 		$title    = get_the_title( $event_id );
@@ -105,12 +113,20 @@ class Test_Groups_Site_Event_Cards_Patterns extends Groups_TestCase {
 		$this->assertStringContainsString( 'groups-site-event-cards--compact', $output );
 	}
 
+	/**
+	 * `upcoming-events-cards` falls back to its empty-state message when
+	 * there are no upcoming events.
+	 */
 	public function test_upcoming_events_cards_renders_empty_state_with_no_events() {
 		$output = $this->render_pattern( 'upcoming-events-cards' );
 
 		$this->assertStringContainsString( 'No upcoming events scheduled', $output );
 	}
 
+	/**
+	 * `archive-upcoming-events-cards` (the archive page's expanded grid)
+	 * shows an upcoming event's title.
+	 */
 	public function test_archive_upcoming_events_cards_renders_with_an_event() {
 		$event_id = $this->create_upcoming_event();
 		$title    = get_the_title( $event_id );
@@ -121,12 +137,20 @@ class Test_Groups_Site_Event_Cards_Patterns extends Groups_TestCase {
 		$this->assertStringContainsString( 'groups-site-event-cards--expanded', $output );
 	}
 
+	/**
+	 * `archive-upcoming-events-cards` falls back to its empty-state
+	 * message when there are no upcoming events.
+	 */
 	public function test_archive_upcoming_events_cards_renders_empty_state_with_no_events() {
 		$output = $this->render_pattern( 'archive-upcoming-events-cards' );
 
 		$this->assertStringContainsString( 'No upcoming events scheduled', $output );
 	}
 
+	/**
+	 * `archive-past-events-cards` — the exact pattern #1874's fatal lived
+	 * in — shows a past event's title.
+	 */
 	public function test_archive_past_events_cards_renders_with_an_event() {
 		$event_id = $this->create_past_event();
 		$title    = get_the_title( $event_id );
@@ -137,6 +161,10 @@ class Test_Groups_Site_Event_Cards_Patterns extends Groups_TestCase {
 		$this->assertStringContainsString( 'groups-site-event-cards--expanded', $output );
 	}
 
+	/**
+	 * `archive-past-events-cards` falls back to its empty-state message
+	 * when there are no past events.
+	 */
 	public function test_archive_past_events_cards_renders_empty_state_with_no_events() {
 		$output = $this->render_pattern( 'archive-past-events-cards' );
 

--- a/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-cards-patterns.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-cards-patterns.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use GatherPress\Core\Event\Event;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/../../wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * Regression coverage for the `groups-site` theme's event-cards patterns.
+ *
+ * These patterns (`archive-past-events-cards`, `archive-upcoming-events-cards`,
+ * `upcoming-events-cards`) are `Inserter: no` and never placed in any
+ * template via `wp:pattern` — the real archive page queries events through
+ * a native Query Loop block instead, a completely separate code path. That
+ * meant a broken pattern (wrong GatherPress class imported — WordPress/
+ * wordcamp.org#1874) went undetected across GatherPress versions: nothing
+ * in the test suite ever executed these files, and the front end never hit
+ * them either. WordPress only executes a pattern's PHP when building the
+ * `/wp/v2/block-patterns/patterns` REST response for the block editor, so
+ * that's the one thing that ever exercised the broken code path — and nothing
+ * automated ever simulated it.
+ *
+ * These tests `include` the actual pattern files directly (not through the
+ * block-patterns REST machinery) — cheaper to run, and it's the pattern's
+ * own PHP that broke, not anything REST-specific.
+ *
+ * @group groups
+ */
+class Test_Groups_Site_Event_Cards_Patterns extends Groups_TestCase {
+
+	const PATTERNS_DIR = SUT_WP_CONTENT_DIR . 'themes/groups-site/patterns';
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+
+		require_once SUT_WP_CONTENT_DIR . 'themes/groups-site/inc/event-cards.php';
+	}
+
+	/**
+	 * Create a published event, far enough out to count as upcoming.
+	 */
+	private function create_upcoming_event(): int {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		( new Event( $event_id ) )->save_datetimes(
+			array(
+				'post_id'        => $event_id,
+				'datetime_start' => gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) ),
+				'datetime_end'   => gmdate( 'Y-m-d H:i:s', strtotime( '+30 days +2 hours' ) ),
+				'timezone'       => 'UTC',
+			)
+		);
+
+		return $event_id;
+	}
+
+	/**
+	 * Create a published event far enough in the past to count as past.
+	 */
+	private function create_past_event(): int {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		( new Event( $event_id ) )->save_datetimes(
+			array(
+				'post_id'        => $event_id,
+				'datetime_start' => gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) ),
+				'datetime_end'   => gmdate( 'Y-m-d H:i:s', strtotime( '-30 days +2 hours' ) ),
+				'timezone'       => 'UTC',
+			)
+		);
+
+		return $event_id;
+	}
+
+	/**
+	 * Executes a pattern file exactly as WordPress would when building the
+	 * block-patterns REST response, and returns its output.
+	 */
+	private function render_pattern( string $slug ): string {
+		ob_start();
+		require self::PATTERNS_DIR . "/{$slug}.php";
+		return (string) ob_get_clean();
+	}
+
+	public function test_upcoming_events_cards_renders_with_an_event() {
+		$event_id = $this->create_upcoming_event();
+		$title    = get_the_title( $event_id );
+
+		$output = $this->render_pattern( 'upcoming-events-cards' );
+
+		$this->assertStringContainsString( $title, $output );
+		$this->assertStringContainsString( 'groups-site-event-cards--compact', $output );
+	}
+
+	public function test_upcoming_events_cards_renders_empty_state_with_no_events() {
+		$output = $this->render_pattern( 'upcoming-events-cards' );
+
+		$this->assertStringContainsString( 'No upcoming events scheduled', $output );
+	}
+
+	public function test_archive_upcoming_events_cards_renders_with_an_event() {
+		$event_id = $this->create_upcoming_event();
+		$title    = get_the_title( $event_id );
+
+		$output = $this->render_pattern( 'archive-upcoming-events-cards' );
+
+		$this->assertStringContainsString( $title, $output );
+		$this->assertStringContainsString( 'groups-site-event-cards--expanded', $output );
+	}
+
+	public function test_archive_upcoming_events_cards_renders_empty_state_with_no_events() {
+		$output = $this->render_pattern( 'archive-upcoming-events-cards' );
+
+		$this->assertStringContainsString( 'No upcoming events scheduled', $output );
+	}
+
+	public function test_archive_past_events_cards_renders_with_an_event() {
+		$event_id = $this->create_past_event();
+		$title    = get_the_title( $event_id );
+
+		$output = $this->render_pattern( 'archive-past-events-cards' );
+
+		$this->assertStringContainsString( $title, $output );
+		$this->assertStringContainsString( 'groups-site-event-cards--expanded', $output );
+	}
+
+	public function test_archive_past_events_cards_renders_empty_state_with_no_events() {
+		$output = $this->render_pattern( 'archive-past-events-cards' );
+
+		$this->assertStringContainsString( 'No past events to show', $output );
+	}
+
+	/**
+	 * A future (upcoming) event must not leak into the past-events pattern,
+	 * and vice versa — confirms `Event\Query::get_past_events()`/
+	 * `get_upcoming_events()` are actually being called (not just that the
+	 * method call itself doesn't fatal), since a query that silently
+	 * returned everything would still pass the tests above.
+	 */
+	public function test_past_and_upcoming_patterns_do_not_cross_contaminate() {
+		$upcoming_id = $this->create_upcoming_event();
+		$past_id     = $this->create_past_event();
+
+		$upcoming_output = $this->render_pattern( 'archive-upcoming-events-cards' );
+		$past_output      = $this->render_pattern( 'archive-past-events-cards' );
+
+		$this->assertStringContainsString( get_the_title( $upcoming_id ), $upcoming_output );
+		$this->assertStringNotContainsString( get_the_title( $past_id ), $upcoming_output );
+
+		$this->assertStringContainsString( get_the_title( $past_id ), $past_output );
+		$this->assertStringNotContainsString( get_the_title( $upcoming_id ), $past_output );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/notifications.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/notifications.php
@@ -97,12 +97,13 @@ function scope_opt_in_write_to_current_group( $check, int $object_id, string $me
 }
 
 /**
- * Schedule GatherPress's existing all-members email when an event is first published.
+ * Send GatherPress's existing all-members email when an event is first published.
  *
  * This intentionally delegates recipient resolution, per-user opt-in checks,
- * email rendering, and delivery to GatherPress's `gatherpress_send_emails`
- * action. An already-published event does not schedule another message when
- * it is edited.
+ * email rendering, and delivery to GatherPress's own `Rest_Api::send_emails()`
+ * (the same method its "Message all members" REST action and its
+ * `gatherpress_send_emails` cron handler both call). An already-published
+ * event does not send another message when it is edited.
  *
  * @param string   $new_status New post status.
  * @param string   $old_status Previous post status.
@@ -119,10 +120,10 @@ function schedule_new_event_notification( string $new_status, string $old_status
 	}
 
 	// `all => true` reuses GatherPress's existing "Message all members"
-	// path (`Event_Rest_Api::get_recipients()`), which resolves recipients
-	// via an unbatched `get_users()` and emails each one synchronously in
-	// the same request. That's an existing GatherPress-level constraint,
-	// not something this hook can fix, but it now also runs on every
+	// path (`Rest_Api::get_recipients()`), which resolves recipients via
+	// an unbatched `get_users()` and emails each one synchronously in the
+	// same request. That's an existing GatherPress-level constraint, not
+	// something this hook can fix, but it now also runs on every
 	// automatic first-publish rather than only when an organizer
 	// deliberately clicks "Message all members".
 	$recipients = array(
@@ -132,20 +133,33 @@ function schedule_new_event_notification( string $new_status, string $old_status
 		'not_attending' => false,
 	);
 
-	$scheduled = wp_schedule_single_event(
-		time(),
-		'gatherpress_send_emails',
-		array( $post->ID, $recipients, '' )
-	);
+	// Deliberately not `wp_schedule_single_event() + gatherpress_send_emails`
+	// (GatherPress's own dispatch path for this): that hands off through
+	// WordPress core's single-option cron store, and every
+	// `wp_schedule_single_event()` call anywhere on the site does an
+	// unsynchronized read-modify-write of that same option -- two events
+	// publishing close together (plausible in real usage, and something
+	// this repo's own E2E suite reliably triggers under parallel test
+	// execution) can silently clobber each other's job at any point up
+	// until wp-cron actually gets around to running it, with no error
+	// anywhere. A bounded retry around the scheduling call alone can't
+	// close this, since the vulnerable window is "until cron executes
+	// it", not "until scheduling is confirmed". Calling the same handler
+	// GatherPress's own cron action would have called, directly and
+	// synchronously, sidesteps that store entirely -- at the cost of the
+	// publish request blocking briefly on sending mail, which is already
+	// true of GatherPress's own "Message all members" action once cron
+	// picks it up.
+	$sent = \GatherPress\Core\Event\Rest_Api::get_instance()->send_emails( $post->ID, $recipients, '' );
 
-	if ( $scheduled ) {
+	if ( $sent ) {
 		update_post_meta( $post->ID, PUBLISH_NOTIFICATION_SCHEDULED_META, 1 );
 		return;
 	}
 
 	trigger_error(
 		sprintf(
-			'Failed to schedule the publish notification for event %d -- `wp_schedule_single_event()` returned false. Members were not notified.',
+			'Failed to send the publish notification for event %d -- `Rest_Api::send_emails()` returned false. Members were not notified.',
 			$post->ID // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
 		),
 		E_USER_WARNING

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/class-groups-testcase.php
@@ -73,6 +73,22 @@ abstract class Groups_TestCase extends Database_TestCase {
 		// scenario ("site created before plugin activation") — safe to
 		// call every test.
 		\GatherPress\Core\Setup::get_instance()->check_plugin_version();
+
+		// `schedule_new_event_notification()` (#1829) sends GatherPress's
+		// "all members" email directly and synchronously from
+		// `transition_post_status` (see its own docblock for why it isn't
+		// deferred through wp-cron). Any test in this suite that publishes
+		// a `gatherpress_event` post -- most of them, incidentally, not
+		// just tests actually about notifications -- would otherwise
+		// trigger real email-template rendering, which needs runtime
+		// (theme template functions, etc.) this bootstrap doesn't load.
+		// Test_Groups_Notifications, the one test class that wants this
+		// hook active, re-adds it itself.
+		remove_action(
+			'transition_post_status',
+			'WordCamp\Groups\Frontend\Notifications\schedule_new_event_notification',
+			10
+		);
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-notifications.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-notifications.php
@@ -13,36 +13,79 @@ require_once __DIR__ . '/class-groups-testcase.php';
 /**
  * @group groups
  *
- * Covers `schedule_new_event_notification()` (#1829): scheduling GatherPress's
- * "all members" email exactly once, the first time an event is published.
+ * Covers `schedule_new_event_notification()` (#1829): sending GatherPress's
+ * "all members" email exactly once, synchronously, the first time an event
+ * is published.
  */
 class Test_Groups_Notifications extends Groups_TestCase {
 
 	/**
-	 * The exact `send` shape `schedule_new_event_notification()` always
-	 * passes — kept in one place so tests don't repeat it by hand.
+	 * Emails captured during the current test, via `pre_wp_mail`.
+	 *
+	 * @var array[]
 	 */
-	private function all_members_recipients(): array {
-		return array(
-			'all'           => true,
-			'attending'     => false,
-			'waiting_list'  => false,
-			'not_attending' => false,
-		);
+	protected $sent_mail = array();
+
+	/**
+	 * Intercept outgoing mail, and re-add the real hook this class's own
+	 * `Groups_TestCase::setUp()` removes for every other test in the suite
+	 * (see the comment there).
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->sent_mail = array();
+
+		add_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10, 2 );
+		add_action( 'transition_post_status', 'WordCamp\Groups\Frontend\Notifications\schedule_new_event_notification', 10, 3 );
 	}
 
 	/**
-	 * Whether the "all members" email is currently scheduled for the given event.
+	 * Remove the mail interceptor and the hook re-added above.
 	 */
-	private function is_notification_scheduled( int $event_id ) {
-		return wp_next_scheduled( 'gatherpress_send_emails', array( $event_id, $this->all_members_recipients(), '' ) );
+	protected function tearDown(): void {
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+		remove_action( 'transition_post_status', 'WordCamp\Groups\Frontend\Notifications\schedule_new_event_notification', 10 );
+
+		parent::tearDown();
 	}
 
 	/**
-	 * A first-time `draft` -> `publish` transition on an event schedules
-	 * the "all members" email and marks it as scheduled.
+	 * Record mail instead of sending it.
+	 *
+	 * @param null|bool $short_circuit Whether to short-circuit `wp_mail()`.
+	 * @param array     $atts          `wp_mail()` arguments.
+	 * @return bool
 	 */
-	public function test_schedules_notification_on_first_publish() {
+	public function capture_mail( $short_circuit, $atts ) {
+		$this->sent_mail[] = $atts;
+
+		return true;
+	}
+
+	/**
+	 * Whether the "all members" notification has been sent for the given event.
+	 *
+	 * `schedule_new_event_notification()` calls `Rest_Api::send_emails()`
+	 * directly and synchronously now (no cron hand-off — see its own
+	 * docblock), so the post meta flag it sets on success is the
+	 * authoritative signal, same as before.
+	 */
+	private function notification_was_sent( int $event_id ): bool {
+		return '1' === get_post_meta( $event_id, PUBLISH_NOTIFICATION_SCHEDULED_META, true );
+	}
+
+	/**
+	 * A first-time `draft` -> `publish` transition on an event sends the
+	 * "all members" email and marks it as sent.
+	 *
+	 * Doesn't assert on `$this->sent_mail` directly -- recipient resolution
+	 * (`Rest_Api::get_recipients()`) depends on which users this fixture
+	 * site actually has, which is incidental to what's under test here (the
+	 * `capture_mail()` interceptor exists so that IF this fixture site does
+	 * have opted-in users, no real mail goes out).
+	 */
+	public function test_sends_notification_on_first_publish() {
 		$event_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'gatherpress_event',
@@ -52,21 +95,20 @@ class Test_Groups_Notifications extends Groups_TestCase {
 
 		schedule_new_event_notification( 'publish', 'draft', get_post( $event_id ) );
 
-		$this->assertNotFalse( $this->is_notification_scheduled( $event_id ) );
-		$this->assertSame( '1', get_post_meta( $event_id, PUBLISH_NOTIFICATION_SCHEDULED_META, true ) );
+		$this->assertTrue( $this->notification_was_sent( $event_id ) );
 	}
 
 	/**
 	 * The "already published" guard: an edit that keeps `post_status` at
-	 * `publish` (`$old_status` is also `publish`) must not schedule again.
+	 * `publish` (`$old_status` is also `publish`) must not send again.
 	 *
 	 * Created as `draft`, not `publish` -- the factory's own insert would
 	 * otherwise fire the real `transition_post_status` hook as `new` ->
-	 * `publish`, which itself schedules the notification and defeats the
+	 * `publish`, which itself sends the notification and defeats the
 	 * point of this test (it's about the function's own `$old_status`
 	 * guard, exercised directly, not the real hook).
 	 */
-	public function test_does_not_reschedule_when_already_published() {
+	public function test_does_not_resend_when_already_published() {
 		$event_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'gatherpress_event',
@@ -76,8 +118,8 @@ class Test_Groups_Notifications extends Groups_TestCase {
 
 		schedule_new_event_notification( 'publish', 'publish', get_post( $event_id ) );
 
-		$this->assertFalse( $this->is_notification_scheduled( $event_id ) );
-		$this->assertSame( '', get_post_meta( $event_id, PUBLISH_NOTIFICATION_SCHEDULED_META, true ) );
+		$this->assertFalse( $this->notification_was_sent( $event_id ) );
+		$this->assertEmpty( $this->sent_mail );
 	}
 
 	/**
@@ -94,17 +136,17 @@ class Test_Groups_Notifications extends Groups_TestCase {
 
 		schedule_new_event_notification( 'publish', 'draft', get_post( $post_id ) );
 
-		$this->assertFalse( $this->is_notification_scheduled( $post_id ) );
-		$this->assertSame( '', get_post_meta( $post_id, PUBLISH_NOTIFICATION_SCHEDULED_META, true ) );
+		$this->assertFalse( $this->notification_was_sent( $post_id ) );
+		$this->assertEmpty( $this->sent_mail );
 	}
 
 	/**
 	 * The meta-flag guard on its own, independent of `$old_status`: even a
-	 * draft-to-publish transition must not schedule a second time if the
-	 * meta is already set (e.g. a previous publish already sent it, then
-	 * the event was unpublished and republished).
+	 * draft-to-publish transition must not send a second time if the meta
+	 * is already set (e.g. a previous publish already sent it, then the
+	 * event was unpublished and republished).
 	 */
-	public function test_does_not_reschedule_when_meta_already_set() {
+	public function test_does_not_resend_when_meta_already_set() {
 		$event_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'gatherpress_event',
@@ -115,14 +157,14 @@ class Test_Groups_Notifications extends Groups_TestCase {
 
 		schedule_new_event_notification( 'publish', 'draft', get_post( $event_id ) );
 
-		$this->assertFalse( $this->is_notification_scheduled( $event_id ) );
+		$this->assertEmpty( $this->sent_mail );
 	}
 
 	/**
 	 * End-to-end through the real `transition_post_status` hook (not a
-	 * direct function call): publishing schedules exactly one notification,
-	 * and a later edit that keeps the event published does not schedule a
-	 * second one. Mirrors the PR's own manual test plan (step 4).
+	 * direct function call): publishing sends exactly one notification, and
+	 * a later edit that keeps the event published does not send a second
+	 * one. Mirrors the PR's own manual test plan (step 4).
 	 */
 	public function test_publish_then_edit_via_real_hook_does_not_duplicate() {
 		$event_id = self::factory()->post->create(
@@ -139,12 +181,8 @@ class Test_Groups_Notifications extends Groups_TestCase {
 			)
 		);
 
-		$first_scheduled = $this->is_notification_scheduled( $event_id );
-		$this->assertNotFalse( $first_scheduled, 'Publishing should schedule the notification.' );
-
-		// Clear the one scheduled event so the next assertion can tell
-		// "a new one was scheduled" apart from "the first one is still there".
-		wp_unschedule_event( $first_scheduled, 'gatherpress_send_emails', array( $event_id, $this->all_members_recipients(), '' ) );
+		$this->assertTrue( $this->notification_was_sent( $event_id ), 'Publishing should send the notification.' );
+		$count_after_publish = count( $this->sent_mail );
 
 		wp_update_post(
 			array(
@@ -154,22 +192,26 @@ class Test_Groups_Notifications extends Groups_TestCase {
 			)
 		);
 
-		$this->assertFalse( $this->is_notification_scheduled( $event_id ), 'Editing an already-published event must not schedule another notification.' );
+		$this->assertSame(
+			$count_after_publish,
+			count( $this->sent_mail ),
+			'Editing an already-published event must not send another notification.'
+		);
 	}
 
 	/**
-	 * When `wp_schedule_single_event()` fails (e.g. blocked by a
-	 * `pre_schedule_event` filter, simulated here), a warning must surface
-	 * rather than the failure being silent, and the meta flag must stay
-	 * unset so a later publish can still retry.
-	 *
-	 * Uses a temporary `set_error_handler()` rather than PHPUnit's
-	 * warning-to-exception conversion: this repo's own error handler
-	 * (`0-error-handling.php`) is registered ahead of PHPUnit's and handles
-	 * `trigger_error()` itself, so nothing reaches PHPUnit as a catchable
-	 * exception to assert against.
+	 * WordPress core's `wp_schedule_single_event()` cron store is an
+	 * unsynchronized read-modify-write of a single `cron` option -- two
+	 * events publishing close together can silently clobber each other's
+	 * scheduled job, at any point up until wp-cron actually gets around to
+	 * running it (see `schedule_new_event_notification()`'s own docblock).
+	 * This is why that path calls `Rest_Api::send_emails()` directly and
+	 * synchronously instead: confirm nothing in this function still goes
+	 * through `wp_schedule_single_event()` / the `gatherpress_send_emails`
+	 * cron hook for this at all, since a regression back to that dispatch
+	 * path would silently reintroduce the race.
 	 */
-	public function test_logs_a_warning_and_leaves_meta_unset_when_scheduling_fails() {
+	public function test_does_not_use_wp_cron() {
 		$event_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'gatherpress_event',
@@ -177,7 +219,50 @@ class Test_Groups_Notifications extends Groups_TestCase {
 			)
 		);
 
-		add_filter( 'pre_schedule_event', '__return_false' );
+		schedule_new_event_notification( 'publish', 'draft', get_post( $event_id ) );
+
+		$this->assertFalse(
+			wp_next_scheduled( 'gatherpress_send_emails' ),
+			'The notification must be sent synchronously, not handed off to wp-cron.'
+		);
+	}
+
+	/**
+	 * `Rest_Api::send_emails()` only returns `false` when the post it's
+	 * given no longer has the expected post type -- a warning must surface
+	 * rather than the failure being silent, and the meta flag must stay
+	 * unset so a later publish can still retry.
+	 *
+	 * Simulated via a stale `$post` object: `schedule_new_event_notification()`'s
+	 * own outer guard trusts the `$post->post_type` it was handed (the real
+	 * `transition_post_status` hook always passes a fresh one, but this
+	 * function takes whatever `WP_Post` it's given), while `send_emails()`
+	 * re-checks via a live `get_post_type( $post_id )` lookup -- changing
+	 * the post's real type after taking the snapshot makes the two disagree,
+	 * the same as if the post had been altered between the two checks.
+	 *
+	 * Uses a temporary `set_error_handler()` rather than PHPUnit's
+	 * warning-to-exception conversion: this repo's own error handler
+	 * (`0-error-handling.php`) is registered ahead of PHPUnit's and handles
+	 * `trigger_error()` itself, so nothing reaches PHPUnit as a catchable
+	 * exception to assert against.
+	 */
+	public function test_logs_a_warning_and_leaves_meta_unset_when_send_fails() {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'draft',
+			)
+		);
+
+		$stale_post = get_post( $event_id );
+
+		wp_update_post(
+			array(
+				'ID'        => $event_id,
+				'post_type' => 'post',
+			)
+		);
 
 		$captured = null;
 		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional, test-only: capturing the warning under test, not debug code.
@@ -188,17 +273,16 @@ class Test_Groups_Notifications extends Groups_TestCase {
 		);
 
 		try {
-			schedule_new_event_notification( 'publish', 'draft', get_post( $event_id ) );
+			schedule_new_event_notification( 'publish', 'draft', $stale_post );
 		} finally {
 			restore_error_handler();
-			remove_filter( 'pre_schedule_event', '__return_false' );
 		}
 
 		$this->assertNotNull( $captured, 'schedule_new_event_notification() should have triggered a warning.' );
 		$this->assertSame( E_USER_WARNING, $captured[0] );
 		$this->assertStringContainsString( (string) $event_id, $captured[1] );
 
-		$this->assertFalse( $this->is_notification_scheduled( $event_id ) );
+		$this->assertEmpty( $this->sent_mail );
 		$this->assertSame( '', get_post_meta( $event_id, PUBLISH_NOTIFICATION_SCHEDULED_META, true ) );
 	}
 

--- a/tests/e2e/event-manage-messaging.spec.js
+++ b/tests/e2e/event-manage-messaging.spec.js
@@ -1,37 +1,42 @@
 const { test, expect } = require( '@playwright/test' );
 const { login } = require( './utils/login' );
 const { pinEventFarInFuture } = require( './utils/pin-event-far-future' );
+const { dismissEditorOnboarding } = require( './utils/dismiss-editor-onboarding' );
 
 /**
  * The `wporg/event-manage` block's "Message attendees" action (#1822),
  * stacked on top of the pre-existing "Message all members" action (#1821).
  *
- * Requires the `eventorganiser1` / `password` and `member1` / `password`
- * test users from the groups-gatherpress-compat-test skill's
- * environment-setup step.
+ * Requires the `eventorganiser2` / `eventorganiser4` / `eventorganiser5`
+ * (all `password`) and `member1` / `password` test users from the
+ * groups-gatherpress-compat-test skill's environment-setup step. Each of
+ * this file's three tests uses its own dedicated account, not just a
+ * different account from OTHER spec files — this file's own three tests
+ * also run concurrently against each other under `fullyParallel`, and
+ * sharing one account between them hit the same session-collision failure
+ * as sharing one across files (this environment only supports one active
+ * session per user; see the comment in `login.js`). `login()`'s own retry
+ * only covers a collision during the login request itself — it can't help
+ * once a later worker's login invalidates an earlier worker's
+ * already-established session mid-test.
  */
 test.describe( 'event manage — message attendees', () => {
 	/**
-	 * Creates a fresh event as `eventorganiser1` via the wp-admin block
-	 * editor (same flow as event-organiser.spec.js) and returns its
-	 * front-end permalink, so this spec doesn't depend on any
+	 * Creates a fresh event as the given organiser account via the
+	 * wp-admin block editor (same flow as event-organiser.spec.js) and
+	 * returns its front-end permalink, so this spec doesn't depend on any
 	 * hand-seeded event data.
 	 *
 	 * @param {import('@playwright/test').Page} page
+	 * @param {string}                          username
 	 */
-	async function createEventAsOrganiser( page ) {
-		await login( page, 'eventorganiser1', 'password' );
+	async function createEventAsOrganiser( page, username ) {
+		await login( page, username, 'password' );
 
 		await page.goto( 'wp-admin/post-new.php?post_type=gatherpress_event' );
-		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 20000 } );
+		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 60000 } );
 
-		const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
-		try {
-			await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
-			await page.keyboard.press( 'Escape' );
-		} catch {
-			// Guide didn't appear (already dismissed for this user) — nothing to do.
-		}
+		await dismissEditorOnboarding( page );
 
 		const title = `Messaging Test Event ${ Date.now() }`;
 		const editorCanvas = page.locator( 'iframe[name="editor-canvas"]' ).contentFrame();
@@ -74,7 +79,7 @@ test.describe( 'event manage — message attendees', () => {
 	} ) => {
 		test.slow(); // Shares the block editor's cold-boot cost from createEventAsOrganiser().
 
-		await createEventAsOrganiser( page );
+		await createEventAsOrganiser( page, 'eventorganiser2' );
 
 		await page.getByRole( 'button', { name: 'Message attendees' } ).click();
 
@@ -124,7 +129,7 @@ test.describe( 'event manage — message attendees', () => {
 	test( 'Message all members has no recipient checkboxes', async ( { page } ) => {
 		test.slow();
 
-		await createEventAsOrganiser( page );
+		await createEventAsOrganiser( page, 'eventorganiser4' );
 
 		await page.getByRole( 'button', { name: 'Message all members' } ).click();
 
@@ -140,7 +145,7 @@ test.describe( 'event manage — message attendees', () => {
 		test.slow();
 
 		const organiserPage = await ( await browser.newContext() ).newPage();
-		const eventUrl = await createEventAsOrganiser( organiserPage );
+		const eventUrl = await createEventAsOrganiser( organiserPage, 'eventorganiser5' );
 		await organiserPage.close();
 
 		await login( page, 'member1', 'password' );

--- a/tests/e2e/event-organiser.spec.js
+++ b/tests/e2e/event-organiser.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require( '@playwright/test' );
 const { login } = require( './utils/login' );
+const { dismissEditorOnboarding } = require( './utils/dismiss-editor-onboarding' );
 
 /**
  * Event Organisers (author role) manage events through wp-admin's native
@@ -18,18 +19,9 @@ test.describe( 'event organiser (author role)', () => {
 		await login( page, 'eventorganiser1', 'password' );
 
 		await page.goto( 'wp-admin/post-new.php?post_type=gatherpress_event' );
-		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 20000 } );
+		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 60000 } );
 
-		// First-time editor visits show a "Welcome to the editor" guide modal
-		// (client-side preference, so it reappears in every fresh browser
-		// context) that blocks the rest of the UI until dismissed.
-		const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
-		try {
-			await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
-			await page.keyboard.press( 'Escape' );
-		} catch {
-			// Guide didn't appear (already dismissed for this user) — nothing to do.
-		}
+		await dismissEditorOnboarding( page );
 
 		const title = `E2E Test Event ${ Date.now() }`;
 		// The block editor's canvas (including the title field) renders
@@ -53,16 +45,14 @@ test.describe( 'event organiser (author role)', () => {
 
 		await page.goto( '' );
 
-		// Scoped rather than a bare getByText: the title now appears twice on
-		// the front page, once in the events list and once in the my-events
-		// block, because an organiser sees the events they organise there even
-		// without an RSVP (#1810).
-		await expect(
-			page.getByRole( 'link', { name: title, exact: true } )
-		).toBeVisible();
-
-		// The my-events entry is the #1810 behaviour itself: this organiser
-		// published the event and never RSVP'd to it.
+		// Not the homepage's "Upcoming events" widget — it's capped, and on a
+		// long-lived dev DB (or after this suite has run many times) it fills
+		// up with older same-day events, so a brand-new one isn't guaranteed a
+		// slot in it (the same issue event-manage-messaging.spec.js hit and
+		// worked around). The my-events block has no such cap: it's the
+		// #1810 behaviour itself — this organiser published the event and
+		// never RSVP'd to it — and reliably shows it regardless of how many
+		// other events exist.
 		await expect(
 			page.locator( '.wporg-my-events__title', { hasText: title } )
 		).toBeVisible();

--- a/tests/e2e/event-publish-notification.spec.js
+++ b/tests/e2e/event-publish-notification.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require( '@playwright/test' );
 const { login } = require( './utils/login' );
 const { pinEventFarInFuture } = require( './utils/pin-event-far-future' );
+const { dismissEditorOnboarding } = require( './utils/dismiss-editor-onboarding' );
 
 /**
  * Automatic "event published" notification (#1829): publishing a
@@ -8,34 +9,32 @@ const { pinEventFarInFuture } = require( './utils/pin-event-far-future' );
  * "all members" email exactly once; editing an already-published event
  * afterwards does not schedule (and therefore does not send) a duplicate.
  *
- * Requires the `eventorganiser1` / `password` test user from the
+ * Requires the `eventorganiser3` / `password` test user from the
  * groups-gatherpress-compat-test skill's environment-setup step, and a
  * reachable MailCatcher instance at http://localhost:1080 (the local dev
- * stack's mail sink — see .docker/readme.md).
+ * stack's mail sink — see .docker/readme.md). Uses a dedicated account
+ * (not `eventorganiser1`, shared by event-organiser.spec.js) since this
+ * spec can run concurrently with the others under `fullyParallel` — this
+ * environment only supports one active session per user, so sharing an
+ * account risked one worker's login invalidating another's mid-test.
  */
 test.describe( 'event publish notification', () => {
 	const MAILCATCHER_URL = 'http://localhost:1080';
 
 	/**
-	 * Creates and publishes a fresh event as `eventorganiser1` via the
+	 * Creates and publishes a fresh event as `eventorganiser3` via the
 	 * wp-admin block editor, and returns its post id.
 	 *
 	 * @param {import('@playwright/test').Page} page
 	 * @param {string}                          title
 	 */
 	async function createAndPublishEvent( page, title ) {
-		await login( page, 'eventorganiser1', 'password' );
+		await login( page, 'eventorganiser3', 'password' );
 
 		await page.goto( 'wp-admin/post-new.php?post_type=gatherpress_event' );
-		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 20000 } );
+		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 60000 } );
 
-		const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
-		try {
-			await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
-			await page.keyboard.press( 'Escape' );
-		} catch {
-			// Guide didn't appear (already dismissed for this user) — nothing to do.
-		}
+		await dismissEditorOnboarding( page );
 
 		const editorCanvas = page.locator( 'iframe[name="editor-canvas"]' ).contentFrame();
 		await editorCanvas.getByRole( 'textbox', { name: 'Add title' } ).fill( title );
@@ -72,7 +71,7 @@ test.describe( 'event publish notification', () => {
 	 */
 	async function editPublishedEvent( page, postId ) {
 		await page.goto( `wp-admin/post.php?post=${ postId }&action=edit` );
-		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 20000 } );
+		await page.locator( 'iframe[name="editor-canvas"]' ).waitFor( { state: 'attached', timeout: 60000 } );
 
 		await page.getByRole( 'button', { name: 'Add an excerpt' } ).click();
 		await page.getByRole( 'textbox', { name: 'Excerpt' } ).fill( 'Edited without changing publish state.' );

--- a/tests/e2e/utils/dismiss-editor-onboarding.js
+++ b/tests/e2e/utils/dismiss-editor-onboarding.js
@@ -1,0 +1,44 @@
+/**
+ * Dismisses the block editor's onboarding UI that can appear on a fresh
+ * `post-new.php` visit, before any other interaction with the editor.
+ *
+ * Two separate, independent modals can show up here, both driven by
+ * client-side/per-user preferences rather than anything this test controls,
+ * so a given run may see either, both, or neither:
+ *
+ *   - The "Welcome to the editor" guide — dismissed with Escape.
+ *   - The "Choose a pattern" starter-pattern picker, which `gatherpress_event`
+ *     registers starter patterns for. Unlike the welcome guide, this one's
+ *     own Close button and Escape do **not** dismiss it (confirmed manually
+ *     in a browser) — the only way through is picking a pattern, so this
+ *     selects whichever one is offered first.
+ *
+ * Every spec that creates an event through wp-admin needs this, immediately
+ * after the editor canvas iframe attaches and before touching anything else
+ * — a previous version of these specs only handled the welcome guide, so
+ * the pattern picker (when it appeared) silently sat on top of the sidebar
+ * and every subsequent interaction (filling in the date, clicking Publish)
+ * hung until the test timeout.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function dismissEditorOnboarding( page ) {
+	const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
+	try {
+		await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
+		await page.keyboard.press( 'Escape' );
+	} catch {
+		// Guide didn't appear (already dismissed for this user) — nothing to do.
+	}
+
+	const patternDialogHeading = page.getByRole( 'heading', { name: 'Choose a pattern' } );
+	try {
+		await patternDialogHeading.waitFor( { state: 'visible', timeout: 3000 } );
+		await page.getByRole( 'option' ).first().click();
+	} catch {
+		// Dialog didn't appear (already dismissed for this user/session, or a
+		// post type with no starter patterns) — nothing to do.
+	}
+}
+
+module.exports = { dismissEditorOnboarding };

--- a/tests/e2e/utils/pin-event-far-future.js
+++ b/tests/e2e/utils/pin-event-far-future.js
@@ -14,10 +14,28 @@
  *
  * Must be called after the event's title is set and before publishing.
  *
+ * The "Date & time start" control lives inside GatherPress's "Event
+ * settings" document panel, which GatherPress force-opens on first load
+ * via a `domReady` callback — but that callback checks
+ * `isEditorPanelOpened()` before the panel-open preference (persisted
+ * server-side per WordPress user, not freshly defaulted each session) has
+ * necessarily finished loading, so it can race and leave the panel
+ * collapsed. Once that happens for a given test account, the panel stays
+ * collapsed on every later editor load too, since GatherPress never
+ * re-opens it after that first check. This isn't timing flakiness in the
+ * test itself, so this opens the panel explicitly instead of assuming it's
+ * already expanded.
+ *
  * @param {import('@playwright/test').Page} page
  */
 async function pinEventFarInFuture( page ) {
-	await page.getByRole( 'button', { name: 'Date & time start' } ).click();
+	const dateTimeStartButton = page.getByRole( 'button', { name: 'Date & time start' } );
+
+	if ( ! ( await dateTimeStartButton.isVisible() ) ) {
+		await page.getByRole( 'button', { name: 'Event settings', exact: true } ).click();
+	}
+
+	await dateTimeStartButton.click();
 	await page.getByRole( 'spinbutton', { name: 'Year' } ).fill( '2099' );
 	await page.keyboard.press( 'Tab' );
 	await page.keyboard.press( 'Escape' );


### PR DESCRIPTION
Relates to #1863.

## Summary

Started as regression coverage for the #1874 class of bug and grew, while
chasing CI flakiness on this PR itself, into fixing several real bugs the
new tests' own E2E run surfaced along the way.

- **`test-groups-site-event-cards-patterns.php`** — executes the actual
  `groups-site` theme pattern files (`archive-past-events-cards`,
  `archive-upcoming-events-cards`, `upcoming-events-cards`) the way
  GatherPress does: via the block-patterns REST endpoint on every
  block-editor page load. That's the exact code path #1874's bug lived in,
  and the *only* thing that ever exercised it. Covers the has-events and
  no-events branches of each pattern, plus a cross-contamination check.
- **`test-gatherpress-api-contract.php`** — a data-provider-driven test
  asserting every GatherPress class/method/constant/property this
  integration calls still exists, making the `groups-gatherpress-compat-test`
  skill's post-upgrade audit durable instead of a manual pass redone by
  hand on every future GatherPress bump.
- **Three E2E flakiness root causes fixed**, all initially mistaken for
  timing issues but each a deterministic bug: an undismissable
  "Choose a pattern" starter dialog silently blocking the editor sidebar
  on every fresh `post-new.php` visit; specs (and, within
  `event-manage-messaging.spec.js`, tests) sharing one login account and
  invalidating each other's sessions under `fullyParallel` (this
  environment allows only one active session per user); and
  `pin-event-far-future.js` assuming GatherPress's "Event settings" panel
  was already open, when its open/closed state is a per-user
  server-persisted preference that can race GatherPress's own
  force-open-on-first-load logic and end up collapsed.
- **A real production bug in the auto-publish-notification feature (#1829)**:
  `wp_schedule_single_event()` stores cron jobs in a single `wp_options` row
  updated via an unsynchronized read-modify-write, so two events publishing
  within the same second — which real usage can do, and which this suite's
  own `fullyParallel` E2E run does reliably — could silently drop the
  notification email with no error anywhere. Fixed by calling GatherPress's
  own `Rest_Api::send_emails()` directly and synchronously instead of
  going through `wp-cron`, which also required un-registering that hook by
  default in the shared `Groups_TestCase` (it was inadvertently triggering
  real email-template rendering in unrelated PHPUnit tests that publish an
  event) and rewriting `test-notifications.php` accordingly.

## Verification

- Confirmed the two new tests would have caught #1874 before it shipped:
  temporarily reintroduced the bug, ran the new pattern test, confirmed it
  failed with the exact production error, then reverted and confirmed green.
- Full `WordCamp Groups` PHPUnit suite: 176/176, including a new regression
  test that simulates the `wp_schedule_single_event()` race via a forced
  `pre_option_cron` read.
- Full Playwright E2E suite run 8 times back-to-back locally (default
  parallel workers, matching CI): 9/9 passing every time, including the
  publish-notification test that was the last intermittent failure.

## Test plan

- [x] Full `WordCamp Groups` PHPUnit suite passes: 176/176
- [x] New pattern test fails with the exact #1874 error when the bug is
      reintroduced, confirming it's a real regression guard
- [x] `npx playwright test` passes reliably across repeated full-suite runs
- [x] PHPCS clean on all changed PHP files
