### PR TITLE
Groups: cover the nested schedule-unlock case

### DIFF
--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -172,6 +172,34 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 		$this->assertSame( 'weekly', get_post_meta( $post_id, Rule::META_PREFIX . 'frequency', true ) );
 	}
 
+	/**
+	 * A nested end-condition write does not cancel the surrounding lift.
+	 *
+	 * Both entry points share one allowlist slot, so an inner lift that
+	 * replaced and then cleared that slot would re-lock the schedule for the
+	 * rest of the outer callback, silently dropping the writes that follow it
+	 * -- the same silent loss the lift exists to prevent, one level down.
+	 */
+	public function test_schedule_unlock_survives_a_nested_end_condition_write(): void {
+		$post_id = $this->create_published_recurring_event();
+
+		Plugin::with_schedule_unlocked(
+			$post_id,
+			static function () use ( $post_id ): void {
+				Plugin::update_end_condition( $post_id, '2026-12-31' );
+
+				update_post_meta( $post_id, Rule::META_PREFIX . 'frequency', 'monthly' );
+			}
+		);
+
+		$this->assertSame( 'until', get_post_meta( $post_id, Rule::META_PREFIX . 'end_type', true ) );
+		$this->assertSame( '2026-12-31', get_post_meta( $post_id, Rule::META_PREFIX . 'until', true ) );
+		$this->assertSame( 'monthly', get_post_meta( $post_id, Rule::META_PREFIX . 'frequency', true ) );
+
+		$this->assertFalse( update_post_meta( $post_id, Rule::META_PREFIX . 'frequency', 'yearly' ) );
+		$this->assertSame( 'monthly', get_post_meta( $post_id, Rule::META_PREFIX . 'frequency', true ) );
+	}
+
 	/** Published recurrence metadata cannot be deleted to bypass the lock. */
 	public function test_published_recurrence_metadata_cannot_be_deleted(): void {
 		$post_id = $this->create_published_recurring_event();


### PR DESCRIPTION
Follow-up to #1865. One test, no production code.

@bor0 restored two regression tests from `56b9907e` during the rebase, which was the right pair for the mechanism as it stood in that commit. The third one came later, in `9938c1b`, alongside the Copilot review fix — so it was outside the range that got carried over.

The fix from that commit **is** in production: `Plugin::with_schedule_keys_allowed()` exists and `update_end_condition()` delegates to it rather than replacing and clearing the shared allowlist slot. Only the test that guards it is missing, which means a future simplification of `update_end_condition()` back to a direct `self::$schedule_updates_allowed[ $post_id ] = …` / `unset()` pair would reintroduce the silent-loss bug with a green suite.

### What it asserts

An end-condition write nested inside `with_schedule_unlocked()` leaves the surrounding lift intact, so schedule writes that follow it still land, and the lock is back afterwards.

### Verification, and its limit

I could not run this suite: it needs the multi-network fixture `.docker/bin/install-test-suite.sh` builds, and WP bails during bootstrap against a plain multisite install, so please treat CI as the verification rather than my word. `php -l` is clean and `phpcs-branch.php` against `production` reports nothing.

What I could check is that the test is not vacuous. Simulating the allowlist bookkeeping for both shapes of `update_end_condition()` against this exact call sequence:

```
end_condition_fixed    -> write after nested call allowed: YES  | lock released after: yes
end_condition_old      -> write after nested call allowed: NO   | lock released after: yes
```

So the third assertion (`frequency` ends up `monthly`) fails against the pre-fix shape and passes against what is in production now — which is what makes it a regression test rather than a restatement.

Props motylanogha
