### PR TITLE
Fix camptix-invoices/wcpt-meetup warnings; bump mcp-adapter to 0.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"require": {
 		"adhocore/jwt": "^1.0",
 		"scssphp/scssphp": "^2.1.0",
-		"wordpress/mcp-adapter": "^0.5.0"
+		"wordpress/mcp-adapter": "^0.6.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 		"process-timeout": 0,
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"composer/installers": true
+			"composer/installers": true,
+			"automattic/jetpack-autoloader": true
 		}
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require": {
 		"adhocore/jwt": "^1.0",
 		"scssphp/scssphp": "^2.1.0",
-		"wordpress/mcp-adapter": "^0.6.0"
+		"wordpress/mcp-adapter": "^0.6.1"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -431,12 +431,13 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 			}
 		}
 
-		// `rename()` can fail with "Operation not permitted" when the source and destination
-		// are on different filesystems/mounts (e.g. a `/tmp` tmpfs vs. the uploads volume).
-		if ( ! @rename( $tmp_path, $invoices_dirname . '/' . $filename ) ) {
-			copy( $tmp_path, $invoices_dirname . '/' . $filename );
-			unlink( $tmp_path );
-		}
+		// `rename()` always fails with "Operation not permitted" here because the PDF is
+		// generated into a `/tmp` mount that is a different filesystem from the uploads
+		// volume, so cross-device renames are never possible in this environment. Copy
+		// across and remove the source instead of attempting (and logging a warning for)
+		// a rename that cannot succeed.
+		copy( $tmp_path, $invoices_dirname . '/' . $filename );
+		unlink( $tmp_path );
 
 		update_post_meta( $invoice_id, 'invoice_document', $filename );
 	}

--- a/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
+++ b/public_html/wp-content/plugins/camptix-invoices/includes/class-camptix-addon-invoices.php
@@ -436,10 +436,10 @@ class CampTix_Addon_Invoices extends \CampTix_Addon {
 		// volume, so cross-device renames are never possible in this environment. Copy
 		// across and remove the source instead of attempting (and logging a warning for)
 		// a rename that cannot succeed.
-		copy( $tmp_path, $invoices_dirname . '/' . $filename );
-		unlink( $tmp_path );
-
-		update_post_meta( $invoice_id, 'invoice_document', $filename );
+		if ( copy( $tmp_path, $invoices_dirname . '/' . $filename ) ) {
+			unlink( $tmp_path );
+			update_post_meta( $invoice_id, 'invoice_document', $filename );
+		}
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -374,7 +374,7 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				return $group_details;
 			}
 
-			if ( isset( $group_details['errors'] ) ) {
+			if ( ! is_array( $group_details ) || isset( $group_details['errors'] ) ) {
 				return new WP_Error( 'invalid-response', __( 'Received invalid response from Meetup API.', 'wordcamporg' ) );
 			}
 
@@ -389,22 +389,23 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 				return $group_leads;
 			}
 
-			if ( isset( $group_leads['errors'] ) ) {
+			if ( ! is_array( $group_leads ) || isset( $group_leads['errors'] ) ) {
 				return new WP_Error( 'invalid-response-leads', __( 'Received invalid response from Meetup API.', 'wordcamporg' ) );
 			}
 
 			$event_hosts = array();
-			if ( isset( $group_leads ) && is_array( $group_leads ) ) {
-				foreach ( $group_leads as $event_host ) {
-					// Skip WordPress admin user.
-					if ( WCPT_WORDPRESS_MEETUP_ID === (int) $event_host['id'] ) {
-						continue;
-					}
-					$event_hosts[] = array(
-						'name' => $event_host['name'],
-						'id'   => $event_host['id'],
-					);
+			foreach ( $group_leads as $event_host ) {
+				if ( ! is_array( $event_host ) ) {
+					continue;
 				}
+				// Skip WordPress admin user.
+				if ( WCPT_WORDPRESS_MEETUP_ID === (int) $event_host['id'] ) {
+					continue;
+				}
+				$event_hosts[] = array(
+					'name' => $event_host['name'],
+					'id'   => $event_host['id'],
+				);
 			}
 
 			update_post_meta( $post_id, 'Meetup Co-organizer names', $event_hosts );


### PR DESCRIPTION
## Summary
- **camptix-invoices**: follow-up to #1887. That PR still called `@rename()` before falling back to `copy()`+`unlink()`, but the sites error-monitoring bot logs warnings even when suppressed with `@` (it does not check `error_reporting() === 0`). `rename()` always fails here (the PDF is generated into a `/tmp` mount that is a different filesystem from the uploads volume), so this drops the doomed `rename()` attempt entirely and always copies + removes the source.
- **wcpt-meetup**: `Meetup_Admin::update_meetup_data()` was throwing "Trying to access array offset on null/false" on every `wcpt_meetup_api_sync` cron run. `get_group_details()` can return `false` (not just `WP_Error`/array) and `get_group_members()` can return entries that are `null`/non-array on a malformed Meetup API response. Added `is_array()` guards before indexing into either response.
- **mcp-adapter**: bump `wordpress/mcp-adapter` from `^0.5.0` to `^0.6.0`. v0.5.0's `RequestRouter.php` calls `McpObservabilityHelperTrait::is_sensitive_key()` statically, which PHP 8.3 deprecates ("should only be called on a class using the trait"), firing on every request to this repo's `wcpt-vetting` MCP server. Fixed upstream in v0.6.0 (github.com/WordPress/mcp-adapter, commit 7cc42a0), which routes the call through `ErrorLogMcpObservabilityHandler` instead. Composer's caret rule on a 0.x version only allows patch bumps, so `^0.5.0` never picks up `0.6.0` on its own -- the constraint has to move explicitly. Checked v0.6.0's breaking changes against this repo: the WP 6.9+ requirement is already met, the removed `McpValidator` MIME helpers are not used here, and the only `WP\MCP` classes referenced (`McpAdapter`, `HttpTransport`, `ErrorLogMcpErrorHandler`, `NullMcpObservabilityHandler`) are unaffected.

## Test plan
- [x] `php -l` on all changed PHP files
- [x] `composer.json` validated as well-formed JSON
- [ ] Confirm invoice PDFs still attach correctly on ticket checkout
- [ ] Confirm `wcpt_meetup_api_sync` cron no longer logs array-offset warnings, and still updates meetup postmeta on a valid API response
- [ ] Confirm the `wcpt-vetting` MCP server still responds correctly after the mcp-adapter bump, and the trait-deprecation notice is gone

Generated with Claude Code