### PR TITLE
Event List: Encode the ID used in the inline script

### DIFF
--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/index.php
@@ -92,8 +92,8 @@ function render( $attributes, $content, $block ) {
 		'wporg-event-list-view-script-2',
 		sprintf(
 			'var globalEventsPayload = globalEventsPayload || {};
-			globalEventsPayload["%s"] = %s;',
-			$attributes['id'],
+			globalEventsPayload[%s] = %s;',
+			wp_json_encode( (string) $attributes['id'] ),
 			wp_json_encode( $payload )
 		),
 		'before'


### PR DESCRIPTION
Pass the `event-list` block's `id` attribute through `wp_json_encode()` when building the inline `globalEventsPayload[…]` script, so the key is always emitted as a valid JS string literal — matching how the payload value is already encoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)