### PR TITLE
Groups: force Open RSVP off and preserve stored GatherPress settings

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -70,8 +70,9 @@ function get_event_venue_post_id( int $event_id ): int {
  *
  * Also disable anonymous RSVP and Open RSVP at the global setting level.
  *
- * Uses `option_`/`default_option_` (not `pre_option_`) so the forced keys
- * overlay the stored settings (or defaults when unset) instead of replacing them.
+ * Uses `option_`/`default_option_` (and `site_option_` variants; not `pre_option_`)
+ * so the forced keys overlay the stored settings (or defaults when unset)
+ * instead of replacing them.
  */
 $force_gatherpress_settings = static function ( $value ) {
 	if ( ! is_array( $value ) ) {
@@ -86,6 +87,8 @@ $force_gatherpress_settings = static function ( $value ) {
 };
 add_filter( 'option_gatherpress_settings', $force_gatherpress_settings );
 add_filter( 'default_option_gatherpress_settings', $force_gatherpress_settings );
+add_filter( 'site_option_gatherpress_settings', $force_gatherpress_settings );
+add_filter( 'default_site_option_gatherpress_settings', $force_gatherpress_settings );
 
 /**
  * Force anonymous RSVP off for all events on group sites.

--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -68,17 +68,21 @@ function get_event_venue_post_id( int $event_id ): int {
  * Disable the "Show Timezone" GatherPress setting so event date blocks
  * never append "GMT+0000" or similar suffixes.
  *
- * Also disable anonymous RSVP at the global setting level.
+ * Also disable anonymous RSVP and Open RSVP at the global setting level.
+ *
+ * Uses `option_` (not `pre_option_`) so the forced keys overlay the stored
+ * settings instead of replacing them.
  */
 add_filter(
-	'pre_option_gatherpress_settings',
+	'option_gatherpress_settings',
 	static function ( $value ) {
 		if ( ! is_array( $value ) ) {
 			$value = array();
 		}
 
-		$value['show_timezone']        = 0;
+		$value['show_timezone']         = 0;
 		$value['enable_anonymous_rsvp'] = 0;
+		$value['enable_open_rsvp']      = 0;
 
 		return $value;
 	}

--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -70,23 +70,22 @@ function get_event_venue_post_id( int $event_id ): int {
  *
  * Also disable anonymous RSVP and Open RSVP at the global setting level.
  *
- * Uses `option_` (not `pre_option_`) so the forced keys overlay the stored
- * settings instead of replacing them.
+ * Uses `option_`/`default_option_` (not `pre_option_`) so the forced keys
+ * overlay the stored settings (or defaults when unset) instead of replacing them.
  */
-add_filter(
-	'option_gatherpress_settings',
-	static function ( $value ) {
-		if ( ! is_array( $value ) ) {
-			$value = array();
-		}
-
-		$value['show_timezone']         = 0;
-		$value['enable_anonymous_rsvp'] = 0;
-		$value['enable_open_rsvp']      = 0;
-
-		return $value;
+$force_gatherpress_settings = static function ( $value ) {
+	if ( ! is_array( $value ) ) {
+		$value = array();
 	}
-);
+
+	$value['show_timezone']         = 0;
+	$value['enable_anonymous_rsvp'] = 0;
+	$value['enable_open_rsvp']      = 0;
+
+	return $value;
+};
+add_filter( 'option_gatherpress_settings', $force_gatherpress_settings );
+add_filter( 'default_option_gatherpress_settings', $force_gatherpress_settings );
 
 /**
  * Force anonymous RSVP off for all events on group sites.

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
@@ -20,6 +20,32 @@ class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 
 		$this->assertSame( 0, $settings['show_timezone'] );
 		$this->assertSame( 0, $settings['enable_anonymous_rsvp'] );
+		$this->assertSame( 0, $settings['enable_open_rsvp'] );
+	}
+
+	/**
+	 * Unrelated GatherPress settings saved on a group site must survive the
+	 * forced overrides: the filter overlays the forced keys, it does not
+	 * replace the whole option.
+	 */
+	public function test_gatherpress_settings_preserved() {
+		update_option(
+			'gatherpress_settings',
+			array(
+				'max_guest_limit'  => 5,
+				'enable_open_rsvp' => 1,
+				'show_timezone'    => 1,
+			)
+		);
+
+		$settings = get_option( 'gatherpress_settings' );
+
+		// Unrelated stored setting is preserved.
+		$this->assertSame( 5, $settings['max_guest_limit'] );
+
+		// Forced keys win regardless of what was stored.
+		$this->assertSame( 0, $settings['show_timezone'] );
+		$this->assertSame( 0, $settings['enable_open_rsvp'] );
 	}
 
 	/**


### PR DESCRIPTION
On group sites, `mu-plugins/groups/gatherpress-groups-tweaks.php` hooked `pre_option_gatherpress_settings` and returned a two-key array. Because `pre_option_{$option}` short-circuits the option lookup entirely (it does not merge), this caused two problems:
1. **Stored settings were discarded.** The saved `gatherpress_settings` option was effectively replaced by `{ show_timezone, enable_anonymous_rsvp }`, so an organizer could not persist any other GatherPress setting.
2. **Open RSVP was left enabled.** GatherPress 0.35.0 added `enable_open_rsvp` (default **on**), which lets visitors RSVP without a WordPress.org account via email verification. The filter only forced the older `enable_anonymous_rsvp`, so the new key fell through to its default - leaving Open RSVP effectively enabled on every group site, contrary to the account-based participation model.

This change hooks `option_gatherpress_settings` (not `pre_option_`) so the forced keys are overlaid on top of the site's real stored settings instead of replacing them, and adds `enable_open_rsvp => 0`. Forcing the sitewide setting off also makes GatherPress's public `event/rsvp-form` REST endpoint reject these submissions.

See #1862
See https://github.com/GatherPress/gatherpress/pull/2155 (upstream endpoint hardening)

Props vanyukov

### Screenshots

N/A

### How to test the changes in this Pull Request:

On a group site (any site on the groups network):

1. Go to **Events → Settings → RSVP**; "Open RSVP" reads as off. Check it and **Save**, reload → it's off again.
2. Change an option e.g. **Maximum Number of Guests**, **Save**, reload → your value persists (before this PR it reverts to default).
3. Create a published, future event, note its ID, then logged out (no cookie/nonce):
```bash
curl -i -X POST "https://<group-site>/wp-json/gatherpress/v1/event/rsvp-form" \
  --data-urlencode "comment_post_ID=<ID>" \
  --data-urlencode "author=Test Visitor" \
  --data-urlencode "email=visitor@example.com"
```
Expect 403 Open RSVP is disabled for this event. (was 200 success).