### PR TITLE
Groups: use three-letter weekday labels in recurrence picker

### DIFF
--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/editor.js
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/editor.js
@@ -20,19 +20,20 @@
 	const weekdayButtonsStyle = {
 		display: 'flex',
 		alignItems: 'center',
-		justifyContent: 'space-between',
+		justifyContent: 'flex-start',
+		flexWrap: 'wrap',
 		gap: '4px',
+		rowGap: '6px',
 	};
 	const weekdayButtonStyle = {
 		display: 'inline-flex',
 		alignItems: 'center',
 		justifyContent: 'center',
-		width: '30px',
-		minWidth: '30px',
+		minWidth: '32px',
 		height: '30px',
-		padding: 0,
+		padding: '0 6px',
 		border: 0,
-		borderRadius: '50%',
+		borderRadius: '15px',
 		background: '#f0f0f0',
 		color: 'var(--wp-admin-theme-color, #3858e9)',
 		fontSize: '13px',
@@ -75,14 +76,14 @@
 		const frequency = get( 'frequency', '' );
 		const weekdays = get( 'weekdays', [] );
 		const dayLabels = { MO: __( 'Mon', 'gpre' ), TU: __( 'Tue', 'gpre' ), WE: __( 'Wed', 'gpre' ), TH: __( 'Thu', 'gpre' ), FR: __( 'Fri', 'gpre' ), SA: __( 'Sat', 'gpre' ), SU: __( 'Sun', 'gpre' ) };
-		const dayButtonLabels = {
-			MO: { short: __( 'M', 'gpre' ), full: __( 'Monday', 'gpre' ) },
-			TU: { short: __( 'T', 'gpre' ), full: __( 'Tuesday', 'gpre' ) },
-			WE: { short: __( 'W', 'gpre' ), full: __( 'Wednesday', 'gpre' ) },
-			TH: { short: __( 'T', 'gpre' ), full: __( 'Thursday', 'gpre' ) },
-			FR: { short: __( 'F', 'gpre' ), full: __( 'Friday', 'gpre' ) },
-			SA: { short: __( 'S', 'gpre' ), full: __( 'Saturday', 'gpre' ) },
-			SU: { short: __( 'S', 'gpre' ), full: __( 'Sunday', 'gpre' ) },
+		const dayFullLabels = {
+			MO: __( 'Monday', 'gpre' ),
+			TU: __( 'Tuesday', 'gpre' ),
+			WE: __( 'Wednesday', 'gpre' ),
+			TH: __( 'Thursday', 'gpre' ),
+			FR: __( 'Friday', 'gpre' ),
+			SA: __( 'Saturday', 'gpre' ),
+			SU: __( 'Sunday', 'gpre' ),
 		};
 		const weekdayCodes = [ 'SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA' ];
 		const startDate = dateTimeStart ? new Date( dateTimeStart.replace( ' ', 'T' ) ) : null;
@@ -124,19 +125,24 @@
 			frequency && el( TextControl, { label: __( 'Repeat every', 'gpre' ), type: 'number', min: 1, value: get( 'interval', 1 ), disabled: locked, onChange: ( value ) => set( 'interval', Math.max( 1, Number( value ) ) ) } ),
 			frequency === 'weekly' && el( 'div', { style: weekdaysStyle, role: 'group', 'aria-label': __( 'Repeat on', 'gpre' ) },
 				el( 'span', { style: sectionLabelStyle }, __( 'Repeat on', 'gpre' ) ),
+				// Buttons render the three-letter dayLabels rather than a single-letter
+				// form. Single letters collide under gettext dedup (e.g. "T" for both
+				// Tue and Thu, "S" for Sat and Sun), which blocks translation in
+				// languages where those days start with different letters — Italian
+				// Martedì/Giovedì, Spanish Sábado/Domingo, etc. See #1893.
 				el( 'div', { style: weekdayButtonsStyle },
-					Object.keys( dayButtonLabels ).map( ( day ) => {
+					Object.keys( dayFullLabels ).map( ( day ) => {
 						const selected = weekdays.includes( day );
 						const buttonStyle = selected ? { ...weekdayButtonStyle, background: 'var(--wp-admin-theme-color, #3858e9)', color: '#fff' } : weekdayButtonStyle;
 
-						return el( Tooltip, { key: day, text: dayButtonLabels[ day ].full },
+						return el( Tooltip, { key: day, text: dayFullLabels[ day ] },
 							el( Button, {
 								style: buttonStyle,
 								disabled: locked,
-								'aria-label': dayButtonLabels[ day ].full,
+								'aria-label': dayFullLabels[ day ],
 								'aria-pressed': selected,
 								onClick: () => set( 'weekdays', selected ? weekdays.filter( ( value ) => value !== day ) : [ ...weekdays, day ] ),
-							}, dayButtonLabels[ day ].short )
+							}, dayLabels[ day ] )
 						);
 					} )
 				)


### PR DESCRIPTION
Fixes #1893.

### Problem
The single-letter buttons in the repeating-event weekday picker used `__()` with source strings `'M'`, `'T'`, `'W'`, `'T'`, `'F'`, `'S'`, `'S'`. gettext dedupes by source, so `T` collapsed into one GlotPress entry (Tue + Thu) and `S` into another (Sat + Sun). English works; Italian (Martedì/Giovedì), Spanish (Sábado/Domingo), and any language where those days start with different letters can't be represented — a translator can only supply one string for both meanings.

### Fix
Render the three-letter `dayLabels` (`Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`) already defined for the ordinal-weekday select as the button content. Those source strings are already distinct in English, so gettext dedup is a non-issue and translators get seven independent entries with no new i18n plumbing to reason about. Drop the parallel `dayButtonLabels` map since its `.short` values were pure indirection back to `dayLabels`; tooltip and `aria-label` still read a separate `dayFullLabels` map for the full name.

Adjust the button style from 30px circles to auto-width pills (min 32px, 6px horizontal padding, 15px radius) so three-character labels fit. Switch the row to `flex-start` with `flex-wrap: wrap` + `rowGap` so longer translated abbreviations wrap gracefully instead of getting pushed to opposite edges of the sidebar.

### Screenshots

_Verified locally against `events.wordpress.test/group/sunshine-coast-qld/` on this branch and on `production`. In English the new pills wrap to 6 + 1 (Mon–Sat on row 1, Sun on row 2); wrap is intentional and left-packed._

**Before** (circles, `M T W T F S S`, collision on T and S):

<kbd><img width="248" height="54" alt="before-weekday-picker" src="https://github.com/user-attachments/assets/a9541243-e335-4c6a-a532-4a715febedb9" /></kbd>

**After** (pills, `Mon Tue Wed Thu Fri Sat Sun`):

<kbd><img width="248" height="90" alt="weekday-picker" src="https://github.com/user-attachments/assets/ea63666b-9d08-470f-8b35-215aa91e32a5" /></kbd>

### Deferred — tracked in #1898
This PR unblocks the string-collision problem the Polyglots hit (the actual bug in #1893), but the mu-plugin's translations don't load at runtime at all: no `wp_set_script_translations()` call, no shipped `.pot`/`.po`/`.json`, no `load_muplugin_textdomain()` for the `gpre` domain. So translated weekday values still won't reach the browser until that wiring lands. **Pre-existing across the whole `gatherpress-recurring-events` plugin; not introduced or widened here.** Follow-up: #1898.

### Alternative considered
An earlier version of this PR used `_x()` with per-day contexts. Dropped because (a) three-letter labels make the collision go away without inventing our own context conventions, (b) core's convention is `'Monday initial'`/`'Sunday initial'` (see `wp-includes/class-wp-locale.php`) — my initial `'Monday abbreviation'` naming was inverted from core, and (c) it's the smaller and easier-to-review change. Note also that neither approach would have rendered translated labels without the #1898 wiring — the `_x()` version would have been just as inert as the current `__()` version.

### Testing
- Local: open a `gatherpress_event` at `events.wordpress.test/group/sunshine-coast-qld/wp-admin/`, set frequency to Weekly — buttons render as pills per the screenshots above. Tooltip and aria-label continue to show the full day name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)