### PR TITLE
Fix PHP deprecation/warning notices from error monitoring

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/csstidy/class.csstidy-print.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/csstidy/class.csstidy-print.php
@@ -239,7 +239,7 @@ class csstidy_print { // phpcs:ignore
 					if ( $this->parser->get_cfg( 'lowercase_s' ) ) {
 						$token[1] = strtolower( $token[1] );
 					}
-					$out .= ( $token[1][0] !== '@' ) ? $template[2] . $this->htmlsp( $token[1], $plain ) : $template[0] . $this->htmlsp( $token[1], $plain );
+					$out .= ( ( $token[1][0] ?? '' ) !== '@' ) ? $template[2] . $this->htmlsp( $token[1], $plain ) : $template[0] . $this->htmlsp( $token[1], $plain );
 					$out .= $template[3];
 					break;
 

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/module-custom-css/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -36,6 +36,7 @@
  * The `lessc_formatter` takes a CSS tree, and dumps it to a formatted string,
  * handling things like indentation.
  */
+#[\AllowDynamicProperties]
 class lessc {
 	static public $VERSION = "v0.5.0";
 
@@ -2279,6 +2280,7 @@ class lessc {
 
 // responsible for taking a string of LESS code and converting it into a
 // syntax tree
+#[\AllowDynamicProperties]
 class lessc_parser {
 	static protected $nextBlockId = 0; // used to uniquely identify blocks
 
@@ -3515,7 +3517,7 @@ class lessc_parser {
 		if ($eatWhitespace === null) $eatWhitespace = $this->eatWhiteDefault;
 
 		$r = '/'.$regex.($eatWhitespace && !$this->writeComments ? '\s*' : '').'/Ais';
-		if (preg_match($r, $this->buffer, $out, null, $this->count)) {
+		if (preg_match($r, $this->buffer, $out, 0, $this->count)) {
 			$this->count += strlen($out[0]);
 			if ($eatWhitespace && $this->writeComments) $this->whitespace();
 			return true;
@@ -3527,7 +3529,7 @@ class lessc_parser {
 	protected function whitespace() {
 		if ($this->writeComments) {
 			$gotWhite = false;
-			while (preg_match(self::$whitePattern, $this->buffer, $m, null, $this->count)) {
+			while (preg_match(self::$whitePattern, $this->buffer, $m, 0, $this->count)) {
 				if (isset($m[1]) && empty($this->seenComments[$this->count])) {
 					$this->append(array("comment", $m[1]));
 					$this->seenComments[$this->count] = true;
@@ -3546,7 +3548,7 @@ class lessc_parser {
 	protected function peek($regex, &$out = null, $from=null) {
 		if (is_null($from)) $from = $this->count;
 		$r = '/'.$regex.'/Ais';
-		$result = preg_match($r, $this->buffer, $out, null, $from);
+		$result = preg_match($r, $this->buffer, $out, 0, $from);
 
 		return $result;
 	}

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -431,7 +431,12 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 			}
 		}
 
-		rename( $tmp_path, $invoices_dirname . '/' . $filename );
+		// `rename()` can fail with "Operation not permitted" when the source and destination
+		// are on different filesystems/mounts (e.g. a `/tmp` tmpfs vs. the uploads volume).
+		if ( ! @rename( $tmp_path, $invoices_dirname . '/' . $filename ) ) {
+			copy( $tmp_path, $invoices_dirname . '/' . $filename );
+			unlink( $tmp_path );
+		}
 
 		update_post_meta( $invoice_id, 'invoice_document', $filename );
 	}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -802,7 +802,7 @@ class WordCamp_Post_Types_Plugin {
 	protected function is_single_cpt_post( $post_type ) {
 		global $wp_query;
 
-		return isset( $wp_query->query[ $post_type ] ) && $post_type === $wp_query->query['post_type'];
+		return isset( $wp_query->query[ $post_type ], $wp_query->query['post_type'] ) && $post_type === $wp_query->query['post_type'];
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Addresses several recurring PHP 8.1+ warnings/deprecations reported by error monitoring.

- **camptix-invoices**: `rename()` was failing with "Operation not permitted" on checkout, because the PDF generator writes to `/tmp` (a different filesystem/mount than the uploads volume) and `rename()` cannot do a cross-device move. Falls back to `copy()` + `unlink()`.
- **wc-post-types**: `is_single_cpt_post()` triggered "Undefined array key 'post_type'" when `$wp_query->query` did not have that key set (e.g. `/speaker/0/`). Added it to the `isset()` check.
- **csstidy** (`class.csstidy-print.php`): "Uninitialized string offset 0" when a selector token was an empty string. Guarded with `?? ''`.
- **lessc** (`lessc.inc.php`):
  - `preg_match(..., null, ...)` deprecated-flags warning (the single most frequent line in the error log) fixed at all 3 call sites by passing `0` instead of `null`.
  - Added `#[\AllowDynamicProperties]` to `lessc` and `lessc_parser` to silence "Creation of dynamic property" deprecations.

Out of scope: the `wordpress/mcp-adapter` trait deprecation and `wporg-mu-plugins/pub-sync` `fputcsv()` deprecation are not part of this repo (separate vendor/private mu-plugins repos).

## Test plan
- [x] `php -l` on all 4 changed files
- [ ] Confirm checkout flow still generates/attaches invoice PDFs correctly (camptix-invoices)
- [ ] Confirm Customizer custom CSS preview/save still works for LESS-processed CSS (lessc/csstidy)
- [ ] Confirm speaker archive/single pages render correctly (wc-post-types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)