### PR TITLE
Fix E2E flakiness: dismissEditorOnboarding races React's event-handler attachment

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -244,38 +244,7 @@ jobs:
         create_page members Members
 
     - name: Run Playwright tests
-      # TEMPORARY (wordcamp.org#1883): samples memory/process state every 5s
-      # while the suite runs, to test the theory that intermittent
-      # "context or browser has been closed" / timeout flakes are caused by
-      # CI-runner resource pressure (e.g. Chromium OOM kills) rather than a
-      # bug in any one spec. Remove once #1883 is diagnosed either way.
-      run: |
-        set +e
-        ( while true; do
-            echo "=== $(date -u +%H:%M:%S) ==="
-            free -h
-            echo "--- docker stats ---"
-            docker stats --no-stream
-            echo "--- top memory consumers (host) ---"
-            ps aux --sort=-%mem | head -15
-            echo "--- top memory consumers (wordcamp.test) ---"
-            docker compose exec -T wordcamp.test sh -c "ps aux --sort=-%mem | head -10" 2>/dev/null
-            sleep 5
-          done ) > /tmp/resource-monitor.log 2>&1 &
-        monitor_pid=$!
-        npx playwright test
-        test_exit=$?
-        kill "$monitor_pid" 2>/dev/null
-        wait "$monitor_pid" 2>/dev/null
-        exit "$test_exit"
-
-    - name: Upload resource monitor log
-      if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: resource-monitor-log
-        path: /tmp/resource-monitor.log
-        retention-days: 14
+      run: npx playwright test
 
     - name: Upload Playwright report
       if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -244,7 +244,38 @@ jobs:
         create_page members Members
 
     - name: Run Playwright tests
-      run: npx playwright test
+      # TEMPORARY (wordcamp.org#1883): samples memory/process state every 5s
+      # while the suite runs, to test the theory that intermittent
+      # "context or browser has been closed" / timeout flakes are caused by
+      # CI-runner resource pressure (e.g. Chromium OOM kills) rather than a
+      # bug in any one spec. Remove once #1883 is diagnosed either way.
+      run: |
+        set +e
+        ( while true; do
+            echo "=== $(date -u +%H:%M:%S) ==="
+            free -h
+            echo "--- docker stats ---"
+            docker stats --no-stream
+            echo "--- top memory consumers (host) ---"
+            ps aux --sort=-%mem | head -15
+            echo "--- top memory consumers (wordcamp.test) ---"
+            docker compose exec -T wordcamp.test sh -c "ps aux --sort=-%mem | head -10" 2>/dev/null
+            sleep 5
+          done ) > /tmp/resource-monitor.log 2>&1 &
+        monitor_pid=$!
+        npx playwright test
+        test_exit=$?
+        kill "$monitor_pid" 2>/dev/null
+        wait "$monitor_pid" 2>/dev/null
+        exit "$test_exit"
+
+    - name: Upload resource monitor log
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: resource-monitor-log
+        path: /tmp/resource-monitor.log
+        retention-days: 14
 
     - name: Upload Playwright report
       if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -284,3 +284,18 @@ jobs:
         name: playwright-report
         path: playwright-report/
         retention-days: 14
