### PR TITLE
Address Copilot follow-ups on #1879

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -12,8 +12,51 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
  * `error_log` destination configured, PHP writes those to stderr, which CI
  * captures inline with the test output. Route them to a file instead so the
  * `Running unit tests` step only shows PHPUnit's own output.
+ *
+ * This redirects every `error_log()` call in the process, not just the
+ * intentional `WordCamp\Logger\log()` ones -- but ordinary PHP warnings/
+ * notices raised during a test are already turned into failures by
+ * `convertWarningsToExceptions`/`convertNoticesToExceptions` in
+ * phpunit.xml.dist, so they never reach `error_log()` in the first place.
+ * What can still land in this file is either an expected logger entry, or
+ * something that bypassed PHPUnit's handler (e.g. a fatal error). The
+ * shutdown function below re-reads the file once the run ends and fails the
+ * build if it contains anything that isn't a recognized `WordCamp\Logger`
+ * entry, so a real error can't silently accumulate in a file CI never
+ * publishes.
  */
-ini_set( 'error_log', sys_get_temp_dir() . '/wordcamp-phpunit-error.log' );
+$wordcamp_phpunit_error_log = sys_get_temp_dir() . '/wordcamp-phpunit-error.log';
+ini_set( 'error_log', $wordcamp_phpunit_error_log );
+
+register_shutdown_function(
+	static function () use ( $wordcamp_phpunit_error_log ) {
+		if ( ! file_exists( $wordcamp_phpunit_error_log ) ) {
+			return;
+		}
+
+		// Matches `[dd-mon-yyyy hh:mm:ss tz] [request-id] file:line - function:code -- {json}`,
+		// the format written by `WordCamp\Logger\log()` (see 1-logger.php).
+		$logger_entry_pattern = '/^\[[^\]]+\] \[[^\]]+\] \S+:\d+ - \S+:\S* -- \{.*\}$/';
+		$unexpected           = array();
+
+		foreach ( file( $wordcamp_phpunit_error_log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES ) as $line ) {
+			if ( ! preg_match( $logger_entry_pattern, $line ) ) {
+				$unexpected[] = $line;
+			}
+		}
+
+		if ( $unexpected ) {
+			fwrite(
+				STDERR,
+				"\nUnexpected entries were written to PHP's error log during the test run " .
+				"(i.e. not WordCamp\\Logger\\log() calls) -- fix the underlying error instead of " .
+				"letting it accumulate silently in " . $wordcamp_phpunit_error_log . ":\n\n" .
+				implode( "\n", $unexpected ) . "\n"
+			);
+			exit( 1 );
+		}
+	}
+);
 
 const WORDCAMP_NETWORK_ID   = 1;
 const WORDCAMP_ROOT_BLOG_ID = 5;

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -28,6 +28,9 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 $wordcamp_phpunit_error_log = sys_get_temp_dir() . '/wordcamp-phpunit-error.log';
 ini_set( 'error_log', $wordcamp_phpunit_error_log );
 
+// Start each run with an empty log, so a stale entry can't fail a later run.
+file_put_contents( $wordcamp_phpunit_error_log, '' );
+
 register_shutdown_function(
 	static function () use ( $wordcamp_phpunit_error_log ) {
 		if ( ! file_exists( $wordcamp_phpunit_error_log ) ) {

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -49,8 +49,8 @@ register_shutdown_function(
 			fwrite(
 				STDERR,
 				"\nUnexpected entries were written to PHP's error log during the test run " .
-				"(i.e. not WordCamp\\Logger\\log() calls) -- fix the underlying error instead of " .
-				"letting it accumulate silently in " . $wordcamp_phpunit_error_log . ":\n\n" .
+				'(i.e. not WordCamp\\Logger\\log() calls) -- fix the underlying error instead of ' .
+				'letting it accumulate silently in ' . $wordcamp_phpunit_error_log . ":\n\n" .
 				implode( "\n", $unexpected ) . "\n"
 			);
 			exit( 1 );

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -403,8 +403,8 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 
 		try {
 			$this->assertSame( Database::SCHEMA_VERSION, get_option( Database::OPTION_NAME ) );
-			$this->assertSame( Database::occurrences_table(), $wpdb->get_var( "SHOW TABLES LIKE '" . Database::occurrences_table() . "'" ) );
-			$this->assertSame( Database::comments_table(), $wpdb->get_var( "SHOW TABLES LIKE '" . Database::comments_table() . "'" ) );
+			$this->assertSame( Database::occurrences_table(), $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', Database::occurrences_table() ) ) );
+			$this->assertSame( Database::comments_table(), $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', Database::comments_table() ) ) );
 		} finally {
 			restore_current_blog();
 		}

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -388,6 +388,29 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A brand-new multisite site gets its occurrence tables installed via the
+	 * `wp_initialize_site` hook, not just on the site that happens to serve
+	 * `init`. Regression test for the production/cron failure where a new
+	 * site's tables didn't exist yet the first time a cross-site cron run
+	 * tried to use them.
+	 */
+	public function test_new_site_gets_occurrence_tables_installed(): void {
+		global $wpdb;
+
+		$site_id = self::factory()->blog->create();
+
+		switch_to_blog( $site_id );
+
+		try {
+			$this->assertSame( Database::SCHEMA_VERSION, get_option( Database::OPTION_NAME ) );
+			$this->assertSame( Database::occurrences_table(), $wpdb->get_var( "SHOW TABLES LIKE '" . Database::occurrences_table() . "'" ) );
+			$this->assertSame( Database::comments_table(), $wpdb->get_var( "SHOW TABLES LIKE '" . Database::comments_table() . "'" ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	/**
 	 * Creates a published weekly event with locked recurrence metadata.
 	 *
 	 * @return int Event post ID.


### PR DESCRIPTION
## Summary
- Adds a regression test that creates a new multisite site and verifies both GatherPress recurring-events occurrence tables get installed via the `wp_initialize_site` hook (`Plugin::on_site_create()`), per [this Copilot comment](https://github.com/WordPress/wordcamp.org/pull/1879#discussion_r3759783768).
- Stops the redirected PHPUnit `error_log` from silently swallowing real errors: a shutdown function re-reads the log file after the run and fails the build if it contains anything other than a recognized `WordCamp\Logger\log()` entry, per [this Copilot comment](https://github.com/WordPress/wordcamp.org/pull/1879#discussion_r3759783818).

## Test plan
- [ ] CI (`unit-tests.yml`) passes, including the new `test_new_site_gets_occurrence_tables_installed` test
- [ ] Confirm CI still passes cleanly (no false positives from the new error-log shutdown check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)