### PR TITLE
Groups: follow-up design updates

### DIFF
--- a/.docker/bin/install-test-suite.sh
+++ b/.docker/bin/install-test-suite.sh
@@ -16,7 +16,7 @@ TESTS_CONFIG="/tmp/wp/wordpress-tests-lib/wp-tests-config.php"
 # Same pinned release used by local dev (see the groups-gatherpress-compat-test
 # skill and PR #1793's test plan). GatherPress is gitignored/third-party, so the
 # `wporg-groups-frontend`/`groups` PHPUnit suites need it installed before they run.
-GATHERPRESS_VERSION="0.35.0"
+GATHERPRESS_VERSION="0.35.1"
 GATHERPRESS_DIR="/app/public_html/wp-content/plugins/gatherpress"
 
 db_ready() {

--- a/.docker/bin/install-test-suite.sh
+++ b/.docker/bin/install-test-suite.sh
@@ -16,7 +16,7 @@ TESTS_CONFIG="/tmp/wp/wordpress-tests-lib/wp-tests-config.php"
 # Same pinned release used by local dev (see the groups-gatherpress-compat-test
 # skill and PR #1793's test plan). GatherPress is gitignored/third-party, so the
 # `wporg-groups-frontend`/`groups` PHPUnit suites need it installed before they run.
-GATHERPRESS_VERSION="0.35.1"
+GATHERPRESS_VERSION="0.35.2"
 GATHERPRESS_DIR="/app/public_html/wp-content/plugins/gatherpress"
 
 db_ready() {

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -131,7 +131,7 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 	 * can still persist it afterwards.
 	 *
 	 * The Groups frontend publishes the post and only then saves the rule, so
-	 * without the lift every field the organiser just changed is dropped.
+	 * without the lift every field the organizer just changed is dropped.
 	 */
 	public function test_schedule_unlock_persists_writes_on_a_published_series(): void {
 		$post_id = $this->create_published_recurring_event();

--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -151,7 +151,7 @@ add_filter(
 			return $allcaps;
 		}
 
-		// Grant to editors (group organisers).
+		// Grant to editors (group organizers).
 		if ( ! empty( $allcaps['edit_others_posts'] ) ) {
 			$allcaps['edit_theme_options'] = true;
 		}

--- a/public_html/wp-content/mu-plugins/groups/network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/network-messaging.php
@@ -6,10 +6,10 @@
  * emailing group people, covering two audiences that were previously
  * impossible to reach without hand-assembling address lists:
  *
- * - Every group organiser across the whole Groups network (#1775).
+ * - Every group organizer across the whole Groups network (#1775).
  * - Every member of a hand-picked set of groups (#1776).
  *
- * Both are the same underlying tool: an audience filter (organisers only vs.
+ * Both are the same underlying tool: an audience filter (organizers only vs.
  * all members) crossed with a group filter (all groups vs. selected ones).
  *
  * Delivery runs on cron in small batches rather than in the submit request,
@@ -75,15 +75,15 @@ const LOCK_RETRY_DELAY = 50000;
  */
 const BATCH_SIZE = 50;
 
-/** Audience: editors and administrators only ("Organisers"). */
+/** Audience: editors and administrators only ("Organizers"). */
 const AUDIENCE_ORGANIZERS = 'organizers';
 
 /** Audience: everyone on the site, whatever their role. */
 const AUDIENCE_MEMBERS = 'members';
 
 /**
- * Roles that make someone a group organiser. Mirrors the "Organiser" tier in
- * `Members_Controller::ROLE_LABELS` — authors are "Event Organisers" and are
+ * Roles that make someone a group organizer. Mirrors the "Organizer" tier in
+ * `Members_Controller::ROLE_LABELS` — authors are "Event Organizers" and are
  * deliberately not included, since they only manage their own events.
  */
 const ORGANIZER_ROLES = array( 'administrator', 'editor' );
@@ -334,7 +334,7 @@ function schedule_next_batch(): void {
  *
  * A unit is one recipient taken off the queue or one per-site recipient
  * lookup — not one email sent. Bounding on emails instead would leave a run
- * unbounded whenever the work doesn't produce mail: someone who organises a
+ * unbounded whenever the work doesn't produce mail: someone who organizes a
  * dozen groups is skipped as a duplicate, and a group with no members yields
  * nothing, so a run could walk any number of sites and queries before hitting
  * a send-based limit. Counting the work itself is what keeps a single cron
@@ -702,7 +702,7 @@ function render_page(): void {
 		<?php render_notice(); ?>
 
 		<p>
-			Send an email to group organisers or members across the Groups network.
+			Send an email to group organizers or members across the Groups network.
 			Messages are delivered in the background, in batches.
 		</p>
 
@@ -718,7 +718,7 @@ function render_page(): void {
 							<legend class="screen-reader-text">Who should receive this message?</legend>
 							<label>
 								<input type="radio" name="audience" value="<?php echo esc_attr( AUDIENCE_ORGANIZERS ); ?>" checked="checked" />
-								Organisers only (editors and administrators)
+								Organizers only (editors and administrators)
 							</label>
 							<br />
 							<label>

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
@@ -30,7 +30,7 @@ class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 	}
 
 	/**
-	 * Editors ("Organisers") are granted `edit_theme_options` so they can use
+	 * Editors ("Organizers") are granted `edit_theme_options` so they can use
 	 * the Site Editor to customise their group site — but nothing broader.
 	 * See the `promote_users` regression test in test-capabilities.php for
 	 * the capability that must NOT be granted this way.

--- a/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-info-card.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-info-card.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use GatherPress\Core\Event\Event;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/../../wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * Regression coverage for the single-event details card's zone dividers.
+ *
+ * The card stacks up to four zones — the date, the RSVP control, the venue
+ * (or the online-event line), and "Add to calendar". Everything below the
+ * RSVP is optional: GatherPress renders `gatherpress/venue`,
+ * `gatherpress/online-event` and `gatherpress/add-to-calendar` as an empty
+ * string when the event has no venue, isn't online, or has no calendar links.
+ *
+ * The card used to separate those zones with standalone `core/separator`
+ * blocks and hide the stragglers from CSS (`hr:last-child`, and an
+ * `hr:has(+ *:empty:last-child)` companion). That could only ever hide the
+ * *last* divider: with all three optional zones empty, the first `<hr>` was
+ * left hanging under the RSVP button with nothing beneath it, because the
+ * second `<hr>` was still in the DOM behind `display: none` and kept it from
+ * matching `:last-child`.
+ *
+ * The dividers are now a `border-top` on the zone itself
+ * (`.groups-site-event-zone`), which makes the dangling case unrepresentable
+ * — a divider cannot outlive the block that draws it. These tests pin both
+ * halves of that: the template carries no separator blocks to strand, and an
+ * event with no details renders no zones at all.
+ *
+ * @group groups
+ */
+class Test_Groups_Site_Event_Info_Card extends Groups_TestCase {
+
+	const TEMPLATE = SUT_WP_CONTENT_DIR . 'themes/groups-site/templates/single-event.html';
+
+	/**
+	 * The block name of each optional zone, in template order.
+	 */
+	const OPTIONAL_ZONES = array(
+		'gatherpress/venue',
+		'gatherpress/online-event',
+		'gatherpress/add-to-calendar',
+	);
+
+	/**
+	 * Create a published event with no venue and no online-event term, so
+	 * every optional zone of the details card renders empty.
+	 */
+	private function create_event_without_details(): int {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+				'post_title'  => 'Event Without Details',
+			)
+		);
+
+		( new Event( $event_id ) )->save_datetimes(
+			array(
+				'post_id'        => $event_id,
+				'datetime_start' => gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) ),
+				'datetime_end'   => gmdate( 'Y-m-d H:i:s', strtotime( '+30 days +2 hours' ) ),
+				'timezone'       => 'UTC',
+			)
+		);
+
+		return $event_id;
+	}
+
+	/**
+	 * Find the details-card group inside a parsed block tree.
+	 *
+	 * @param array $blocks Parsed blocks to walk.
+	 *
+	 * @return array|null The card block, or null when it isn't present.
+	 */
+	private function find_info_card( array $blocks ): ?array {
+		foreach ( $blocks as $block ) {
+			$class_name = $block['attrs']['className'] ?? '';
+
+			if ( 'core/group' === $block['blockName'] && str_contains( $class_name, 'groups-site-event-info-card' ) ) {
+				return $block;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = $this->find_info_card( $block['innerBlocks'] );
+
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse `single-event.html` and return the details-card block.
+	 */
+	private function get_info_card_block(): array {
+		$template = file_get_contents( self::TEMPLATE );
+
+		$this->assertNotFalse( $template, 'Could not read single-event.html.' );
+
+		$card = $this->find_info_card( parse_blocks( $template ) );
+
+		$this->assertNotNull( $card, 'single-event.html no longer contains .groups-site-event-info-card.' );
+
+		return $card;
+	}
+
+	/**
+	 * The dangling-divider regression: an event with no venue, no online
+	 * link and no calendar output renders a card with no zones — and so no
+	 * divider stranded under the RSVP button.
+	 */
+	public function test_info_card_renders_no_zone_divider_when_all_optional_zones_are_empty() {
+		$event_id = $this->create_event_without_details();
+
+		$this->go_to( home_url( "?p={$event_id}&post_type=gatherpress_event" ) );
+
+		$output = render_block( $this->get_info_card_block() );
+
+		// The card itself still rendered — otherwise the assertions below
+		// would pass on an empty string.
+		$this->assertStringContainsString( 'groups-site-event-info-card', $output );
+		$this->assertStringContainsString( 'Date and time', $output );
+
+		$this->assertStringNotContainsString( 'groups-site-event-zone', $output );
+		$this->assertStringNotContainsString( '<hr', $output );
+	}
+
+	/**
+	 * The structural half: the card separates its zones with a border on the
+	 * zone, never with a sibling `core/separator` that can outlive it.
+	 */
+	public function test_info_card_contains_no_standalone_separator_blocks() {
+		$card = $this->get_info_card_block();
+
+		$separators = array_filter(
+			$card['innerBlocks'],
+			static function ( array $block ): bool {
+				return 'core/separator' === $block['blockName'];
+			}
+		);
+
+		$this->assertSame(
+			array(),
+			$separators,
+			'The details card is back to standalone separators; a divider can now outlive its zone.'
+		);
+	}
+
+	/**
+	 * Every optional zone carries the class that draws its divider, so a
+	 * zone added without one doesn't silently lose its boundary.
+	 */
+	public function test_optional_zones_carry_the_zone_class() {
+		$card = $this->get_info_card_block();
+
+		$zone_classes = array();
+
+		foreach ( $card['innerBlocks'] as $block ) {
+			if ( in_array( $block['blockName'], self::OPTIONAL_ZONES, true ) ) {
+				$zone_classes[ $block['blockName'] ] = $block['attrs']['className'] ?? '';
+			}
+		}
+
+		$this->assertSame(
+			self::OPTIONAL_ZONES,
+			array_keys( $zone_classes ),
+			'The details card no longer holds the expected optional zones.'
+		);
+
+		foreach ( $zone_classes as $block_name => $class_name ) {
+			$this->assertStringContainsString(
+				'groups-site-event-zone',
+				$class_name,
+				"{$block_name} is missing the groups-site-event-zone class that draws its divider."
+			);
+		}
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-network-messaging.php
@@ -182,8 +182,8 @@ class Test_Groups_Network_Messaging extends Groups_TestCase {
 	}
 
 	/**
-	 * The organiser audience is the "Organiser" tier only — editors and
-	 * administrators. Authors ("Event Organisers") and members are excluded.
+	 * The organizer audience is the "Organizer" tier only — editors and
+	 * administrators. Authors ("Event Organizers") and members are excluded.
 	 */
 	public function test_organizer_audience_only_includes_editors_and_admins() {
 		$site_id = $this->group_sites['brisbane'];
@@ -246,7 +246,7 @@ class Test_Groups_Network_Messaging extends Groups_TestCase {
 	}
 
 	/**
-	 * #1775: a broadcast reaches every organiser on every group, and nobody
+	 * #1775: a broadcast reaches every organizer on every group, and nobody
 	 * else.
 	 */
 	public function test_broadcast_reaches_every_organizer_on_the_network() {
@@ -619,7 +619,7 @@ class Test_Groups_Network_Messaging extends Groups_TestCase {
 	}
 
 	/**
-	 * Group organisers — even administrators of their own group — can't reach
+	 * Group organizers — even administrators of their own group — can't reach
 	 * the whole network.
 	 */
 	public function test_group_administrators_cannot_send_messages() {

--- a/public_html/wp-content/mu-plugins/groups/wporg-groups-archive.php
+++ b/public_html/wp-content/mu-plugins/groups/wporg-groups-archive.php
@@ -3,7 +3,7 @@
  * Network administration for archiving and reactivating group sites.
  *
  * Uses WordPress multisite's native archived-site flag so group content,
- * RSVPs, and memberships remain intact. Organisers cannot request archival
+ * RSVPs, and memberships remain intact. Organizers cannot request archival
  * in v1; only users who can manage network sites can use this screen.
  *
  * Only loaded on the Groups network, via

--- a/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-group-info-rest.php
@@ -18,8 +18,8 @@ require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/rest.php';
  * Tests for the `wporg-groups/v1/group-info` routes.
  *
  * These exist because core's `/wp/v2/settings` gates `blogname` and
- * `blogdescription` behind `manage_options`, which Organisers don't have.
- * The routes hand Organisers write access to those options and the site's
+ * `blogdescription` behind `manage_options`, which Organizers don't have.
+ * The routes hand Organizers write access to those options and the site's
  * location metadata, so the interesting cases are the ones where a write
  * should be refused or existing data should be preserved.
  *
@@ -69,7 +69,7 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An Organiser (editor) can read the group's name and description.
+	 * An Organizer (editor) can read the group's name and description.
 	 */
 	public function test_editor_can_read_group_info() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
@@ -86,7 +86,7 @@ class Test_Groups_Group_Info_REST extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An Organiser (editor) can write both fields.
+	 * An Organizer (editor) can write both fields.
 	 */
 	public function test_editor_can_update_group_info() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );

--- a/public_html/wp-content/mu-plugins/tests/test-groups-my-events.php
+++ b/public_html/wp-content/mu-plugins/tests/test-groups-my-events.php
@@ -13,7 +13,7 @@ require_once dirname( __DIR__ ) . '/wporg-groups-frontend/inc/my-events.php';
 /**
  * Tests for the my-events block's notion of "my events".
  *
- * The block used to answer purely from RSVP data, so an organiser who had
+ * The block used to answer purely from RSVP data, so an organizer who had
  * created events but never clicked RSVP saw an empty block (#1810). These
  * cover both halves of the definition and the boundaries between them:
  * authored events count, attending events count, an event that is both is
@@ -137,7 +137,7 @@ class Test_Groups_My_Events extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The reported case: an organiser who created events and never RSVP'd.
+	 * The reported case: an organizer who created events and never RSVP'd.
 	 */
 	public function test_authored_events_are_included_without_an_rsvp() {
 		$organiser = self::factory()->user->create();
@@ -146,7 +146,7 @@ class Test_Groups_My_Events extends WP_UnitTestCase {
 		$this->assertSame(
 			array( $event_id ),
 			get_upcoming_event_ids( $organiser ),
-			'An event the member organises should be listed even with no RSVP.'
+			'An event the member organizes should be listed even with no RSVP.'
 		);
 	}
 
@@ -168,7 +168,7 @@ class Test_Groups_My_Events extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An organiser who also RSVPs to their own event sees it once.
+	 * An organizer who also RSVPs to their own event sees it once.
 	 */
 	public function test_authored_and_attending_event_is_listed_once() {
 		$organiser = self::factory()->user->create();
@@ -179,7 +179,7 @@ class Test_Groups_My_Events extends WP_UnitTestCase {
 		$this->assertSame(
 			array( $event_id ),
 			get_upcoming_event_ids( $organiser ),
-			'An event that is both organised and RSVPed should not be duplicated.'
+			'An event that is both organized and RSVPed should not be duplicated.'
 		);
 	}
 
@@ -198,7 +198,7 @@ class Test_Groups_My_Events extends WP_UnitTestCase {
 		$this->assertSame(
 			array(),
 			get_upcoming_event_ids( $organiser ),
-			'A finished event the member organised should not be listed.'
+			'A finished event the member organized should not be listed.'
 		);
 		$this->assertSame(
 			array(),
@@ -219,7 +219,7 @@ class Test_Groups_My_Events extends WP_UnitTestCase {
 		$this->assertSame(
 			array(),
 			get_upcoming_event_ids( $stranger ),
-			'A member should not see events they neither organise nor attend.'
+			'A member should not see events they neither organize nor attend.'
 		);
 	}
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
@@ -16,7 +16,7 @@ defined( 'WPINC' ) || die();
  * WordPress roles that can create and manage their own events on a group
  * site. Mirrors the role tiers surfaced elsewhere in this plugin (see
  * `Members_Controller::ROLE_LABELS`): administrators and editors are full
- * "Organisers", authors are "Event Organisers".
+ * "Organizers", authors are "Event Organizers".
  *
  * Checked by role rather than by a raw capability (e.g. `edit_posts`) so
  * that a stray `contributor` account doesn't slip in — contributors also
@@ -28,17 +28,17 @@ const EVENT_MANAGER_ROLES = array( 'administrator', 'editor', 'author' );
 /**
  * Whether the current user is allowed to create / edit events on this group.
  *
- * Authors ("Event Organisers") can create and manage their own events; the
+ * Authors ("Event Organizers") can create and manage their own events; the
  * REST layer's per-post capability checks (`edit_post`/`publish_post`)
  * already restrict them to events they own. Editors and administrators
- * ("Organisers") can manage everyone's events.
+ * ("Organizers") can manage everyone's events.
  *
  * Super admins are recognised explicitly because this is a role-array check
  * rather than a `current_user_can()` capability check (see the docblock on
  * `EVENT_MANAGER_ROLES`) — unlike `current_user_can_manage_group_settings()`,
  * it doesn't automatically pick up core's super-admin capability elevation.
  * Without this, a super admin whose nominal role on a given group is
- * `subscriber` (e.g. a deputy who isn't the group's own organiser) would see
+ * `subscriber` (e.g. a deputy who isn't the group's own organizer) would see
  * the "Set up your group" button — gated by `current_user_can_manage_group_settings()`,
  * which does elevate — but the modal would render invisibly, because the
  * `wp-components`/`wp-block-editor` styles enqueued in `Modal::enqueue_supplementary_assets()`
@@ -64,7 +64,7 @@ function current_user_can_manage_events(): bool {
 
 /**
  * Whether the current user is allowed to access the group settings UI
- * (venues, group info, member role management) — the full "Organiser"
+ * (venues, group info, member role management) — the full "Organizer"
  * tier only (editors and administrators), distinct from event management.
  */
 function current_user_can_manage_group_settings(): bool {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
@@ -26,6 +26,35 @@ defined( 'WPINC' ) || die();
 const EVENT_MANAGER_ROLES = array( 'administrator', 'editor', 'author' );
 
 /**
+ * WordPress roles that make up the full "Organizer" tier — a narrower set
+ * than `EVENT_MANAGER_ROLES`, since it excludes authors ("Event
+ * Organizers"), who only manage their own events. Single source for the
+ * role-set checked when deciding whether a member can be left without an
+ * organizer, or whether they're shown the "Organizer" label.
+ */
+const ORGANIZER_ROLES = array( 'administrator', 'editor' );
+
+/**
+ * Translated display label for a member's role tier.
+ *
+ * Mirrors `Members_Controller::ROLE_LABELS`, which stays untranslated
+ * because it's also read directly by `group-members/render.php` and
+ * asserted against verbatim in `test-class-members-controller.php`'s REST
+ * response checks. This is the translated counterpart for front-end markup
+ * rendered directly by PHP (not consumed as REST JSON), such as the
+ * `group-membership` block.
+ */
+function get_role_tier_label( string $role ): string {
+	$labels = array(
+		'administrator' => __( 'Organizer', 'wporg-groups-frontend' ),
+		'editor'        => __( 'Organizer', 'wporg-groups-frontend' ),
+		'author'        => __( 'Event Organizer', 'wporg-groups-frontend' ),
+	);
+
+	return $labels[ $role ] ?? __( 'Member', 'wporg-groups-frontend' );
+}
+
+/**
  * Whether the current user is allowed to create / edit events on this group.
  *
  * Authors ("Event Organizers") can create and manage their own events; the

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
@@ -10,6 +10,8 @@
 
 namespace WordCamp\Groups\Frontend\Members;
 
+use const WordCamp\Groups\Frontend\Capabilities\ORGANIZER_ROLES;
+
 defined( 'WPINC' ) || die();
 
 /**
@@ -328,7 +330,7 @@ class Members_Controller extends \WP_REST_Users_Controller {
 		$user    = get_userdata( $user_id );
 
 		// Prevent organizers from leaving without demotion.
-		if ( $user && array_intersect( $user->roles, array( 'administrator', 'editor' ) ) ) {
+		if ( $user && array_intersect( $user->roles, ORGANIZER_ROLES ) ) {
 			return new \WP_Error(
 				'cannot_leave',
 				__( 'Organizers cannot leave the group. Ask another organizer to change your role first.', 'wporg-groups-frontend' ),
@@ -623,16 +625,14 @@ class Members_Controller extends \WP_REST_Users_Controller {
 	 * @return bool
 	 */
 	private function can_demote_organizer( \WP_User $user, string $new_role ): bool {
-		$organizer_roles = array( 'administrator', 'editor' );
-
-		if ( ! array_intersect( $user->roles, $organizer_roles ) || in_array( $new_role, $organizer_roles, true ) ) {
+		if ( ! array_intersect( $user->roles, ORGANIZER_ROLES ) || in_array( $new_role, ORGANIZER_ROLES, true ) ) {
 			return true;
 		}
 
 		$other_organizers = get_users(
 			array(
 				'blog_id'     => get_current_blog_id(),
-				'role__in'    => $organizer_roles,
+				'role__in'    => ORGANIZER_ROLES,
 				'exclude'     => array( $user->ID ),
 				'number'      => 1,
 				'count_total' => false,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
@@ -37,9 +37,9 @@ class Members_Controller extends \WP_REST_Users_Controller {
 	 * @var array<string, string>
 	 */
 	const ROLE_LABELS = array(
-		'administrator' => 'Organiser',
-		'editor'        => 'Organiser',
-		'author'        => 'Event Organiser',
+		'administrator' => 'Organizer',
+		'editor'        => 'Organizer',
+		'author'        => 'Event Organizer',
 		'contributor'   => 'Member',
 		'subscriber'    => 'Member',
 	);
@@ -219,7 +219,7 @@ class Members_Controller extends \WP_REST_Users_Controller {
 		$query = new \WP_User_Query( $query_args );
 		$users = $query->get_results();
 
-		// Sort: organisers first, then event organisers, then members.
+		// Sort: organizers first, then event organizers, then members.
 		usort( $users, array( $this, 'sort_by_role' ) );
 
 		$data = array();
@@ -327,11 +327,11 @@ class Members_Controller extends \WP_REST_Users_Controller {
 		$blog_id = get_current_blog_id();
 		$user    = get_userdata( $user_id );
 
-		// Prevent organisers from leaving without demotion.
+		// Prevent organizers from leaving without demotion.
 		if ( $user && array_intersect( $user->roles, array( 'administrator', 'editor' ) ) ) {
 			return new \WP_Error(
 				'cannot_leave',
-				__( 'Organisers cannot leave the group. Ask another organiser to change your role first.', 'wporg-groups-frontend' ),
+				__( 'Organizers cannot leave the group. Ask another organizer to change your role first.', 'wporg-groups-frontend' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -472,7 +472,7 @@ class Members_Controller extends \WP_REST_Users_Controller {
 		if ( ! $this->can_demote_organizer( $user, $role ) ) {
 			return new \WP_Error(
 				'cannot_remove_last_organizer',
-				__( 'A group must have at least one organiser.', 'wporg-groups-frontend' ),
+				__( 'A group must have at least one organizer.', 'wporg-groups-frontend' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -506,7 +506,7 @@ class Members_Controller extends \WP_REST_Users_Controller {
 	}
 
 	/**
-	 * Sort users by role weight (organisers first).
+	 * Sort users by role weight (organizers first).
 	 *
 	 * @param \WP_User $a First user.
 	 * @param \WP_User $b Second user.

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/group-location.php
@@ -24,11 +24,11 @@ const TYPE_ONLINE   = 'online';
 /**
  * Missing metadata is treated as an unspecified location.
  *
- * A stored country code that no longer resolves to a name (e.g. CLDR data
- * changed) is still returned rather than collapsed to null here: the About
- * tab builds its form from this response, and a null location would make
- * the next save of any field — even just the group name — post
- * `location: null` and silently wipe the type, city, and country.
+ * Whatever is stored is reported back verbatim, including a country code that no
+ * longer resolves to a name. Collapsing that to `null` would leave the settings
+ * form with no location selected, so the next save of any other field would post
+ * `location: null` and silently wipe the city and country. Validation belongs on
+ * the write path, in `normalize_location()`.
  */
 function get_location( int $site_id = 0 ): ?array {
 	$site_id = $site_id ?: get_current_blog_id();
@@ -45,7 +45,7 @@ function get_location( int $site_id = 0 ): ?array {
 	$city         = trim( (string) get_site_meta( $site_id, CITY_META_KEY, true ) );
 	$country_code = strtoupper( (string) get_site_meta( $site_id, COUNTRY_META_KEY, true ) );
 
-	if ( '' === $city || '' === $country_code ) {
+	if ( '' === $city && '' === $country_code ) {
 		return null;
 	}
 
@@ -153,6 +153,9 @@ function clear_location(): void {
 
 /**
  * Build the public location label, or an empty string when unspecified.
+ *
+ * A stored country code that no longer resolves is dropped from the label rather
+ * than shown as a bare code or an empty half of "City, ".
  */
 function get_location_label(): string {
 	$location = get_location();
@@ -165,16 +168,17 @@ function get_location_label(): string {
 		return __( 'Online', 'wporg-groups-frontend' );
 	}
 
-	$country_name = wcorg_get_country_name_from_code( $location['countryCode'] );
+	$city         = $location['city'];
+	$country_name = (string) wcorg_get_country_name_from_code( $location['countryCode'] );
 
-	if ( '' === $country_name ) {
-		return $location['city'];
+	if ( '' === $city || '' === $country_name ) {
+		return $city . $country_name;
 	}
 
 	return sprintf(
 		/* translators: 1: city name, 2: country name. */
 		__( '%1$s, %2$s', 'wporg-groups-frontend' ),
-		$location['city'],
+		$city,
 		$country_name
 	);
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/my-events.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/my-events.php
@@ -15,17 +15,17 @@ defined( 'WPINC' ) || die();
 /**
  * Upcoming event IDs for a member, soonest first.
  *
- * "Mine" means either of two things, and an organiser is usually both:
+ * "Mine" means either of two things, and an organizer is usually both:
  *
  * - events the member has RSVP'd to as attending,
  * - events the member authored, which on a group site means the ones they
- *   organise.
+ *   organize.
  *
  * Authorship is unioned in rather than written into the RSVP data, so
  * "attending" keeps meaning that the person said they are coming. That
  * distinction matters because the RSVP data feeds attendee counts, and
- * an organiser who creates an event they will not personally attend is a
- * normal thing on a group with several organisers.
+ * an organizer who creates an event they will not personally attend is a
+ * normal thing on a group with several organizers.
  *
  * @param int $user_id Member to resolve events for.
  *

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -233,7 +233,7 @@ function register_routes(): void {
 
 	// ----- Group info -----------------------------------------------------
 	//
-	// Organisers cannot use core's /wp/v2/settings endpoint because it requires
+	// Organizers cannot use core's /wp/v2/settings endpoint because it requires
 	// `manage_options`. Expose only the fields managed by this UI behind the
 	// group-settings capability instead.
 
@@ -559,7 +559,7 @@ function current_user_can_publish_event( int $event_id = 0 ): bool {
  * Whether the current user may use an attachment as an event's featured
  * image. Mirrors core's own visibility rules for attachments (public/
  * inherited attachments readable by anyone, private ones only by their
- * owner or users with `read_private_posts`) so a group organiser can't
+ * owner or users with `read_private_posts`) so a group organizer can't
  * point their event at another user's private/unattached media just by
  * guessing its ID.
  */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-labels.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-labels.php
@@ -112,15 +112,76 @@ function get_count_label( int $count, bool $is_attending ): string {
  * counts until the next page load re-renders the line through
  * `get_count_label()`.
  *
+ * Keyed positionally by `COUNT_FORMAT_KEYS` rather than spelling the keys
+ * out a second time, so the two can't drift from each other.
+ *
  * @return array<string, string> Keyed by `COUNT_FORMAT_KEYS`.
  */
 function get_count_formats(): array {
+	return array_combine(
+		COUNT_FORMAT_KEYS,
+		array(
+			get_count_parts( 0, false )[0],
+			get_count_parts( 1, false )[0],
+			get_count_parts( 2, false )[0],
+			get_count_parts( 1, true )[0],
+			get_count_parts( 2, true )[0],
+			get_count_parts( 3, true )[0],
+		)
+	);
+}
+
+/**
+ * The keys `get_modal_title_formats()` returns, which are also the keys
+ * `modalTitle` in `view.js` selects between.
+ */
+const MODAL_TITLE_FORMAT_KEYS = array( 'modalTitleSingular', 'modalTitlePlural' );
+
+/**
+ * The RSVP modal title's format string and the count to substitute.
+ *
+ * Same one-`_n()`-call-serves-both-callers shape as `get_count_parts()`:
+ * `get_modal_title_label()` finishes the server-rendered title,
+ * `get_modal_title_formats()` harvests the singular/plural formats for the
+ * view module.
+ *
+ * @param int $count Number of attendees.
+ * @return array{0: string, 1: int} The format, and the count to substitute.
+ */
+function get_modal_title_parts( int $count ): array {
 	return array(
-		'countZero'           => get_count_parts( 0, false )[0],
-		'countSingular'       => get_count_parts( 1, false )[0],
-		'countPlural'         => get_count_parts( 2, false )[0],
-		'countYouFirst'       => get_count_parts( 1, true )[0],
-		'countYouAndOneOther' => get_count_parts( 2, true )[0],
-		'countYouAndOthers'   => get_count_parts( 3, true )[0],
+		/* translators: 1: attendee count, 2: event title */
+		_n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', $count, 'wporg-groups-frontend' ),
+		$count,
+	);
+}
+
+/**
+ * The finished modal title for the server-rendered markup.
+ *
+ * @param int    $count       Number of attendees.
+ * @param string $event_title Event title.
+ * @return string
+ */
+function get_modal_title_label( int $count, string $event_title ): string {
+	list( $format, $value ) = get_modal_title_parts( $count );
+
+	return sprintf( $format, number_format_i18n( $value ), $event_title );
+}
+
+/**
+ * The modal-title formats the view module picks between, keyed for
+ * `context.labels`. Resolved at n=1 and n=2 — the same two-entry-table
+ * tradeoff `get_count_formats()` makes, for the same reason.
+ *
+ * @return array<string, string> Keyed by `MODAL_TITLE_FORMAT_KEYS`.
+ */
+function get_modal_title_formats(): array {
+	return array_combine(
+		MODAL_TITLE_FORMAT_KEYS,
+		array(
+			get_modal_title_parts( 1 )[0],
+			get_modal_title_parts( 2 )[0],
+		)
 	);
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-labels.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rsvp-labels.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * The RSVP count line, in one place.
+ *
+ * The line under the RSVP button ("14 going", "You and 3 others") has to be
+ * produced twice: PHP renders it into the markup, and `view.js` re-renders it
+ * in the browser when an RSVP changes the count without a reload. Script
+ * modules can't depend on `wp-i18n` — modules and classic scripts aren't
+ * interoperable — so the view module can't call `_n()` itself. It gets the
+ * translated formats through `context.labels` instead and picks between them.
+ *
+ * That makes two branch implementations unavoidable. What is avoidable is two
+ * copies of the *strings*: `get_count_parts()` below holds the only `_n()`
+ * calls, `get_count_label()` finishes the server-rendered line from them, and
+ * `get_count_formats()` harvests the same formats for the view module. Adding
+ * a state means editing one function here and its mirror in `view.js`.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+namespace WordCamp\Groups\Frontend\RSVP_Labels;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * The keys `get_count_formats()` returns, which are also the keys
+ * `getCountParts()` in `view.js` selects between. Named here so the test suite
+ * can assert the two sides still agree on the vocabulary.
+ */
+const COUNT_FORMAT_KEYS = array(
+	'countZero',
+	'countSingular',
+	'countPlural',
+	'countYouFirst',
+	'countYouAndOneOther',
+	'countYouAndOthers',
+);
+
+/**
+ * The count line's format string and the number that goes into it.
+ *
+ * Returns the format rather than the finished string so one set of branches
+ * can serve both callers — `get_count_label()` fills it in with the real
+ * count, `get_count_formats()` takes the format itself.
+ *
+ * The four states each add to what the RSVP button already says. Once you're
+ * attending the button reads "Attending", so a bare "1 going" would just be
+ * telling you about yourself — that state counts the *others* instead. Zero
+ * gets the same treatment in reverse: nobody yet is an invitation, not a
+ * headcount.
+ *
+ * @param int  $count        Number of attendees.
+ * @param bool $is_attending Whether the current user is one of them.
+ * @return array{0: string, 1: int|null} The format, and the number to
+ *                                       substitute into it — or null when the
+ *                                       format takes no argument.
+ */
+function get_count_parts( int $count, bool $is_attending ): array {
+	$others = max( 0, $count - 1 );
+
+	if ( $is_attending && $others > 0 ) {
+		return array(
+			/* translators: %s: number of attendees other than the current user. */
+			_n( 'You and %s other', 'You and %s others', $others, 'wporg-groups-frontend' ),
+			$others,
+		);
+	}
+
+	if ( $is_attending ) {
+		return array( __( 'First one in', 'wporg-groups-frontend' ), null );
+	}
+
+	if ( $count > 0 ) {
+		return array(
+			/* translators: %s: attendee count. */
+			_n( '%s going', '%s going', $count, 'wporg-groups-frontend' ),
+			$count,
+		);
+	}
+
+	return array( __( 'Be the first to RSVP', 'wporg-groups-frontend' ), null );
+}
+
+/**
+ * The finished count line for the server-rendered markup.
+ *
+ * Passes the real count to `_n()`, so languages with more than two plural
+ * forms get the right one — something the view module can't do with a
+ * two-entry format table.
+ *
+ * @param int  $count        Number of attendees.
+ * @param bool $is_attending Whether the current user is one of them.
+ * @return string
+ */
+function get_count_label( int $count, bool $is_attending ): string {
+	list( $format, $value ) = get_count_parts( $count, $is_attending );
+
+	if ( null === $value ) {
+		return $format;
+	}
+
+	return sprintf( $format, number_format_i18n( $value ) );
+}
+
+/**
+ * The count formats the view module picks between, keyed for `context.labels`.
+ *
+ * Each one is harvested from `get_count_parts()` at the smallest count that
+ * reaches that branch, so the strings stay written once. The singular/plural
+ * pairs are resolved here at n=1 and n=2, which is as far as a lookup table
+ * goes: a language with a third plural form gets its n=2 wording for larger
+ * counts until the next page load re-renders the line through
+ * `get_count_label()`.
+ *
+ * @return array<string, string> Keyed by `COUNT_FORMAT_KEYS`.
+ */
+function get_count_formats(): array {
+	return array(
+		'countZero'           => get_count_parts( 0, false )[0],
+		'countSingular'       => get_count_parts( 1, false )[0],
+		'countPlural'         => get_count_parts( 2, false )[0],
+		'countYouFirst'       => get_count_parts( 1, true )[0],
+		'countYouAndOneOther' => get_count_parts( 2, true )[0],
+		'countYouAndOthers'   => get_count_parts( 3, true )[0],
+	);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/sponsors.php
@@ -136,7 +136,7 @@ function with_store_site( callable $callback ) {
 /**
  * Register the sponsor post type.
  *
- * The admin UI is only exposed on the store site, so a group organiser never
+ * The admin UI is only exposed on the store site, so a group organizer never
  * sees the post type on their own site, and every capability maps to
  * `manage_network` so only network admins can add, edit or delete sponsors
  * even if they somehow reach the screen.

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -657,7 +657,7 @@ const MINIMUM_EVENT_DATE = window.wporgGroupsEventModal?.minimumEventDate || '';
 					? __( 'Edit event', 'wporg-groups-frontend' )
 					: __( 'Create event', 'wporg-groups-frontend' ),
 				onRequestClose: handleClose,
-				className: 'wporg-groups-event-modal',
+				className: 'wporg-groups-modal-accent wporg-groups-event-modal',
 				size: 'large',
 				shouldCloseOnClickOutside: false,
 			},

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/message-members-modal.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/message-members-modal.js
@@ -72,7 +72,7 @@ export default function MessageMembersModal( { eventId, recipientMode, onClose }
 				? __( 'Message all members', 'wporg-groups-frontend' )
 				: __( 'Message event attendees', 'wporg-groups-frontend' ),
 			onRequestClose: onClose,
-			className: 'wporg-groups-message-modal',
+			className: 'wporg-groups-modal-accent wporg-groups-message-modal',
 			shouldCloseOnClickOutside: false,
 		},
 		sent

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -3,6 +3,7 @@
  */
 
 @import '../../components/recurrence-controls.css';
+@import '../../components/component-accents.css';
 
 /* === Message members modal === */
 
@@ -186,7 +187,7 @@
 }
 
 .wporg-groups-event-modal__autosave--saving {
-	color: #2271b1;
+	color: var(--wp--preset--color--blueberry-1);
 }
 
 .wporg-groups-event-modal__autosave--saved {
@@ -219,8 +220,8 @@
 }
 
 .wporg-groups-event-modal__editor:focus-within {
-	border-color: #3858e9;
-	box-shadow: 0 0 0 1px #3858e9;
+	border-color: var(--wp--preset--color--blueberry-1);
+	box-shadow: 0 0 0 1px var(--wp--preset--color--blueberry-1);
 }
 
 .wporg-groups-event-modal__editor .block-editor-block-list__layout {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/venue-editor.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/venue-editor.js
@@ -259,7 +259,9 @@ export default function VenueEditor( { venueId, onSave, onCancel, inline, hideHe
 			document.removeEventListener( 'keydown', onEscape, true );
 	}, [ onCancel ] );
 
-	const wrapperClass = inline ? 'wporg-groups-venue-editor--inline' : 'wporg-groups-venue-editor';
+	const wrapperClass = inline
+		? 'wporg-groups-venue-editor--inline'
+		: 'wporg-groups-modal-accent wporg-groups-venue-editor';
 
 	if ( loading ) {
 		return h(

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -202,6 +202,13 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			class="wp-block-button<?php echo $is_attending ? ' is-style-outline' : ''; ?>"
 			data-wp-class--is-style-outline="state.isAttending"
 		>
+			<?php
+			/*
+			 * `aria-busy="true"` does two things: the theme's custom.css
+			 * draws the loading spinner from it, and screen readers use it
+			 * to announce the button as busy rather than unavailable.
+			 */
+			?>
 			<button
 				type="button"
 				class="wp-block-button__link wp-element-button<?php echo $is_attending ? ' is-attending' : ''; ?>"
@@ -209,6 +216,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				data-wp-text="state.rsvpButtonLabel"
 				data-wp-class--is-attending="state.isAttending"
 				data-wp-bind--disabled="context.rsvpLoading"
+				data-wp-bind--aria-busy="context.rsvpLoading"
 			>
 				<?php
 				if ( $is_attending ) {
@@ -342,6 +350,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 									data-wp-on--click="actions.saveAnswers"
 									data-wp-class--is-hidden="state.isNotAttending"
 									data-wp-bind--disabled="context.rsvpLoading"
+									data-wp-bind--aria-busy="context.rsvpLoading"
 								>
 									<?php esc_html_e( 'Save answers', 'wporg-groups-frontend' ); ?>
 								</button>
@@ -355,6 +364,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 							data-wp-text="state.modalRsvpLabel"
 							data-wp-class--is-attending="state.isAttending"
 							data-wp-bind--disabled="context.rsvpLoading"
+							data-wp-bind--aria-busy="context.rsvpLoading"
 						>
 							<?php
 							if ( $is_attending ) {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -10,6 +10,8 @@ use GatherPress\Core\Rsvp\Rsvp;
 
 use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_formats;
 use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_label;
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_modal_title_formats;
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_modal_title_label;
 use function WordCamp\Groups\Frontend\RSVP_Questions\current_user_can_view_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\get_labelled_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\get_questions;
@@ -98,16 +100,12 @@ foreach ( $records as $record ) {
 // Show at most $max_avatars avatars; the remaining $overflow_count is
 // rendered as a "+N" pill, and the modal lists every attendee. Five avatars
 // fit on one line at any card width — more would wrap onto a second row.
-$max_avatars    = 5;
-$overflow_count = max( 0, $count - $max_avatars );
-$event_title    = get_the_title( $event_post_id );
-$is_attending   = 'attending' === $current_status;
-$modal_title    = sprintf(
-	/* translators: 1: attendee count, 2: event title */
-	_n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', $count, 'wporg-groups-frontend' ),
-	number_format_i18n( $count ),
-	$event_title
-);
+$max_avatars     = 5;
+$overflow_count  = max( 0, $count - $max_avatars );
+$event_title     = get_the_title( $event_post_id );
+$is_attending    = 'attending' === $current_status;
+$has_no_attendees = 0 === $count;
+$modal_title     = get_modal_title_label( $count, $event_title );
 
 // Shared across the labels array, the SSR label, and the modal button
 // below — keep in a local so the translator context can't drift.
@@ -120,11 +118,8 @@ $count_label = get_count_label( $count, $is_attending );
 
 $rsvp_labels = array_merge(
 	get_count_formats(),
+	get_modal_title_formats(),
 	array(
-		/* translators: 1: attendee count, 2: event title. */
-		'modalTitleSingular'      => _n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', 1, 'wporg-groups-frontend' ),
-		/* translators: 1: attendee count, 2: event title. */
-		'modalTitlePlural'        => _n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', 2, 'wporg-groups-frontend' ),
 		'loading'                 => "\u{2026}",
 		'attending'               => "\u{2713} " . __( 'Attending', 'wporg-groups-frontend' ),
 		'rsvp'                    => __( 'RSVP', 'wporg-groups-frontend' ),
@@ -150,6 +145,7 @@ $context = array(
 	'isPastEvent'       => $is_past,
 	'currentUserStatus' => $current_status,
 	'attendingCount'    => $count,
+	'maxAvatars'        => $max_avatars,
 	'eventTitle'        => $event_title,
 	'loginUrl'          => wp_login_url( get_permalink( $event_post_id ) ),
 	'apiBase'           => rest_url( 'gatherpress/v1/event' ),
@@ -172,7 +168,7 @@ wp_interactivity_state(
 	array(
 		'isAttending'    => $is_attending,
 		'isNotAttending' => ! $is_attending,
-		'hasNoAttendees' => 0 === $count,
+		'hasNoAttendees' => $has_no_attendees,
 		'countLabel'     => $count_label,
 		'modalTitle'     => $modal_title,
 		'isMember'        => $is_member,
@@ -239,7 +235,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 
 	<button
 		type="button"
-		class="wporg-event-rsvp__summary<?php echo 0 === $count ? ' has-no-attendees' : ''; ?>"
+		class="wporg-event-rsvp__summary<?php echo $has_no_attendees ? ' has-no-attendees' : ''; ?>"
 		data-wp-class--has-no-attendees="state.hasNoAttendees"
 		data-wp-on--click="actions.openModal"
 		aria-label="<?php esc_attr_e( 'View attendees', 'wporg-groups-frontend' ); ?>">

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -8,6 +8,8 @@
 use GatherPress\Core\Event\Event;
 use GatherPress\Core\Rsvp\Rsvp;
 
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_formats;
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_label;
 use function WordCamp\Groups\Frontend\RSVP_Questions\current_user_can_view_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\get_labelled_answers;
 use function WordCamp\Groups\Frontend\RSVP_Questions\get_questions;
@@ -93,7 +95,10 @@ foreach ( $records as $record ) {
 	);
 }
 
-$max_avatars    = 12;
+// Show at most $max_avatars avatars; the remaining $overflow_count is
+// rendered as a "+N" pill, and the modal lists every attendee. Five avatars
+// fit on one line at any card width — more would wrap onto a second row.
+$max_avatars    = 5;
 $overflow_count = max( 0, $count - $max_avatars );
 $event_title    = get_the_title( $event_post_id );
 $is_attending   = 'attending' === $current_status;
@@ -103,34 +108,39 @@ $modal_title    = sprintf(
 	number_format_i18n( $count ),
 	$event_title
 );
+
 // Shared across the labels array, the SSR label, and the modal button
 // below — keep in a local so the translator context can't drift.
 $cancel_rsvp = _x( 'Cancel RSVP', 'button to withdraw attendance from an event', 'wporg-groups-frontend' );
 
-$rsvp_labels    = array(
-	/* translators: %s: attendee count. */
-	'countSingular'           => _n( '%s going', '%s going', 1, 'wporg-groups-frontend' ),
-	/* translators: %s: attendee count. */
-	'countPlural'             => _n( '%s going', '%s going', 2, 'wporg-groups-frontend' ),
-	/* translators: 1: attendee count, 2: event title. */
-	'modalTitleSingular'      => _n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', 1, 'wporg-groups-frontend' ),
-	/* translators: 1: attendee count, 2: event title. */
-	'modalTitlePlural'        => _n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', 2, 'wporg-groups-frontend' ),
-	'loading'                 => "\u{2026}",
-	'attending'               => "\u{2713} " . __( 'Attending', 'wporg-groups-frontend' ),
-	'rsvp'                    => __( 'RSVP', 'wporg-groups-frontend' ),
-	'joinRsvp'                => __( 'Join & RSVP', 'wporg-groups-frontend' ),
-	'statusAttending'         => __( 'You are attending this event.', 'wporg-groups-frontend' ),
-	'statusNotAttending'      => __( 'You have not RSVPed to this event.', 'wporg-groups-frontend' ),
-	'cancelRsvp'              => $cancel_rsvp,
-	'attend'                  => __( 'Attend', 'wporg-groups-frontend' ),
-	'emptyAttendees'          => __( 'No attendees yet. Be the first to RSVP!', 'wporg-groups-frontend' ),
-	'rsvpSuccessAttending'    => __( 'You are now attending this event.', 'wporg-groups-frontend' ),
-	'rsvpSuccessNotAttending' => __( 'Your RSVP has been cancelled.', 'wporg-groups-frontend' ),
-	'rsvpSuccessWaitingList'  => __( 'You have joined the event waiting list.', 'wporg-groups-frontend' ),
-	'rsvpError'               => __( 'Your RSVP could not be updated. Please try again.', 'wporg-groups-frontend' ),
-	'missingAnswers'          => __( 'Please answer the required questions.', 'wporg-groups-frontend' ),
-	'answersSaved'            => __( 'Your answers have been saved.', 'wporg-groups-frontend' ),
+// Both the count line and the formats the view module re-renders it from come
+// out of `inc/rsvp-labels.php`, so the wording lives in one place. See
+// `getCountParts()` in view.js for the browser-side half of the branching.
+$count_label = get_count_label( $count, $is_attending );
+
+$rsvp_labels = array_merge(
+	get_count_formats(),
+	array(
+		/* translators: 1: attendee count, 2: event title. */
+		'modalTitleSingular'      => _n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', 1, 'wporg-groups-frontend' ),
+		/* translators: 1: attendee count, 2: event title. */
+		'modalTitlePlural'        => _n( '%1$s Attendee of %2$s', '%1$s Attendees of %2$s', 2, 'wporg-groups-frontend' ),
+		'loading'                 => "\u{2026}",
+		'attending'               => "\u{2713} " . __( 'Attending', 'wporg-groups-frontend' ),
+		'rsvp'                    => __( 'RSVP', 'wporg-groups-frontend' ),
+		'joinRsvp'                => __( 'Join & RSVP', 'wporg-groups-frontend' ),
+		'statusAttending'         => __( 'You are attending this event.', 'wporg-groups-frontend' ),
+		'statusNotAttending'      => __( 'You have not RSVPed to this event.', 'wporg-groups-frontend' ),
+		'cancelRsvp'              => $cancel_rsvp,
+		'attend'                  => __( 'Attend', 'wporg-groups-frontend' ),
+		'emptyAttendees'          => __( 'No attendees yet. Be the first to RSVP!', 'wporg-groups-frontend' ),
+		'rsvpSuccessAttending'    => __( 'You are now attending this event.', 'wporg-groups-frontend' ),
+		'rsvpSuccessNotAttending' => __( 'Your RSVP has been cancelled.', 'wporg-groups-frontend' ),
+		'rsvpSuccessWaitingList'  => __( 'You have joined the event waiting list.', 'wporg-groups-frontend' ),
+		'rsvpError'               => __( 'Your RSVP could not be updated. Please try again.', 'wporg-groups-frontend' ),
+		'missingAnswers'          => __( 'Please answer the required questions.', 'wporg-groups-frontend' ),
+		'answersSaved'            => __( 'Your answers have been saved.', 'wporg-groups-frontend' ),
+	)
 );
 
 $context = array(
@@ -162,11 +172,8 @@ wp_interactivity_state(
 	array(
 		'isAttending'    => $is_attending,
 		'isNotAttending' => ! $is_attending,
-		'countLabel'     => sprintf(
-			/* translators: %s: attendee count. */
-			_n( '%s going', '%s going', $count, 'wporg-groups-frontend' ),
-			number_format_i18n( $count )
-		),
+		'hasNoAttendees' => 0 === $count,
+		'countLabel'     => $count_label,
 		'modalTitle'     => $modal_title,
 		'isMember'        => $is_member,
 		'rsvpButtonLabel' => $is_attending
@@ -189,40 +196,6 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes escapes. ?>>
-
-	<button
-		type="button"
-		class="wporg-event-rsvp__summary"
-		data-wp-on--click="actions.openModal"
-		aria-label="<?php esc_attr_e( 'View attendees', 'wporg-groups-frontend' ); ?>">
-
-		<span class="wporg-event-rsvp__avatars" aria-hidden="true">
-			<?php foreach ( array_slice( $attendees, 0, $max_avatars ) as $attendee ) : ?>
-				<img
-					class="wporg-event-rsvp__avatar"
-					src="<?php echo esc_url( $attendee['photo'] ); ?>"
-					alt=""
-					width="40"
-					height="40"
-					loading="lazy"
-				/>
-			<?php endforeach; ?>
-			<?php if ( $overflow_count > 0 ) : ?>
-				<span class="wporg-event-rsvp__overflow">+<?php echo (int) $overflow_count; ?></span>
-			<?php endif; ?>
-		</span>
-
-		<span class="wporg-event-rsvp__count" data-wp-text="state.countLabel">
-			<?php
-			echo esc_html(
-				sprintf(
-					_n( '%s going', '%s going', $count, 'wporg-groups-frontend' ),
-					number_format_i18n( $count )
-				)
-			);
-			?>
-		</span>
-	</button>
 
 	<?php if ( ! $is_past ) : ?>
 		<div
@@ -255,6 +228,34 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			</button>
 		</div>
 	<?php endif; ?>
+
+	<button
+		type="button"
+		class="wporg-event-rsvp__summary<?php echo 0 === $count ? ' has-no-attendees' : ''; ?>"
+		data-wp-class--has-no-attendees="state.hasNoAttendees"
+		data-wp-on--click="actions.openModal"
+		aria-label="<?php esc_attr_e( 'View attendees', 'wporg-groups-frontend' ); ?>">
+
+		<span class="wporg-event-rsvp__avatars" aria-hidden="true">
+			<?php foreach ( array_slice( $attendees, 0, $max_avatars ) as $attendee ) : ?>
+				<img
+					class="wporg-event-rsvp__avatar"
+					src="<?php echo esc_url( $attendee['photo'] ); ?>"
+					alt=""
+					width="28"
+					height="28"
+					loading="lazy"
+				/>
+			<?php endforeach; ?>
+			<?php if ( $overflow_count > 0 ) : ?>
+				<span class="wporg-event-rsvp__overflow">+<?php echo (int) $overflow_count; ?></span>
+			<?php endif; ?>
+		</span>
+
+		<span class="wporg-event-rsvp__count" data-wp-text="state.countLabel">
+			<?php echo esc_html( $count_label ); ?>
+		</span>
+	</button>
 
 	<p
 		class="screen-reader-text wporg-event-rsvp__notice"

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
@@ -4,10 +4,16 @@
  * @package WordCamp\Groups\Frontend
  */
 
-/* === Summary (avatar stack + count) === */
+/* === Summary (avatar stack + count) ===
+   The button under the RSVP button that opens the attendee modal. `inline-flex`
+   keeps the avatars and the "N attending" label on a single row, and shrinks the
+   button to the width of that row instead of the full column, so the clickable
+   area matches the visible content. */
 .wporg-event-rsvp__summary {
-	display: block;
-	width: 100%;
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	max-width: 100%;
 	padding: 0;
 	border: 0;
 	background: transparent;
@@ -15,55 +21,71 @@
 	font: inherit;
 	text-align: left;
 	cursor: pointer;
-	margin-bottom: 16px;
-}
-
-.wporg-event-rsvp__summary:hover {
-	opacity: 0.85;
+	margin: 10px 0 0;
+	border-radius: 2px;
 }
 
 .wporg-event-rsvp__summary:focus-visible {
-	outline: 2px solid;
+	outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
 	outline-offset: 4px;
 }
 
 .wporg-event-rsvp__avatars {
 	display: flex;
-	flex-wrap: wrap;
-	margin-left: 10px;
-	margin-bottom: 8px;
+	flex: 0 0 auto;
+}
+
+/* Overlap the faces by offsetting each one onto the previous. Only between
+   siblings, so a lone avatar keeps its full width and the row never measures
+   narrower than the circle inside it. */
+.wporg-event-rsvp__avatars > * + * {
+	margin-left: -6px;
+}
+
+/* No one's going yet, so there's no stack to show. */
+.wporg-event-rsvp__summary.has-no-attendees .wporg-event-rsvp__avatars {
+	display: none;
+}
+
+.wporg-event-rsvp__avatar,
+.wporg-event-rsvp__overflow {
+	width: 28px;
+	height: 28px;
+	border-radius: 9999px;
+	border: 2px solid #fff;
+	flex: 0 0 auto;
 }
 
 .wporg-event-rsvp__avatar {
-	width: 40px;
-	height: 40px;
-	border-radius: 9999px;
-	border: 2px solid #fff;
 	box-shadow: 0 1px 2px rgba(30, 30, 30, 0.08);
-	margin-left: -10px;
 	object-fit: cover;
-	flex: 0 0 auto;
 }
 
 .wporg-event-rsvp__overflow {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 40px;
-	height: 40px;
-	border-radius: 9999px;
-	border: 2px solid #fff;
-	margin-left: -10px;
-	background: #f6f6f6;
+	background: #f0f0f1;
 	color: #656a71;
-	font-size: 12px;
+	font-size: 11px;
 	font-weight: 600;
-	flex: 0 0 auto;
+	letter-spacing: -0.02em;
 }
 
 .wporg-event-rsvp__count {
 	font-size: 14px;
 	color: #656a71;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* Hovering anywhere on the button highlights only the count, not the avatars:
+   the avatars are decorative (`aria-hidden`), so the count is the part that
+   should read as the link into the attendee modal. */
+.wporg-event-rsvp__summary:hover .wporg-event-rsvp__count {
+	color: #1a1919;
+	text-decoration: underline;
 }
 
 /* === RSVP button === */
@@ -77,20 +99,31 @@
 	justify-content: center;
 }
 
-.wp-block-wporg-event-rsvp .wp-block-button__link.is-attending {
-	background: var(--wp--preset--color--acid-green-3, #e2ffed);
-	color: var(--wp--preset--color--charcoal-0, #1a1919);
-	border: 1px solid var(--wp--preset--color--acid-green-1, #33f078);
+/*
+ * The site's one non-blue button. Attending reports a state instead of
+ * offering an action, so green reads as "done", not "click me again".
+ *
+ * Set as an override of the parent theme's outline tokens rather than as a
+ * competing rule — the same idiom the parent uses for its own
+ * `is-style-fill-on-dark` variant. The wrapper carries `is-style-outline`
+ * exactly when the link carries `is-attending` (both are bound to
+ * `state.isAttending`), so scoping to the wrapper needs no extra weight and
+ * nothing here has to outrank anything.
+ */
+.wp-block-wporg-event-rsvp .wp-block-button.is-style-outline {
+	--wp--custom--button--outline--color--background: var(--wp--preset--color--acid-green-3, #e2ffed);
+	--wp--custom--button--outline--color--text: var(--wp--preset--color--charcoal-0, #1a1919);
+	--wp--custom--button--outline--border--color: var(--wp--preset--color--acid-green-1, #33f078);
+	--wp--custom--button--outline--hover--color--background: #c8f5d9;
+	--wp--custom--button--outline--hover--color--text: var(--wp--preset--color--charcoal-0, #1a1919);
+	--wp--custom--button--outline--hover--border--color: #17c257;
+	--wp--custom--button--outline--active--color--background: #c8f5d9;
+	--wp--custom--button--outline--active--color--text: var(--wp--preset--color--charcoal-0, #1a1919);
+	--wp--custom--button--outline--active--border--color: #17c257;
 }
 
-.wp-block-wporg-event-rsvp .wp-block-button__link.is-attending:hover {
-	background: #c8f5d9;
-}
-
-.wp-block-wporg-event-rsvp .wp-block-button__link.is-past {
-	opacity: 0.5;
-	cursor: not-allowed;
-}
+/* A past event's button is `disabled`, so the theme's disabled treatment
+   already greys it out — the class is left as a styling hook only. */
 
 /* === Full-screen modal === */
 .wporg-event-rsvp__modal {
@@ -188,10 +221,22 @@
 	display: none;
 }
 
+/* Compact button size — matches the comment composer's submit. */
 .wporg-event-rsvp__save-answers {
 	align-self: flex-start;
-	font-size: 13px;
-	padding: 6px 12px;
+	padding: 10px 20px;
+	font-size: var(--wp--preset--font-size--small, 14px);
+	font-weight: 600;
+	line-height: 1.3;
+	border: 1px solid transparent;
+	border-radius: 2px;
+}
+
+.wporg-event-rsvp__save-answers:disabled {
+	background: var(--wp--preset--color--light-grey-2, #f6f6f6);
+	border-color: var(--wp--preset--color--light-grey-1, #d9d9d9);
+	color: var(--wp--preset--color--charcoal-4, #656a71);
+	cursor: not-allowed;
 }
 
 .wporg-event-rsvp__save-answers.is-hidden {
@@ -239,7 +284,7 @@
 }
 
 .wporg-event-rsvp__modal-status a {
-	color: #3858e9;
+	color: var(--wp--preset--color--blueberry-1);
 }
 
 .wporg-event-rsvp__modal-rsvp-btn {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -490,10 +490,8 @@ async function refreshAttendees( ctx, actionElement ) {
 
 			const avatars = block.querySelector( '.wporg-event-rsvp__avatars' );
 			if ( avatars ) {
-				// Keep in step with `$max_avatars` in render.php.
-				const maxAvatars = 5;
-				const visible = records.slice( 0, maxAvatars );
-				const overflow = Math.max( 0, data.data.attending.count - maxAvatars );
+				const visible = records.slice( 0, ctx.maxAvatars );
+				const overflow = Math.max( 0, data.data.attending.count - ctx.maxAvatars );
 
 				avatars.innerHTML =
 					visible

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -29,11 +29,15 @@ store( 'wporg/event-rsvp', {
 			return getContext().currentUserStatus !== 'attending';
 		},
 
+		get hasNoAttendees() {
+			return 0 === getContext().attendingCount;
+		},
+
 		get countLabel() {
-			const count = getContext().attendingCount;
-			return formatLabel( label( 1 === count ? 'countSingular' : 'countPlural' ), [
-				formatNumber( count ),
-			] );
+			const ctx = getContext();
+			const [ key, value ] = getCountParts( ctx.attendingCount, ctx.currentUserStatus === 'attending' );
+
+			return null === value ? label( key ) : formatLabel( label( key ), [ formatNumber( value ) ] );
 		},
 
 		get modalTitle() {
@@ -486,7 +490,8 @@ async function refreshAttendees( ctx, actionElement ) {
 
 			const avatars = block.querySelector( '.wporg-event-rsvp__avatars' );
 			if ( avatars ) {
-				const maxAvatars = 12;
+				// Keep in step with `$max_avatars` in render.php.
+				const maxAvatars = 5;
 				const visible = records.slice( 0, maxAvatars );
 				const overflow = Math.max( 0, data.data.attending.count - maxAvatars );
 
@@ -496,7 +501,7 @@ async function refreshAttendees( ctx, actionElement ) {
 							( record ) =>
 								'<img class="wporg-event-rsvp__avatar" src="' +
 								escAttr( record.photo ) +
-								'" alt="" width="40" height="40" loading="lazy" />'
+								'" alt="" width="28" height="28" loading="lazy" />'
 						)
 						.join( '' ) +
 					( overflow > 0 ? '<span class="wporg-event-rsvp__overflow">+' + overflow + '</span>' : '' );
@@ -505,6 +510,41 @@ async function refreshAttendees( ctx, actionElement ) {
 	} catch {
 		// The optimistic context update already reflects the new state.
 	}
+}
+
+/**
+ * The count line's label key and the number that goes into it.
+ *
+ * The browser-side half of `get_count_parts()` in `inc/rsvp-labels.php`, which
+ * this mirrors branch for branch: PHP renders the line initially, this
+ * re-renders it when an RSVP changes the count without a reload. Script
+ * modules can't depend on `wp-i18n`, so the translated formats arrive
+ * pre-resolved in `context.labels` and this only picks between them — see
+ * `get_count_formats()` for how that table is built. Adding a state means
+ * editing both functions.
+ *
+ * @param {number}  count       Number of attendees.
+ * @param {boolean} isAttending Whether the current user is one of them.
+ * @return {[string, number|null]} Key into `context.labels`, and the number to
+ *                                 substitute — or null when the format takes
+ *                                 no argument.
+ */
+function getCountParts( count, isAttending ) {
+	const others = Math.max( 0, count - 1 );
+
+	if ( isAttending && others > 0 ) {
+		return [ 1 === others ? 'countYouAndOneOther' : 'countYouAndOthers', others ];
+	}
+
+	if ( isAttending ) {
+		return [ 'countYouFirst', null ];
+	}
+
+	if ( count > 0 ) {
+		return [ 1 === count ? 'countSingular' : 'countPlural', count ];
+	}
+
+	return [ 'countZero', null ];
 }
 
 function label( key ) {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-speakers/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-speakers/style.css
@@ -28,7 +28,7 @@
 }
 
 .wporg-event-speakers__card:hover {
-	border-color: #3858e9;
+	border-color: var(--wp--preset--color--blueberry-1);
 	text-decoration: none;
 }
 
@@ -59,7 +59,7 @@
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
-	color: #3858e9;
+	color: var(--wp--preset--color--blueberry-1);
 }
 
 .wporg-event-speakers__bio {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/render.php
@@ -57,7 +57,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<h2 class="wporg-group-members__heading">
+	<h2 class="wporg-section-heading wporg-group-members__heading">
 		<?php
 		echo esc_html(
 			sprintf(

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/render.php
@@ -25,7 +25,7 @@ $users = get_users(
 // `get_the_author_meta( 'description', ... )` call per user below.
 update_meta_cache( 'user', wp_list_pluck( $users, 'ID' ) );
 
-// Sort: organisers first, then event organisers, then members.
+// Sort: organizers first, then event organizers, then members.
 $weights = array(
 	'administrator' => 0,
 	'editor'        => 1,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
@@ -6,15 +6,7 @@
  * follows the shared card spec.
  */
 
-.wporg-group-members__heading {
-	margin: 0 0 var(--wp--preset--spacing--30) !important;
-	padding: 0 !important;
-	font-family: var(--wp--preset--font-family--eb-garamond);
-	font-size: var(--wp--preset--font-size--heading-3);
-	font-weight: 400;
-	line-height: 1.3;
-	color: var(--wp--preset--color--charcoal-0);
-}
+@import '../../components/section-heading.css';
 
 .wporg-group-members__grid {
 	display: grid;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
@@ -1,34 +1,44 @@
 /**
  * Group Members block styles.
+ *
+ * The members page's only section, so its heading takes the same main-column
+ * Heading 3 treatment as the front page's sections, and each member card
+ * follows the shared card spec.
  */
 
 .wporg-group-members__heading {
-	font-size: 24px;
-	font-weight: 600;
-	margin: 0 0 24px !important;
+	margin: 0 0 var(--wp--preset--spacing--30) !important;
 	padding: 0 !important;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-3);
+	font-weight: 400;
+	line-height: 1.3;
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-group-members__grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-	gap: 16px;
+	gap: var(--wp--preset--spacing--20);
 }
 
 .wporg-group-members__card {
 	display: flex;
 	align-items: flex-start;
-	gap: 14px;
-	padding: 16px;
-	border: 1px solid #d9d9d9;
+	gap: var(--wp--preset--spacing--20);
+	/* 20px rather than 24px: an avatar-plus-two-lines row is a compact card,
+	   the same call made for `.wporg-my-events__card`. */
+	padding: var(--wp--preset--spacing--20);
+	border: 1px solid var(--wp--preset--color--light-grey-1);
 	border-radius: 4px;
 	text-decoration: none;
 	color: inherit;
 	transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.wporg-group-members__card:hover {
-	border-color: #3858e9;
+.wporg-group-members__card:hover,
+.wporg-group-members__card:focus-visible {
+	border-color: var(--wp--preset--color--blueberry-1);
 	box-shadow: 0 2px 8px rgba(56, 88, 233, 0.1);
 	text-decoration: none;
 }
@@ -49,32 +59,33 @@
 }
 
 .wporg-group-members__name {
-	font-size: 15px;
+	font-size: var(--wp--preset--font-size--normal);
 	font-weight: 600;
-	color: #1a1919;
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-group-members__role {
-	font-size: 12px;
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--extra-small);
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
-	color: #656a71;
+	color: var(--wp--preset--color--charcoal-4);
 }
 
 .wporg-group-members__role--administrator,
 .wporg-group-members__role--editor {
-	color: #3858e9;
+	color: var(--wp--preset--color--blueberry-1);
 }
 
 .wporg-group-members__role--author {
-	color: #008a20;
+	color: #007a2f;
 }
 
 .wporg-group-members__bio {
-	font-size: 13px;
-	color: #656a71;
-	line-height: 1.4;
+	font-size: var(--wp--preset--font-size--small);
+	color: var(--wp--preset--color--charcoal-4);
+	line-height: 1.55;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	display: -webkit-box;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -5,6 +5,9 @@
  * @package WordCamp\Groups\Frontend
  */
 
+use function WordCamp\Groups\Frontend\Capabilities\get_role_tier_label;
+use const WordCamp\Groups\Frontend\Capabilities\ORGANIZER_ROLES;
+
 $variant = $attributes['variant'] ?? 'combined';
 if ( ! in_array( $variant, array( 'combined', 'membership', 'preference' ), true ) ) {
 	$variant = 'combined';
@@ -19,19 +22,12 @@ $user_role    = '';
 $role_label   = '';
 
 if ( $shows_membership && $is_member ) {
-	$user      = wp_get_current_user();
-	$user_role = reset( $user->roles ) ?: 'subscriber';
-
-	$labels = array(
-		'administrator' => __( 'Organizer', 'wporg-groups-frontend' ),
-		'editor'        => __( 'Organizer', 'wporg-groups-frontend' ),
-		'author'        => __( 'Event Organizer', 'wporg-groups-frontend' ),
-	);
-
-	$role_label = $labels[ $user_role ] ?? __( 'Member', 'wporg-groups-frontend' );
+	$user       = wp_get_current_user();
+	$user_role  = reset( $user->roles ) ?: 'subscriber';
+	$role_label = get_role_tier_label( $user_role );
 }
 
-$is_organizer       = in_array( $user_role, array( 'administrator', 'editor' ), true );
+$is_organizer       = in_array( $user_role, ORGANIZER_ROLES, true );
 $renders_leave      = $shows_membership && $is_member && ! $is_organizer;
 $renders_preference = $shows_preference && $is_member;
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -23,16 +23,16 @@ if ( $shows_membership && $is_member ) {
 	$user_role = reset( $user->roles ) ?: 'subscriber';
 
 	$labels = array(
-		'administrator' => __( 'Organiser', 'wporg-groups-frontend' ),
-		'editor'        => __( 'Organiser', 'wporg-groups-frontend' ),
-		'author'        => __( 'Event Organiser', 'wporg-groups-frontend' ),
+		'administrator' => __( 'Organizer', 'wporg-groups-frontend' ),
+		'editor'        => __( 'Organizer', 'wporg-groups-frontend' ),
+		'author'        => __( 'Event Organizer', 'wporg-groups-frontend' ),
 	);
 
 	$role_label = $labels[ $user_role ] ?? __( 'Member', 'wporg-groups-frontend' );
 }
 
-$is_organiser       = in_array( $user_role, array( 'administrator', 'editor' ), true );
-$renders_leave      = $shows_membership && $is_member && ! $is_organiser;
+$is_organizer       = in_array( $user_role, array( 'administrator', 'editor' ), true );
+$renders_leave      = $shows_membership && $is_member && ! $is_organizer;
 $renders_preference = $shows_preference && $is_member;
 
 if ( ! $shows_membership && ! $renders_preference ) {
@@ -176,7 +176,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 					data-wp-bind--checked="context.notificationOptIn"
 					data-wp-bind--disabled="context.preferenceSaving"
 				/>
-				<span><?php esc_html_e( 'Email me updates and information about events from organisers.', 'wporg-groups-frontend' ); ?></span>
+				<span><?php esc_html_e( 'Email me updates and information about events from organizers.', 'wporg-groups-frontend' ); ?></span>
 			</label>
 			<span class="wporg-group-membership__preference-help">
 				<?php esc_html_e( 'This preference applies to this group only. Set it separately for each group you belong to.', 'wporg-groups-frontend' ); ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/render.php
@@ -136,6 +136,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 					data-wp-on--click="actions.join"
 					data-wp-text="state.buttonLabel"
 					data-wp-bind--disabled="context.loading"
+					data-wp-bind--aria-busy="context.loading"
 				><?php esc_html_e( 'Join this group', 'wporg-groups-frontend' ); ?></button>
 			</div>
 		<?php endif; ?>
@@ -157,6 +158,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			class="wporg-group-membership__leave"
 			data-wp-on--click="actions.leave"
 			data-wp-bind--disabled="context.loading"
+			data-wp-bind--aria-busy="context.loading"
 		><?php esc_html_e( 'Leave group', 'wporg-groups-frontend' ); ?></button>
 	<?php endif; ?>
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-membership/style.css
@@ -1,11 +1,16 @@
 /**
  * Group Membership block styles.
+ *
+ * Two variants share this file: the membership block (join button or role
+ * badge, plus the member count) and the notification-preference checkbox.
+ * Both live in the front page's sidebar, so text here is the 14px secondary
+ * size rather than the 16px body size used in the main column.
  */
 
 .wporg-group-membership {
 	display: flex;
 	align-items: center;
-	gap: 12px;
+	gap: var(--wp--preset--spacing--10);
 	flex-wrap: wrap;
 }
 
@@ -14,95 +19,116 @@
 	align-items: center;
 	gap: 4px;
 	padding: 6px 14px;
-	font-size: 13px;
+	font-size: var(--wp--preset--font-size--small);
 	font-weight: 600;
-	color: #1a1919;
-	background: #e2ffed;
-	border: 1px solid #33f078;
+	color: var(--wp--preset--color--charcoal-0);
+	background: var(--wp--preset--color--acid-green-3);
+	border: 1px solid var(--wp--preset--color--acid-green-1);
 	border-radius: 100px;
 }
 
 .wporg-group-membership__leave {
 	background: none;
 	border: none;
+	border-radius: 2px;
 	padding: 0;
-	font-size: 12px;
-	color: #656a71;
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--small);
+	color: var(--wp--preset--color--charcoal-4);
 	cursor: pointer;
 	text-decoration: underline;
 }
 
 .wporg-group-membership__leave:hover {
-	color: #d63638;
+	color: #b32d0f;
+}
+
+.wporg-group-membership__leave:disabled {
+	color: var(--wp--preset--color--charcoal-5);
+	cursor: not-allowed;
+	text-decoration: none;
 }
 
 .wporg-group-membership__count {
-	font-size: 13px;
-	color: #656a71;
+	font-size: var(--wp--preset--font-size--small);
+	color: var(--wp--preset--color--charcoal-4);
 }
 
 .wporg-group-membership__preference {
 	display: flex;
 	flex-basis: 100%;
 	flex-direction: column;
-	gap: 2px;
-	font-size: 13px;
+	gap: 4px;
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
 }
 
 .wporg-group-membership__preference label {
 	display: flex;
 	align-items: flex-start;
 	gap: 8px;
-	color: #1a1919;
+	color: var(--wp--preset--color--charcoal-0);
 	cursor: pointer;
 }
 
 .wporg-group-membership__preference input {
 	margin-top: 3px;
+	flex: 0 0 auto;
+}
+
+.wporg-group-membership__preference input:disabled,
+.wporg-group-membership__preference input:disabled + span {
+	cursor: not-allowed;
+	color: var(--wp--preset--color--charcoal-4);
 }
 
 .wporg-group-membership__preference-help {
 	padding-left: 24px;
-	color: #656a71;
+	color: var(--wp--preset--color--charcoal-4);
 }
 
 .wporg-group-membership__preference-status:empty {
 	display: none;
 }
 
+/*
+ * Success and error use the theme's status treatment: a bordered strip in
+ * the palette's green or pomegranate rather than the WP-admin notice
+ * colours this used to borrow. Left-aligned with an icon in the leading
+ * position — centring the text made a one-line "Saved" read as a banner.
+ */
 .wporg-group-membership__preference-status:not(:empty) {
 	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	margin-top: 10px;
-	padding: 12px 16px;
+	align-items: flex-start;
+	gap: var(--wp--preset--spacing--10);
+	margin-top: var(--wp--preset--spacing--10);
+	padding: 10px 20px;
 	border: 1px solid;
 	border-radius: 2px;
-	font-weight: 600;
-	text-align: center;
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
 }
 
 .wporg-group-membership__preference-status.is-success {
-	border-color: #00a32a;
-	background: #edfaef;
-	color: #1a1919;
+	border-color: #007a2f;
+	background: var(--wp--preset--color--acid-green-3);
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-group-membership__preference-status.is-success::before {
 	content: "\2713";
-	font-size: 18px;
-	line-height: 1;
+	font-weight: 600;
+	line-height: 1.55;
 }
 
 .wporg-group-membership__preference-status.is-error {
-	border-color: #d63638;
-	background: #fcf0f1;
-	color: #8a2424;
+	border-color: #b32d0f;
+	background: var(--wp--preset--color--pomegranate-3);
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-group-membership__preference-status.is-error::before {
 	content: "!";
-	font-size: 18px;
-	line-height: 1;
+	font-weight: 600;
+	line-height: 1.55;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/render.php
@@ -26,7 +26,7 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <section <?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by core. ?>>
-	<h2 class="wporg-group-news__heading"><?php esc_html_e( 'News', 'wporg-groups-frontend' ); ?></h2>
+	<h2 class="wporg-section-heading wporg-group-news__heading"><?php esc_html_e( 'News', 'wporg-groups-frontend' ); ?></h2>
 
 	<div class="wporg-group-news__list">
 		<?php foreach ( $wporg_posts as $wporg_post ) : ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
@@ -1,8 +1,19 @@
+/**
+ * Group News block styles.
+ *
+ * A main-column section, so its heading takes the same Heading 3 treatment
+ * as "My upcoming events", "Upcoming events" and "About this group". Only
+ * the sidebar gets the Inter 16px/600 utility heading.
+ */
+
 .wporg-group-news__heading {
-	margin: 0 0 16px !important;
+	margin: 0 0 var(--wp--preset--spacing--30) !important;
 	padding: 0 !important;
-	font-size: 24px;
-	font-weight: 700;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-3);
+	font-weight: 400;
+	line-height: 1.3;
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-group-news__list {
@@ -10,36 +21,51 @@
 }
 
 .wporg-group-news__item {
-	padding: 20px 0;
+	padding: var(--wp--preset--spacing--20) 0;
 	border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
 }
 
+/* Blueberry, like every date eyebrow on the site — see the note on
+   `.groups-site-event-card__date` in the theme's custom.css. A post's date
+   matters less than an event's, but splitting the two by colour just read
+   as an inconsistency between two adjacent, identically shaped lists. */
 .wporg-group-news__date {
 	display: block;
-	margin-bottom: 4px;
-	color: var(--wp--preset--color--charcoal-4);
-	font-size: 12px;
+	margin-bottom: var(--wp--preset--spacing--10);
+	color: var(--wp--preset--color--blueberry-1);
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--extra-small);
 	font-weight: 600;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
 }
 
+/* Card H3 treatment — the same size a post title takes in an event card, so
+   a news item and an event item read as the same weight of thing. */
 .wporg-group-news__title {
 	margin: 0 !important;
 	padding: 0 !important;
-	font-size: 20px;
-	line-height: 1.3;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-6);
+	font-weight: 400;
+	line-height: 1.2;
 }
 
 .wporg-group-news__title a {
+	color: var(--wp--preset--color--charcoal-0);
 	text-decoration: none;
 }
 
-.wporg-group-news__title a:hover {
+.wporg-group-news__title a:hover,
+.wporg-group-news__title a:focus-visible {
+	color: var(--wp--preset--color--blueberry-1);
 	text-decoration: underline;
 }
 
 .wporg-group-news__excerpt {
-	margin: 8px 0 0;
+	margin: var(--wp--preset--spacing--10) 0 0;
+	max-width: 68ch;
 	color: var(--wp--preset--color--charcoal-3);
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
@@ -6,15 +6,7 @@
  * the sidebar gets the Inter 16px/600 utility heading.
  */
 
-.wporg-group-news__heading {
-	margin: 0 0 var(--wp--preset--spacing--30) !important;
-	padding: 0 !important;
-	font-family: var(--wp--preset--font-family--eb-garamond);
-	font-size: var(--wp--preset--font-size--heading-3);
-	font-weight: 400;
-	line-height: 1.3;
-	color: var(--wp--preset--color--charcoal-0);
-}
+@import '../../components/section-heading.css';
 
 .wporg-group-news__list {
 	border-top: 1px solid var(--wp--preset--color--light-grey-1);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/block.json
@@ -6,7 +6,7 @@
 	"title": "Group Settings",
 	"category": "widgets",
 	"icon": "admin-generic",
-	"description": "Organiser settings panel for managing events, venues, members, design, and group info.",
+	"description": "Organizer settings panel for managing events, venues, members, design, and group info.",
 	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
@@ -41,14 +41,24 @@ export default function AboutTab() {
 		apiFetch( { path: '/wporg-groups/v1/group-info' } )
 			.then( ( data ) => {
 				const location = data.location || {};
+				const countryOptions = data.countries || [];
+				const storedCountry = location.countryCode || '';
+
+				// A stored code the country list no longer recognizes has no
+				// option to select, so blank it and let the required-field check
+				// prompt for a replacement instead of posting a code the server
+				// would reject.
+				const isKnownCountry = countryOptions.some( ( country ) => country.code === storedCountry );
+				const countryCode = isKnownCountry ? storedCountry : '';
+
 				setForm( {
 					blogname: data.title || '',
 					blogdescription: data.description || '',
 					locationType: location.type || '',
 					city: location.city || '',
-					countryCode: location.countryCode || '',
+					countryCode,
 				} );
-				setCountries( data.countries || [] );
+				setCountries( countryOptions );
 				setLoading( false );
 			} )
 			.catch( ( err ) => {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/about-tab.js
@@ -36,6 +36,16 @@ export default function AboutTab() {
 		city: '',
 		countryCode: '',
 	} );
+	// A stored code the country list no longer recognizes has no option to
+	// select in the dropdown, so the field starts blank — which would make
+	// the location look incomplete even though the user hasn't touched it.
+	// Tracking whether they've actually edited the location lets save leave
+	// it out of the request entirely when they haven't, so the backend's own
+	// re-validation (which would reject that same stale code right back)
+	// never runs, and unrelated fields like the group name can still be
+	// saved. Only an explicit edit — including "Clear location" — should
+	// submit a location change.
+	const [ locationDirty, setLocationDirty ] = useState( false );
 
 	useEffect( () => {
 		apiFetch( { path: '/wporg-groups/v1/group-info' } )
@@ -43,20 +53,14 @@ export default function AboutTab() {
 				const location = data.location || {};
 				const countryOptions = data.countries || [];
 				const storedCountry = location.countryCode || '';
-
-				// A stored code the country list no longer recognizes has no
-				// option to select, so blank it and let the required-field check
-				// prompt for a replacement instead of posting a code the server
-				// would reject.
 				const isKnownCountry = countryOptions.some( ( country ) => country.code === storedCountry );
-				const countryCode = isKnownCountry ? storedCountry : '';
 
 				setForm( {
 					blogname: data.title || '',
 					blogdescription: data.description || '',
 					locationType: location.type || '',
 					city: location.city || '',
-					countryCode,
+					countryCode: isKnownCountry ? storedCountry : '',
 				} );
 				setCountries( countryOptions );
 				setLoading( false );
@@ -77,25 +81,29 @@ export default function AboutTab() {
 		setSaving( true );
 		setNotice( '' );
 		try {
-			let location = null;
-			if ( 'online' === form.locationType ) {
-				location = { type: 'online' };
-			} else if ( 'physical' === form.locationType ) {
-				location = {
-					type: 'physical',
-					city: form.city,
-					countryCode: form.countryCode,
-				};
+			const data = {
+				title: form.blogname,
+				description: form.blogdescription,
+			};
+
+			if ( locationDirty ) {
+				if ( 'online' === form.locationType ) {
+					data.location = { type: 'online' };
+				} else if ( 'physical' === form.locationType ) {
+					data.location = {
+						type: 'physical',
+						city: form.city,
+						countryCode: form.countryCode,
+					};
+				} else {
+					data.location = null;
+				}
 			}
 
 			await apiFetch( {
 				path: '/wporg-groups/v1/group-info',
 				method: 'POST',
-				data: {
-					title: form.blogname,
-					description: form.blogdescription,
-					location,
-				},
+				data,
 			} );
 			setNoticeType( 'success' );
 			setNotice( __( 'Settings saved.', 'wporg-groups-frontend' ) );
@@ -108,6 +116,7 @@ export default function AboutTab() {
 	};
 
 	const physicalLocationIsIncomplete =
+		locationDirty &&
 		'physical' === form.locationType &&
 		( '' === form.city.trim() || '' === form.countryCode );
 
@@ -157,7 +166,10 @@ export default function AboutTab() {
 					{ label: __( 'In person', 'wporg-groups-frontend' ), value: 'physical' },
 					{ label: __( 'Online', 'wporg-groups-frontend' ), value: 'online' },
 				],
-				onChange: ( v ) => setForm( { ...form, locationType: v } ),
+				onChange: ( v ) => {
+					setLocationDirty( true );
+					setForm( { ...form, locationType: v } );
+				},
 			} ),
 			'physical' === form.locationType &&
 				h(
@@ -166,7 +178,10 @@ export default function AboutTab() {
 					h( TextControl, {
 						label: __( 'City', 'wporg-groups-frontend' ),
 						value: form.city,
-						onChange: ( v ) => setForm( { ...form, city: v } ),
+						onChange: ( v ) => {
+							setLocationDirty( true );
+							setForm( { ...form, city: v } );
+						},
 						disabled: loadFailed,
 						required: true,
 						__nextHasNoMarginBottom: true,
@@ -182,7 +197,10 @@ export default function AboutTab() {
 								value: country.code,
 							} ) )
 						),
-						onChange: ( v ) => setForm( { ...form, countryCode: v } ),
+						onChange: ( v ) => {
+							setLocationDirty( true );
+							setForm( { ...form, countryCode: v } );
+						},
 						disabled: loadFailed,
 						required: true,
 						__nextHasNoMarginBottom: true,
@@ -201,12 +219,15 @@ export default function AboutTab() {
 						variant: 'link',
 						isDestructive: true,
 						disabled: loadFailed,
-						onClick: () => setForm( {
-							...form,
-							locationType: '',
-							city: '',
-							countryCode: '',
-						} ),
+						onClick: () => {
+							setLocationDirty( true );
+							setForm( {
+								...form,
+								locationType: '',
+								city: '',
+								countryCode: '',
+							} );
+						},
 					},
 					__( 'Clear location', 'wporg-groups-frontend' )
 				)

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/members-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/members-tab.js
@@ -24,8 +24,8 @@ import { __ } from '@wordpress/i18n';
 
 const ROLE_OPTIONS = [
 	{ label: __( 'Member', 'wporg-groups-frontend' ), value: 'subscriber' },
-	{ label: __( 'Event Organiser', 'wporg-groups-frontend' ), value: 'author' },
-	{ label: __( 'Organiser', 'wporg-groups-frontend' ), value: 'editor' },
+	{ label: __( 'Event Organizer', 'wporg-groups-frontend' ), value: 'author' },
+	{ label: __( 'Organizer', 'wporg-groups-frontend' ), value: 'editor' },
 ];
 
 const PER_PAGE = 20;
@@ -165,7 +165,7 @@ export default function MembersTab( { canManageRoles = false } ) {
 							className: 'wporg-members-tab__role-select',
 						} )
 						: h( 'span', { className: 'wporg-members-tab__role-readonly' },
-							member.roleLabel || __( 'Organiser', 'wporg-groups-frontend' )
+							member.roleLabel || __( 'Organizer', 'wporg-groups-frontend' )
 						)
 				);
 			} )

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/settings-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/settings-app.js
@@ -77,7 +77,7 @@ export default function SettingsApp( {
 		{
 			title: siteName || __( 'Group Settings', 'wporg-groups-frontend' ),
 			onRequestClose: onClose,
-			className: 'wporg-group-settings-modal',
+			className: 'wporg-groups-modal-accent wporg-group-settings-modal',
 			isFullScreen: true,
 			shouldCloseOnClickOutside: false,
 		},

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -5,6 +5,7 @@
  */
 
 @import '../../components/recurrence-controls.css';
+@import '../../components/component-accents.css';
 
 // === Trigger button ===
 
@@ -19,6 +20,8 @@
 // === Full-screen modal ===
 
 .wporg-group-settings-modal {
+	// Accent tokens come from `components/component-accents.css`.
+
 	.components-modal__content {
 		padding: 0;
 		display: flex;
@@ -129,7 +132,7 @@
 		transition: border-color 0.12s ease;
 
 		&:hover {
-			border-color: #3858e9;
+			border-color: var(--wp--preset--color--blueberry-1);
 		}
 
 		&-info {
@@ -196,8 +199,8 @@
 		isolation: isolate;
 
 		&:focus-within {
-			border-color: #3858e9;
-			box-shadow: 0 0 0 1px #3858e9;
+			border-color: var(--wp--preset--color--blueberry-1);
+			box-shadow: 0 0 0 1px var(--wp--preset--color--blueberry-1);
 		}
 
 		.block-editor-block-list__layout {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
@@ -4,7 +4,7 @@
  *
  * Shows the current logged-in member their upcoming events, meaning both the
  * ones they have RSVP'd to as attending and the ones they authored, which on a
- * group site are the ones they organise. Authorship is unioned into the query
+ * group site are the ones they organize. Authorship is unioned into the query
  * rather than written into the RSVP data, so "attending" keeps meaning that the
  * person said they are coming (#1810).
  *
@@ -45,7 +45,7 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 	</h2>
 	<?php if ( empty( $wporg_upcoming_events ) ) : ?>
 		<p class="wporg-my-events__empty">
-			<?php esc_html_e( 'Nothing on your calendar yet. Events you RSVP to, and events you organise, will show up here.', 'wporg-groups-frontend' ); ?>
+			<?php esc_html_e( 'Nothing on your calendar yet. Events you RSVP to, and events you organize, will show up here.', 'wporg-groups-frontend' ); ?>
 		</p>
 	<?php else : ?>
 		<div class="wporg-my-events__list">

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
@@ -44,7 +44,7 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 <section <?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-	<h2 class="wporg-my-events__heading">
+	<h2 class="wporg-section-heading wporg-my-events__heading">
 		<?php esc_html_e( 'My upcoming events', 'wporg-groups-frontend' ); ?>
 	</h2>
 	<?php if ( empty( $wporg_upcoming_events ) ) : ?>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/render.php
@@ -23,6 +23,10 @@ if ( ! is_user_logged_in() || ! is_user_member_of_blog() ) {
 
 $wporg_upcoming_ids = get_upcoming_event_ids( get_current_user_id() );
 
+/*
+ * Uncapped on purpose: the block exists so a member can confirm their event is
+ * listed (#1810), and truncating could hide the one they came to check.
+ */
 $wporg_upcoming_events = empty( $wporg_upcoming_ids )
 	? array()
 	: get_posts(
@@ -39,7 +43,7 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'wporg-my-events' )
 );
 ?>
-<div <?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+<section <?php echo $wporg_wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<h2 class="wporg-my-events__heading">
 		<?php esc_html_e( 'My upcoming events', 'wporg-groups-frontend' ); ?>
 	</h2>
@@ -53,21 +57,42 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 			foreach ( $wporg_upcoming_events as $wporg_event_post ) :
 				$wporg_start      = get_post_meta( $wporg_event_post->ID, 'gatherpress_datetime_start', true );
 				$wporg_date_label = '';
+				$wporg_date_attr  = '';
 
 				if ( $wporg_start ) {
 					try {
 						$wporg_datetime   = new \DateTime( $wporg_start );
 						$wporg_date_label = $wporg_datetime->format( 'M j, Y · g:i A' );
+
+						/*
+						 * Local time with no offset. The stored value is
+						 * already in the event's own timezone, and PHP's
+						 * default timezone — which `c` would stamp on it —
+						 * is not necessarily that one.
+						 */
+						$wporg_date_attr = $wporg_datetime->format( 'Y-m-d\TH:i' );
 					} catch ( \Exception $e ) {
 						$wporg_date_label = $wporg_start;
 					}
 				}
 				?>
-				<a class="wporg-my-events__item" href="<?php echo esc_url( get_permalink( $wporg_event_post->ID ) ); ?>">
-					<span class="wporg-my-events__date"><?php echo esc_html( $wporg_date_label ); ?></span>
-					<span class="wporg-my-events__title"><?php echo esc_html( get_the_title( $wporg_event_post->ID ) ); ?></span>
-				</a>
+				<div class="wporg-my-events__card">
+					<?php if ( $wporg_date_label ) : ?>
+						<p class="wporg-my-events__date">
+							<?php if ( $wporg_date_attr ) : ?>
+								<time datetime="<?php echo esc_attr( $wporg_date_attr ); ?>"><?php echo esc_html( $wporg_date_label ); ?></time>
+							<?php else : ?>
+								<?php echo esc_html( $wporg_date_label ); ?>
+							<?php endif; ?>
+						</p>
+					<?php endif; ?>
+					<h3 class="wporg-my-events__title">
+						<a href="<?php echo esc_url( get_permalink( $wporg_event_post->ID ) ); ?>">
+							<?php echo esc_html( get_the_title( $wporg_event_post->ID ) ); ?>
+						</a>
+					</h3>
+				</div>
 			<?php endforeach; ?>
 		</div>
 	<?php endif; ?>
-</div>
+</section>

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/style.css
@@ -1,53 +1,135 @@
 /**
  * My Events block styles.
+ *
+ * A compact variant of the theme's event card: same border, radius, hover
+ * treatment, and date/title typography, but without the 16:9 media region,
+ * excerpt, attendee count, or venue. That leaves two lines per card.
+ *
+ * Kept in step with `.groups-site-event-card` in the theme's custom.css.
  */
 
 .wporg-my-events__heading {
-	font-size: 18px;
-	font-weight: 600;
-	margin: 0 0 12px !important;
+	margin: 0 0 var(--wp--preset--spacing--30) !important;
 	padding: 0 !important;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-3);
+	font-weight: 400;
+	line-height: 1.3;
+	color: var(--wp--preset--color--charcoal-0);
 }
 
+/*
+ * One card per row, full width of the column, so the serif title fits on one
+ * line — in the "Upcoming events" grid the same title wraps to three. Also
+ * keeps this list visually distinct from that grid despite the shared card
+ * treatment.
+ */
 .wporg-my-events__list {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr);
+	gap: var(--wp--preset--spacing--10);
 }
 
-.wporg-my-events__item {
+.wporg-my-events__card {
+	position: relative;
 	display: flex;
 	flex-direction: column;
-	gap: 2px;
-	padding: 12px 16px;
-	border: 1px solid #d9d9d9;
+	gap: var(--wp--preset--spacing--10);
+	/*
+	 * 20px all round rather than the 24px card spec — the same compact-card
+	 * value `.wporg-group-members__card` uses, for the same reason: the card
+	 * holds only a 12px eyebrow and a one-line title.
+	 */
+	padding: var(--wp--preset--spacing--20);
+	background: var(--wp--preset--color--white);
+	border: 1px solid var(--wp--preset--color--light-grey-1);
 	border-radius: 4px;
-	text-decoration: none;
-	color: inherit;
-	transition: border-color 0.12s ease;
+	transition: border-color 0.18s ease, box-shadow 0.18s ease,
+		transform 0.18s ease;
 }
 
-.wporg-my-events__item:hover {
-	border-color: #3858e9;
-	text-decoration: none;
+.wporg-my-events__card:hover,
+.wporg-my-events__card:has(a:focus-visible) {
+	border-color: var(--wp--preset--color--blueberry-1);
+	box-shadow: 0 18px 36px -16px rgba(56, 88, 233, 0.22),
+		0 4px 12px rgba(30, 30, 30, 0.04);
+	transform: translateY(-2px);
 }
 
+/*
+ * The title's link covers the whole card, so the focus ring belongs on the
+ * card too — on the link alone it would trace the text and leave the rest
+ * of the click target unmarked. Only swapped in where `:has()` can move it;
+ * without that the link keeps the global ring rather than losing it.
+ */
+@supports selector(:has(*)) {
+	.wporg-my-events__card:has(a:focus-visible) {
+		outline: 2px solid var(--wp--preset--color--blueberry-1);
+		outline-offset: 2px;
+	}
+
+	.wporg-my-events__title a:focus-visible {
+		outline: none;
+	}
+}
+
+/*
+ * 12px, the low end of the 12–14px metadata range, matching the News list's
+ * date rather than the event card's 14px — on a full-width card holding only
+ * a date and a one-line title, 14px tracked uppercase competes with the title.
+ *
+ * The metadata spec pins no line-height, and the secondary-text default of
+ * 1.55 leaves half-leading that reads as a gap above the title; 1.2 removes it
+ * while keeping two wrapped lines of caps clear of each other.
+ *
+ * Blueberry, like every date eyebrow on the site — see the note on
+ * `.groups-site-event-card__date` in the theme's custom.css.
+ */
 .wporg-my-events__date {
-	font-size: 12px;
+	margin: 0;
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--extra-small);
 	font-weight: 600;
+	line-height: 1.2;
+	color: var(--wp--preset--color--blueberry-1);
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
-	color: #3858e9;
+	/* "Wednesday, September 13, 2026 · 6:00 PM" is wider than the card at
+	   320px, and uppercase with tracking is wider still. */
+	overflow-wrap: break-word;
 }
 
 .wporg-my-events__title {
-	font-size: 15px;
-	font-weight: 600;
-	color: #1a1919;
+	margin: 0 !important;
+	padding: 0 !important;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-6);
+	font-weight: 400;
+	line-height: 1.2;
+}
+
+.wporg-my-events__title a {
+	color: var(--wp--preset--color--charcoal-0);
+	text-decoration: none;
+}
+
+/* Stretch the title's link over the whole card. */
+.wporg-my-events__title a::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+}
+
+.wporg-my-events__card:hover .wporg-my-events__title a,
+.wporg-my-events__title a:focus-visible {
+	color: var(--wp--preset--color--blueberry-1);
+	text-decoration: none;
 }
 
 .wporg-my-events__empty {
 	margin: 0;
-	font-size: 14px;
-	color: #50575e;
+	max-width: 68ch;
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
+	color: var(--wp--preset--color--charcoal-3);
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/style.css
@@ -8,15 +8,7 @@
  * Kept in step with `.groups-site-event-card` in the theme's custom.css.
  */
 
-.wporg-my-events__heading {
-	margin: 0 0 var(--wp--preset--spacing--30) !important;
-	padding: 0 !important;
-	font-family: var(--wp--preset--font-family--eb-garamond);
-	font-size: var(--wp--preset--font-size--heading-3);
-	font-weight: 400;
-	line-height: 1.3;
-	color: var(--wp--preset--color--charcoal-0);
-}
+@import '../../components/section-heading.css';
 
 /*
  * One card per row, full width of the column, so the serif title fits on one

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/block.json
@@ -6,7 +6,7 @@
 	"title": "Page Content",
 	"category": "widgets",
 	"icon": "media-text",
-	"description": "Embeds a page's content by slug. Organisers see an edit link to modify the page.",
+	"description": "Embeds a page's content by slug. Organizers see an edit link to modify the page.",
 	"attributes": {
 		"slug": {
 			"type": "string",

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering for the wporg/page-content block.
  *
- * Renders a page's content by slug, with an edit link for organisers.
+ * Renders a page's content by slug, with an edit link for organizers.
  *
  * @package WordCamp\Groups\Frontend
  */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/render.php
@@ -35,7 +35,7 @@ $wporg_wrapper_attributes = get_block_wrapper_attributes(
 	<?php echo wp_interactivity_data_wp_context( array( 'isExpanded' => false ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 >
 	<div class="wporg-sponsors__header">
-		<<?php echo esc_html( $wporg_heading ); ?> class="wporg-sponsors__heading">
+		<<?php echo esc_html( $wporg_heading ); ?> class="wporg-section-heading wporg-sponsors__heading">
 			<?php esc_html_e( 'Sponsors', 'wporg-groups-frontend' ); ?>
 		</<?php echo esc_html( $wporg_heading ); ?>>
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
@@ -1,40 +1,53 @@
 /**
  * Sponsors block styles.
+ *
+ * Renders in two places: the front page's main column, where it's the last
+ * section, and the single-event sidebar, where it's a card beside the event
+ * details. One treatment covers both — a bordered card whose rows are
+ * separated by rules rather than by a second nested border, which is what
+ * the list used to have inside the card's own.
  */
 
 .wporg-sponsors {
 	padding: 24px;
-	border: 1px solid #d9d9d9;
-	border-radius: 8px;
-	background: #fff;
+	border: 1px solid var(--wp--preset--color--light-grey-1);
+	border-radius: 4px;
+	background: var(--wp--preset--color--white);
 }
 
 .wporg-sponsors__header {
 	display: flex;
 	align-items: baseline;
 	justify-content: space-between;
-	gap: 16px;
-	margin-bottom: 16px;
+	gap: var(--wp--preset--spacing--20);
+	margin-bottom: var(--wp--preset--spacing--10);
 }
 
 .wporg-sponsors__heading {
-	font-size: 24px;
-	font-weight: 700;
 	margin: 0 !important;
 	padding: 0 !important;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-3);
+	font-weight: 400;
+	line-height: 1.3;
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-sponsors__show-all {
+	flex-shrink: 0;
 	background: none;
 	border: 0;
+	border-radius: 2px;
 	padding: 0;
-	font-size: 14px;
-	font-weight: 500;
-	color: #3858e9;
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--small);
+	font-weight: 600;
+	color: var(--wp--preset--color--blueberry-1);
 	cursor: pointer;
 }
 
 .wporg-sponsors__show-all:hover {
+	color: var(--wp--preset--color--deep-blueberry);
 	text-decoration: underline;
 }
 
@@ -42,12 +55,21 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
-	border: 1px solid #e0e0e0;
-	border-radius: 8px;
+}
+
+/*
+ * Negative inline margin pulls each row out to the card's edge, so both the
+ * divider and the hover fill span the full card instead of floating inside
+ * a 24px moat. The row's own padding puts the text back on the card's text
+ * column. Applied to the item rather than the link so the two stay in
+ * register — a bled hover under an inset rule reads as a mistake.
+ */
+.wporg-sponsors__item {
+	margin: 0 -24px;
 }
 
 .wporg-sponsors__item + .wporg-sponsors__item {
-	border-top: 1px solid #e0e0e0;
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);
 }
 
 .wporg-sponsors__item[hidden] {
@@ -58,15 +80,15 @@
 	display: grid;
 	grid-template-columns: 96px 1fr auto;
 	align-items: center;
-	gap: 16px;
-	padding: 16px;
+	gap: var(--wp--preset--spacing--20);
+	padding: var(--wp--preset--spacing--20) 24px;
 	text-decoration: none;
 	color: inherit;
 }
 
 a.wporg-sponsors__link:hover {
 	text-decoration: none;
-	background: #f6f7f7;
+	background: var(--wp--preset--color--light-grey-2);
 }
 
 .wporg-sponsors__logo {
@@ -92,30 +114,49 @@ a.wporg-sponsors__link:hover {
 }
 
 .wporg-sponsors__name {
-	font-size: 16px;
+	font-size: var(--wp--preset--font-size--normal);
 	font-weight: 600;
-	color: #1a1919;
+	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-sponsors__description {
-	font-size: 14px;
-	line-height: 1.4;
-	color: #40464d;
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
+	color: var(--wp--preset--color--charcoal-3);
 }
 
 .wporg-sponsors__external {
 	display: flex;
 	align-items: center;
-	color: #40464d;
+	color: var(--wp--preset--color--charcoal-3);
 }
 
 a.wporg-sponsors__link:hover .wporg-sponsors__external {
-	color: #3858e9;
+	color: var(--wp--preset--color--blueberry-1);
 }
 
+/*
+ * Below 480px the logo column gives up a third of its width, and at the
+ * very narrowest the card's own padding drops so the 64px logo and the
+ * sponsor name still get a usable measure between them.
+ */
 @media (max-width: 480px) {
 	.wporg-sponsors__link {
 		grid-template-columns: 64px 1fr auto;
-		gap: 12px;
+		gap: var(--wp--preset--spacing--10);
+	}
+}
+
+@media (max-width: 380px) {
+	.wporg-sponsors {
+		padding: var(--wp--preset--spacing--20);
+	}
+
+	.wporg-sponsors__item {
+		margin: 0 calc(-1 * var(--wp--preset--spacing--20));
+	}
+
+	.wporg-sponsors__link {
+		padding: var(--wp--preset--spacing--20);
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
@@ -8,6 +8,8 @@
  * the list used to have inside the card's own.
  */
 
+@import '../../components/section-heading.css';
+
 .wporg-sponsors {
 	padding: 24px;
 	border: 1px solid var(--wp--preset--color--light-grey-1);
@@ -23,14 +25,10 @@
 	margin-bottom: var(--wp--preset--spacing--10);
 }
 
+/* Sits in a header row with the "Manage" link, unlike the other three
+ * section headings, so it doesn't need the shared class's bottom margin. */
 .wporg-sponsors__heading {
 	margin: 0 !important;
-	padding: 0 !important;
-	font-family: var(--wp--preset--font-family--eb-garamond);
-	font-size: var(--wp--preset--font-size--heading-3);
-	font-weight: 400;
-	line-height: 1.3;
-	color: var(--wp--preset--color--charcoal-0);
 }
 
 .wporg-sponsors__show-all {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
@@ -6,14 +6,15 @@
  * off ours on hover and active. Setting them is the supported way to recolor
  * it — the alternative is overriding every component's rules by hand.
  *
- * Every modal is listed because `Modal` renders at the end of <body>, not
- * inside the block — so there's no shared parent to hang the variables on.
+ * `Modal` renders at the end of <body>, not inside the block — so there's no
+ * shared parent to hang the variables on. Every one of this plugin's modals
+ * (and the venue editor's hand-rolled overlay, which isn't a `Modal` but
+ * behaves like one) carries this class alongside its own, so a new modal
+ * only needs the class added where it's rendered — nothing to keep in step
+ * with here.
  */
 
-.wporg-groups-event-modal,
-.wporg-groups-message-modal,
-.wporg-groups-venue-editor,
-.wporg-group-settings-modal {
+.wporg-groups-modal-accent {
 	--wp-components-color-accent: var(--wp--preset--color--blueberry-1, #3858e9);
 	--wp-components-color-accent-darker-10: var(--wp--preset--color--deep-blueberry, #213fd4);
 	--wp-components-color-accent-darker-20: var(--wp--preset--color--dark-blueberry, #1d35b4);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
@@ -1,0 +1,21 @@
+/**
+ * Blueberry accents for `@wordpress/components`.
+ *
+ * `@wordpress/components` colors its primary buttons and focus rings from
+ * these four variables. Leave them unset and it uses its own blues, a shade
+ * off ours on hover and active. Setting them is the supported way to recolor
+ * it — the alternative is overriding every component's rules by hand.
+ *
+ * Every modal is listed because `Modal` renders at the end of <body>, not
+ * inside the block — so there's no shared parent to hang the variables on.
+ */
+
+.wporg-groups-event-modal,
+.wporg-groups-message-modal,
+.wporg-groups-venue-editor,
+.wporg-group-settings-modal {
+	--wp-components-color-accent: var(--wp--preset--color--blueberry-1, #3858e9);
+	--wp-components-color-accent-darker-10: var(--wp--preset--color--deep-blueberry, #213fd4);
+	--wp-components-color-accent-darker-20: var(--wp--preset--color--dark-blueberry, #1d35b4);
+	--wp-components-color-accent-inverted: var(--wp--preset--color--white, #fff);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/section-heading.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/section-heading.css
@@ -1,0 +1,18 @@
+/**
+ * Shared "Heading 3" treatment for a main-column section heading.
+ *
+ * Used by `my-events`, `group-members`, `group-news`, and `sponsors` — each
+ * imports this file into its own block style.css and adds the class
+ * alongside its own `__heading` class, so the four never have to be kept in
+ * step by hand.
+ */
+
+.wporg-section-heading {
+	margin: 0 0 var(--wp--preset--spacing--30) !important;
+	padding: 0 !important;
+	font-family: var(--wp--preset--font-family--eb-garamond);
+	font-size: var(--wp--preset--font-size--heading-3);
+	font-weight: 400;
+	line-height: 1.3;
+	color: var(--wp--preset--color--charcoal-0);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
@@ -552,3 +552,84 @@ describe( 'event RSVP custom registration questions', () => {
 		expect( mockContext.questionsError ).toBe( '' );
 	} );
 } );
+
+/**
+ * The browser-side half of the RSVP count line.
+ *
+ * These cases mirror `data_count_labels()` in `tests/test-rsvp-labels.php` —
+ * same counts, same expected wording — because the branching exists twice by
+ * necessity: PHP renders the line, this re-renders it after an RSVP changes
+ * the count without a reload. A change to one set of branches should fail the
+ * other suite.
+ *
+ * The fixture below is what `get_count_formats()` produces for English, and it
+ * carries only the six documented keys, so asking for a key PHP doesn't ship
+ * renders empty and fails the assertion rather than passing quietly.
+ */
+describe( 'event RSVP count label', () => {
+	const countFormats = {
+		countZero: 'Be the first to RSVP',
+		countSingular: '%s going',
+		countPlural: '%s going',
+		countYouFirst: 'First one in',
+		countYouAndOneOther: 'You and %s other',
+		countYouAndOthers: 'You and %s others',
+	};
+
+	beforeEach( () => {
+		mockContext = createContext();
+		mockContext.labels = countFormats;
+		mockElement = null;
+		mockStoreConfig = null;
+	} );
+
+	test.each( [
+		[ 'nobody yet', 0, 'no_status', 'Be the first to RSVP' ],
+		[ 'one other person', 1, 'no_status', '1 going' ],
+		[ 'several other people', 14, 'no_status', '14 going' ],
+		[ 'you, alone', 1, 'attending', 'First one in' ],
+		[ 'you and one other', 2, 'attending', 'You and 1 other' ],
+		[ 'you and several others', 15, 'attending', 'You and 14 others' ],
+		[ 'attending with a zero count', 0, 'attending', 'First one in' ],
+	] )( 'describes %s', ( _name, attendingCount, currentUserStatus, expected ) => {
+		const { state } = loadStore();
+		mockContext.attendingCount = attendingCount;
+		mockContext.currentUserStatus = currentUserStatus;
+
+		expect( state.countLabel ).toBe( expected );
+	} );
+
+	test( 'follows the count as an RSVP changes it', () => {
+		const { state } = loadStore();
+		mockContext.attendingCount = 3;
+		mockContext.currentUserStatus = 'no_status';
+
+		expect( state.countLabel ).toBe( '3 going' );
+
+		mockContext.attendingCount = 4;
+		mockContext.currentUserStatus = 'attending';
+
+		expect( state.countLabel ).toBe( 'You and 3 others' );
+	} );
+
+	test( 'only asks for keys the server ships', () => {
+		const { state } = loadStore();
+		const asked = new Set();
+		mockContext.labels = new Proxy( countFormats, {
+			get( target, key ) {
+				asked.add( key );
+				return target[ key ];
+			},
+		} );
+
+		for ( const count of [ 0, 1, 2, 15 ] ) {
+			for ( const status of [ 'no_status', 'attending' ] ) {
+				mockContext.attendingCount = count;
+				mockContext.currentUserStatus = status;
+				expect( state.countLabel ).not.toBe( '' );
+			}
+		}
+
+		expect( [ ...asked ].sort() ).toEqual( Object.keys( countFormats ).sort() );
+	} );
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -164,6 +164,21 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	}
 
 	/**
+	 * A country code that no longer resolves is dropped from the label.
+	 */
+	public function test_group_location_block_omits_unrecognized_country() {
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_type', 'physical' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_city', 'İstanbul' );
+		update_site_meta( get_current_blog_id(), 'wporg_group_location_country', 'ZZ' );
+
+		$output = do_blocks( '<!-- wp:wporg/group-location /-->' );
+
+		$this->assertStringContainsString( 'İstanbul', $output );
+		$this->assertStringNotContainsString( 'İstanbul,', $output );
+		$this->assertStringNotContainsString( 'ZZ', $output );
+	}
+
+	/**
 	 * The online label depends only on the group location type.
 	 */
 	public function test_group_location_block_renders_online_location() {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -110,6 +110,29 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	}
 
 	/**
+	 * The RSVP action should precede the attendee summary in the rendered block.
+	 */
+	public function test_event_rsvp_action_precedes_attendee_summary() {
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+				'post_title'  => 'RSVP Action Order Event',
+			)
+		);
+
+		$this->go_to( home_url( "?p={$event_id}&post_type=gatherpress_event" ) );
+		$output = do_blocks( '<!-- wp:wporg/event-rsvp /-->' );
+
+		$action_position  = strpos( $output, 'class="wp-block-button__link wp-element-button' );
+		$summary_position = strpos( $output, 'class="wporg-event-rsvp__summary' );
+
+		$this->assertNotFalse( $action_position );
+		$this->assertNotFalse( $summary_position );
+		$this->assertLessThan( $summary_position, $action_position );
+	}
+
+	/**
 	 * RSVP success and failure messages need an always-present live region;
 	 * the modal itself is hidden for the main RSVP-button flow.
 	 */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -320,7 +320,7 @@ class Test_Groups_Blocks extends Groups_TestCase {
 
 		$output = do_blocks( '<!-- wp:wporg/group-news /-->' );
 
-		$this->assertStringContainsString( '<h2 class="wporg-group-news__heading">News</h2>', $output );
+		$this->assertStringContainsString( '<h2 class="wporg-section-heading wporg-group-news__heading">News</h2>', $output );
 		$this->assertStringContainsString( 'A group update', $output );
 		$this->assertStringContainsString( 'What the group has been working on.', $output );
 	}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -71,7 +71,7 @@ class Test_Groups_Capabilities extends Groups_TestCase {
 	/**
 	 * Regression test: a super admin whose nominal role on a given group is
 	 * `subscriber` (e.g. a deputy checking in on a group they don't
-	 * personally organise) must still be treated as able to manage events.
+	 * personally organize) must still be treated as able to manage events.
 	 *
 	 * `current_user_can_manage_group_settings()` naturally picks up core's
 	 * super-admin capability elevation (it calls `current_user_can()`), so

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
@@ -47,12 +47,12 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$editor_request = $this->request( 'GET', '/members/' . $editor->ID );
 		$editor_request->set_param( 'id', $editor->ID );
 		$response = self::$controller->get_item( $editor_request );
-		$this->assertSame( 'Organiser', $response->get_data()['roleLabel'] );
+		$this->assertSame( 'Organizer', $response->get_data()['roleLabel'] );
 
 		$author_request = $this->request( 'GET', '/members/' . $author->ID );
 		$author_request->set_param( 'id', $author->ID );
 		$response = self::$controller->get_item( $author_request );
-		$this->assertSame( 'Event Organiser', $response->get_data()['roleLabel'] );
+		$this->assertSame( 'Event Organizer', $response->get_data()['roleLabel'] );
 
 		$subscriber_request = $this->request( 'GET', '/members/' . $subscriber->ID );
 		$subscriber_request->set_param( 'id', $subscriber->ID );
@@ -73,7 +73,7 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 	}
 
 	/**
-	 * Authors (Event Organisers) can manage events but not member roles.
+	 * Authors (Event Organizers) can manage events but not member roles.
 	 */
 	public function test_author_blocked_from_role_changes() {
 		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
@@ -92,7 +92,7 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 	}
 
 	/**
-	 * Editors (Organisers) can promote a member to Event Organiser.
+	 * Editors (Organizers) can promote a member to Event Organizer.
 	 */
 	public function test_editor_promotes_subscriber_to_author() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
@@ -113,7 +113,7 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 	}
 
 	/**
-	 * No one can change their own group role, even an Organiser.
+	 * No one can change their own group role, even an Organizer.
 	 */
 	public function test_cannot_change_own_role() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
@@ -130,10 +130,10 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 	}
 
 	/**
-	 * A group must always keep at least one organiser.
+	 * A group must always keep at least one organizer.
 	 */
 	public function test_cannot_remove_last_organizer() {
-		// Clear any organisers left over from fixture/site creation so the
+		// Clear any organizers left over from fixture/site creation so the
 		// count below is deterministic.
 		$existing_organizers = get_users(
 			array(
@@ -148,7 +148,7 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 
-		// A second organiser performs the (attempted) demotion so this isn't
+		// A second organizer performs the (attempted) demotion so this isn't
 		// also blocked by the separate "can't change your own role" check.
 		$actor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		get_userdata( $actor_id )->set_role( 'subscriber' );
@@ -181,7 +181,7 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 	}
 
 	/**
-	 * Organisers must be demoted before they can leave the group.
+	 * Organizers must be demoted before they can leave the group.
 	 */
 	public function test_organiser_cannot_leave_without_demotion() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -39,7 +39,7 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 	}
 
 	/**
-	 * An Organiser (editor) viewing any event, including one they don't
+	 * An Organizer (editor) viewing any event, including one they don't
 	 * own, sees both messaging buttons — editors can edit any event via
 	 * `edit_others_posts`.
 	 */
@@ -58,7 +58,7 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 	}
 
 	/**
-	 * An Event Organiser (author) viewing their own event sees both
+	 * An Event Organizer (author) viewing their own event sees both
 	 * messaging buttons.
 	 */
 	public function test_message_buttons_rendered_for_event_organiser_on_own_event() {
@@ -75,7 +75,7 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 
 	/**
 	 * IDOR check mirroring `test_author_cannot_edit_another_authors_event`
-	 * in test-rest.php: an Event Organiser (author) viewing another
+	 * in test-rest.php: an Event Organizer (author) viewing another
 	 * author's event lacks `edit_post` on it, so `$show_edit` is false and
 	 * neither messaging button — nor any other management UI — should
 	 * render, even though this author otherwise passes

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -71,7 +71,7 @@ class Test_Groups_REST extends Groups_TestCase {
 	}
 
 	/**
-	 * An editor (Organiser) can create and publish an event in one request.
+	 * An editor (Organizer) can create and publish an event in one request.
 	 */
 	public function test_create_event_as_editor() {
 		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -10,6 +10,8 @@ use WordPressdotorg\GatherPress_Recurring_Events\Rule;
 
 use function WordCamp\Groups\Frontend\REST\create_event;
 use function WordCamp\Groups\Frontend\REST\event_args_schema;
+use function WordCamp\Groups\Frontend\REST\get_group_info;
+use function WordCamp\Groups\Frontend\REST\update_group_info;
 use function WordCamp\Groups\Frontend\REST\get_event_form_data;
 use function WordCamp\Groups\Frontend\REST\update_event;
 use function WordCamp\Groups\Frontend\REST\save_draft;
@@ -545,5 +547,80 @@ class Test_Groups_REST extends Groups_TestCase {
 
 		$this->assertNotWPError( $publish_response );
 		$this->assertSame( 'publish', get_post_status( $draft_id ) );
+	}
+
+	/**
+	 * A country code that no longer resolves still reports the stored location.
+	 *
+	 * The settings form is built from this response, so collapsing it to `null`
+	 * would leave the location unselected and let the next save of any other
+	 * field wipe the city and country.
+	 */
+	public function test_group_info_reports_location_with_unrecognized_country() {
+		$site_id = get_current_blog_id();
+
+		update_site_meta( $site_id, 'wporg_group_location_type', 'physical' );
+		update_site_meta( $site_id, 'wporg_group_location_city', 'İstanbul' );
+		update_site_meta( $site_id, 'wporg_group_location_country', 'ZZ' );
+
+		$this->assertSame( '', wcorg_get_country_name_from_code( 'ZZ' ), 'ZZ is expected to be an unrecognized code.' );
+
+		$location = get_group_info()->get_data()['location'];
+
+		$this->assertSame(
+			array(
+				'type'        => 'physical',
+				'city'        => 'İstanbul',
+				'countryCode' => 'ZZ',
+			),
+			$location
+		);
+	}
+
+	/**
+	 * Saving an unrelated field leaves a location with a stale country intact.
+	 */
+	public function test_group_info_update_without_location_preserves_stale_country() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$site_id = get_current_blog_id();
+
+		update_site_meta( $site_id, 'wporg_group_location_type', 'physical' );
+		update_site_meta( $site_id, 'wporg_group_location_city', 'İstanbul' );
+		update_site_meta( $site_id, 'wporg_group_location_country', 'ZZ' );
+
+		$request = new WP_REST_Request( 'POST', '/wporg-groups/v1/group-info' );
+		$request->set_param( 'description', 'A new tagline.' );
+
+		$response = update_group_info( $request );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( 'physical', get_site_meta( $site_id, 'wporg_group_location_type', true ) );
+		$this->assertSame( 'İstanbul', get_site_meta( $site_id, 'wporg_group_location_city', true ) );
+		$this->assertSame( 'ZZ', get_site_meta( $site_id, 'wporg_group_location_country', true ) );
+	}
+
+	/**
+	 * A stale country code cannot be saved back; the write path still validates.
+	 */
+	public function test_group_info_update_rejects_unrecognized_country() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wporg-groups/v1/group-info' );
+		$request->set_param(
+			'location',
+			array(
+				'type'        => 'physical',
+				'city'        => 'İstanbul',
+				'countryCode' => 'ZZ',
+			)
+		);
+
+		$response = update_group_info( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'wporg_groups_invalid_country', $response->get_error_code() );
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-labels.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rsvp-labels.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_UnitTestCase;
+
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_formats;
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_label;
+use function WordCamp\Groups\Frontend\RSVP_Labels\get_count_parts;
+
+use const WordCamp\Groups\Frontend\RSVP_Labels\COUNT_FORMAT_KEYS;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Covers the RSVP count line.
+ *
+ * The wording is produced twice — here for the server-rendered markup, and in
+ * `view.js` for the post-RSVP update — so these tests pin the four branches
+ * and the format table that the view module selects from. The matching
+ * browser-side cases live in `tests-js/event-rsvp.test.js`; the two files
+ * share a case list on purpose, so a change to one branch fails the other.
+ *
+ * @group groups
+ */
+class Test_Groups_RSVP_Labels extends WP_UnitTestCase {
+	/**
+	 * Every count/attending combination the line has to describe.
+	 *
+	 * @return array<string, array{0: int, 1: bool, 2: string}>
+	 */
+	public function data_count_labels(): array {
+		return array(
+			'nobody yet'                 => array( 0, false, 'Be the first to RSVP' ),
+			'one other person'           => array( 1, false, '1 going' ),
+			'several other people'       => array( 14, false, '14 going' ),
+			'you, alone'                 => array( 1, true, 'First one in' ),
+			'you and one other'          => array( 2, true, 'You and 1 other' ),
+			'you and several others'     => array( 15, true, 'You and 14 others' ),
+			// Not reachable through the UI, but `$count` comes from GatherPress
+			// and the branch order shouldn't fall through to "N going" if it
+			// ever disagrees with the stored RSVP.
+			'attending with a zero count' => array( 0, true, 'First one in' ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_count_labels
+	 *
+	 * @param int    $count        Number of attendees.
+	 * @param bool   $is_attending Whether the current user is one of them.
+	 * @param string $expected     The finished line.
+	 */
+	public function test_get_count_label( int $count, bool $is_attending, string $expected ): void {
+		$this->assertSame( $expected, get_count_label( $count, $is_attending ) );
+	}
+
+	/**
+	 * The view module indexes `context.labels` by these exact keys, so a rename
+	 * here without the matching rename in `view.js` would silently render an
+	 * empty count line rather than fail.
+	 */
+	public function test_count_formats_cover_the_documented_keys(): void {
+		$formats = get_count_formats();
+
+		$this->assertSame( COUNT_FORMAT_KEYS, array_keys( $formats ) );
+		$this->assertNotContains( '', $formats, 'Every count format should be a non-empty string.' );
+	}
+
+	/**
+	 * The formats are harvested from `get_count_parts()` rather than restated,
+	 * so each one has to come back as the untouched format string — a filled-in
+	 * number here would mean the table was built from finished labels and the
+	 * view module would render "You and 1 other" for every count.
+	 */
+	public function test_count_formats_keep_their_placeholder(): void {
+		$formats = get_count_formats();
+
+		foreach ( array( 'countSingular', 'countPlural', 'countYouAndOneOther', 'countYouAndOthers' ) as $key ) {
+			$this->assertStringContainsString( '%s', $formats[ $key ], "$key should still take an argument." );
+		}
+
+		foreach ( array( 'countZero', 'countYouFirst' ) as $key ) {
+			$this->assertStringNotContainsString( '%s', $formats[ $key ], "$key takes no argument." );
+		}
+	}
+
+	/**
+	 * `get_count_label()` has to agree with the table the view module gets,
+	 * otherwise the line would change wording on RSVP for reasons unrelated to
+	 * the count. Checked at the counts the table itself is harvested from.
+	 */
+	public function test_server_label_matches_the_harvested_formats(): void {
+		$formats = get_count_formats();
+
+		$this->assertSame( $formats['countZero'], get_count_label( 0, false ) );
+		$this->assertSame( $formats['countYouFirst'], get_count_label( 1, true ) );
+		$this->assertSame( sprintf( $formats['countSingular'], '1' ), get_count_label( 1, false ) );
+		$this->assertSame( sprintf( $formats['countPlural'], '2' ), get_count_label( 2, false ) );
+		$this->assertSame( sprintf( $formats['countYouAndOneOther'], '1' ), get_count_label( 2, true ) );
+		$this->assertSame( sprintf( $formats['countYouAndOthers'], '2' ), get_count_label( 3, true ) );
+	}
+
+	/**
+	 * The server side passes the real count to `_n()` rather than picking from
+	 * the two-entry table, which is what lets languages with more than two
+	 * plural forms get the right one on first paint.
+	 */
+	public function test_parts_pass_the_real_count_to_the_translator(): void {
+		$this->assertSame( array( '%s going', 9 ), get_count_parts( 9, false ) );
+		$this->assertSame( array( 'You and %s others', 8 ), get_count_parts( 9, true ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-sponsors.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-sponsors.php
@@ -117,7 +117,7 @@ class Test_Groups_Sponsors extends Groups_TestCase {
 	}
 
 	/**
-	 * The admin screens only exist on the store site. A group organiser
+	 * The admin screens only exist on the store site. A group organizer
 	 * browsing their own wp-admin should never find a Sponsors menu, quite
 	 * apart from not having the capability to use one.
 	 *
@@ -265,7 +265,7 @@ class Test_Groups_Sponsors extends Groups_TestCase {
 	}
 
 	/**
-	 * A group organiser — an administrator on their own group site, but not a
+	 * A group organizer — an administrator on their own group site, but not a
 	 * network admin — must not be able to edit the shared sponsor list.
 	 */
 	public function test_group_organisers_cannot_edit_sponsors() {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
@@ -17,6 +17,7 @@ const VERSION = '0.2.0';
 require_once __DIR__ . '/inc/capabilities.php';
 require_once __DIR__ . '/inc/defaults.php';
 require_once __DIR__ . '/inc/group-location.php';
+require_once __DIR__ . '/inc/rsvp-labels.php';
 require_once __DIR__ . '/inc/rsvp-questions.php';
 require_once __DIR__ . '/inc/rest.php';
 require_once __DIR__ . '/inc/modal.php';

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -55,7 +55,106 @@ body.error404 .site-content-container h1 {
 	color: inherit;
 }
 
+/* ==========================================================================
+   Buttons
 
+   The parent theme already drives every button state from
+   `--wp--custom--button--*` custom properties, including the filled/outline
+   size parity core can't express on its own: the filled variant gets
+   `padding + border-width` with no border, the outline variant gets the bare
+   padding plus a 1px border, so both resolve to the same box.
+
+   So the values that differ from the parent's — the active blues, and the
+   whole outline ramp — are set as token overrides in `theme.json`
+   (`settings.custom.button`), where the parent's own rules pick them up.
+   Buttons given a colour in the editor are unaffected: core emits its
+   `has-*-color` / `has-*-background-color` classes with `!important`, which
+   outranks the token-driven rules in every state. That's what keeps the
+   footer's pomegranate CTA pomegranate.
+
+   What's left here is only what the token system has no slot for.
+
+   The compact size — Inter 14px/600 in 10px 20px — is deliberately *not*
+   the parent's `is-small`: that variant is 7px/12px and only applies under a
+   `[class*="wp-block"]` wrapper, while both users here (the comment form's
+   submit and the RSVP answers fieldset's) are plain `.wp-element-button`s
+   with no block wrapper at all. Each carries its own rule.
+   ========================================================================== */
+
+.wp-block-button > .wp-block-button__link.wp-element-button {
+	transition: background-color 0.15s ease, border-color 0.15s ease,
+		color 0.15s ease;
+}
+
+/* ----------  Disabled  ---------- */
+
+/*
+ * The parent has no disabled token, so the treatment lives here. One rule
+ * for both variants, so a disabled outline button doesn't stay blue and read
+ * as still-actionable. Grey on the light surface rather than a faded blue:
+ * `opacity` on the live colours would drop the label to roughly 2:1, and
+ * while disabled controls are exempt from the contrast minimum,
+ * "unavailable" shouldn't also mean "unreadable".
+ *
+ * The outline selector is listed separately to outweigh the parent's
+ * `[class*="wp-block"].is-style-outline .wp-block-button__link:hover`, which
+ * would otherwise repaint a disabled button on hover from equal weight.
+ */
+.wp-block-button > .wp-block-button__link.wp-element-button:disabled,
+.wp-block-button.is-style-outline > .wp-block-button__link.wp-element-button:disabled {
+	background-color: var(--wp--preset--color--light-grey-2);
+	border-color: var(--wp--preset--color--light-grey-1);
+	color: var(--wp--preset--color--charcoal-4);
+	cursor: not-allowed;
+}
+
+/* ----------  Loading  ---------- */
+
+/*
+ * Draws the in-flight spinner for buttons the blocks mark `aria-busy` — see
+ * the note in `event-rsvp/render.php` for why they set it alongside
+ * `disabled`. The label stays put: replacing it with a spinner would reflow
+ * the row and drop the accessible name mid-action.
+ */
+/* Second selector only exists to outweigh the parent theme's
+   `[class*="wp-block"] .wp-block-button__link { cursor: pointer }`, which
+   ties with the first on specificity and wins on source order. */
+.wp-element-button[aria-busy="true"],
+.wp-block-button > .wp-block-button__link.wp-element-button[aria-busy="true"] {
+	cursor: progress;
+}
+
+.wp-element-button[aria-busy="true"]::after {
+	content: '';
+	display: inline-block;
+	width: 12px;
+	height: 12px;
+	margin-left: 10px;
+	vertical-align: -1px;
+	border: 2px solid currentColor;
+	border-right-color: transparent;
+	border-radius: 9999px;
+	animation: groups-site-spin 0.7s linear infinite;
+}
+
+@keyframes groups-site-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+/*
+ * The blanket reduced-motion rule below only shortens durations, which for
+ * an infinite animation means strobing rather than stopping. Close the ring
+ * and mute it instead: still legibly "working", with nothing moving.
+ */
+@media (prefers-reduced-motion: reduce) {
+	.wp-element-button[aria-busy="true"]::after {
+		animation-name: none;
+		border-right-color: currentColor;
+		opacity: 0.5;
+	}
+}
 
 /* ==========================================================================
    Front-page hero

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -157,6 +157,87 @@ body.error404 .site-content-container h1 {
 }
 
 /* ==========================================================================
+   Front-page identity row
+   ========================================================================== */
+
+/*
+ * The local navigation bar directly above is blueberry-4 and already carries
+ * the group name. Giving this row a background of its own merged the two into
+ * a single pale slab that restated the name 60px lower at three times the
+ * size; it stays on the page background and closes with a hairline instead.
+ */
+.groups-site-identity {
+	border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.groups-site-identity .wp-block-site-title {
+	text-wrap: balance;
+}
+
+/* ==========================================================================
+   Front-page content and sidebar
+   ========================================================================== */
+
+.groups-site-home-layout {
+	align-items: flex-start !important;
+}
+
+.groups-site-sidebar {
+	box-sizing: border-box;
+	width: 100%;
+	padding-left: var(--wp--preset--spacing--40);
+	border-left: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.groups-site-sidebar .wporg-event-manage,
+.groups-site-sidebar .wporg-group-settings-block,
+.groups-site-sidebar .wporg-group-membership {
+	width: 100%;
+}
+
+.groups-site-sidebar .wporg-event-manage,
+.groups-site-sidebar .wporg-group-membership {
+	flex-direction: column;
+	align-items: flex-start;
+}
+
+.groups-site-sidebar .wporg-event-manage {
+	gap: var(--wp--preset--spacing--10);
+}
+
+/*
+ * Sidebar headings are the one place that keeps the Inter 16px/600 utility
+ * treatment. Every heading in the main column — My upcoming events,
+ * Upcoming events, About this group, News, Sponsors — takes the Heading 3
+ * serif; a 36px serif in a 26%-wide rail would outrank the section it
+ * labels. Sponsors is listed because it renders in both places.
+ */
+.groups-site-sidebar .wporg-sponsors__heading,
+.groups-site-event-sidebar .wporg-sponsors__heading,
+.groups-site-sidebar .wporg-group-membership__heading,
+.groups-site-sidebar .wporg-group-membership__preference-heading {
+	box-sizing: border-box;
+	width: 100%;
+	padding: 0;
+	margin: 0 !important;
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: 600;
+	line-height: 1.4;
+	color: var(--wp--preset--color--charcoal-1);
+}
+
+.groups-site-sidebar:has(.wporg-event-manage) .groups-site-sidebar-preference {
+	margin-top: var(--wp--preset--spacing--10) !important;
+	padding-top: var(--wp--preset--spacing--20);
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.groups-site-main-column {
+	min-width: 0;
+}
+
+/* ==========================================================================
    Front-page hero
    ========================================================================== */
 
@@ -283,6 +364,23 @@ body.error404 .site-content-container h1 {
 	object-fit: cover;
 }
 
+/*
+ * Core's featured-image block renders nothing at all when a post has no
+ * thumbnail, so in a row of three cards a single image-less event used to
+ * start its date 158px higher than its neighbours. `functions.php`
+ * substitutes this element instead, keeping the same 16:9 region and the
+ * same rounded top corners.
+ *
+ * Flat Blueberry 4 and nothing else: a generated pattern would be artwork the
+ * group never chose, and it competes with the real photography in the cards
+ * beside it.
+ */
+.groups-site-featured-placeholder {
+	aspect-ratio: 16 / 9;
+	background: var(--wp--preset--color--blueberry-4);
+	border-radius: 3px 3px 0 0;
+}
+
 .wp-block-post-template .wp-block-post-title a:hover {
 	text-decoration: none;
 	color: var(--wp--preset--color--blueberry-1);
@@ -304,10 +402,30 @@ body.error404 .site-content-container h1 {
    Single event layout
    ========================================================================== */
 
-/* ----------  Date header row  ---------- */
+/* Keep the title, event details, and main content in semantic source order. */
+.wp-block-columns.groups-site-event-layout {
+	display: grid;
+	grid-template-columns: minmax(0, 62fr) minmax(0, 38fr);
+	grid-template-rows: auto 1fr;
+	column-gap: var(--wp--preset--spacing--60);
+	row-gap: 0;
+	align-items: start;
+}
 
-.groups-site-event-date-header .wp-block-gatherpress-add-to-calendar .wp-block-gatherpress-dropdown__trigger {
-	font-size: var(--wp--preset--font-size--small);
+.groups-site-event-title {
+	grid-column: 1;
+	grid-row: 1;
+}
+
+.groups-site-event-sidebar {
+	grid-column: 2;
+	grid-row: 1 / span 2;
+}
+
+.groups-site-event-content {
+	display: block;
+	grid-column: 1;
+	grid-row: 2;
 }
 
 /* ----------  Venue extras (description + access) ---------- */
@@ -329,10 +447,90 @@ body.error404 .site-content-container h1 {
 		0 2px 8px rgba(30, 30, 30, 0.04);
 }
 
-.groups-site-event-info-card hr.wp-block-separator {
-	border-color: var(--wp--preset--color--light-grey-1) !important;
-	opacity: 1;
-	margin: 0;
+/*
+ * The card reads as zones — When, Where, Add to calendar — rather than one
+ * flat stack, so each zone after the first opens with a divider.
+ *
+ * The divider is a border on the zone itself, not a `<hr>` sibling. Every
+ * zone below "When" is optional: GatherPress renders the venue, online-event
+ * and add-to-calendar blocks as an empty string when the event has no venue,
+ * isn't online, or has no calendar links. A separate `<hr>` outlives the zone
+ * it introduces in that case — with all three empty, the first divider was
+ * left hanging under the RSVP button with nothing beneath it. Carrying the
+ * border on the zone makes that unrepresentable: no zone, no divider.
+ *
+ * Generous, symmetric room (more than the 20px `blockGap` used *within* a
+ * zone) so it reads as a hard boundary rather than another item in the list.
+ */
+.groups-site-event-info-card > .groups-site-event-zone {
+	margin-top: 32px;
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);
+	padding-top: 32px;
+}
+
+/* GatherPress's wrapper-`<div>` blocks seed their inner blocks in the editor,
+   so one rendered from a theme template can arrive as an empty wrapper rather
+   than as no element at all. Hiding the zone takes its border with it. */
+.groups-site-event-info-card > .groups-site-event-zone:empty {
+	display: none;
+}
+
+/*
+ * The info card is two label/value pairs, not a stack of headings: an
+ * eyebrow (12/600 uppercase, muted), the answer (Inter 16/1.4/600), and
+ * the supporting details (14/1.55/400). Both answers get the same size, so
+ * "when before where" comes from order and the eyebrow rather than from
+ * size — which also keeps the card off the serif scale reserved for the
+ * event title and the main-column card headings. The three sizes live on
+ * the blocks in single-event.html; only the label's tracking needs CSS.
+ */
+.groups-site-event-info-card .groups-site-event-label {
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+/*
+ * Address, phone, and website are three unlabelled values on consecutive
+ * lines, so the glyph identifies which is which. The date gets no icon: its
+ * eyebrow already reads "Date and time", and a calendar chip put a second
+ * blue block directly above the blue RSVP button.
+ *
+ * One muted tone for all of them, so they don't compete with the blue links
+ * beside them.
+ */
+.groups-site-event-info-card .gatherpress--has-venue-address .wp-block-icon,
+.groups-site-event-info-card .gatherpress--has-venue-phone .wp-block-icon,
+.groups-site-event-info-card .gatherpress--has-venue-website .wp-block-icon,
+.groups-site-event-info-card .groups-site-online-event .wp-block-icon {
+	color: var(--wp--preset--color--charcoal-4);
+	flex: 0 0 auto;
+}
+
+/* GatherPress renders the address in an <address>, which every browser
+   italicises by default — next to the upright phone and website lines it
+   read as a pull quote rather than the third fact in the list. */
+.groups-site-event-info-card .gatherpress-venue-detail__address {
+	font-style: normal;
+}
+
+/* A wrapping address puts the pin halfway down the block if it stays
+   centred, so anchor it to the first line instead. */
+.groups-site-event-info-card .gatherpress--has-venue-address {
+	align-items: flex-start;
+}
+
+.groups-site-event-info-card .gatherpress--has-venue-address .wp-block-icon {
+	margin-top: 2px;
+}
+
+/* Address, phone, and website are one list of three contact facts. The
+   block markup splits them across two groups, which lets the wrap push
+   phone flush under the address and leave the website adrift below —
+   force one rhythm over the three regardless of how they break. */
+.groups-site-event-info-card .groups-site-venue-contact {
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--wp--preset--spacing--10);
 }
 
 
@@ -483,6 +681,38 @@ body.error404 .site-content-container h1 {
 }
 
 /* ==========================================================================
+   About this group
+
+   Pulled from the group's own About page by `wporg/page-content`, so the
+   prose is edited in one place and this is only ever a view of it. It sits
+   *below* Upcoming events: a visitor who already knows the group came for
+   the dates, and a newcomer still finds the context one scroll down,
+   ahead of News and Sponsors.
+   ========================================================================== */
+
+.groups-site-about > :first-child {
+	margin-top: 0;
+}
+
+.groups-site-about > :last-child {
+	margin-bottom: 0;
+}
+
+/* An About page is prose, not a layout — hold it to a comfortable measure
+   rather than letting it run the full 860px of the main column. */
+.groups-site-about p {
+	max-width: 68ch;
+	text-wrap: pretty;
+}
+
+/* Organizer-only affordance. Deliberately quiet: it's a maintenance link on
+   someone else's reading experience, not a call to action. */
+.wporg-page-content__edit {
+	margin: var(--wp--preset--spacing--20) 0 0;
+	font-size: var(--wp--preset--font-size--small);
+}
+
+/* ==========================================================================
    Search block
    ========================================================================== */
 
@@ -491,10 +721,15 @@ body.error404 .site-content-container h1 {
 	border-radius: 2px !important;
 }
 
+/*
+ * Border colour only. The old rule swapped the focus ring for a 3px
+ * Blueberry 3 glow — #c7d1ff against white is about 1.5:1, well under the
+ * 3:1 a focus indicator needs, and `outline: none` had already removed the
+ * one indicator that did pass. The global `:focus-visible` outline now
+ * does that job; this just confirms the field is the active one.
+ */
 .wp-block-search__input:focus {
 	border-color: var(--wp--preset--color--blueberry-1) !important;
-	outline: none;
-	box-shadow: 0 0 0 3px var(--wp--preset--color--blueberry-3);
 }
 
 .wp-block-search__button {
@@ -518,6 +753,18 @@ body.error404 .site-content-container h1 {
 
 .groups-site-footer a:hover {
 	text-decoration: underline;
+}
+
+/* ==========================================================================
+   Comments
+   ========================================================================== */
+
+/* Avatars are round everywhere on the site. Core's avatar block ships no
+   radius of its own — only the `is-style-rounded` variation adds one, and
+   that isn't registered here — so the comment avatars were the one square
+   set among the RSVP, speaker, and member stacks. */
+.wp-block-avatar img {
+	border-radius: 9999px;
 }
 
 /* ==========================================================================
@@ -566,10 +813,10 @@ body.error404 .site-content-container h1 {
 .wp-block-post-comments-form textarea#comment {
 	width: 100%;
 	min-height: 88px;
-	padding: 12px 14px;
+	padding: 8px 12px;
 	background: var(--wp--preset--color--white);
 	border: 1px solid var(--wp--preset--color--light-grey-1);
-	border-radius: 4px;
+	border-radius: 2px;
 	font-family: var(--wp--preset--font-family--inter);
 	font-size: var(--wp--preset--font-size--normal);
 	line-height: 1.5;
@@ -583,10 +830,9 @@ body.error404 .site-content-container h1 {
 	color: var(--wp--preset--color--charcoal-4);
 }
 
+/* Border colour only — see the note on the search input above. */
 .wp-block-post-comments-form textarea#comment:focus {
-	outline: none;
 	border-color: var(--wp--preset--color--blueberry-1);
-	box-shadow: 0 0 0 3px var(--wp--preset--color--blueberry-3);
 }
 
 /* Hide the author/email/url fields that core injects for guests — keep the
@@ -605,39 +851,95 @@ body.error404 .site-content-container h1 {
 	justify-content: flex-end;
 }
 
+/* Compact size — see the note in the Buttons section. The composer is a
+   16px textarea in a 16px-padded well; a 32px-padded submit under it would
+   outweigh the thing it submits. */
 .wp-block-post-comments-form .form-submit .submit {
+	padding: 10px 20px;
 	background: var(--wp--preset--color--blueberry-1);
 	color: var(--wp--preset--color--white);
-	border: none;
+	border: 1px solid transparent;
 	border-radius: 2px;
-	padding: 10px 22px;
 	font-family: var(--wp--preset--font-family--inter);
 	font-size: var(--wp--preset--font-size--small);
 	font-weight: 600;
+	line-height: 1.3;
 	cursor: pointer;
-	transition: background-color 0.15s ease;
+	transition: background-color 0.15s ease, border-color 0.15s ease,
+		color 0.15s ease;
 }
 
 .wp-block-post-comments-form .form-submit .submit:hover,
 .wp-block-post-comments-form .form-submit .submit:focus-visible {
 	background: var(--wp--preset--color--deep-blueberry);
+	color: var(--wp--preset--color--white);
 }
 
-/* Comment list — read like a chat thread, not a blog comment list. */
+.wp-block-post-comments-form .form-submit .submit:disabled {
+	background: var(--wp--preset--color--light-grey-2);
+	border-color: var(--wp--preset--color--light-grey-1);
+	color: var(--wp--preset--color--charcoal-4);
+	cursor: not-allowed;
+}
+
+/* Comment list — read like a compact chat thread, not a blog comment list. */
 .wp-block-comments .wp-block-comment-template {
 	list-style: none;
 	padding: 0;
 	margin: 0 0 24px;
 	display: flex;
 	flex-direction: column;
-	gap: 20px;
+	gap: 12px;
 }
 
 .wp-block-comments .wp-block-comment-template > li {
-	padding: 16px;
+	padding: 14px 16px;
 	background: var(--wp--preset--color--light-grey-2);
 	border: 1px solid var(--wp--preset--color--light-grey-1);
 	border-radius: 4px;
+}
+
+.wp-block-comments .groups-site-comment {
+	align-items: flex-start !important;
+	margin: 0;
+}
+
+.wp-block-comments .groups-site-comment__meta {
+	align-items: baseline;
+	line-height: 1.35;
+}
+
+.wp-block-comments .groups-site-comment__meta .wp-block-comment-author-name,
+.wp-block-comments .groups-site-comment__meta .wp-block-comment-date {
+	margin: 0;
+}
+
+.wp-block-comments .wp-block-comment-content {
+	margin-top: 6px;
+}
+
+.wp-block-comments .wp-block-comment-content > :first-child {
+	margin-top: 0;
+}
+
+.wp-block-comments .wp-block-comment-content > :last-child {
+	margin-bottom: 0;
+}
+
+.wp-block-comments .wp-block-comment-reply-link {
+	margin-top: 6px;
+}
+
+.wp-block-comments .wp-block-comment-template > li > ol {
+	list-style: none;
+	padding: 0;
+	margin: 12px 0 0 48px;
+}
+
+@media (max-width: 480px) {
+	.wp-block-comments .wp-block-comment-template > li > ol {
+		margin-left: 20px;
+	}
 }
 
 /* ==========================================================================
@@ -709,5 +1011,9 @@ body.error404 .site-content-container h1 {
 	*::after {
 		transition-duration: 0.01ms !important;
 		animation-duration: 0.01ms !important;
+		/* Without this, a looping animation doesn't stop — it just loops
+		   0.01ms at a time, which is worse than the motion it replaced. */
+		animation-iteration-count: 1 !important;
+		scroll-behavior: auto !important;
 	}
 }

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -58,21 +58,10 @@ body.error404 .site-content-container h1 {
 /* ==========================================================================
    Buttons
 
-   The parent theme already drives every button state from
-   `--wp--custom--button--*` custom properties, including the filled/outline
-   size parity core can't express on its own: the filled variant gets
-   `padding + border-width` with no border, the outline variant gets the bare
-   padding plus a 1px border, so both resolve to the same box.
-
-   So the values that differ from the parent's — the active blues, and the
-   whole outline ramp — are set as token overrides in `theme.json`
-   (`settings.custom.button`), where the parent's own rules pick them up.
-   Buttons given a colour in the editor are unaffected: core emits its
-   `has-*-color` / `has-*-background-color` classes with `!important`, which
-   outranks the token-driven rules in every state. That's what keeps the
-   footer's pomegranate CTA pomegranate.
-
-   What's left here is only what the token system has no slot for.
+   The parent theme drives every state from `--wp--custom--button--*` custom
+   properties; the values that differ are token overrides in `theme.json`
+   (`settings.custom.button`). What's left here is only what the token system
+   has no slot for.
 
    The compact size — Inter 14px/600 in 10px 20px — is deliberately *not*
    the parent's `is-small`: that variant is 7px/12px and only applies under a
@@ -160,12 +149,8 @@ body.error404 .site-content-container h1 {
    Front-page identity row
    ========================================================================== */
 
-/*
- * The local navigation bar directly above is blueberry-4 and already carries
- * the group name. Giving this row a background of its own merged the two into
- * a single pale slab that restated the name 60px lower at three times the
- * size; it stays on the page background and closes with a hairline instead.
- */
+/* The nav bar above already carries the group name — this row stays on the
+   page background and closes with a hairline instead of a second slab. */
 .groups-site-identity {
 	border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
 }

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -4,9 +4,14 @@
  * @package WordCamp\Groups\Site
  */
 
-img,
-video,
-iframe {
+/* Keep authored media inside its column — an oversized image in a group's
+   page content would otherwise force the whole page to scroll sideways on a
+   phone. Scoped to the containers that render authored HTML rather than
+   applied to every `img` on the site: UI chrome (avatars, logos) sets its own
+   dimensions, and a global rule fights those instead of helping them.
+   Editor-inserted images and featured images are already handled by core. */
+:where(.wp-block-post-content, .wp-block-comment-content, .wp-block-wporg-page-content)
+	:where(img, video, iframe) {
 	max-width: 100%;
 	height: auto;
 }
@@ -14,25 +19,27 @@ iframe {
 @media (max-width: 960px) {
 	.groups-site-home-layout {
 		flex-wrap: wrap !important;
+		/* Columns only carry `blockGap.left`, which becomes `column-gap` —
+		   once they wrap there is nothing holding the two apart vertically. */
+		row-gap: var(--wp--preset--spacing--60);
 	}
 
 	.groups-site-home-layout > .wp-block-column {
 		flex-basis: 100% !important;
 	}
 
-	.groups-site-sidebar-column {
-		order: 1;
-	}
-
-	.groups-site-main-column-wrapper {
-		order: 2;
-	}
-
+	/*
+	 * The sidebar is second in the source, so wrapping puts it *below* the
+	 * main column — its divider belongs on the leading edge. It used to
+	 * draw a bottom border here, left over from when the sidebar came
+	 * first in the DOM and CSS `order` moved it; that ordering was removed
+	 * in favour of one semantic order, and this is the last piece of it.
+	 */
 	.groups-site-sidebar {
 		padding-left: 0;
-		padding-bottom: var(--wp--preset--spacing--50);
+		padding-top: var(--wp--preset--spacing--40);
 		border-left: 0;
-		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+		border-top: 1px solid var(--wp--preset--color--light-grey-1);
 	}
 }
 
@@ -41,19 +48,26 @@ iframe {
    ========================================================================== */
 
 @media (max-width: 781px) {
-
-	/* Single event: collapse two-column layout to stacked. */
-	.groups-site-event-layout {
-		flex-direction: column !important;
+	.wp-block-columns.groups-site-event-layout {
+		grid-template-columns: minmax(0, 1fr);
+		grid-template-rows: auto;
+		column-gap: 0;
+		row-gap: var(--wp--preset--spacing--20);
 	}
 
-	.groups-site-event-layout .wp-block-column {
-		flex-basis: 100% !important;
+	.groups-site-event-title,
+	.groups-site-event-sidebar,
+	.groups-site-event-content {
+		grid-column: 1;
+		grid-row: auto;
+		max-width: 100%;
 	}
 
-	/* Date header: let text wrap. */
-	.groups-site-event-date-header {
-		gap: 12px !important;
+	.groups-site-event-content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--wp--preset--spacing--20);
+		padding-top: var(--wp--preset--spacing--20);
 	}
 
 	/* Query Loop event cards: single column. */
@@ -87,11 +101,6 @@ iframe {
 		max-width: none !important;
 		max-height: none !important;
 		height: 100% !important;
-	}
-
-	/* Cover block hero: reduce padding. */
-	.wp-block-cover.alignfull {
-		min-height: auto !important;
 	}
 }
 

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -28,13 +28,8 @@
 		flex-basis: 100% !important;
 	}
 
-	/*
-	 * The sidebar is second in the source, so wrapping puts it *below* the
-	 * main column — its divider belongs on the leading edge. It used to
-	 * draw a bottom border here, left over from when the sidebar came
-	 * first in the DOM and CSS `order` moved it; that ordering was removed
-	 * in favour of one semantic order, and this is the last piece of it.
-	 */
+	/* The sidebar is second in the source, so wrapping puts it *below* the
+	   main column — its divider belongs on the leading edge. */
 	.groups-site-sidebar {
 		padding-left: 0;
 		padding-top: var(--wp--preset--spacing--40);

--- a/public_html/wp-content/themes/groups-site/functions.php
+++ b/public_html/wp-content/themes/groups-site/functions.php
@@ -54,20 +54,37 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
- * Remove the featured image link from keyboard tab order in event card grids.
+ * Adjust the featured image inside event card grids.
  *
- * The title link already provides keyboard access to the event. A second
- * focusable link on the image is redundant and slows tab navigation.
+ * Two changes, both scoped so the single-event hero is left alone. The guard
+ * tests `is_singular( 'gatherpress_event' )` rather than a bare
+ * `is_singular()`: the group front page is a static Page, so it is singular
+ * too, and the broader test excluded the very cards this is meant to fix.
+ *
+ *   - Drop the image link from the keyboard tab order. The title link already
+ *     provides keyboard access to the event, so a second focusable link on
+ *     the image is redundant and slows tab navigation.
+ *   - Substitute a placeholder when the event has no thumbnail. Core renders
+ *     the block as an empty string in that case, so one image-less event in a
+ *     row of three used to start its date where its neighbours started their
+ *     image — the cards shared a grid row but no baseline. The placeholder
+ *     holds the same 16:9 region; `custom.css` fills it with flat
+ *     Blueberry 4 rather than invented artwork.
  */
 add_filter(
 	'render_block_core/post-featured-image',
 	static function ( string $content, array $block ): string {
 		$post_type = $block['context']['postType'] ?? get_post_type();
 
-		if ( ! is_singular() && 'gatherpress_event' === $post_type ) {
-			$content = str_replace( '<a href=', '<a tabindex="-1" href=', $content );
+		if ( 'gatherpress_event' !== $post_type || is_singular( 'gatherpress_event' ) ) {
+			return $content;
 		}
-		return $content;
+
+		if ( '' === trim( $content ) ) {
+			return '<div class="wp-block-post-featured-image groups-site-featured-placeholder" aria-hidden="true"></div>';
+		}
+
+		return str_replace( '<a href=', '<a tabindex="-1" href=', $content );
 	},
 	10,
 	2

--- a/public_html/wp-content/themes/groups-site/parts/footer.html
+++ b/public_html/wp-content/themes/groups-site/parts/footer.html
@@ -22,8 +22,8 @@
 				<div class="wp-block-button"><a class="wp-block-button__link has-charcoal-1-color has-pomegranate-1-background-color has-text-color has-background wp-element-button" href="https://make.wordpress.org/community/">Get involved</a></div>
 				<!-- /wp:button -->
 
-				<!-- wp:button {"textColor":"white","className":"is-style-outline","style":{"border":{"color":"var:preset|color|white","width":"1px"}}} -->
-				<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-white-color has-text-color has-border-color wp-element-button" href="https://events.wordpress.org/" style="border-color:var(--wp--preset--color--white);border-width:1px">All groups</a></div>
+				<!-- wp:button {"textColor":"white","className":"is-style-outline-on-dark","style":{"border":{"color":"var:preset|color|white","width":"1px"}}} -->
+				<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link has-white-color has-text-color has-border-color wp-element-button" href="https://events.wordpress.org/" style="border-color:var(--wp--preset--color--white);border-width:1px">All groups</a></div>
 				<!-- /wp:button -->
 			</div>
 			<!-- /wp:buttons -->

--- a/public_html/wp-content/themes/groups-site/templates/archive-gatherpress_event.html
+++ b/public_html/wp-content/themes/groups-site/templates/archive-gatherpress_event.html
@@ -53,17 +53,17 @@
 			<!-- wp:wporg/query-total /-->
 
 			<!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
-				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"}},"layout":{"type":"constrained"}} -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group has-border-color" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px">
 					<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9","style":{"border":{"radius":{"topLeft":"3px","topRight":"3px","bottomLeft":"0px","bottomRight":"0px"}}}} /-->
-					<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
-					<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+					<!-- wp:group {"style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
+					<div class="wp-block-group" style="padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px">
 						<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M j, Y","showTimezone":"no","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.04em"}}} /-->
-						<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.3"}}} /-->
+						<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-6","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.2"}}} /-->
 						<!-- wp:post-excerpt {"moreText":"","excerptLength":25,"fontSize":"small","textColor":"charcoal-3"} /-->
 						<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
 						<!-- wp:gatherpress/venue -->
-							<!-- wp:post-title {"level":4,"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
+							<!-- wp:post-title {"level":4,"fontSize":"small","fontFamily":"inter","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":"400","lineHeight":"1.55"}}} /-->
 						<!-- /wp:gatherpress/venue -->
 					</div>
 					<!-- /wp:group -->

--- a/public_html/wp-content/themes/groups-site/templates/front-page.html
+++ b/public_html/wp-content/themes/groups-site/templates/front-page.html
@@ -7,53 +7,29 @@
 	<!-- /wp:navigation -->
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:cover {"overlayColor":"blueberry-4","isUserOverlayColor":true,"align":"full","lock":{"move":true,"remove":true},"style":{"dimensions":{"minHeight":"0"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
-<div class="wp-block-cover alignfull" style="min-height:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-4-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
+<!-- wp:group {"align":"full","className":"groups-site-identity","lock":{"move":true,"remove":true},"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
+<div class="wp-block-group alignfull groups-site-identity" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:site-title {"level":1,"fontSize":"heading-2","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":"1.1"}}} /-->
 
-	<!-- wp:group {"className":"groups-site-hero","style":{"dimensions":{"minHeight":"0"},"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained","contentSize":"720px","justifyContent":"left"}} -->
-	<div class="wp-block-group groups-site-hero" style="min-height:0">
-		<!-- wp:site-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"lineHeight":"1.05"}}} /-->
+	<!-- wp:wporg/group-location {"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"lock":{"move":true,"remove":true}} /-->
+</div>
+<!-- /wp:group -->
 
-		<!-- wp:site-tagline {"fontSize":"large","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
-
-		<!-- wp:wporg/group-location {"fontSize":"small","textColor":"charcoal-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"lock":{"move":true,"remove":true}} /-->
-	</div>
-	<!-- /wp:group -->
-
-</div></div>
-<!-- /wp:cover -->
-
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:columns {"align":"wide","className":"groups-site-home-layout","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
 	<div class="wp-block-columns alignwide groups-site-home-layout">
-		<!-- wp:column {"width":"26%","className":"groups-site-sidebar-column"} -->
-		<div class="wp-block-column groups-site-sidebar-column" style="flex-basis:26%">
-			<!-- wp:group {"tagName":"aside","className":"groups-site-sidebar","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-			<aside class="wp-block-group groups-site-sidebar">
-				<!-- wp:wporg/group-membership {"variant":"membership","lock":{"move":true,"remove":true}} /-->
-
-				<!-- wp:wporg/event-manage {"mode":"create","lock":{"move":true,"remove":true}} /-->
-
-				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
-
-				<!-- wp:wporg/group-membership {"variant":"preference","className":"groups-site-sidebar-preference","lock":{"move":true,"remove":true}} /-->
-			</aside>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:column -->
-
 		<!-- wp:column {"width":"74%","className":"groups-site-main-column-wrapper"} -->
 		<div class="wp-block-column groups-site-main-column-wrapper" style="flex-basis:74%">
-			<!-- wp:group {"className":"groups-site-main-column","style":{"spacing":{"blockGap":"var:preset|spacing|70"}},"layout":{"type":"constrained"}} -->
+			<!-- wp:group {"className":"groups-site-main-column","style":{"spacing":{"blockGap":"var:preset|spacing|60"}},"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group groups-site-main-column">
 				<!-- wp:wporg/my-events {"lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:group {"className":"groups-site-section","anchor":"upcoming","layout":{"type":"constrained","justifyContent":"left"}} -->
 				<div id="upcoming" class="wp-block-group groups-site-section">
-					<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"}} -->
-					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+					<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"}} -->
+					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--30)">
 						<!-- wp:heading {"level":2,"fontSize":"heading-3","style":{"spacing":{"margin":{"bottom":"0"}}}} -->
 						<h2 class="wp-block-heading has-heading-3-font-size" style="margin-bottom:0">Upcoming events</h2>
 						<!-- /wp:heading -->
@@ -65,17 +41,17 @@
 					<!-- wp:query {"query":{"postType":"gatherpress_event","perPage":3,"offset":0,"order":"asc","orderBy":"datetime","gatherpress_event_query":"upcoming","include_unfinished":1,"inherit":false},"namespace":"gatherpress-event-query","className":"gatherpress-event-query"} -->
 					<div class="wp-block-query gatherpress-event-query">
 						<!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
-							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"}},"layout":{"type":"constrained"}} -->
+							<!-- wp:group {"style":{"spacing":{"blockGap":"0"},"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"}},"layout":{"type":"constrained"}} -->
 							<div class="wp-block-group has-border-color" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px">
 								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9","style":{"border":{"radius":{"topLeft":"3px","topRight":"3px","bottomLeft":"0px","bottomRight":"0px"}}}} /-->
-								<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
-								<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+								<!-- wp:group {"style":{"spacing":{"padding":{"top":"24px","right":"24px","bottom":"24px","left":"24px"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
+								<div class="wp-block-group" style="padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px">
 									<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M j, Y","showTimezone":"no","fontSize":"small","textColor":"blueberry-1","style":{"typography":{"fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.04em"}}} /-->
-									<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.3"}}} /-->
+									<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-6","style":{"spacing":{"margin":{"top":"0"}},"typography":{"lineHeight":"1.2"}}} /-->
 									<!-- wp:post-excerpt {"moreText":"","excerptLength":18,"fontSize":"small","textColor":"charcoal-3"} /-->
 									<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
 									<!-- wp:gatherpress/venue -->
-										<!-- wp:post-title {"level":4,"fontSize":"small","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
+										<!-- wp:post-title {"level":4,"fontSize":"small","fontFamily":"inter","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":"400","lineHeight":"1.55"}}} /-->
 									<!-- /wp:gatherpress/venue -->
 								</div>
 								<!-- /wp:group -->
@@ -93,10 +69,28 @@
 				</div>
 				<!-- /wp:group -->
 
+				<!-- wp:wporg/page-content {"slug":"about","heading":"About this group","headingLevel":2,"className":"groups-site-about","lock":{"move":true,"remove":true}} /-->
+
 				<!-- wp:wporg/group-news {"limit":3,"lock":{"move":true,"remove":true}} /-->
 
 				<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"className":"groups-site-sponsors"} /-->
 			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"26%","className":"groups-site-sidebar-column"} -->
+		<div class="wp-block-column groups-site-sidebar-column" style="flex-basis:26%">
+			<!-- wp:group {"tagName":"aside","className":"groups-site-sidebar","style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+			<aside class="wp-block-group groups-site-sidebar">
+				<!-- wp:wporg/group-membership {"variant":"membership","lock":{"move":true,"remove":true}} /-->
+
+				<!-- wp:wporg/event-manage {"mode":"create","lock":{"move":true,"remove":true}} /-->
+
+				<!-- wp:wporg/group-settings {"lock":{"move":true,"remove":true}} /-->
+
+				<!-- wp:wporg/group-membership {"variant":"preference","className":"groups-site-sidebar-preference","lock":{"move":true,"remove":true}} /-->
+			</aside>
 			<!-- /wp:group -->
 		</div>
 		<!-- /wp:column -->

--- a/public_html/wp-content/themes/groups-site/templates/single-event.html
+++ b/public_html/wp-content/themes/groups-site/templates/single-event.html
@@ -15,42 +15,70 @@
 	<!-- wp:columns {"className":"groups-site-event-layout","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}}} -->
 	<div class="wp-block-columns groups-site-event-layout">
 
-		<!-- wp:column {"width":"62%","className":"groups-site-event-content"} -->
-		<div class="wp-block-column groups-site-event-content" style="flex-basis:62%">
+		<!-- wp:column {"className":"groups-site-event-title"} -->
+		<div class="wp-block-column groups-site-event-title">
 
-			<!-- wp:group {"className":"groups-site-event-date-header","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
-			<div class="wp-block-group groups-site-event-date-header" style="margin-bottom:var(--wp--preset--spacing--30)">
-				<!-- wp:group {"style":{"border":{"width":"1px","color":"var:preset|color|light-grey-1","radius":"4px"},"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group has-border-color" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px">
-					<!-- wp:group {"backgroundColor":"blueberry-1","style":{"border":{"radius":{"topLeft":"3px","topRight":"3px","bottomLeft":"0px","bottomRight":"0px"}},"spacing":{"padding":{"top":"4px","right":"var:preset|spacing|20","bottom":"4px","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
-					<div class="wp-block-group has-blueberry-1-background-color has-background" style="border-top-left-radius:3px;border-top-right-radius:3px;border-bottom-left-radius:0px;border-bottom-right-radius:0px;padding-top:4px;padding-right:var(--wp--preset--spacing--20);padding-bottom:4px;padding-left:var(--wp--preset--spacing--20)">
-						<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"M","showTimezone":"no","style":{"typography":{"fontWeight":"700","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"white","fontSize":"extra-small"} /-->
-					</div>
-					<!-- /wp:group -->
-					<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
-					<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
-						<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"j","showTimezone":"no","textColor":"charcoal-1","fontSize":"extra-large","style":{"typography":{"fontWeight":"800","lineHeight":"1"}}} /-->
-					</div>
-					<!-- /wp:group -->
-				</div>
-				<!-- /wp:group -->
+			<!-- wp:post-title {"level":1,"fontSize":"heading-2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
+		</div>
+		<!-- /wp:column -->
 
-				<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"2px"}}} -->
-				<div class="wp-block-group">
-					<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"l, F j","showTimezone":"no","textColor":"charcoal-1","fontSize":"large","style":{"typography":{"fontWeight":"700"}}} /-->
-					<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
-					<div class="wp-block-group">
-						<!-- wp:gatherpress/event-date {"startDateFormat":"g:i A","endDateFormat":"g:i A","showTimezone":"no","textColor":"charcoal-4","fontSize":"small"} /-->
-						<!-- wp:gatherpress/add-to-calendar /-->
-					</div>
+		<!-- wp:column {"width":"38%","className":"groups-site-event-sidebar"} -->
+		<div class="wp-block-column groups-site-event-sidebar" style="flex-basis:38%">
+			<!-- wp:group {"className":"groups-site-event-info-card","templateLock":"contentOnly","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"},"border":{"radius":"4px","width":"1px","color":"var:preset|color|light-grey-1"}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group groups-site-event-info-card has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+
+					<!-- wp:group {"className":"groups-site-event-date","style":{"spacing":{"blockGap":"var:preset|spacing|10","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+					<div class="wp-block-group groups-site-event-date" style="margin-top:0;margin-bottom:0"><!-- wp:paragraph {"className":"groups-site-event-label","textColor":"charcoal-4","fontSize":"extra-small","style":{"typography":{"fontWeight":"600"},"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+					<p class="groups-site-event-label has-charcoal-4-color has-text-color has-extra-small-font-size" style="margin-top:0;margin-bottom:0;font-weight:600">Date and time</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:group {"className":"groups-site-event-date__details","style":{"spacing":{"blockGap":"2px","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+					<div class="wp-block-group groups-site-event-date__details" style="margin-top:0;margin-bottom:0">
+					<!-- wp:gatherpress/event-date {"displayType":"start","startDateFormat":"l, F j","showTimezone":"no","textColor":"charcoal-1","fontSize":"normal","style":{"typography":{"fontWeight":"600","lineHeight":"1.4"}}} /-->
+					<!-- wp:gatherpress/event-date {"startDateFormat":"g:i A","endDateFormat":"g:i A","showTimezone":"no","textColor":"charcoal-4","fontSize":"small"} /--></div>
+					<!-- /wp:group --></div>
 					<!-- /wp:group -->
-				</div>
-				<!-- /wp:group -->
+
+					<!-- wp:wporg/event-rsvp {"lock":{"move":true,"remove":true}} /-->
+
+					<!-- wp:gatherpress/venue {"className":"groups-site-event-zone","lock":{"move":true,"remove":true}} -->
+					<!-- wp:paragraph {"className":"groups-site-event-label","textColor":"charcoal-4","fontSize":"extra-small","style":{"typography":{"fontWeight":"600"},"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}}} -->
+					<p class="groups-site-event-label has-charcoal-4-color has-text-color has-extra-small-font-size" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--10);font-weight:600">Location</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:post-title {"level":0,"isLink":false,"textColor":"charcoal-1","fontFamily":"inter","fontSize":"normal","style":{"typography":{"fontWeight":"600","lineHeight":"1.4"},"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}}} /-->
+					<!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-address","style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+					<div class="wp-block-group gatherpress--has-venue-address" style="margin-top:0;margin-bottom:0"><!-- wp:icon {"icon":"core/map-marker","style":{"dimensions":{"width":"24px"}}} /-->
+					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue address…","fieldType":"address","textColor":"charcoal-4","fontSize":"small"} /--></div>
+					<!-- /wp:group -->
+					<!-- wp:group {"className":"groups-site-venue-contact","style":{"spacing":{"margin":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+					<div class="wp-block-group groups-site-venue-contact" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:var(--wp--preset--spacing--30)"><!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-phone","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group gatherpress--has-venue-phone"><!-- wp:icon {"icon":"core/mobile","style":{"dimensions":{"width":"24px"}}} /-->
+					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue phone…","fieldType":"phone","textColor":"charcoal-4","fontSize":"small"} /--></div>
+					<!-- /wp:group -->
+					<!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-website","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group gatherpress--has-venue-website"><!-- wp:icon {"icon":"core/external","style":{"dimensions":{"width":"24px"}}} /-->
+					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue website URL…","fieldType":"url","textColor":"charcoal-4","fontSize":"small"} /--></div>
+					<!-- /wp:group --></div>
+					<!-- /wp:group -->
+					<!-- wp:gatherpress/venue-map /-->
+					<!-- /wp:gatherpress/venue -->
+
+					<!-- wp:gatherpress/online-event {"className":"groups-site-event-zone"} -->
+					<div class="wp-block-gatherpress-online-event groups-site-event-zone"><!-- wp:group {"className":"groups-site-online-event","style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group groups-site-online-event" style="margin-top:0;margin-bottom:0"><!-- wp:icon {"icon":"core/capture-video","style":{"dimensions":{"width":"24px"}}} /-->
+					<!-- wp:gatherpress/online-event-link {"fontSize":"small","linkText":"\u003cspan class=\u0022gatherpress-tooltip\u0022 data-gatherpress-tooltip=\u0022Link available for attendees only.\u0022\u003eOnline event\u003c/span\u003e"} /--></div>
+					<!-- /wp:group --></div>
+					<!-- /wp:gatherpress/online-event -->
+
+					<!-- wp:gatherpress/add-to-calendar {"className":"groups-site-event-zone"} /-->
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:post-title {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} /-->
+			<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"limit":3,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} /-->
+		</div>
+		<!-- /wp:column -->
 
+		<!-- wp:column {"width":"62%","className":"groups-site-event-content"} -->
+		<div class="wp-block-column groups-site-event-content" style="flex-basis:62%">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 			<div class="wp-block-group">
 				<!-- wp:wporg/event-manage {"lock":{"move":true,"remove":true}} /-->
@@ -76,8 +104,8 @@
 				<!-- wp:comments {"lock":{"move":true,"remove":true}} -->
 				<div class="wp-block-comments">
 					<!-- wp:comment-template -->
-						<!-- wp:columns {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
-						<div class="wp-block-columns">
+						<!-- wp:columns {"className":"groups-site-comment","style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
+						<div class="wp-block-columns groups-site-comment">
 							<!-- wp:column {"width":"40px"} -->
 							<div class="wp-block-column" style="flex-basis:40px">
 								<!-- wp:avatar {"size":40} /-->
@@ -86,8 +114,12 @@
 
 							<!-- wp:column -->
 							<div class="wp-block-column">
-								<!-- wp:comment-author-name {"fontSize":"small"} /-->
-								<!-- wp:comment-date {"fontSize":"small"} /-->
+								<!-- wp:group {"className":"groups-site-comment__meta","style":{"spacing":{"blockGap":"var:preset|spacing|10","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+								<div class="wp-block-group groups-site-comment__meta" style="margin-top:0;margin-bottom:0">
+									<!-- wp:comment-author-name {"fontSize":"small"} /-->
+									<!-- wp:comment-date {"fontSize":"small"} /-->
+								</div>
+								<!-- /wp:group -->
 								<!-- wp:comment-content /-->
 								<!-- wp:comment-reply-link {"fontSize":"small"} /-->
 							</div>
@@ -107,55 +139,6 @@
 				<!-- /wp:comments -->
 			</div>
 			<!-- /wp:group -->
-		</div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"width":"38%","className":"groups-site-event-sidebar"} -->
-		<div class="wp-block-column groups-site-event-sidebar" style="flex-basis:38%">
-			<!-- wp:group {"className":"groups-site-event-info-card","templateLock":"contentOnly","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"},"border":{"radius":"4px","width":"1px","color":"var:preset|color|light-grey-1"}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
-			<div class="wp-block-group groups-site-event-info-card has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
-
-					<!-- wp:wporg/event-rsvp {"lock":{"move":true,"remove":true}} /-->
-
-					<!-- wp:gatherpress/venue {"lock":{"move":true,"remove":true}} -->
-					<!-- wp:post-title {"level":4,"isLink":false,"fontSize":"heading-5","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|10"}}}} /-->
-					<!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-address","style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-					<div class="wp-block-group gatherpress--has-venue-address" style="margin-top:0;margin-bottom:0"><!-- wp:icon {"icon":"core/map-marker","style":{"dimensions":{"width":"24px"}}} /-->
-					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue address…","fieldType":"address"} /--></div>
-					<!-- /wp:group -->
-					<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-					<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--30)"><!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-phone","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-					<div class="wp-block-group gatherpress--has-venue-phone"><!-- wp:icon {"icon":"core/mobile","style":{"dimensions":{"width":"24px"}}} /-->
-					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue phone…","fieldType":"phone"} /--></div>
-					<!-- /wp:group -->
-					<!-- wp:group {"className":"gatherpress\u002d\u002dhas-venue-website","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-					<div class="wp-block-group gatherpress--has-venue-website"><!-- wp:icon {"icon":"core/external","style":{"dimensions":{"width":"24px"}}} /-->
-					<!-- wp:gatherpress/venue-detail {"placeholder":"Venue website URL…","fieldType":"url"} /--></div>
-					<!-- /wp:group --></div>
-					<!-- /wp:group -->
-					<!-- wp:gatherpress/venue-map /-->
-					<!-- /wp:gatherpress/venue -->
-
-					<!-- wp:separator {"className":"is-style-wide","backgroundColor":"light-grey-1"} -->
-					<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide"/>
-					<!-- /wp:separator -->
-
-					<!-- wp:gatherpress/online-event -->
-					<div class="wp-block-gatherpress-online-event"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-					<div class="wp-block-group" style="margin-top:0;margin-bottom:0"><!-- wp:icon {"icon":"core/capture-video","style":{"dimensions":{"width":"24px"}}} /-->
-					<!-- wp:gatherpress/online-event-link {"linkText":"\u003cspan class=\u0022gatherpress-tooltip\u0022 data-gatherpress-tooltip=\u0022Link available for attendees only.\u0022\u003eOnline event\u003c/span\u003e"} /--></div>
-					<!-- /wp:group --></div>
-					<!-- /wp:gatherpress/online-event -->
-
-					<!-- wp:separator {"className":"is-style-wide","backgroundColor":"light-grey-1"} -->
-					<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide"/>
-					<!-- /wp:separator -->
-
-					<!-- wp:gatherpress/add-to-calendar /-->
-			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:wporg/sponsors {"lock":{"move":true,"remove":true},"limit":3,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>

--- a/public_html/wp-content/themes/groups-site/theme.json
+++ b/public_html/wp-content/themes/groups-site/theme.json
@@ -28,7 +28,7 @@
 			]
 		},
 		"typography": {
-			"fluid": true,
+			"fluid": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "'EB Garamond', serif",

--- a/public_html/wp-content/themes/groups-site/theme.json
+++ b/public_html/wp-content/themes/groups-site/theme.json
@@ -87,6 +87,35 @@
 				"typography": { "lineHeight": "1.3", "fontWeight": "600" },
 				"spacing": {
 					"padding": { "top": "14px", "right": "32px", "bottom": "14px", "left": "32px" }
+				},
+				"active": {
+					"color": {
+						"background": "var(--wp--preset--color--dark-blueberry)",
+						"text": "var(--wp--preset--color--white)"
+					},
+					"border": { "color": "var(--wp--preset--color--dark-blueberry)" }
+				},
+				"outline": {
+					"color": { "text": "var(--wp--preset--color--blueberry-1)" },
+					"border": { "color": "var(--wp--preset--color--blueberry-1)" },
+					"hover": {
+						"color": {
+							"background": "var(--wp--preset--color--blueberry-4)",
+							"text": "var(--wp--preset--color--deep-blueberry)"
+						},
+						"border": { "color": "var(--wp--preset--color--deep-blueberry)" }
+					},
+					"focus": {
+						"color": { "background": "var(--wp--preset--color--blueberry-4)" },
+						"border": { "color": "var(--wp--preset--color--blueberry-1)" }
+					},
+					"active": {
+						"color": {
+							"background": "var(--wp--preset--color--blueberry-3)",
+							"text": "var(--wp--preset--color--dark-blueberry)"
+						},
+						"border": { "color": "var(--wp--preset--color--dark-blueberry)" }
+					}
 				}
 			}
 		}

--- a/tests/e2e/anonymous.spec.js
+++ b/tests/e2e/anonymous.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require( '@playwright/test' );
 /**
  * A logged-out visitor should be able to browse the group site normally,
  * and should never see any event/member management UI (that's gated to
- * Organiser/Event Organiser roles — see the group settings + event-manage
+ * Organizer/Event Organizer roles — see the group settings + event-manage
  * block permission checks in the groups-gatherpress-compat-test skill).
  */
 test.describe( 'anonymous visitor', () => {

--- a/tests/e2e/anonymous.spec.js
+++ b/tests/e2e/anonymous.spec.js
@@ -14,7 +14,7 @@ test.describe( 'anonymous visitor', () => {
 		const sidebar = page.locator( '.groups-site-sidebar' );
 		await expect( sidebar.getByRole( 'button', { name: 'Join this group' } ) ).toBeVisible();
 		await expect( sidebar.locator( '.wporg-group-membership__count' ) ).toHaveText( /\d+ members?/ );
-		await expect( page.locator( '.groups-site-hero .wporg-group-membership' ) ).toHaveCount( 0 );
+		await expect( page.locator( '.groups-site-identity .wporg-group-membership' ) ).toHaveCount( 0 );
 	} );
 
 	test( 'no management UI is rendered on the front page', async ( { page } ) => {

--- a/tests/e2e/event-manage-messaging.spec.js
+++ b/tests/e2e/event-manage-messaging.spec.js
@@ -22,7 +22,7 @@ const { dismissEditorOnboarding } = require( './utils/dismiss-editor-onboarding'
  */
 test.describe( 'event manage — message attendees', () => {
 	/**
-	 * Creates a fresh event as the given organiser account via the
+	 * Creates a fresh event as the given organizer account via the
 	 * wp-admin block editor (same flow as event-organiser.spec.js) and
 	 * returns its front-end permalink, so this spec doesn't depend on any
 	 * hand-seeded event data.

--- a/tests/e2e/event-organiser.spec.js
+++ b/tests/e2e/event-organiser.spec.js
@@ -3,7 +3,7 @@ const { login } = require( './utils/login' );
 const { dismissEditorOnboarding } = require( './utils/dismiss-editor-onboarding' );
 
 /**
- * Event Organisers (author role) manage events through wp-admin's native
+ * Event Organizers (author role) manage events through wp-admin's native
  * GatherPress editor — the custom `wporg/event-manage` front-end block is
  * registered but not placed in any template (a known, tracked issue; see
  * the "Known-issues appendix" in the groups-gatherpress-compat-test skill),
@@ -12,7 +12,7 @@ const { dismissEditorOnboarding } = require( './utils/dismiss-editor-onboarding'
  * Requires the `eventorganiser1` / `password` test user from the skill's
  * environment-setup step.
  */
-test.describe( 'event organiser (author role)', () => {
+test.describe( 'event organizer (author role)', () => {
 	test( 'can create and publish an event via wp-admin, and it appears on the front page', async ( { page } ) => {
 		test.slow(); // The block editor can be slow to boot on a cold local dev stack.
 
@@ -50,7 +50,7 @@ test.describe( 'event organiser (author role)', () => {
 		// up with older same-day events, so a brand-new one isn't guaranteed a
 		// slot in it (the same issue event-manage-messaging.spec.js hit and
 		// worked around). The my-events block has no such cap: it's the
-		// #1810 behaviour itself — this organiser published the event and
+		// #1810 behaviour itself — this organizer published the event and
 		// never RSVP'd to it — and reliably shows it regardless of how many
 		// other events exist.
 		await expect(

--- a/tests/e2e/member-directory.spec.js
+++ b/tests/e2e/member-directory.spec.js
@@ -14,8 +14,8 @@ test.describe( 'member directory', () => {
 		const grid = page.locator( '.wporg-group-members__grid' );
 		await expect( grid ).toBeVisible();
 
-		await expect( grid.locator( '.wporg-group-members__role--editor' ).first() ).toHaveText( /Organiser/ );
-		await expect( grid.locator( '.wporg-group-members__role--author' ).first() ).toHaveText( /Event Organiser/ );
+		await expect( grid.locator( '.wporg-group-members__role--editor' ).first() ).toHaveText( /Organizer/ );
+		await expect( grid.locator( '.wporg-group-members__role--author' ).first() ).toHaveText( /Event Organizer/ );
 		await expect( grid.locator( '.wporg-group-members__role--subscriber' ).first() ).toHaveText( /Member/ );
 	} );
 

--- a/tests/e2e/recurring-events-frontend.spec.js
+++ b/tests/e2e/recurring-events-frontend.spec.js
@@ -2,13 +2,13 @@ const { test, expect } = require( '@playwright/test' );
 const { login } = require( './utils/login' );
 
 /**
- * Recurrence controls in the organiser-facing group settings block.
+ * Recurrence controls in the organizer-facing group settings block.
  *
  * Requires the `organiser1` / `password` test user from the local Groups
  * environment setup.
  */
 test.describe( 'recurring events frontend', () => {
-	test( 'an organiser can configure a weekly recurrence', async ( { page } ) => {
+	test( 'an organizer can configure a weekly recurrence', async ( { page } ) => {
 		await login( page, 'organiser1', 'password' );
 		await page.goto( '' );
 

--- a/tests/e2e/source-order.spec.js
+++ b/tests/e2e/source-order.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require( '@playwright/test' );
+
+test.describe( 'visual and source order', () => {
+	test( 'homepage columns follow the same order in the DOM and layout', async ( { page } ) => {
+		await page.setViewportSize( { width: 1280, height: 900 } );
+		await page.goto( '', { waitUntil: 'domcontentloaded' } );
+
+		const main = page.locator( '.groups-site-main-column-wrapper' );
+		const sidebar = page.locator( '.groups-site-sidebar-column' );
+
+		await expect( main ).toHaveCount( 1 );
+		await expect( sidebar ).toHaveCount( 1 );
+
+		const sourceOrder = await page.evaluate( () => {
+			const mainColumn = document.querySelector( '.groups-site-main-column-wrapper' );
+			const sidebarColumn = document.querySelector( '.groups-site-sidebar-column' );
+
+			return mainColumn.nextElementSibling === sidebarColumn;
+		} );
+		expect( sourceOrder ).toBe( true );
+
+		const desktopMainBox = await main.boundingBox();
+		const desktopSidebarBox = await sidebar.boundingBox();
+		expect( desktopMainBox.x ).toBeLessThan( desktopSidebarBox.x );
+
+		await page.setViewportSize( { width: 375, height: 900 } );
+		const mobileMainBox = await main.boundingBox();
+		const mobileSidebarBox = await sidebar.boundingBox();
+		expect( mobileMainBox.y ).toBeLessThan( mobileSidebarBox.y );
+	} );
+} );


### PR DESCRIPTION
- Applies the remaining #1858 design review: fixes source order on the homepage and event pages, and brings the drifted blocks (RSVP, My Events, members, news, sponsors, membership) onto the shared card/heading/button spec.
- Unifies the button model (filled/outline/disabled/loading), switches to preset vars and Blueberry accents, fixes focus indicators, honors reduced motion.
- Standardizes on American spelling ("Organizer").
- Testing — flows only, in the local environment on `events.wordpress.test` and the `sunshine-coast-qld` group:
  - Front page — `https://events.wordpress.test/group/sunshine-coast-qld/`: renders without errors; Upcoming events cards and the sidebar membership controls are present.
  - Single event — open any event from Upcoming events: the page renders with the details card and RSVP button; logged in as a group member, RSVP flips the button to attending and the count line updates, RSVP again to cancel.
  - Members — `https://events.wordpress.test/group/sunshine-coast-qld/members/`: renders the member grid.
  - Events archive — `https://events.wordpress.test/group/sunshine-coast-qld/events/`: renders the card grid.
- See #1858
- Stacked on #1860