+
+    - name: Upload Playwright traces
+      # `playwright-report/` above is consistently empty -- the `github`
+      # reporter (see playwright.config.js) doesn't produce an HTML report
+      # there. `trace: 'on-first-retry'` traces actually land in Playwright's
+      # default `test-results/` output dir instead, and were never
+      # uploaded -- meaning every flaky/failed run to date had no trace
+      # artifact to actually inspect (network, console, DOM snapshots at
+      # the moment of failure), for #1883.
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-traces
+        path: test-results/
+        retention-days: 14

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -24,7 +24,12 @@ module.exports = defineConfig( {
 		// The local dev cert is self-signed (matches the `-k` flag used
 		// throughout the project's curl-based test plans).
 		ignoreHTTPSErrors: true,
-		trace: 'on-first-retry',
+		// 'on-first-retry' only captures starting from the first retry --
+		// for a flaky test that recovers, that's the attempt that PASSED,
+		// leaving nothing to actually debug the failure with (see #1883).
+		// 'retain-on-failure' traces every attempt and keeps the ones that
+		// failed, whichever attempt number that is.
+		trace: 'retain-on-failure',
 	},
 	projects: [
 		{

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,13 +13,6 @@ module.exports = defineConfig( {
 	fullyParallel: true,
 	forbidOnly: !! process.env.CI,
 	retries: process.env.CI ? 2 : 0,
-	// TEMPORARY EXPERIMENT (#1883): serializing to test the CPU-contention
-	// theory -- diagnostics showed combined CPU across concurrent Chromium
-	// instances spiking to 200-370% on the runner's 4 vCPUs, cyclically,
-	// consistent with two workers' page loads (each executing the full
-	// Gutenberg editor bundle) overlapping and starving whatever UI wait
-	// was in flight. Revert once confirmed/refuted either way.
-	workers: process.env.CI ? 1 : undefined,
 	reporter: process.env.CI ? 'github' : 'list',
 	use: {
 		// Trailing slash matters: Playwright/URL resolution treats a

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,6 +13,13 @@ module.exports = defineConfig( {
 	fullyParallel: true,
 	forbidOnly: !! process.env.CI,
 	retries: process.env.CI ? 2 : 0,
+	// TEMPORARY EXPERIMENT (#1883): serializing to test the CPU-contention
+	// theory -- diagnostics showed combined CPU across concurrent Chromium
+	// instances spiking to 200-370% on the runner's 4 vCPUs, cyclically,
+	// consistent with two workers' page loads (each executing the full
+	// Gutenberg editor bundle) overlapping and starving whatever UI wait
+	// was in flight. Revert once confirmed/refuted either way.
+	workers: process.env.CI ? 1 : undefined,
 	reporter: process.env.CI ? 'github' : 'list',
 	use: {
 		// Trailing slash matters: Playwright/URL resolution treats a

--- a/tests/e2e/utils/dismiss-editor-onboarding.js
+++ b/tests/e2e/utils/dismiss-editor-onboarding.js
@@ -20,12 +20,23 @@
  * and every subsequent interaction (filling in the date, clicking Publish)
  * hung until the test timeout.
  *
+ * The wait windows below are generous (not the usual few seconds) for the
+ * same reason: on a loaded CI runner (see #1883), the guide can render
+ * later than a short window accounts for. A too-short wait here doesn't
+ * fail fast -- it silently returns as if the dialog isn't coming, and the
+ * dialog then appears anyway a moment later and blocks every interaction
+ * for the rest of the test until *its* timeout expires. A trace captured
+ * via #1883's investigation confirmed exactly this: `dismissEditorOnboarding`
+ * had already returned by the time "Welcome to the editor" rendered and
+ * intercepted the title field, hanging the test for its full 90s budget on
+ * a `.fill()` that could never succeed.
+ *
  * @param {import('@playwright/test').Page} page
  */
 async function dismissEditorOnboarding( page ) {
 	const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
 	try {
-		await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 3000 } );
+		await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 15000 } );
 		await page.keyboard.press( 'Escape' );
 	} catch {
 		// Guide didn't appear (already dismissed for this user) — nothing to do.
@@ -33,7 +44,7 @@ async function dismissEditorOnboarding( page ) {
 
 	const patternDialogHeading = page.getByRole( 'heading', { name: 'Choose a pattern' } );
 	try {
-		await patternDialogHeading.waitFor( { state: 'visible', timeout: 3000 } );
+		await patternDialogHeading.waitFor( { state: 'visible', timeout: 15000 } );
 		await page.getByRole( 'option' ).first().click();
 	} catch {
 		// Dialog didn't appear (already dismissed for this user/session, or a

--- a/tests/e2e/utils/dismiss-editor-onboarding.js
+++ b/tests/e2e/utils/dismiss-editor-onboarding.js
@@ -6,7 +6,7 @@
  * client-side/per-user preferences rather than anything this test controls,
  * so a given run may see either, both, or neither:
  *
- *   - The "Welcome to the editor" guide — dismissed with Escape.
+ *   - The "Welcome to the editor" guide — dismissed via its own Close button.
  *   - The "Choose a pattern" starter-pattern picker, which `gatherpress_event`
  *     registers starter patterns for. Unlike the welcome guide, this one's
  *     own Close button and Escape do **not** dismiss it (confirmed manually
@@ -20,24 +20,24 @@
  * and every subsequent interaction (filling in the date, clicking Publish)
  * hung until the test timeout.
  *
- * The wait windows below are generous (not the usual few seconds) for the
- * same reason: on a loaded CI runner (see #1883), the guide can render
- * later than a short window accounts for. A too-short wait here doesn't
- * fail fast -- it silently returns as if the dialog isn't coming, and the
- * dialog then appears anyway a moment later and blocks every interaction
- * for the rest of the test until *its* timeout expires. A trace captured
- * via #1883's investigation confirmed exactly this: `dismissEditorOnboarding`
- * had already returned by the time "Welcome to the editor" rendered and
- * intercepted the title field, hanging the test for its full 90s budget on
- * a `.fill()` that could never succeed.
+ * The welcome guide used to be dismissed with a global `page.keyboard.press(
+ * 'Escape' )` after waiting for its heading to become visible. Traces from
+ * #1883 showed the dialog still open and blocking the page well after that
+ * wait resolved -- Escape is a blind keypress that depends on focus already
+ * being in the right place and the dialog's own event handlers already
+ * being wired up, and evidently that's not reliable here (a heading can be
+ * visible in the DOM slightly before React finishes attaching its
+ * handlers). Clicking the dialog's own Close button instead is a real
+ * actionability-checked interaction -- Playwright waits for it to exist,
+ * be visible, be stable, and actually receive the click, which rides out
+ * exactly this kind of hydration race instead of hoping a keypress lands.
  *
  * @param {import('@playwright/test').Page} page
  */
 async function dismissEditorOnboarding( page ) {
-	const welcomeGuideHeading = page.getByRole( 'heading', { name: 'Welcome to the editor' } );
+	const welcomeGuideDialog = page.getByRole( 'dialog', { name: 'Welcome to the editor' } );
 	try {
-		await welcomeGuideHeading.waitFor( { state: 'visible', timeout: 15000 } );
-		await page.keyboard.press( 'Escape' );
+		await welcomeGuideDialog.getByRole( 'button', { name: 'Close' } ).click( { timeout: 15000 } );
 	} catch {
 		// Guide didn't appear (already dismissed for this user) — nothing to do.
 	}

--- a/tests/e2e/utils/dismiss-editor-onboarding.js
+++ b/tests/e2e/utils/dismiss-editor-onboarding.js
@@ -35,20 +35,37 @@
  * @param {import('@playwright/test').Page} page
  */
 async function dismissEditorOnboarding( page ) {
-	const welcomeGuideDialog = page.getByRole( 'dialog', { name: 'Welcome to the editor' } );
+	const welcomeGuideCloseButton = page
+		.getByRole( 'dialog', { name: 'Welcome to the editor' } )
+		.getByRole( 'button', { name: 'Close' } );
+	let welcomeGuideAppeared = true;
 	try {
-		await welcomeGuideDialog.getByRole( 'button', { name: 'Close' } ).click( { timeout: 15000 } );
+		// Only "never appeared" is expected/swallowed here. Once we know it's
+		// there, the click itself runs outside the try -- if that fails for
+		// some other reason, the test should fail loudly at the real cause
+		// instead of this silently misclassifying it as "didn't appear" and
+		// leaving the same dialog open to block everything after it.
+		await welcomeGuideCloseButton.waitFor( { state: 'visible', timeout: 15000 } );
 	} catch {
 		// Guide didn't appear (already dismissed for this user) — nothing to do.
+		welcomeGuideAppeared = false;
+	}
+	if ( welcomeGuideAppeared ) {
+		await welcomeGuideCloseButton.click();
 	}
 
+	// Independent of the welcome guide above -- a given run may see either,
+	// both, or neither, so this always runs regardless of the outcome above.
 	const patternDialogHeading = page.getByRole( 'heading', { name: 'Choose a pattern' } );
 	try {
-		await patternDialogHeading.waitFor( { state: 'visible', timeout: 15000 } );
+		await patternDialogHeading.waitFor( { state: 'visible', timeout: 3000 } );
 		await page.getByRole( 'option' ).first().click();
 	} catch {
 		// Dialog didn't appear (already dismissed for this user/session, or a
-		// post type with no starter patterns) — nothing to do.
+		// post type with no starter patterns) — nothing to do. Not implicated
+		// in #1883's investigation, so this keeps its original short timeout
+		// rather than paying the welcome guide's longer one on every run
+		// where it's absent (the common case).
 	}
 }
 

--- a/tests/e2e/utils/dismiss-editor-onboarding.js
+++ b/tests/e2e/utils/dismiss-editor-onboarding.js
@@ -51,7 +51,13 @@ async function dismissEditorOnboarding( page ) {
 		welcomeGuideAppeared = false;
 	}
 	if ( welcomeGuideAppeared ) {
-		await welcomeGuideCloseButton.click();
+		// Bounded, rather than inheriting the test's full (90s under
+		// test.slow()) default action timeout -- by this point we already
+		// know the dialog exists, so a normal click shouldn't need long. If
+		// something's actually wrong (e.g. the dialog stuck detaching and
+		// reattaching in a render loop), this fails fast and loud instead of
+		// burning the whole test budget on one action.
+		await welcomeGuideCloseButton.click( { timeout: 10000 } );
 	}
 
 	// Independent of the welcome guide above -- a given run may see either,

--- a/tests/e2e/utils/dismiss-editor-onboarding.js
+++ b/tests/e2e/utils/dismiss-editor-onboarding.js
@@ -32,25 +32,35 @@
  * be visible, be stable, and actually receive the click, which rides out
  * exactly this kind of hydration race instead of hoping a keypress lands.
  *
+ * That alone still wasn't enough: a trace showed the *fill* right after
+ * this function returns failing with the dialog open again, despite this
+ * function already having dismissed it. The editor's app state appears to
+ * reinitialize a second time shortly after the first load (a duplicate
+ * wave of editor asset requests shows up ~1-2s after the first), bringing
+ * a fresh, not-yet-dismissed instance of the same dialog back with it. One
+ * dismissal isn't durable, so this loops -- checking again after each
+ * dismissal -- until the dialog genuinely stops reappearing.
+ *
  * @param {import('@playwright/test').Page} page
  */
 async function dismissEditorOnboarding( page ) {
 	const welcomeGuideCloseButton = page
 		.getByRole( 'dialog', { name: 'Welcome to the editor' } )
 		.getByRole( 'button', { name: 'Close' } );
-	let welcomeGuideAppeared = true;
-	try {
-		// Only "never appeared" is expected/swallowed here. Once we know it's
-		// there, the click itself runs outside the try -- if that fails for
-		// some other reason, the test should fail loudly at the real cause
-		// instead of this silently misclassifying it as "didn't appear" and
-		// leaving the same dialog open to block everything after it.
-		await welcomeGuideCloseButton.waitFor( { state: 'visible', timeout: 15000 } );
-	} catch {
-		// Guide didn't appear (already dismissed for this user) — nothing to do.
-		welcomeGuideAppeared = false;
-	}
-	if ( welcomeGuideAppeared ) {
+
+	// First check is generous (cold JS boot); rechecks after a dismissal are
+	// shorter, since by then we're only confirming a reappearance didn't
+	// happen, not waiting through an initial render.
+	for ( let attempt = 0; attempt < 3; attempt++ ) {
+		try {
+			await welcomeGuideCloseButton.waitFor( {
+				state: 'visible',
+				timeout: attempt === 0 ? 15000 : 5000,
+			} );
+		} catch {
+			// Didn't (re)appear — nothing left to dismiss.
+			break;
+		}
 		// Bounded, rather than inheriting the test's full (90s under
 		// test.slow()) default action timeout -- by this point we already
 		// know the dialog exists, so a normal click shouldn't need long. If


### PR DESCRIPTION
## Summary
Fixes #1883 — the intermittent E2E flakiness across `event-publish-notification.spec.js`, `event-organiser.spec.js`, and `event-manage-messaging.spec.js` (discovered while validating #1882's speedup work). This went through several rounds as CI validation kept surfacing new layers — full trail is in #1883's comments; this description reflects the final state.

**Root causes found (two, layered):**

1. `dismiss-editor-onboarding.js` dismissed the "Welcome to the editor" guide dialog with a blind `page.keyboard.press('Escape')` after waiting for its heading to become visible. A heading can be visible in the DOM slightly before React finishes attaching the dialog's own event handlers, so the Escape press could fire just before the dialog was able to respond. **Fix**: click the dialog's own Close button instead — a real actionability-checked interaction, not a blind keypress.
2. Even after (1), a trace showed the *next* action (filling the event title) failing with the same dialog open again, despite already being dismissed. The editor's app state appears to reinitialize a second time shortly after first load (a duplicate wave of editor asset requests shows up ~1-2s after the first), bringing a fresh, not-yet-dismissed instance of the dialog back with it. **Fix**: loop the dismissal — check whether it reappeared after each dismissal (up to 3 attempts) instead of assuming one dismissal is durable.

**Ruled out along the way** (see #1883 for full detail): CPU/memory contention between concurrent Playwright workers (memory never dropped under pressure; CPU spiked identically even at `workers: 1`), and simply widening the wait window alone (3s → 15s wasn't sufficient by itself — the dialog was still open even with the longer wait, which is what led to finding root cause #1).

**Remaining, accepted flakiness**: the dialog's Close button occasionally still hits a bounded 10s "element detached from the DOM, retrying" pattern during the *first* dismissal attempt — the underlying cause of that (why the dialog's DOM node churns at all) is unexplained, but it's now bounded (fails in 10s, not 90s) and reliably recovered by `retries: 2`. Two consecutive CI runs show this at ~30-40% of relevant tests per run, always recovering on retry with the overall run passing. Not blocking here; documented in #1883 for anyone who wants to dig further into *why* the dialog's DOM churns.

**Also fixed**: the E2E workflow's "Upload Playwright report" step had been uploading an always-empty `playwright-report/` directory on every run (the `github` reporter doesn't write there), while trace data actually lands in `test-results/` and was never captured — meaning no prior flaky run had any trace to diagnose from. Added a proper `playwright-traces` artifact upload (this is what made root-causing this possible), and switched `trace` from `on-first-retry` to `retain-on-failure` so the trace captured is of the attempt that actually *failed*, not a successful retry.

## Test plan
- [x] Verified locally throughout: all 5 affected tests pass against the running dev stack.
- [x] Multiple CI validation runs on the fix branch, including two consecutive runs after the final (loop-based) fix: both passed overall, zero recurrence of the dialog-reappears-during-fill bug specifically, only the separate/accepted bounded-detach pattern (recovered via retry).
