### PR TITLE
Groups: Show event description toolbar without requiring focus

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -44,7 +44,7 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { parse, serialize } from '@wordpress/blocks';
+import { createBlock, parse, serialize } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import VenueEditor from './venue-editor';
@@ -113,7 +113,14 @@ const MINIMUM_EVENT_DATE = window.wporgGroupsEventModal?.minimumEventDate || '';
 	}
 
 	function DescriptionEditor( { initialValue, getValueRef, onDirty } ) {
-		const [ blocks, setBlocks ] = useState( () => parse( initialValue || '' ) );
+		// A description with no supported blocks (empty string, or markup
+		// that doesn't parse into anything) yields `[]`, leaving no block to
+		// select and the toolbar permanently empty — fall back to an empty
+		// paragraph so there's always a first block.
+		const [ blocks, setBlocks ] = useState( () => {
+			const parsed = parse( initialValue || '' );
+			return parsed.length ? parsed : [ createBlock( 'core/paragraph' ) ];
+		} );
 
 		if ( getValueRef ) {
 			getValueRef.current = () => serialize( blocks );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/event-modal-app.js
@@ -40,7 +40,9 @@ import {
 	WritingFlow,
 	ObserveTyping,
 	BlockTools,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse, serialize } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
@@ -88,6 +90,28 @@ const MINIMUM_EVENT_DATE = window.wporgGroupsEventModal?.minimumEventDate || '';
 	 * breaking the slash inserter (parent re-renders were tearing down the
 	 * editor's internal state on every input event).
 	 */
+	// `BlockEditorProvider` gives its subtree an isolated `core/block-editor`
+	// registry, so this dispatch only reaches it from a component rendered
+	// *inside* the provider — a sibling effect would select a block in the
+	// wrong (default) store and `BlockToolbar` would never see it.
+	function SelectFirstBlockOnMount( { clientId } ) {
+		const { selectBlock } = useDispatch( blockEditorStore );
+
+		useEffect( () => {
+			if ( clientId ) {
+				// `null` (instead of the default `0`) selects the block
+				// without also moving real DOM focus into it — see
+				// `useFocusFirstElement` in `@wordpress/block-editor`. We
+				// only need the toolbar to appear, not to steal focus from
+				// the modal on open.
+				selectBlock( clientId, null );
+			}
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] );
+
+		return null;
+	}
+
 	function DescriptionEditor( { initialValue, getValueRef, onDirty } ) {
 		const [ blocks, setBlocks ] = useState( () => parse( initialValue || '' ) );
 
@@ -115,6 +139,7 @@ const MINIMUM_EVENT_DATE = window.wporgGroupsEventModal?.minimumEventDate || '';
 						hasFixedToolbar: true,
 					},
 				},
+				h( SelectFirstBlockOnMount, { clientId: blocks[ 0 ]?.clientId } ),
 				h(
 					'div',
 					{ className: 'wporg-groups-event-modal__editor-toolbar' },

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
@@ -33,7 +33,7 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { parse, serialize } from '@wordpress/blocks';
+import { createBlock, parse, serialize } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import VenueEditor from '../../event-manage/venue-editor';
@@ -108,7 +108,14 @@ function SelectFirstBlockOnMount( { clientId } ) {
 }
 
 function DescriptionEditor( { initialValue, getValueRef, onDirty } ) {
-	const [ blocks, setBlocks ] = useState( () => parse( initialValue || '' ) );
+	// A description with no supported blocks (empty string, or markup that
+	// doesn't parse into anything) yields `[]`, leaving no block to select
+	// and the toolbar permanently empty — fall back to an empty paragraph
+	// so there's always a first block.
+	const [ blocks, setBlocks ] = useState( () => {
+		const parsed = parse( initialValue || '' );
+		return parsed.length ? parsed : [ createBlock( 'core/paragraph' ) ];
+	} );
 	if ( getValueRef ) getValueRef.current = () => serialize( blocks );
 
 	const handleChange = ( newBlocks ) => {

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/events-tab.js
@@ -29,7 +29,9 @@ import {
 	WritingFlow,
 	ObserveTyping,
 	BlockTools,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse, serialize } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
@@ -83,9 +85,32 @@ function getMinutesBetween( start, end ) {
 
 // === Sub-components ===
 
+// `BlockEditorProvider` gives its subtree an isolated `core/block-editor`
+// registry, so this dispatch only reaches it from a component rendered
+// *inside* the provider — a sibling effect would select a block in the
+// wrong (default) store and `BlockToolbar` would never see it.
+function SelectFirstBlockOnMount( { clientId } ) {
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( clientId ) {
+			// `null` (instead of the default `0`) selects the block
+			// without also moving real DOM focus into it — see
+			// `useFocusFirstElement` in `@wordpress/block-editor`. We only
+			// need the toolbar to appear, not to steal focus from the
+			// modal on open.
+			selectBlock( clientId, null );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return null;
+}
+
 function DescriptionEditor( { initialValue, getValueRef, onDirty } ) {
 	const [ blocks, setBlocks ] = useState( () => parse( initialValue || '' ) );
 	if ( getValueRef ) getValueRef.current = () => serialize( blocks );
+
 	const handleChange = ( newBlocks ) => {
 		setBlocks( newBlocks );
 		if ( onDirty ) onDirty();
@@ -95,6 +120,7 @@ function DescriptionEditor( { initialValue, getValueRef, onDirty } ) {
 			value: blocks, onInput: handleChange, onChange: handleChange,
 			settings: { hasFixedToolbar: true },
 		},
+			h( SelectFirstBlockOnMount, { clientId: blocks[ 0 ]?.clientId } ),
 			h( 'div', { className: 'wporg-event-form__editor-toolbar' },
 				h( BlockToolbar, { hideDragHandle: true } ) ),
 			h( BlockTools, {},


### PR DESCRIPTION
## Summary

Fixes #1891. The event create/edit modal's description field embeds a bare `@wordpress/block-editor` instance, and `BlockToolbar` renders nothing until a block is selected — so the toolbar stayed empty until the user clicked into the text. There are two independent copies of this editor (`event-manage/event-modal-app.js` and `group-settings/components/events-tab.js`, used depending on whether the current user can manage group settings), both had the same bug.

- Select the first block on mount so the toolbar shows immediately when the modal opens.
- `BlockEditorProvider` gives its subtree an isolated `core/block-editor` registry, so the `selectBlock` dispatch has to happen from a component actually rendered inside the provider (added `SelectFirstBlockOnMount`) rather than a sibling effect, or it silently selects in the wrong store.
- Pass `initialPosition: null` to `selectBlock` (instead of the default `0`) so the selection doesn't also move real DOM focus into the field — otherwise the description looks/behaves as pre-focused as soon as the modal opens, before the user has done anything.

## Test plan

- [x] Opened the edit-event modal (both the `event-manage` standalone modal and the `group-settings` Events tab) for an event with an existing description — toolbar (block type icon + options) appears immediately, no click required.
- [x] Confirmed `document.activeElement` stays on the modal itself on open, not the description field — no outline/focus is stolen.
- [x] Typing, saving, and closing the modal still work with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
