### PR TITLE
Groups: add formal ownership-transfer workflow

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/group-ownership-transfer-notifications.php
+++ b/public_html/wp-content/mu-plugins/groups/group-ownership-transfer-notifications.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Email notifications for the group-ownership transfer workflow.
+ *
+ * Plain-text `wp_mail()` only, matching `Groups\Messaging\send_message()` —
+ * no templating system. There are no magic-link tokens: accept/decline/
+ * approve are all gated by the acting user's logged-in identity (via REST or
+ * the Network Admin screen), so these emails just point people at the
+ * group's home URL rather than carrying any auth of their own.
+ *
+ * Kept as its own file, separate from the state machine in
+ * `group-ownership-transfer.php`, mirroring how `wporg-groups-frontend`
+ * keeps `inc/notifications.php` separate from the controllers it supports.
+ *
+ * Only loaded on the Groups network, via
+ * `load-other-mu-plugins.php::wcorg_include_network_only_plugins()`.
+ *
+ * @package WordCamp\Groups
+ */
+
+namespace WordCamp\Groups\Ownership_Transfer\Notifications;
+
+use WordCamp\Groups\Ownership_Transfer as Transfer;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'wporg_groups_ownership_transfer_initiated', __NAMESPACE__ . '\notify_candidate_nominated', 10, 2 );
+add_action( 'wporg_groups_ownership_transfer_accepted', __NAMESPACE__ . '\notify_admins_awaiting_approval', 10, 2 );
+add_action( 'wporg_groups_ownership_transfer_declined', __NAMESPACE__ . '\notify_initiator_declined', 10, 2 );
+add_action( 'wporg_groups_ownership_transfer_cancelled', __NAMESPACE__ . '\notify_candidate_cancelled', 10, 2 );
+add_action( 'wporg_groups_ownership_transfer_executed', __NAMESPACE__ . '\notify_parties_executed', 10, 2 );
+add_action( 'wporg_groups_ownership_transfer_rejected', __NAMESPACE__ . '\notify_parties_rejected', 10, 3 );
+
+/**
+ * Get every network admin's email address and display name.
+ *
+ * @return array<int, array{email: string, name: string}>
+ */
+function get_network_admin_emails(): array {
+	$recipients = array();
+
+	// `site_admins` is shared, mutable network state; a plugin or a stale
+	// `update_site_option()` call elsewhere on the network can leave it in a
+	// shape `get_super_admins()` doesn't expect. Cast defensively rather
+	// than let a malformed option value turn a missed approval-notice email
+	// into a fatal error.
+	foreach ( (array) get_super_admins() as $login ) {
+		$user = get_user_by( 'login', $login );
+
+		if ( $user && is_email( $user->user_email ) ) {
+			$recipients[] = array(
+				'email' => $user->user_email,
+				'name'  => $user->display_name,
+			);
+		}
+	}
+
+	return $recipients;
+}
+
+/**
+ * Send a single plain-text email.
+ *
+ * @param array{email: string, name: string} $recipient Recipient.
+ * @param string                             $subject   Message subject.
+ * @param string                             $body      Message body.
+ * @return bool Whether the mail was handed off successfully.
+ */
+function send_notification( array $recipient, string $subject, string $body ): bool {
+	if ( ! is_email( $recipient['email'] ) ) {
+		return false;
+	}
+
+	$to = $recipient['name']
+		? sprintf( '%s <%s>', $recipient['name'], $recipient['email'] )
+		: $recipient['email'];
+
+	// Passed as an array, exactly as in `Groups\Messaging\send_message()`, so a
+	// display name containing a comma can't smuggle in an extra recipient.
+	$sent = wp_mail(
+		array( $to ),
+		$subject,
+		$body,
+		array( 'Content-Type: text/plain; charset=UTF-8' )
+	);
+
+	if ( ! $sent ) {
+		trigger_error(
+			sprintf(
+				'Failed to send an ownership-transfer notification ("%1$s") to %2$s.',
+				$subject, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; relayed to Slack by this repo's error handler.
+				$recipient['email'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			),
+			E_USER_WARNING
+		);
+	}
+
+	return $sent;
+}
+
+/**
+ * Build the `{name, email}` pair for a user, for use with `send_notification()`.
+ *
+ * @param int $user_id User ID.
+ * @return array{email: string, name: string}|null
+ */
+function recipient_for_user( int $user_id ): ?array {
+	$user = get_userdata( $user_id );
+
+	if ( ! $user || ! is_email( $user->user_email ) ) {
+		return null;
+	}
+
+	return array(
+		'email' => $user->user_email,
+		'name'  => $user->display_name,
+	);
+}
+
+/**
+ * Notify the candidate that they've been nominated.
+ */
+function notify_candidate_nominated( int $site_id, array $pending ): void {
+	$recipient = recipient_for_user( (int) $pending['to_user_id'] );
+
+	if ( ! $recipient ) {
+		return;
+	}
+
+	$group_name = get_blog_option( $site_id, 'blogname' );
+	$group_url  = get_home_url( $site_id, '/' );
+
+	send_notification(
+		$recipient,
+		sprintf( __( 'You\'ve been nominated to take over "%s"', 'wordcamporg' ), $group_name ),
+		sprintf(
+			/* translators: 1: group name, 2: group URL. */
+			__( "You've been nominated to become the owner of the WordPress group \"%1\$s\".\n\nTo accept or decline, visit the group's Members settings:\n%2\$s", 'wordcamporg' ),
+			$group_name,
+			$group_url
+		)
+	);
+}
+
+/**
+ * Notify network admins that a transfer needs their approval.
+ */
+function notify_admins_awaiting_approval( int $site_id, array $pending ): void {
+	$group_name = get_blog_option( $site_id, 'blogname' );
+	$from_user  = get_userdata( (int) $pending['from_user_id'] );
+	$to_user    = get_userdata( (int) $pending['to_user_id'] );
+
+	$body = sprintf(
+		/* translators: 1: group name, 2: current owner, 3: nominated owner, 4: URL of the approval screen. */
+		__( "A group ownership transfer is awaiting your approval.\n\nGroup: %1\$s\nCurrent owner: %2\$s\nNominated owner: %3\$s\n\nReview it here:\n%4\$s", 'wordcamporg' ),
+		$group_name,
+		$from_user ? $from_user->display_name : __( '(deleted user)', 'wordcamporg' ),
+		$to_user ? $to_user->display_name : __( '(deleted user)', 'wordcamporg' ),
+		network_admin_url( 'admin.php?page=' . Transfer\MENU_SLUG )
+	);
+
+	foreach ( get_network_admin_emails() as $recipient ) {
+		send_notification(
+			$recipient,
+			sprintf( __( 'Approval needed: ownership transfer for "%s"', 'wordcamporg' ), $group_name ),
+			$body
+		);
+	}
+}
+
+/**
+ * Notify the initiator that the candidate declined.
+ */
+function notify_initiator_declined( int $site_id, array $pending ): void {
+	$recipient = recipient_for_user( (int) $pending['initiated_by'] );
+
+	if ( ! $recipient ) {
+		return;
+	}
+
+	$group_name = get_blog_option( $site_id, 'blogname' );
+
+	send_notification(
+		$recipient,
+		sprintf( __( 'Ownership transfer declined for "%s"', 'wordcamporg' ), $group_name ),
+		sprintf(
+			/* translators: %s: group name. */
+			__( 'The candidate you nominated to take over "%s" has declined the transfer.', 'wordcamporg' ),
+			$group_name
+		)
+	);
+}
+
+/**
+ * Notify the candidate that their pending nomination was cancelled.
+ */
+function notify_candidate_cancelled( int $site_id, array $pending ): void {
+	$recipient = recipient_for_user( (int) $pending['to_user_id'] );
+
+	if ( ! $recipient ) {
+		return;
+	}
+
+	$group_name = get_blog_option( $site_id, 'blogname' );
+
+	send_notification(
+		$recipient,
+		sprintf( __( 'Ownership transfer cancelled for "%s"', 'wordcamporg' ), $group_name ),
+		sprintf(
+			/* translators: %s: group name. */
+			__( 'Your nomination to take over "%s" has been cancelled.', 'wordcamporg' ),
+			$group_name
+		)
+	);
+}
+
+/**
+ * Notify both parties that the transfer executed.
+ */
+function notify_parties_executed( int $site_id, array $pending ): void {
+	$group_name = get_blog_option( $site_id, 'blogname' );
+	$group_url  = get_home_url( $site_id, '/' );
+
+	$body = sprintf(
+		/* translators: 1: group name, 2: group URL. */
+		__( "Ownership of \"%1\$s\" has been transferred.\n\n%2\$s", 'wordcamporg' ),
+		$group_name,
+		$group_url
+	);
+
+	foreach ( array( $pending['from_user_id'], $pending['to_user_id'] ) as $user_id ) {
+		$recipient = recipient_for_user( (int) $user_id );
+
+		if ( $recipient ) {
+			send_notification(
+				$recipient,
+				sprintf( __( 'Ownership transfer completed for "%s"', 'wordcamporg' ), $group_name ),
+				$body
+			);
+		}
+	}
+}
+
+/**
+ * Notify both parties that a network admin rejected the transfer.
+ */
+function notify_parties_rejected( int $site_id, array $pending, string $reason ): void {
+	$group_name = get_blog_option( $site_id, 'blogname' );
+
+	$body = sprintf(
+		/* translators: 1: group name, 2: optional reason. */
+		__( 'The proposed ownership transfer for "%1$s" was rejected by a network admin.%2$s', 'wordcamporg' ),
+		$group_name,
+		$reason ? "\n\n" . sprintf( /* translators: %s: reason given. */ __( 'Reason: %s', 'wordcamporg' ), $reason ) : ''
+	);
+
+	foreach ( array( $pending['from_user_id'], $pending['to_user_id'] ) as $user_id ) {
+		$recipient = recipient_for_user( (int) $user_id );
+
+		if ( $recipient ) {
+			send_notification(
+				$recipient,
+				sprintf( __( 'Ownership transfer rejected for "%s"', 'wordcamporg' ), $group_name ),
+				$body
+			);
+		}
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/group-ownership-transfer-notifications.php
+++ b/public_html/wp-content/mu-plugins/groups/group-ownership-transfer-notifications.php
@@ -118,12 +118,40 @@ function recipient_for_user( int $user_id ): ?array {
 }
 
 /**
+ * Report a notification that had no one to go to.
+ *
+ * A transfer whose emails silently go nowhere looks, to everyone involved,
+ * exactly like a transfer nobody has got round to yet: the candidate never
+ * learns they were nominated, or the network admins never learn something is
+ * waiting on them. `send_notification()` already warns when handing a message
+ * to `wp_mail()` fails; this covers the other half -- never getting that far
+ * because there was no usable address to send to.
+ *
+ * @param string $event   Which notification was being sent.
+ * @param int    $site_id Group site ID.
+ * @param string $who     Who the message was meant for.
+ */
+function warn_no_recipient( string $event, int $site_id, string $who ): void {
+	trigger_error(
+		sprintf(
+			'Skipped the "%1$s" ownership-transfer notification for site %2$d: no usable email address for %3$s.',
+			$event, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; relayed to Slack by this repo's error handler.
+			$site_id, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			$who // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+		),
+		E_USER_WARNING
+	);
+}
+
+/**
  * Notify the candidate that they've been nominated.
  */
 function notify_candidate_nominated( int $site_id, array $pending ): void {
 	$recipient = recipient_for_user( (int) $pending['to_user_id'] );
 
 	if ( ! $recipient ) {
+		warn_no_recipient( 'nominated', $site_id, sprintf( 'the candidate (user %d)', (int) $pending['to_user_id'] ) );
+
 		return;
 	}
 
@@ -146,6 +174,14 @@ function notify_candidate_nominated( int $site_id, array $pending ): void {
  * Notify network admins that a transfer needs their approval.
  */
 function notify_admins_awaiting_approval( int $site_id, array $pending ): void {
+	$recipients = get_network_admin_emails();
+
+	if ( empty( $recipients ) ) {
+		warn_no_recipient( 'awaiting approval', $site_id, 'any network admin' );
+
+		return;
+	}
+
 	$group_name = get_blog_option( $site_id, 'blogname' );
 	$from_user  = get_userdata( (int) $pending['from_user_id'] );
 	$to_user    = get_userdata( (int) $pending['to_user_id'] );
@@ -159,7 +195,7 @@ function notify_admins_awaiting_approval( int $site_id, array $pending ): void {
 		network_admin_url( 'admin.php?page=' . Transfer\MENU_SLUG )
 	);
 
-	foreach ( get_network_admin_emails() as $recipient ) {
+	foreach ( $recipients as $recipient ) {
 		send_notification(
 			$recipient,
 			sprintf( __( 'Approval needed: ownership transfer for "%s"', 'wordcamporg' ), $group_name ),
@@ -175,6 +211,8 @@ function notify_initiator_declined( int $site_id, array $pending ): void {
 	$recipient = recipient_for_user( (int) $pending['initiated_by'] );
 
 	if ( ! $recipient ) {
+		warn_no_recipient( 'declined', $site_id, sprintf( 'the initiator (user %d)', (int) $pending['initiated_by'] ) );
+
 		return;
 	}
 
@@ -198,6 +236,8 @@ function notify_candidate_cancelled( int $site_id, array $pending ): void {
 	$recipient = recipient_for_user( (int) $pending['to_user_id'] );
 
 	if ( ! $recipient ) {
+		warn_no_recipient( 'cancelled', $site_id, sprintf( 'the candidate (user %d)', (int) $pending['to_user_id'] ) );
+
 		return;
 	}
 
@@ -231,13 +271,17 @@ function notify_parties_executed( int $site_id, array $pending ): void {
 	foreach ( array( $pending['from_user_id'], $pending['to_user_id'] ) as $user_id ) {
 		$recipient = recipient_for_user( (int) $user_id );
 
-		if ( $recipient ) {
-			send_notification(
-				$recipient,
-				sprintf( __( 'Ownership transfer completed for "%s"', 'wordcamporg' ), $group_name ),
-				$body
-			);
+		if ( ! $recipient ) {
+			warn_no_recipient( 'completed', $site_id, sprintf( 'user %d', (int) $user_id ) );
+
+			continue;
 		}
+
+		send_notification(
+			$recipient,
+			sprintf( __( 'Ownership transfer completed for "%s"', 'wordcamporg' ), $group_name ),
+			$body
+		);
 	}
 }
 
@@ -257,12 +301,16 @@ function notify_parties_rejected( int $site_id, array $pending, string $reason )
 	foreach ( array( $pending['from_user_id'], $pending['to_user_id'] ) as $user_id ) {
 		$recipient = recipient_for_user( (int) $user_id );
 
-		if ( $recipient ) {
-			send_notification(
-				$recipient,
-				sprintf( __( 'Ownership transfer rejected for "%s"', 'wordcamporg' ), $group_name ),
-				$body
-			);
+		if ( ! $recipient ) {
+			warn_no_recipient( 'rejected', $site_id, sprintf( 'user %d', (int) $user_id ) );
+
+			continue;
 		}
+
+		send_notification(
+			$recipient,
+			sprintf( __( 'Ownership transfer rejected for "%s"', 'wordcamporg' ), $group_name ),
+			$body
+		);
 	}
 }

--- a/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
@@ -60,8 +60,83 @@ const MENU_SLUG = 'wporg-groups-ownership-transfer';
 /** `admin_post_` action the approve/reject forms submit to. */
 const DECIDE_ACTION = 'wporg_groups_ownership_transfer_decide';
 
+/** Object-cache group for per-site transfer locks. Registered global, see below. */
+const LOCK_GROUP = 'wporg-groups-ownership-transfer';
+
+/**
+ * Seconds before an abandoned lock expires on its own, so a process that
+ * dies mid-transition can't wedge a group's transfer state permanently.
+ */
+const LOCK_TIMEOUT = 10;
+
+/** Lock acquisition attempts, `LOCK_RETRY_DELAY` apart. */
+const LOCK_ATTEMPTS = 20;
+
+/** Microseconds between lock acquisition attempts. */
+const LOCK_RETRY_DELAY = 50000;
+
 add_action( 'network_admin_menu', __NAMESPACE__ . '\add_page' );
 add_action( 'admin_post_' . DECIDE_ACTION, __NAMESPACE__ . '\handle_decision' );
+
+/*
+ * A lock is keyed by site ID and acquired from contexts where the current
+ * blog varies (the REST routes run on the group's own site; the Network
+ * Admin handler runs after `switch_to_blog()`). Non-global cache groups are
+ * keyed per blog, so without this, the same site's lock key would resolve
+ * to different cache buckets depending on which blog happens to be current
+ * -- mirrors `Groups\Messaging`'s identical reasoning for its own lock.
+ */
+wp_cache_add_global_groups( array( LOCK_GROUP ) );
+
+/**
+ * Run `$callback` with exclusive access to one group's transfer state.
+ *
+ * Every state transition (initiate/accept/decline/cancel/execute/reject)
+ * does a read-then-write against this group's site meta with no
+ * database-level locking of its own. Two concurrent requests -- a
+ * double-click, a retried request, a network admin approving while the
+ * candidate is declining -- would otherwise race: both read the same "no
+ * pending transfer" (or the same pending record), and the second write
+ * silently clobbers the first, potentially after both sides have already
+ * been emailed. `wp_cache_add()` is atomic on a shared backend (memcached
+ * in production), making it a usable cross-process mutex per group --
+ * mirrors `Groups\Messaging\with_jobs_lock()`, scoped to one site instead
+ * of one global job queue. Without a persistent object cache this
+ * degrades to the unsynchronised behaviour it replaces -- no worse than
+ * not having it.
+ *
+ * @param int      $site_id  Group site ID being locked.
+ * @param callable $callback Runs while the lock is held.
+ * @return mixed The callback's return value, or a `WP_Error` if the lock
+ *               could not be acquired.
+ */
+function with_transfer_lock( int $site_id, callable $callback ) {
+	$lock_key = 'transfer_' . $site_id;
+	$acquired = false;
+
+	for ( $attempt = 0; $attempt < LOCK_ATTEMPTS; $attempt++ ) {
+		if ( wp_cache_add( $lock_key, 1, LOCK_GROUP, LOCK_TIMEOUT ) ) {
+			$acquired = true;
+			break;
+		}
+
+		usleep( LOCK_RETRY_DELAY );
+	}
+
+	if ( ! $acquired ) {
+		return new WP_Error(
+			'transfer_busy',
+			__( "This group's ownership transfer is being updated by another request. Please try again.", 'wordcamporg' ),
+			array( 'status' => 409 )
+		);
+	}
+
+	try {
+		return $callback();
+	} finally {
+		wp_cache_delete( $lock_key, LOCK_GROUP );
+	}
+}
 
 /*
  * ----------------------------------------------------------------------
@@ -285,6 +360,18 @@ function validate_candidate( int $candidate_id, int $from_user_id, int $site_id 
  * @return true|WP_Error
  */
 function initiate_transfer( int $site_id, int $from_user_id, int $to_user_id, int $initiated_by ) {
+	return with_transfer_lock(
+		$site_id,
+		static function () use ( $site_id, $from_user_id, $to_user_id, $initiated_by ) {
+			return initiate_transfer_unlocked( $site_id, $from_user_id, $to_user_id, $initiated_by );
+		}
+	);
+}
+
+/**
+ * @see initiate_transfer() -- runs under that function's per-site lock.
+ */
+function initiate_transfer_unlocked( int $site_id, int $from_user_id, int $to_user_id, int $initiated_by ) {
 	if ( get_pending_transfer( $site_id ) ) {
 		return new WP_Error(
 			'transfer_already_pending',
@@ -348,6 +435,18 @@ function initiate_transfer( int $site_id, int $from_user_id, int $to_user_id, in
  * @return true|WP_Error
  */
 function accept_transfer( int $site_id, int $user_id ) {
+	return with_transfer_lock(
+		$site_id,
+		static function () use ( $site_id, $user_id ) {
+			return accept_transfer_unlocked( $site_id, $user_id );
+		}
+	);
+}
+
+/**
+ * @see accept_transfer() -- runs under that function's per-site lock.
+ */
+function accept_transfer_unlocked( int $site_id, int $user_id ) {
 	$pending = get_pending_transfer( $site_id );
 
 	if ( ! $pending ) {
@@ -388,6 +487,18 @@ function accept_transfer( int $site_id, int $user_id ) {
  * @return true|WP_Error
  */
 function decline_transfer( int $site_id, int $user_id ) {
+	return with_transfer_lock(
+		$site_id,
+		static function () use ( $site_id, $user_id ) {
+			return decline_transfer_unlocked( $site_id, $user_id );
+		}
+	);
+}
+
+/**
+ * @see decline_transfer() -- runs under that function's per-site lock.
+ */
+function decline_transfer_unlocked( int $site_id, int $user_id ) {
 	$pending = get_pending_transfer( $site_id );
 
 	if ( ! $pending ) {
@@ -421,6 +532,18 @@ function decline_transfer( int $site_id, int $user_id ) {
  * @return true|WP_Error
  */
 function cancel_transfer( int $site_id, int $user_id ) {
+	return with_transfer_lock(
+		$site_id,
+		static function () use ( $site_id, $user_id ) {
+			return cancel_transfer_unlocked( $site_id, $user_id );
+		}
+	);
+}
+
+/**
+ * @see cancel_transfer() -- runs under that function's per-site lock.
+ */
+function cancel_transfer_unlocked( int $site_id, int $user_id ) {
 	$pending = get_pending_transfer( $site_id );
 
 	if ( ! $pending ) {
@@ -461,6 +584,18 @@ function cancel_transfer( int $site_id, int $user_id ) {
  * @return true|WP_Error
  */
 function execute_transfer( int $site_id, int $decided_by ) {
+	return with_transfer_lock(
+		$site_id,
+		static function () use ( $site_id, $decided_by ) {
+			return execute_transfer_unlocked( $site_id, $decided_by );
+		}
+	);
+}
+
+/**
+ * @see execute_transfer() -- runs under that function's per-site lock.
+ */
+function execute_transfer_unlocked( int $site_id, int $decided_by ) {
 	$pending = get_pending_transfer( $site_id );
 
 	if ( ! $pending ) {
@@ -480,6 +615,26 @@ function execute_transfer( int $site_id, int $decided_by ) {
 
 	if ( ! $old_owner || ! $new_owner ) {
 		return new WP_Error( 'transfer_user_missing', __( 'One of the users in this transfer no longer exists.', 'wordcamporg' ), array( 'status' => 400 ) );
+	}
+
+	// Re-validate both parties immediately before mutating roles. Approval
+	// can land long after acceptance, long enough for either side to have
+	// changed hands in the meantime (candidate removed from the group,
+	// demoted, or promoted elsewhere; old owner already demoted by someone
+	// else) -- without this, a removed candidate would be silently re-added
+	// to the site as a full administrator, and an unrelated user's role
+	// would be overwritten.
+	if ( ! in_array( 'administrator', $old_owner->roles, true ) ) {
+		return new WP_Error(
+			'transfer_owner_no_longer_administrator',
+			__( 'The current owner named in this transfer no longer holds the administrator role. Reject this transfer and ask the owner to start a new one.', 'wordcamporg' ),
+			array( 'status' => 409 )
+		);
+	}
+
+	$candidate_check = validate_candidate( $new_owner->ID, $old_owner->ID, $site_id );
+	if ( is_wp_error( $candidate_check ) ) {
+		return $candidate_check;
 	}
 
 	$new_owner->set_role( 'administrator' );
@@ -554,6 +709,18 @@ function execute_transfer( int $site_id, int $decided_by ) {
  * @return true|WP_Error
  */
 function reject_transfer( int $site_id, int $decided_by, string $reason = '' ) {
+	return with_transfer_lock(
+		$site_id,
+		static function () use ( $site_id, $decided_by, $reason ) {
+			return reject_transfer_unlocked( $site_id, $decided_by, $reason );
+		}
+	);
+}
+
+/**
+ * @see reject_transfer() -- runs under that function's per-site lock.
+ */
+function reject_transfer_unlocked( int $site_id, int $decided_by, string $reason = '' ) {
 	$pending = get_pending_transfer( $site_id );
 
 	if ( ! $pending ) {
@@ -619,7 +786,7 @@ function add_page(): void {
 function get_sites_with_pending_transfers(): array {
 	$rows = array();
 
-	foreach ( Archive\get_group_sites( true ) as $site ) {
+	foreach ( get_group_sites_with_meta_key( META_KEY_PENDING ) as $site ) {
 		$pending = get_pending_transfer( (int) $site->blog_id );
 
 		if ( $pending ) {
@@ -642,7 +809,7 @@ function get_sites_with_pending_transfers(): array {
 function get_recent_decided_transfers( int $limit = 20 ): array {
 	$rows = array();
 
-	foreach ( Archive\get_group_sites( true ) as $site ) {
+	foreach ( get_group_sites_with_meta_key( META_KEY_HISTORY ) as $site ) {
 		foreach ( get_transfer_history( (int) $site->blog_id ) as $entry ) {
 			$rows[] = array(
 				'site'  => $site,
@@ -659,6 +826,69 @@ function get_recent_decided_transfers( int $limit = 20 ): array {
 	);
 
 	return array_slice( $rows, 0, $limit );
+}
+
+/**
+ * Get the Groups-network sites carrying a specific blog meta key.
+ *
+ * The Network Admin screen only ever needs sites that actually HAVE a
+ * pending transfer or decided-transfer history -- almost always a tiny
+ * fraction of the network. Querying `wp_blogmeta` directly for that key
+ * scales with how many groups have ever used this feature, instead of
+ * `Archive\get_group_sites( true )`'s O(every group on the network), which
+ * the existing Archive screen paginates at `wporg-groups-archive.php::PER_PAGE`
+ * precisely because it doesn't scale otherwise.
+ *
+ * @param string $meta_key Blog meta key to look for.
+ * @return \WP_Site[]
+ */
+function get_group_sites_with_meta_key( string $meta_key ): array {
+	global $wpdb;
+
+	$site_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT DISTINCT blog_id FROM {$wpdb->blogmeta} WHERE meta_key = %s",
+			$meta_key
+		)
+	);
+
+	$sites = array();
+
+	foreach ( $site_ids as $site_id ) {
+		$site_id = (int) $site_id;
+		$site    = get_site( $site_id );
+
+		// Same exclusions as `Archive\get_group_sites()`: only sites on this
+		// network, never the placeholder root, never a deleted site.
+		if ( ! $site || GROUPS_ROOT_BLOG_ID === $site_id || GROUPS_NETWORK_ID !== (int) $site->network_id || $site->deleted ) {
+			continue;
+		}
+
+		$sites[] = $site;
+	}
+
+	return $sites;
+}
+
+/**
+ * Translate a stored `final_status` value for display.
+ *
+ * Mirrors the `$final_status` values `finalize_transfer()` ever writes.
+ * Falls back to the raw value for anything unrecognised, so a status this
+ * function hasn't been updated for still shows something instead of blank.
+ *
+ * @param string $status Stored final-status value.
+ * @return string
+ */
+function get_final_status_label( string $status ): string {
+	$labels = array(
+		'declined'  => __( 'Declined', 'wordcamporg' ),
+		'cancelled' => __( 'Cancelled', 'wordcamporg' ),
+		'completed' => __( 'Completed', 'wordcamporg' ),
+		'rejected'  => __( 'Rejected', 'wordcamporg' ),
+	);
+
+	return $labels[ $status ] ?? $status;
 }
 
 /**
@@ -850,7 +1080,7 @@ function render_page(): void {
 								<td><?php echo esc_html( get_blog_option( $site_id, 'blogname' ) ?: $row['site']->domain . $row['site']->path ); ?></td>
 								<td><?php echo esc_html( $from_user ? $from_user->display_name : __( '(deleted user)', 'wordcamporg' ) ); ?></td>
 								<td><?php echo esc_html( $to_user ? $to_user->display_name : __( '(deleted user)', 'wordcamporg' ) ); ?></td>
-								<td><?php echo esc_html( $entry['final_status'] ?? '' ); ?></td>
+								<td><?php echo esc_html( get_final_status_label( $entry['final_status'] ?? '' ) ); ?></td>
 								<td><?php echo esc_html( ! empty( $entry['decided_at'] ) ? wp_date( 'Y-m-d', (int) $entry['decided_at'] ) : '' ); ?></td>
 							</tr>
 						<?php endforeach; ?>

--- a/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
@@ -54,6 +54,14 @@ const STATUS_PENDING_APPROVAL = 'pending_approval';
  */
 const CANDIDATE_ROLE = 'editor';
 
+/**
+ * Longest rejection reason kept. The field is network-admin-only, so this
+ * isn't a trust boundary -- it just stops a stray paste from bloating the
+ * site meta this history is stored in, which is capped by entry count
+ * (`HISTORY_LIMIT`) but not by size.
+ */
+const REASON_MAX_LENGTH = 500;
+
 /** Network Admin page slug. */
 const MENU_SLUG = 'wporg-groups-ownership-transfer';
 
@@ -1185,6 +1193,20 @@ function get_final_status_label( string $status ): string {
 }
 
 /**
+ * Clean up a rejection reason for storage and email.
+ *
+ * `maxlength` on the input is a courtesy to whoever is typing, not a
+ * constraint -- the POST can carry any length regardless of what the form
+ * said.
+ *
+ * @param string $reason Raw reason from the request.
+ * @return string
+ */
+function sanitize_reason( string $reason ): string {
+	return mb_substr( sanitize_text_field( $reason ), 0, REASON_MAX_LENGTH );
+}
+
+/**
  * Process an approve/reject decision from the Network Admin screen.
  */
 function handle_decision(): void {
@@ -1194,7 +1216,7 @@ function handle_decision(): void {
 
 	$site_id  = isset( $_POST['site_id'] ) ? absint( wp_unslash( $_POST['site_id'] ) ) : 0;
 	$decision = isset( $_POST['decision'] ) ? sanitize_key( wp_unslash( $_POST['decision'] ) ) : '';
-	$reason   = isset( $_POST['reason'] ) ? sanitize_text_field( wp_unslash( $_POST['reason'] ) ) : '';
+	$reason   = isset( $_POST['reason'] ) ? sanitize_reason( wp_unslash( $_POST['reason'] ) ) : '';
 
 	check_admin_referer( DECIDE_ACTION . '_' . $site_id );
 
@@ -1285,7 +1307,7 @@ function render_page(): void {
 					<th scope="col"><?php esc_html_e( 'Current owner', 'wordcamporg' ); ?></th>
 					<th scope="col"><?php esc_html_e( 'Nominated owner', 'wordcamporg' ); ?></th>
 					<th scope="col"><?php esc_html_e( 'Initiated', 'wordcamporg' ); ?></th>
-					<th scope="col"><?php esc_html_e( 'Action', 'wordcamporg' ); ?></th>
+					<th scope="col" style="width:22%;"><?php esc_html_e( 'Action', 'wordcamporg' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -1342,7 +1364,7 @@ function render_page(): void {
 								<?php if ( $awaiting ) : ?>
 									<p class="description"><?php esc_html_e( 'Not yet accepted by the candidate.', 'wordcamporg' ); ?></p>
 								<?php else : ?>
-									<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;">
+									<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:block; margin-bottom:8px;">
 										<input type="hidden" name="action" value="<?php echo esc_attr( DECIDE_ACTION ); ?>" />
 										<input type="hidden" name="site_id" value="<?php echo esc_attr( $site_id ); ?>" />
 										<input type="hidden" name="decision" value="approve" />
@@ -1354,11 +1376,34 @@ function render_page(): void {
 										><?php esc_html_e( 'Approve', 'wordcamporg' ); ?></button>
 									</form>
 								<?php endif; ?>
-								<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;">
+								<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:block;">
 									<input type="hidden" name="action" value="<?php echo esc_attr( DECIDE_ACTION ); ?>" />
 									<input type="hidden" name="site_id" value="<?php echo esc_attr( $site_id ); ?>" />
 									<input type="hidden" name="decision" value="reject" />
 									<?php wp_nonce_field( DECIDE_ACTION . '_' . $site_id ); ?>
+									<?php
+									/*
+									 * Optional, but worth offering: a rejection is the one
+									 * outcome where both parties are told "no" by someone
+									 * they never spoke to, and this is the only thing in the
+									 * notification that can tell them why. Left blank, the
+									 * email simply omits the reason line.
+									 */
+									$reason_field_id = 'wporg-transfer-reason-' . $site_id;
+									?>
+									<label class="screen-reader-text" for="<?php echo esc_attr( $reason_field_id ); ?>">
+										<?php esc_html_e( 'Reason for rejecting this transfer. Optional; included in the email to both parties.', 'wordcamporg' ); ?>
+									</label>
+									<input
+										type="text"
+										id="<?php echo esc_attr( $reason_field_id ); ?>"
+										name="reason"
+										value=""
+										maxlength="<?php echo esc_attr( REASON_MAX_LENGTH ); ?>"
+										placeholder="<?php esc_attr_e( 'Reason (optional)', 'wordcamporg' ); ?>"
+										title="<?php esc_attr_e( 'Included in the email sent to both parties.', 'wordcamporg' ); ?>"
+										style="display:block; width:100%; margin-bottom:4px;"
+									/>
 									<button
 										type="submit"
 										class="button button-link-delete"

--- a/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
@@ -105,6 +105,14 @@ wp_cache_add_global_groups( array( LOCK_GROUP ) );
  * degrades to the unsynchronised behaviour it replaces -- no worse than
  * not having it.
  *
+ * `$callback` must stay short: nothing slower than the site-meta reads and
+ * writes the transition itself needs. Anything that can outlast
+ * `LOCK_TIMEOUT` -- `wp_mail()` fan-out above all -- runs after the lock is
+ * released, exactly as `Groups\Messaging\process_batch()` sends outside
+ * `with_jobs_lock()`. That is what makes the ownership check below a
+ * belt-and-braces measure rather than the only thing standing between an
+ * expired lock and a caller deleting a lock someone else now holds.
+ *
  * @param int      $site_id  Group site ID being locked.
  * @param callable $callback Runs while the lock is held.
  * @return mixed The callback's return value, or a `WP_Error` if the lock
@@ -114,8 +122,16 @@ function with_transfer_lock( int $site_id, callable $callback ) {
 	$lock_key = 'transfer_' . $site_id;
 	$acquired = false;
 
+	/*
+	 * A value unique to this acquisition, so the release below can tell "my
+	 * lock" from "a lock someone else acquired after mine expired". Without
+	 * it, a critical section that outran LOCK_TIMEOUT would end by deleting
+	 * the next holder's lock and let a third request in alongside them.
+	 */
+	$token = uniqid( 'transfer_lock_', true );
+
 	for ( $attempt = 0; $attempt < LOCK_ATTEMPTS; $attempt++ ) {
-		if ( wp_cache_add( $lock_key, 1, LOCK_GROUP, LOCK_TIMEOUT ) ) {
+		if ( wp_cache_add( $lock_key, $token, LOCK_GROUP, LOCK_TIMEOUT ) ) {
 			$acquired = true;
 			break;
 		}
@@ -134,7 +150,13 @@ function with_transfer_lock( int $site_id, callable $callback ) {
 	try {
 		return $callback();
 	} finally {
-		wp_cache_delete( $lock_key, LOCK_GROUP );
+		// Not atomic -- there is no portable compare-and-delete across
+		// object-cache backends -- but it turns "always steals" into "only
+		// on a read/delete interleave that is itself narrower than the
+		// window it protects".
+		if ( wp_cache_get( $lock_key, LOCK_GROUP ) === $token ) {
+			wp_cache_delete( $lock_key, LOCK_GROUP );
+		}
 	}
 }
 
@@ -181,14 +203,20 @@ function set_pending_transfer( int $site_id, array $record ): void {
 /**
  * Move a decided transfer from "pending" into the capped history list.
  *
+ * History is written before the pending record is cleared, and the clear is
+ * skipped entirely if that write failed: the failure mode of this order is a
+ * transfer that is still pending and can be decided again, while the reverse
+ * order's is a decided transfer that vanished without a trace. Callers MUST
+ * check the return value -- a dropped write here is what turns "rejected" or
+ * "completed" into a record that keeps showing up as awaiting a decision.
+ *
  * @param int    $site_id      Group site ID.
  * @param array  $pending      The pending record being decided.
  * @param string $final_status One of 'declined', 'cancelled', 'completed', 'rejected'.
  * @param array  $extra        Extra fields to merge in (e.g. `decided_by`, `reason`).
+ * @return bool Whether both meta writes landed.
  */
-function finalize_transfer( int $site_id, array $pending, string $final_status, array $extra = array() ): void {
-	delete_site_meta( $site_id, META_KEY_PENDING );
-
+function finalize_transfer( int $site_id, array $pending, string $final_status, array $extra = array() ): bool {
 	$entry = array_merge(
 		$pending,
 		array(
@@ -202,7 +230,43 @@ function finalize_transfer( int $site_id, array $pending, string $final_status, 
 	array_unshift( $history, $entry );
 	$history = array_slice( $history, 0, HISTORY_LIMIT );
 
-	update_site_meta( $site_id, META_KEY_HISTORY, $history );
+	if ( ! update_site_meta( $site_id, META_KEY_HISTORY, $history ) ) {
+		return false;
+	}
+
+	return (bool) delete_site_meta( $site_id, META_KEY_PENDING );
+}
+
+/**
+ * The `WP_Error` returned when `finalize_transfer()` couldn't persist a decision.
+ *
+ * @param int    $site_id      Group site ID.
+ * @param string $final_status The decision that couldn't be recorded.
+ * @return WP_Error
+ */
+function finalize_failed_error( int $site_id, string $final_status ): WP_Error {
+	trigger_error(
+		sprintf(
+			'Could not record the "%1$s" ownership-transfer decision for site %2$d -- the site-meta write failed. The transfer is still listed as pending.',
+			$final_status, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
+			$site_id // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+		),
+		E_USER_WARNING
+	);
+
+	Logger\log(
+		'groups_ownership_transfer_finalize_failed',
+		array(
+			'site_id'      => $site_id,
+			'final_status' => $final_status,
+		)
+	);
+
+	return new WP_Error(
+		'transfer_not_recorded',
+		__( 'The decision could not be saved. Please try again.', 'wordcamporg' ),
+		array( 'status' => 500 )
+	);
 }
 
 /*
@@ -346,6 +410,15 @@ function validate_candidate( int $candidate_id, int $from_user_id, int $site_id 
 /*
  * ----------------------------------------------------------------------
  * State transitions.
+ *
+ * Each transition is a thin public wrapper around a `*_unlocked()` worker.
+ * The wrapper holds the per-site lock for exactly as long as the worker's
+ * site-meta reads and writes take, then fires the transition's `do_action`
+ * once the lock is released -- the notification layer hanging off those
+ * hooks does `wp_mail()` fan-out, and mail transport can easily outlast
+ * `LOCK_TIMEOUT`. The workers therefore return the record the hook needs
+ * rather than a bare `true`, and the wrappers normalise that back to
+ * `true|WP_Error` for callers.
  * ----------------------------------------------------------------------
  */
 
@@ -360,16 +433,32 @@ function validate_candidate( int $candidate_id, int $from_user_id, int $site_id 
  * @return true|WP_Error
  */
 function initiate_transfer( int $site_id, int $from_user_id, int $to_user_id, int $initiated_by ) {
-	return with_transfer_lock(
+	$record = with_transfer_lock(
 		$site_id,
 		static function () use ( $site_id, $from_user_id, $to_user_id, $initiated_by ) {
 			return initiate_transfer_unlocked( $site_id, $from_user_id, $to_user_id, $initiated_by );
 		}
 	);
+
+	if ( is_wp_error( $record ) ) {
+		return $record;
+	}
+
+	/**
+	 * Fires after a transfer has been initiated.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $record  The new pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_initiated', $site_id, $record );
+
+	return true;
 }
 
 /**
  * @see initiate_transfer() -- runs under that function's per-site lock.
+ *
+ * @return array|WP_Error The new pending record, for the caller to announce.
  */
 function initiate_transfer_unlocked( int $site_id, int $from_user_id, int $to_user_id, int $initiated_by ) {
 	if ( get_pending_transfer( $site_id ) ) {
@@ -416,15 +505,7 @@ function initiate_transfer_unlocked( int $site_id, int $from_user_id, int $to_us
 		)
 	);
 
-	/**
-	 * Fires after a transfer has been initiated.
-	 *
-	 * @param int   $site_id Group site ID.
-	 * @param array $record  The new pending-transfer record.
-	 */
-	do_action( 'wporg_groups_ownership_transfer_initiated', $site_id, $record );
-
-	return true;
+	return $record;
 }
 
 /**
@@ -435,16 +516,32 @@ function initiate_transfer_unlocked( int $site_id, int $from_user_id, int $to_us
  * @return true|WP_Error
  */
 function accept_transfer( int $site_id, int $user_id ) {
-	return with_transfer_lock(
+	$record = with_transfer_lock(
 		$site_id,
 		static function () use ( $site_id, $user_id ) {
 			return accept_transfer_unlocked( $site_id, $user_id );
 		}
 	);
+
+	if ( is_wp_error( $record ) ) {
+		return $record;
+	}
+
+	/**
+	 * Fires after the candidate accepts a transfer.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $record  The updated pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_accepted', $site_id, $record );
+
+	return true;
 }
 
 /**
  * @see accept_transfer() -- runs under that function's per-site lock.
+ *
+ * @return array|WP_Error The updated pending record, for the caller to announce.
  */
 function accept_transfer_unlocked( int $site_id, int $user_id ) {
 	$pending = get_pending_transfer( $site_id );
@@ -468,15 +565,7 @@ function accept_transfer_unlocked( int $site_id, int $user_id ) {
 
 	Logger\log( 'groups_ownership_transfer_accepted', array( 'site_id' => $site_id ) + $pending );
 
-	/**
-	 * Fires after the candidate accepts a transfer.
-	 *
-	 * @param int   $site_id Group site ID.
-	 * @param array $pending The updated pending-transfer record.
-	 */
-	do_action( 'wporg_groups_ownership_transfer_accepted', $site_id, $pending );
-
-	return true;
+	return $pending;
 }
 
 /**
@@ -487,16 +576,32 @@ function accept_transfer_unlocked( int $site_id, int $user_id ) {
  * @return true|WP_Error
  */
 function decline_transfer( int $site_id, int $user_id ) {
-	return with_transfer_lock(
+	$record = with_transfer_lock(
 		$site_id,
 		static function () use ( $site_id, $user_id ) {
 			return decline_transfer_unlocked( $site_id, $user_id );
 		}
 	);
+
+	if ( is_wp_error( $record ) ) {
+		return $record;
+	}
+
+	/**
+	 * Fires after the candidate declines a transfer.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $record  The declined pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_declined', $site_id, $record );
+
+	return true;
 }
 
 /**
  * @see decline_transfer() -- runs under that function's per-site lock.
+ *
+ * @return array|WP_Error The declined record, for the caller to announce.
  */
 function decline_transfer_unlocked( int $site_id, int $user_id ) {
 	$pending = get_pending_transfer( $site_id );
@@ -505,23 +610,27 @@ function decline_transfer_unlocked( int $site_id, int $user_id ) {
 		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
 	}
 
+	// Same guard as `accept_transfer_unlocked()`, for the same reason:
+	// declining is the candidate's half of the acceptance step, and once
+	// they have accepted, the decision belongs to a network admin. Without
+	// this, a candidate could pull an already-accepted transfer out from
+	// under the admin about to approve it -- and, since `finalize_transfer()`
+	// is unconditional, do it from a stale panel that never saw the accept.
+	if ( STATUS_PENDING_ACCEPTANCE !== $pending['status'] ) {
+		return new WP_Error( 'transfer_not_awaiting_acceptance', __( 'This transfer is not awaiting acceptance. Ask a network admin to reject it instead.', 'wordcamporg' ), array( 'status' => 400 ) );
+	}
+
 	if ( (int) $pending['to_user_id'] !== $user_id ) {
 		return new WP_Error( 'not_the_candidate', __( 'Only the nominated candidate can decline this transfer.', 'wordcamporg' ), array( 'status' => 403 ) );
 	}
 
-	finalize_transfer( $site_id, $pending, 'declined' );
+	if ( ! finalize_transfer( $site_id, $pending, 'declined' ) ) {
+		return finalize_failed_error( $site_id, 'declined' );
+	}
 
 	Logger\log( 'groups_ownership_transfer_declined', array( 'site_id' => $site_id ) + $pending );
 
-	/**
-	 * Fires after the candidate declines a transfer.
-	 *
-	 * @param int   $site_id Group site ID.
-	 * @param array $pending The declined pending-transfer record.
-	 */
-	do_action( 'wporg_groups_ownership_transfer_declined', $site_id, $pending );
-
-	return true;
+	return $pending;
 }
 
 /**
@@ -532,16 +641,32 @@ function decline_transfer_unlocked( int $site_id, int $user_id ) {
  * @return true|WP_Error
  */
 function cancel_transfer( int $site_id, int $user_id ) {
-	return with_transfer_lock(
+	$record = with_transfer_lock(
 		$site_id,
 		static function () use ( $site_id, $user_id ) {
 			return cancel_transfer_unlocked( $site_id, $user_id );
 		}
 	);
+
+	if ( is_wp_error( $record ) ) {
+		return $record;
+	}
+
+	/**
+	 * Fires after a pending transfer is cancelled.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $record  The cancelled pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_cancelled', $site_id, $record );
+
+	return true;
 }
 
 /**
  * @see cancel_transfer() -- runs under that function's per-site lock.
+ *
+ * @return array|WP_Error The cancelled record, for the caller to announce.
  */
 function cancel_transfer_unlocked( int $site_id, int $user_id ) {
 	$pending = get_pending_transfer( $site_id );
@@ -554,46 +679,57 @@ function cancel_transfer_unlocked( int $site_id, int $user_id ) {
 		return new WP_Error( 'cannot_cancel_transfer', __( 'Sorry, you are not allowed to cancel this transfer.', 'wordcamporg' ), array( 'status' => 403 ) );
 	}
 
-	finalize_transfer( $site_id, $pending, 'cancelled', array( 'decided_by' => $user_id ) );
+	if ( ! finalize_transfer( $site_id, $pending, 'cancelled', array( 'decided_by' => $user_id ) ) ) {
+		return finalize_failed_error( $site_id, 'cancelled' );
+	}
 
 	Logger\log( 'groups_ownership_transfer_cancelled', array( 'site_id' => $site_id ) + $pending );
 
-	/**
-	 * Fires after a pending transfer is cancelled.
-	 *
-	 * @param int   $site_id Group site ID.
-	 * @param array $pending The cancelled pending-transfer record.
-	 */
-	do_action( 'wporg_groups_ownership_transfer_cancelled', $site_id, $pending );
-
-	return true;
+	return $pending;
 }
 
 /**
  * A network admin approves an accepted transfer, executing the role swap.
  *
  * Promotes the new owner to `administrator` before demoting the old owner to
- * `editor`, so the site is never briefly without an administrator — see the
- * file docblock section on atomicity for why this isn't wrapped in a raw SQL
- * transaction instead. After both role changes, re-reads both users and
- * bails with a `WP_Error` (and a Slack-relayed warning) if the result isn't
- * exactly what was expected, rather than reporting false success.
+ * `editor`, so the site is never briefly without an administrator. Each half
+ * is verified by re-reading the user before the next step depends on it:
+ * a promotion that didn't land stops the transfer before anything is demoted,
+ * and a demotion that didn't land cleanly is rolled back. Either way the
+ * result is a `WP_Error` plus a Slack-relayed warning, and the transfer stays
+ * pending so it can be retried -- never a false report of success.
  *
  * @param int $site_id    Group site ID. The current blog MUST already be this site.
  * @param int $decided_by The approving network admin.
  * @return true|WP_Error
  */
 function execute_transfer( int $site_id, int $decided_by ) {
-	return with_transfer_lock(
+	$record = with_transfer_lock(
 		$site_id,
 		static function () use ( $site_id, $decided_by ) {
 			return execute_transfer_unlocked( $site_id, $decided_by );
 		}
 	);
+
+	if ( is_wp_error( $record ) ) {
+		return $record;
+	}
+
+	/**
+	 * Fires after a transfer has executed and roles were swapped.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $record  The completed pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_executed', $site_id, $record );
+
+	return true;
 }
 
 /**
  * @see execute_transfer() -- runs under that function's per-site lock.
+ *
+ * @return array|WP_Error The completed record, for the caller to announce.
  */
 function execute_transfer_unlocked( int $site_id, int $decided_by ) {
 	$pending = get_pending_transfer( $site_id );
@@ -638,6 +774,29 @@ function execute_transfer_unlocked( int $site_id, int $decided_by ) {
 	}
 
 	$new_owner->set_role( 'administrator' );
+
+	/*
+	 * Confirm the promotion actually landed BEFORE demoting anyone.
+	 * `WP_User::set_role()` returns nothing, and another plugin hooked to
+	 * `set_user_role` can undo or replace what it just wrote, so "the call
+	 * returned" is not evidence the new owner is an administrator. Demoting
+	 * on that assumption is precisely how a single-owner group ends up with
+	 * zero administrators. Bailing here instead leaves every role exactly as
+	 * it was and the record still pending, so the decision can simply be
+	 * retried once whatever interfered is dealt with.
+	 */
+	$new_owner_after = get_userdata( (int) $pending['to_user_id'] );
+
+	if ( ! $new_owner_after || ! in_array( 'administrator', $new_owner_after->roles, true ) ) {
+		report_inconsistent_execution( $site_id, $pending, 'promotion_failed', false );
+
+		return new WP_Error(
+			'transfer_promotion_failed',
+			__( 'The new owner could not be promoted, so no roles were changed. Please try again, or check wp-admin → Users for this site directly.', 'wordcamporg' ),
+			array( 'status' => 500 )
+		);
+	}
+
 	$old_owner->set_role( CANDIDATE_ROLE );
 
 	// Re-read both users; `set_role()` above may have been intercepted by
@@ -645,41 +804,60 @@ function execute_transfer_unlocked( int $site_id, int $decided_by ) {
 	$old_owner_after = get_userdata( (int) $pending['from_user_id'] );
 	$new_owner_after = get_userdata( (int) $pending['to_user_id'] );
 
-	$old_is_admin = $old_owner_after && in_array( 'administrator', $old_owner_after->roles, true );
-	$new_is_admin = $new_owner_after && in_array( 'administrator', $new_owner_after->roles, true );
+	// `$old_is_candidate` is checked as well as `$old_is_admin` because "no
+	// longer an administrator" is also satisfied by a user whose capabilities
+	// were wiped entirely -- that would pass as a clean demotion while
+	// actually locking them out of the group they still co-organise.
+	$old_is_admin     = $old_owner_after && in_array( 'administrator', $old_owner_after->roles, true );
+	$new_is_admin     = $new_owner_after && in_array( 'administrator', $new_owner_after->roles, true );
+	$old_is_candidate = $old_owner_after && in_array( CANDIDATE_ROLE, $old_owner_after->roles, true );
 
-	if ( $old_is_admin || ! $new_is_admin ) {
+	if ( $old_is_admin || ! $old_is_candidate || ! $new_is_admin ) {
+		$rolled_back = roll_back_execution( $pending );
+
+		report_inconsistent_execution( $site_id, $pending, 'swap_incomplete', $rolled_back );
+
+		return new WP_Error(
+			'transfer_execution_inconsistent',
+			$rolled_back
+				? __( 'The ownership transfer did not complete cleanly and the previous roles were restored. Please try again.', 'wordcamporg' )
+				: __( 'The ownership transfer did not complete cleanly. Please check wp-admin → Users for this site directly.', 'wordcamporg' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	if ( ! finalize_transfer( $site_id, $pending, 'completed', array( 'decided_by' => $decided_by ) ) ) {
+		/*
+		 * The roles ARE swapped at this point, so this is deliberately not
+		 * rolled back -- undoing a transfer that succeeded because its
+		 * bookkeeping didn't is the worse outcome. The pending record
+		 * lingering means the group keeps appearing on the approvals screen,
+		 * where a second approve now fails on `candidate_already_administrator`
+		 * and a reject clears it without touching roles, which is the correct
+		 * way out. Loud, because nothing about the UI would otherwise say so.
+		 */
 		trigger_error(
 			sprintf(
-				'Ownership transfer execution left inconsistent roles for site %1$d (old owner %2$d admin=%3$s, new owner %4$d admin=%5$s). Manual review required in wp-admin -> Users.',
-				$site_id, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
-				$pending['from_user_id'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
-				$old_is_admin ? 'yes' : 'no',
-				$pending['to_user_id'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
-				$new_is_admin ? 'yes' : 'no'
+				'Ownership transfer for site %1$d swapped roles successfully but could not clear its pending record. The transfer is complete; reject the leftover request on the Ownership Transfers screen to clear it.',
+				$site_id // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
 			),
 			E_USER_WARNING
 		);
 
 		Logger\log(
-			'groups_ownership_transfer_inconsistent',
+			'groups_ownership_transfer_finalize_failed',
 			array(
 				'site_id'      => $site_id,
-				'from_user_id' => $pending['from_user_id'],
-				'to_user_id'   => $pending['to_user_id'],
-				'old_is_admin' => $old_is_admin,
-				'new_is_admin' => $new_is_admin,
-			)
+				'final_status' => 'completed',
+			) + $pending
 		);
 
 		return new WP_Error(
-			'transfer_execution_inconsistent',
-			__( 'The ownership transfer did not complete cleanly. Please check wp-admin → Users for this site directly.', 'wordcamporg' ),
+			'transfer_not_recorded',
+			__( 'The roles were swapped, but the transfer record could not be cleared. Reject the leftover request to tidy it up — the ownership change itself is done.', 'wordcamporg' ),
 			array( 'status' => 500 )
 		);
 	}
-
-	finalize_transfer( $site_id, $pending, 'completed', array( 'decided_by' => $decided_by ) );
 
 	Logger\log(
 		'groups_ownership_transfer_executed',
@@ -689,15 +867,78 @@ function execute_transfer_unlocked( int $site_id, int $decided_by ) {
 		) + $pending
 	);
 
-	/**
-	 * Fires after a transfer has executed and roles were swapped.
-	 *
-	 * @param int   $site_id Group site ID.
-	 * @param array $pending The completed pending-transfer record.
-	 */
-	do_action( 'wporg_groups_ownership_transfer_executed', $site_id, $pending );
+	return $pending;
+}
 
-	return true;
+/**
+ * Put both parties back the way they were after a half-applied role swap.
+ *
+ * Restores the old owner first, so the group is never momentarily without an
+ * administrator during the rollback either, then puts the candidate back on
+ * `CANDIDATE_ROLE`. Verifies the result the same way the forward path does --
+ * a rollback that silently failed would be worse than none, since it would
+ * turn a reported failure into a reported-and-supposedly-clean one.
+ *
+ * @param array $pending The pending record being executed.
+ * @return bool Whether both parties are back in their original roles.
+ */
+function roll_back_execution( array $pending ): bool {
+	$old_owner = get_userdata( (int) $pending['from_user_id'] );
+	$new_owner = get_userdata( (int) $pending['to_user_id'] );
+
+	if ( ! $old_owner || ! $new_owner ) {
+		return false;
+	}
+
+	$old_owner->set_role( 'administrator' );
+	$new_owner->set_role( CANDIDATE_ROLE );
+
+	$old_owner_after = get_userdata( (int) $pending['from_user_id'] );
+	$new_owner_after = get_userdata( (int) $pending['to_user_id'] );
+
+	return $old_owner_after && in_array( 'administrator', $old_owner_after->roles, true )
+		&& $new_owner_after && ! in_array( 'administrator', $new_owner_after->roles, true )
+		&& in_array( CANDIDATE_ROLE, $new_owner_after->roles, true );
+}
+
+/**
+ * Raise the alarm about a role swap that didn't come out as expected.
+ *
+ * @param int    $site_id     Group site ID.
+ * @param array  $pending     The pending record being executed.
+ * @param string $stage       Which check failed: 'promotion_failed' or 'swap_incomplete'.
+ * @param bool   $rolled_back Whether the original roles were successfully restored.
+ */
+function report_inconsistent_execution( int $site_id, array $pending, string $stage, bool $rolled_back ): void {
+	$old_owner = get_userdata( (int) $pending['from_user_id'] );
+	$new_owner = get_userdata( (int) $pending['to_user_id'] );
+
+	$context = array(
+		'site_id'      => $site_id,
+		'stage'        => $stage,
+		'rolled_back'  => $rolled_back,
+		'from_user_id' => (int) $pending['from_user_id'],
+		'to_user_id'   => (int) $pending['to_user_id'],
+		'from_roles'   => $old_owner ? $old_owner->roles : array(),
+		'to_roles'     => $new_owner ? $new_owner->roles : array(),
+	);
+
+	trigger_error(
+		sprintf(
+			'Ownership transfer execution failed at "%1$s" for site %2$d (old owner %3$d roles=[%4$s], new owner %5$d roles=[%6$s], rolled back: %7$s). %8$s',
+			$stage, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
+			$site_id, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			$context['from_user_id'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			implode( ',', $context['from_roles'] ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			$context['to_user_id'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			implode( ',', $context['to_roles'] ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			$rolled_back ? 'yes' : 'no',
+			$rolled_back ? 'The transfer can be retried.' : 'Manual review required in wp-admin -> Users.' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+		),
+		E_USER_WARNING
+	);
+
+	Logger\log( 'groups_ownership_transfer_inconsistent', $context );
 }
 
 /**
@@ -709,16 +950,33 @@ function execute_transfer_unlocked( int $site_id, int $decided_by ) {
  * @return true|WP_Error
  */
 function reject_transfer( int $site_id, int $decided_by, string $reason = '' ) {
-	return with_transfer_lock(
+	$record = with_transfer_lock(
 		$site_id,
 		static function () use ( $site_id, $decided_by, $reason ) {
 			return reject_transfer_unlocked( $site_id, $decided_by, $reason );
 		}
 	);
+
+	if ( is_wp_error( $record ) ) {
+		return $record;
+	}
+
+	/**
+	 * Fires after a transfer is rejected by a network admin.
+	 *
+	 * @param int    $site_id Group site ID.
+	 * @param array  $record  The rejected pending-transfer record.
+	 * @param string $reason  Optional reason given by the network admin.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_rejected', $site_id, $record, $reason );
+
+	return true;
 }
 
 /**
  * @see reject_transfer() -- runs under that function's per-site lock.
+ *
+ * @return array|WP_Error The rejected record, for the caller to announce.
  */
 function reject_transfer_unlocked( int $site_id, int $decided_by, string $reason = '' ) {
 	$pending = get_pending_transfer( $site_id );
@@ -727,7 +985,7 @@ function reject_transfer_unlocked( int $site_id, int $decided_by, string $reason
 		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
 	}
 
-	finalize_transfer(
+	$finalized = finalize_transfer(
 		$site_id,
 		$pending,
 		'rejected',
@@ -736,6 +994,10 @@ function reject_transfer_unlocked( int $site_id, int $decided_by, string $reason
 			'reason'     => $reason,
 		)
 	);
+
+	if ( ! $finalized ) {
+		return finalize_failed_error( $site_id, 'rejected' );
+	}
 
 	Logger\log(
 		'groups_ownership_transfer_rejected',
@@ -746,16 +1008,7 @@ function reject_transfer_unlocked( int $site_id, int $decided_by, string $reason
 		) + $pending
 	);
 
-	/**
-	 * Fires after a transfer is rejected by a network admin.
-	 *
-	 * @param int    $site_id Group site ID.
-	 * @param array  $pending The rejected pending-transfer record.
-	 * @param string $reason  Optional reason given by the network admin.
-	 */
-	do_action( 'wporg_groups_ownership_transfer_rejected', $site_id, $pending, $reason );
-
-	return true;
+	return $pending;
 }
 
 /*
@@ -781,12 +1034,18 @@ function add_page(): void {
 /**
  * Get every group site with a transfer awaiting a decision.
  *
- * @return array{site: \WP_Site, pending: array}[]
+ * @return array{site: \WP_Site, pending: array}[]|WP_Error
  */
-function get_sites_with_pending_transfers(): array {
+function get_sites_with_pending_transfers() {
+	$sites = get_group_sites_with_meta_key( META_KEY_PENDING );
+
+	if ( is_wp_error( $sites ) ) {
+		return $sites;
+	}
+
 	$rows = array();
 
-	foreach ( get_group_sites_with_meta_key( META_KEY_PENDING ) as $site ) {
+	foreach ( $sites as $site ) {
 		$pending = get_pending_transfer( (int) $site->blog_id );
 
 		if ( $pending ) {
@@ -804,12 +1063,18 @@ function get_sites_with_pending_transfers(): array {
  * Get the most recently decided transfers across every group site, newest first.
  *
  * @param int $limit Maximum rows to return.
- * @return array{site: \WP_Site, entry: array}[]
+ * @return array{site: \WP_Site, entry: array}[]|WP_Error
  */
-function get_recent_decided_transfers( int $limit = 20 ): array {
+function get_recent_decided_transfers( int $limit = 20 ) {
+	$sites = get_group_sites_with_meta_key( META_KEY_HISTORY );
+
+	if ( is_wp_error( $sites ) ) {
+		return $sites;
+	}
+
 	$rows = array();
 
-	foreach ( get_group_sites_with_meta_key( META_KEY_HISTORY ) as $site ) {
+	foreach ( $sites as $site ) {
 		foreach ( get_transfer_history( (int) $site->blog_id ) as $entry ) {
 			$rows[] = array(
 				'site'  => $site,
@@ -840,9 +1105,9 @@ function get_recent_decided_transfers( int $limit = 20 ): array {
  * precisely because it doesn't scale otherwise.
  *
  * @param string $meta_key Blog meta key to look for.
- * @return \WP_Site[]
+ * @return \WP_Site[]|WP_Error
  */
-function get_group_sites_with_meta_key( string $meta_key ): array {
+function get_group_sites_with_meta_key( string $meta_key ) {
 	global $wpdb;
 
 	$site_ids = $wpdb->get_col(
@@ -852,6 +1117,30 @@ function get_group_sites_with_meta_key( string $meta_key ): array {
 		)
 	);
 
+	/*
+	 * An empty result set and a failed query are the same `array()` here, and
+	 * the screen renders the former as "No transfers are awaiting approval."
+	 * Silently reporting "nothing to do" to the people responsible for acting
+	 * on these is the one outcome this screen must never produce, so the
+	 * difference is surfaced rather than swallowed.
+	 */
+	if ( $wpdb->last_error ) {
+		trigger_error(
+			sprintf(
+				'Could not list group sites carrying "%1$s": %2$s',
+				$meta_key, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
+				$wpdb->last_error // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+			),
+			E_USER_WARNING
+		);
+
+		return new WP_Error(
+			'transfer_query_failed',
+			__( 'The list of ownership transfers could not be loaded. Please reload the page.', 'wordcamporg' ),
+			array( 'status' => 500 )
+		);
+	}
+
 	$sites = array();
 
 	foreach ( $site_ids as $site_id ) {
@@ -859,8 +1148,12 @@ function get_group_sites_with_meta_key( string $meta_key ): array {
 		$site    = get_site( $site_id );
 
 		// Same exclusions as `Archive\get_group_sites()`: only sites on this
-		// network, never the placeholder root, never a deleted site.
-		if ( ! $site || GROUPS_ROOT_BLOG_ID === $site_id || GROUPS_NETWORK_ID !== (int) $site->network_id || $site->deleted ) {
+		// network, never the placeholder root, and never a site that is
+		// deleted, spammed, or archived. The last two matter most here: those
+		// groups are out of circulation, and an Approve button next to one
+		// would hand a live group's ownership over on the strength of a
+		// request made before it was taken down.
+		if ( ! $site || GROUPS_ROOT_BLOG_ID === $site_id || GROUPS_NETWORK_ID !== (int) $site->network_id || $site->deleted || $site->spam || $site->archived ) {
 			continue;
 		}
 
@@ -949,9 +1242,25 @@ function render_page(): void {
 	$pending_rows = get_sites_with_pending_transfers();
 	$recent_rows  = get_recent_decided_transfers();
 	$updated      = isset( $_GET['updated'] ) ? sanitize_key( wp_unslash( $_GET['updated'] ) ) : '';
+
+	// A failed lookup must read as "we could not check", never as the
+	// identical-looking "there is nothing to approve" empty state below.
+	$pending_error = is_wp_error( $pending_rows ) ? $pending_rows : null;
+
+	if ( $pending_error ) {
+		$pending_rows = array();
+	}
+
+	if ( is_wp_error( $recent_rows ) ) {
+		$recent_rows = array();
+	}
 	?>
 	<div class="wrap">
 		<h1><?php esc_html_e( 'Ownership Transfers', 'wordcamporg' ); ?></h1>
+
+		<?php if ( $pending_error ) : ?>
+			<div class="notice notice-error"><p><?php echo esc_html( $pending_error->get_error_message() ); ?></p></div>
+		<?php endif; ?>
 
 		<?php if ( in_array( $updated, array( 'approved', 'rejected' ), true ) ) : ?>
 			<div class="notice notice-success is-dismissible"><p>
@@ -981,7 +1290,15 @@ function render_page(): void {
 			</thead>
 			<tbody>
 				<?php if ( empty( $pending_rows ) ) : ?>
-					<tr><td colspan="5"><?php esc_html_e( 'No transfers are awaiting approval.', 'wordcamporg' ); ?></td></tr>
+					<tr><td colspan="5">
+						<?php
+						echo esc_html(
+							$pending_error
+								? __( 'The list of pending transfers could not be loaded.', 'wordcamporg' )
+								: __( 'No transfers are awaiting approval.', 'wordcamporg' )
+						);
+						?>
+					</td></tr>
 				<?php else : ?>
 					<?php foreach ( $pending_rows as $row ) : ?>
 						<?php

--- a/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/group-ownership-transfer.php
@@ -1,0 +1,863 @@
+<?php
+/**
+ * Formal group-ownership transfer workflow.
+ *
+ * Ordinary co-organizer role changes (Member/Event Organiser/Organiser) are
+ * handled entirely by `Members_Controller::update_member_role()` in the
+ * `wporg-groups-frontend` mu-plugin. That endpoint explicitly refuses to
+ * touch anyone who already holds the site's `administrator` role, so there
+ * has never been a supported way for a group owner to hand off their group.
+ *
+ * This file adds that missing path as a four-stage state machine — initiate,
+ * accept, approve, execute — plus the Network Admin screen where the
+ * "approve" step happens. It lives here, rather than in
+ * `wporg-groups-frontend`, because that plugin's `bootstrap()` only runs
+ * when GatherPress is active on the current site, while this workflow (and
+ * especially its Network Admin screen, which acts across every group site at
+ * once) must work regardless. `wporg-groups-frontend`'s REST controller is a
+ * thin client of the functions defined here.
+ *
+ * Only loaded on the Groups network, via
+ * `load-other-mu-plugins.php::wcorg_include_network_only_plugins()`.
+ *
+ * @package WordCamp\Groups
+ */
+
+namespace WordCamp\Groups\Ownership_Transfer;
+
+use WordCamp\Groups\Archive;
+use WordCamp\Logger;
+use WP_Error;
+
+defined( 'WPINC' ) || die();
+
+/** Site meta key holding the single in-flight transfer for a group, if any. */
+const META_KEY_PENDING = '_wporg_groups_ownership_transfer';
+
+/** Site meta key holding a capped, newest-first list of decided transfers. */
+const META_KEY_HISTORY = '_wporg_groups_ownership_transfer_history';
+
+/** Maximum number of decided transfers kept per group. */
+const HISTORY_LIMIT = 20;
+
+/** A candidate has been nominated and must accept before anything else happens. */
+const STATUS_PENDING_ACCEPTANCE = 'pending_acceptance';
+
+/** The candidate has accepted; a network admin must approve before execution. */
+const STATUS_PENDING_APPROVAL = 'pending_approval';
+
+/**
+ * The only role a transfer target may hold. Mirrors "Organiser tier" from
+ * `Members_Controller::ROLE_LABELS`, minus `administrator` itself — there's
+ * nothing to transfer to someone who already holds it, so that case gets its
+ * own validation error instead of being folded into this constant.
+ */
+const CANDIDATE_ROLE = 'editor';
+
+/** Network Admin page slug. */
+const MENU_SLUG = 'wporg-groups-ownership-transfer';
+
+/** `admin_post_` action the approve/reject forms submit to. */
+const DECIDE_ACTION = 'wporg_groups_ownership_transfer_decide';
+
+add_action( 'network_admin_menu', __NAMESPACE__ . '\add_page' );
+add_action( 'admin_post_' . DECIDE_ACTION, __NAMESPACE__ . '\handle_decision' );
+
+/*
+ * ----------------------------------------------------------------------
+ * State.
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ * Get the in-flight transfer for a group, if any.
+ *
+ * @param int $site_id Group site ID.
+ * @return array{from_user_id:int,to_user_id:int,status:string,initiated_by:int,initiated_at:int,accepted_at:?int}|null
+ */
+function get_pending_transfer( int $site_id ): ?array {
+	$pending = get_site_meta( $site_id, META_KEY_PENDING, true );
+
+	return ( is_array( $pending ) && ! empty( $pending ) ) ? $pending : null;
+}
+
+/**
+ * Get a group's decided-transfer history, newest first.
+ *
+ * @param int $site_id Group site ID.
+ * @return array[]
+ */
+function get_transfer_history( int $site_id ): array {
+	$history = get_site_meta( $site_id, META_KEY_HISTORY, true );
+
+	return is_array( $history ) ? $history : array();
+}
+
+/**
+ * Store a group's in-flight transfer.
+ *
+ * @param int   $site_id Group site ID.
+ * @param array $record  Pending-transfer record.
+ */
+function set_pending_transfer( int $site_id, array $record ): void {
+	update_site_meta( $site_id, META_KEY_PENDING, $record );
+}
+
+/**
+ * Move a decided transfer from "pending" into the capped history list.
+ *
+ * @param int    $site_id      Group site ID.
+ * @param array  $pending      The pending record being decided.
+ * @param string $final_status One of 'declined', 'cancelled', 'completed', 'rejected'.
+ * @param array  $extra        Extra fields to merge in (e.g. `decided_by`, `reason`).
+ */
+function finalize_transfer( int $site_id, array $pending, string $final_status, array $extra = array() ): void {
+	delete_site_meta( $site_id, META_KEY_PENDING );
+
+	$entry = array_merge(
+		$pending,
+		array(
+			'final_status' => $final_status,
+			'decided_at'   => time(),
+		),
+		$extra
+	);
+
+	$history = get_transfer_history( $site_id );
+	array_unshift( $history, $entry );
+	$history = array_slice( $history, 0, HISTORY_LIMIT );
+
+	update_site_meta( $site_id, META_KEY_HISTORY, $history );
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * Capabilities.
+ *
+ * Deliberately narrow, purpose-built checks rather than a broad core
+ * capability — see `gatherpress-groups-tweaks.php`'s removed `promote_users`
+ * grant to editors for the class of bug this is avoiding repeating.
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ * Whether the current user may initiate a transfer on `$site_id`.
+ *
+ * The current owner (the site's `administrator`) may always initiate. A
+ * network admin may also initiate, on behalf of an unresponsive/inactive
+ * owner — the candidate must still explicitly accept and a network admin
+ * must still approve, so this only skips the "owner clicks initiate" step,
+ * not any safety check.
+ *
+ * Callers MUST ensure `get_current_blog_id() === $site_id` before calling
+ * this — the role check below reads the current user's roles on whatever
+ * blog is currently active, exactly like the existing inline check in
+ * `Members_Controller::update_member_role()`.
+ *
+ * @param int $site_id Group site ID. Unused directly; documents the caller's
+ *                      blog-context obligation and allows a future per-site
+ *                      capability without changing this function's signature.
+ */
+function current_user_can_initiate( int $site_id ): bool { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Deliberately unused; see docblock.
+	if ( ! is_user_logged_in() ) {
+		return false;
+	}
+
+	if ( is_super_admin() ) {
+		return true;
+	}
+
+	return in_array( 'administrator', wp_get_current_user()->roles, true );
+}
+
+/**
+ * Whether the current user may approve or reject a pending transfer.
+ *
+ * `manage_sites` matches `Archive\current_user_can_archive_groups()` — this
+ * codebase already uses that capability for "one specific group's sensitive
+ * state, decided one at a time, surfaced on a network-wide listing screen,"
+ * which is exactly this shape of action. `manage_network` is reserved
+ * elsewhere in this codebase (`Groups\Messaging`) for tooling that
+ * broadcasts to every group at once, which this isn't.
+ */
+function current_user_can_approve(): bool {
+	return current_user_can( 'manage_sites' );
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * Queries used by both the REST controller and the Network Admin screen.
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ * Get every user holding `administrator` on a group site.
+ *
+ * @param int $site_id Group site ID.
+ * @return \WP_User[]
+ */
+function get_site_administrators( int $site_id ): array {
+	return get_users(
+		array(
+			'blog_id' => $site_id,
+			'role'    => 'administrator',
+			'orderby' => 'display_name',
+		)
+	);
+}
+
+/**
+ * Get every member eligible to be nominated as a transfer target.
+ *
+ * @param int $site_id Group site ID.
+ * @return \WP_User[]
+ */
+function get_eligible_candidates( int $site_id ): array {
+	return get_users(
+		array(
+			'blog_id' => $site_id,
+			'role'    => CANDIDATE_ROLE,
+			'orderby' => 'display_name',
+		)
+	);
+}
+
+/**
+ * Validate a nominated transfer target.
+ *
+ * @param int $candidate_id Candidate user ID.
+ * @param int $from_user_id The owner being replaced.
+ * @param int $site_id      Group site ID.
+ * @return true|WP_Error
+ */
+function validate_candidate( int $candidate_id, int $from_user_id, int $site_id ) {
+	if ( $candidate_id === $from_user_id ) {
+		return new WP_Error(
+			'cannot_transfer_to_self',
+			__( 'You cannot transfer ownership to the current owner.', 'wordcamporg' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$candidate = get_userdata( $candidate_id );
+
+	if ( ! $candidate || ! is_user_member_of_blog( $candidate_id, $site_id ) ) {
+		return new WP_Error(
+			'candidate_not_found',
+			__( 'That user is not a member of this group.', 'wordcamporg' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	if ( in_array( 'administrator', $candidate->roles, true ) ) {
+		return new WP_Error(
+			'candidate_already_administrator',
+			__( 'That user is already an administrator of this group.', 'wordcamporg' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	if ( ! in_array( CANDIDATE_ROLE, $candidate->roles, true ) ) {
+		return new WP_Error(
+			'candidate_not_eligible',
+			__( 'Ownership can only be transferred to an existing Organiser (editor) of this group.', 'wordcamporg' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	return true;
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * State transitions.
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ * Initiate a transfer.
+ *
+ * @param int $site_id      Group site ID. The current blog MUST already be this site.
+ * @param int $from_user_id The owner being replaced.
+ * @param int $to_user_id   The nominated candidate.
+ * @param int $initiated_by The acting user (may differ from `$from_user_id` when a
+ *                           network admin initiates on an inactive owner's behalf).
+ * @return true|WP_Error
+ */
+function initiate_transfer( int $site_id, int $from_user_id, int $to_user_id, int $initiated_by ) {
+	if ( get_pending_transfer( $site_id ) ) {
+		return new WP_Error(
+			'transfer_already_pending',
+			__( 'A transfer is already pending for this group.', 'wordcamporg' ),
+			array( 'status' => 409 )
+		);
+	}
+
+	$from_user = get_userdata( $from_user_id );
+
+	if ( ! $from_user || ! in_array( 'administrator', $from_user->roles, true ) ) {
+		return new WP_Error(
+			'invalid_from_user',
+			__( 'The selected current owner does not hold the administrator role on this group.', 'wordcamporg' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$candidate_check = validate_candidate( $to_user_id, $from_user_id, $site_id );
+	if ( is_wp_error( $candidate_check ) ) {
+		return $candidate_check;
+	}
+
+	$record = array(
+		'from_user_id' => $from_user_id,
+		'to_user_id'   => $to_user_id,
+		'status'       => STATUS_PENDING_ACCEPTANCE,
+		'initiated_by' => $initiated_by,
+		'initiated_at' => time(),
+		'accepted_at'  => null,
+	);
+
+	set_pending_transfer( $site_id, $record );
+
+	Logger\log(
+		'groups_ownership_transfer_initiated',
+		array(
+			'site_id'      => $site_id,
+			'from_user_id' => $from_user_id,
+			'to_user_id'   => $to_user_id,
+			'initiated_by' => $initiated_by,
+		)
+	);
+
+	/**
+	 * Fires after a transfer has been initiated.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $record  The new pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_initiated', $site_id, $record );
+
+	return true;
+}
+
+/**
+ * The nominated candidate accepts the transfer.
+ *
+ * @param int $site_id Group site ID.
+ * @param int $user_id The acting user; must be the pending record's `to_user_id`.
+ * @return true|WP_Error
+ */
+function accept_transfer( int $site_id, int $user_id ) {
+	$pending = get_pending_transfer( $site_id );
+
+	if ( ! $pending ) {
+		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
+	}
+
+	if ( STATUS_PENDING_ACCEPTANCE !== $pending['status'] ) {
+		return new WP_Error( 'transfer_not_awaiting_acceptance', __( 'This transfer is not awaiting acceptance.', 'wordcamporg' ), array( 'status' => 400 ) );
+	}
+
+	if ( (int) $pending['to_user_id'] !== $user_id ) {
+		return new WP_Error( 'not_the_candidate', __( 'Only the nominated candidate can accept this transfer.', 'wordcamporg' ), array( 'status' => 403 ) );
+	}
+
+	$pending['status']      = STATUS_PENDING_APPROVAL;
+	$pending['accepted_at'] = time();
+
+	set_pending_transfer( $site_id, $pending );
+
+	Logger\log( 'groups_ownership_transfer_accepted', array( 'site_id' => $site_id ) + $pending );
+
+	/**
+	 * Fires after the candidate accepts a transfer.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $pending The updated pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_accepted', $site_id, $pending );
+
+	return true;
+}
+
+/**
+ * The nominated candidate declines the transfer.
+ *
+ * @param int $site_id Group site ID.
+ * @param int $user_id The acting user; must be the pending record's `to_user_id`.
+ * @return true|WP_Error
+ */
+function decline_transfer( int $site_id, int $user_id ) {
+	$pending = get_pending_transfer( $site_id );
+
+	if ( ! $pending ) {
+		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
+	}
+
+	if ( (int) $pending['to_user_id'] !== $user_id ) {
+		return new WP_Error( 'not_the_candidate', __( 'Only the nominated candidate can decline this transfer.', 'wordcamporg' ), array( 'status' => 403 ) );
+	}
+
+	finalize_transfer( $site_id, $pending, 'declined' );
+
+	Logger\log( 'groups_ownership_transfer_declined', array( 'site_id' => $site_id ) + $pending );
+
+	/**
+	 * Fires after the candidate declines a transfer.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $pending The declined pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_declined', $site_id, $pending );
+
+	return true;
+}
+
+/**
+ * The initiating audience (owner or network admin) cancels a pending transfer.
+ *
+ * @param int $site_id Group site ID. The current blog MUST already be this site.
+ * @param int $user_id The acting user.
+ * @return true|WP_Error
+ */
+function cancel_transfer( int $site_id, int $user_id ) {
+	$pending = get_pending_transfer( $site_id );
+
+	if ( ! $pending ) {
+		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
+	}
+
+	if ( ! current_user_can_initiate( $site_id ) ) {
+		return new WP_Error( 'cannot_cancel_transfer', __( 'Sorry, you are not allowed to cancel this transfer.', 'wordcamporg' ), array( 'status' => 403 ) );
+	}
+
+	finalize_transfer( $site_id, $pending, 'cancelled', array( 'decided_by' => $user_id ) );
+
+	Logger\log( 'groups_ownership_transfer_cancelled', array( 'site_id' => $site_id ) + $pending );
+
+	/**
+	 * Fires after a pending transfer is cancelled.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $pending The cancelled pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_cancelled', $site_id, $pending );
+
+	return true;
+}
+
+/**
+ * A network admin approves an accepted transfer, executing the role swap.
+ *
+ * Promotes the new owner to `administrator` before demoting the old owner to
+ * `editor`, so the site is never briefly without an administrator — see the
+ * file docblock section on atomicity for why this isn't wrapped in a raw SQL
+ * transaction instead. After both role changes, re-reads both users and
+ * bails with a `WP_Error` (and a Slack-relayed warning) if the result isn't
+ * exactly what was expected, rather than reporting false success.
+ *
+ * @param int $site_id    Group site ID. The current blog MUST already be this site.
+ * @param int $decided_by The approving network admin.
+ * @return true|WP_Error
+ */
+function execute_transfer( int $site_id, int $decided_by ) {
+	$pending = get_pending_transfer( $site_id );
+
+	if ( ! $pending ) {
+		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
+	}
+
+	if ( STATUS_PENDING_APPROVAL !== $pending['status'] ) {
+		return new WP_Error( 'transfer_not_awaiting_approval', __( 'This transfer has not been accepted by the candidate yet.', 'wordcamporg' ), array( 'status' => 400 ) );
+	}
+
+	if ( get_current_blog_id() !== $site_id ) {
+		return new WP_Error( 'wrong_site_context', 'execute_transfer() must be called with the target site as the current blog.' );
+	}
+
+	$old_owner = get_userdata( (int) $pending['from_user_id'] );
+	$new_owner = get_userdata( (int) $pending['to_user_id'] );
+
+	if ( ! $old_owner || ! $new_owner ) {
+		return new WP_Error( 'transfer_user_missing', __( 'One of the users in this transfer no longer exists.', 'wordcamporg' ), array( 'status' => 400 ) );
+	}
+
+	$new_owner->set_role( 'administrator' );
+	$old_owner->set_role( CANDIDATE_ROLE );
+
+	// Re-read both users; `set_role()` above may have been intercepted by
+	// another plugin's hook, so the in-memory objects aren't trustworthy.
+	$old_owner_after = get_userdata( (int) $pending['from_user_id'] );
+	$new_owner_after = get_userdata( (int) $pending['to_user_id'] );
+
+	$old_is_admin = $old_owner_after && in_array( 'administrator', $old_owner_after->roles, true );
+	$new_is_admin = $new_owner_after && in_array( 'administrator', $new_owner_after->roles, true );
+
+	if ( $old_is_admin || ! $new_is_admin ) {
+		trigger_error(
+			sprintf(
+				'Ownership transfer execution left inconsistent roles for site %1$d (old owner %2$d admin=%3$s, new owner %4$d admin=%5$s). Manual review required in wp-admin -> Users.',
+				$site_id, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Not HTML output; an internal log message this repo's error handler (0-error-handling.php) relays to Slack.
+				$pending['from_user_id'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+				$old_is_admin ? 'yes' : 'no',
+				$pending['to_user_id'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Ditto.
+				$new_is_admin ? 'yes' : 'no'
+			),
+			E_USER_WARNING
+		);
+
+		Logger\log(
+			'groups_ownership_transfer_inconsistent',
+			array(
+				'site_id'      => $site_id,
+				'from_user_id' => $pending['from_user_id'],
+				'to_user_id'   => $pending['to_user_id'],
+				'old_is_admin' => $old_is_admin,
+				'new_is_admin' => $new_is_admin,
+			)
+		);
+
+		return new WP_Error(
+			'transfer_execution_inconsistent',
+			__( 'The ownership transfer did not complete cleanly. Please check wp-admin → Users for this site directly.', 'wordcamporg' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	finalize_transfer( $site_id, $pending, 'completed', array( 'decided_by' => $decided_by ) );
+
+	Logger\log(
+		'groups_ownership_transfer_executed',
+		array(
+			'site_id'    => $site_id,
+			'decided_by' => $decided_by,
+		) + $pending
+	);
+
+	/**
+	 * Fires after a transfer has executed and roles were swapped.
+	 *
+	 * @param int   $site_id Group site ID.
+	 * @param array $pending The completed pending-transfer record.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_executed', $site_id, $pending );
+
+	return true;
+}
+
+/**
+ * A network admin rejects an in-flight transfer, at either pending stage.
+ *
+ * @param int    $site_id    Group site ID.
+ * @param int    $decided_by The rejecting network admin.
+ * @param string $reason     Optional reason shown to both parties by email.
+ * @return true|WP_Error
+ */
+function reject_transfer( int $site_id, int $decided_by, string $reason = '' ) {
+	$pending = get_pending_transfer( $site_id );
+
+	if ( ! $pending ) {
+		return new WP_Error( 'no_pending_transfer', __( 'There is no pending transfer for this group.', 'wordcamporg' ), array( 'status' => 404 ) );
+	}
+
+	finalize_transfer(
+		$site_id,
+		$pending,
+		'rejected',
+		array(
+			'decided_by' => $decided_by,
+			'reason'     => $reason,
+		)
+	);
+
+	Logger\log(
+		'groups_ownership_transfer_rejected',
+		array(
+			'site_id'    => $site_id,
+			'decided_by' => $decided_by,
+			'reason'     => $reason,
+		) + $pending
+	);
+
+	/**
+	 * Fires after a transfer is rejected by a network admin.
+	 *
+	 * @param int    $site_id Group site ID.
+	 * @param array  $pending The rejected pending-transfer record.
+	 * @param string $reason  Optional reason given by the network admin.
+	 */
+	do_action( 'wporg_groups_ownership_transfer_rejected', $site_id, $pending, $reason );
+
+	return true;
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * Network Admin screen.
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ * Register the "Ownership Transfers" submenu under the Groups menu.
+ */
+function add_page(): void {
+	add_submenu_page(
+		Archive\PAGE_SLUG,
+		__( 'Ownership Transfers', 'wordcamporg' ),
+		__( 'Ownership Transfers', 'wordcamporg' ),
+		'manage_sites',
+		MENU_SLUG,
+		__NAMESPACE__ . '\render_page'
+	);
+}
+
+/**
+ * Get every group site with a transfer awaiting a decision.
+ *
+ * @return array{site: \WP_Site, pending: array}[]
+ */
+function get_sites_with_pending_transfers(): array {
+	$rows = array();
+
+	foreach ( Archive\get_group_sites( true ) as $site ) {
+		$pending = get_pending_transfer( (int) $site->blog_id );
+
+		if ( $pending ) {
+			$rows[] = array(
+				'site'    => $site,
+				'pending' => $pending,
+			);
+		}
+	}
+
+	return $rows;
+}
+
+/**
+ * Get the most recently decided transfers across every group site, newest first.
+ *
+ * @param int $limit Maximum rows to return.
+ * @return array{site: \WP_Site, entry: array}[]
+ */
+function get_recent_decided_transfers( int $limit = 20 ): array {
+	$rows = array();
+
+	foreach ( Archive\get_group_sites( true ) as $site ) {
+		foreach ( get_transfer_history( (int) $site->blog_id ) as $entry ) {
+			$rows[] = array(
+				'site'  => $site,
+				'entry' => $entry,
+			);
+		}
+	}
+
+	usort(
+		$rows,
+		static function ( array $a, array $b ): int {
+			return ( $b['entry']['decided_at'] ?? 0 ) <=> ( $a['entry']['decided_at'] ?? 0 );
+		}
+	);
+
+	return array_slice( $rows, 0, $limit );
+}
+
+/**
+ * Process an approve/reject decision from the Network Admin screen.
+ */
+function handle_decision(): void {
+	if ( ! current_user_can_approve() ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to decide group ownership transfers.', 'wordcamporg' ), '', array( 'response' => 403 ) );
+	}
+
+	$site_id  = isset( $_POST['site_id'] ) ? absint( wp_unslash( $_POST['site_id'] ) ) : 0;
+	$decision = isset( $_POST['decision'] ) ? sanitize_key( wp_unslash( $_POST['decision'] ) ) : '';
+	$reason   = isset( $_POST['reason'] ) ? sanitize_text_field( wp_unslash( $_POST['reason'] ) ) : '';
+
+	check_admin_referer( DECIDE_ACTION . '_' . $site_id );
+
+	if ( ! in_array( $decision, array( 'approve', 'reject' ), true ) ) {
+		wp_die( esc_html__( 'Invalid decision.', 'wordcamporg' ), '', array( 'response' => 400 ) );
+	}
+
+	switch_to_blog( $site_id );
+	$decided_by = get_current_user_id();
+
+	$result = 'approve' === $decision
+		? execute_transfer( $site_id, $decided_by )
+		: reject_transfer( $site_id, $decided_by, $reason );
+
+	restore_current_blog();
+
+	if ( is_wp_error( $result ) ) {
+		wp_die(
+			esc_html( $result->get_error_message() ),
+			esc_html__( 'Could not process transfer', 'wordcamporg' ),
+			array( 'response' => 400 )
+		);
+	}
+
+	$redirect_url = add_query_arg(
+		array(
+			'page'    => MENU_SLUG,
+			'updated' => 'approve' === $decision ? 'approved' : 'rejected',
+		),
+		network_admin_url( 'admin.php' )
+	);
+
+	wp_safe_redirect( $redirect_url );
+	exit;
+}
+
+/**
+ * Render the Ownership Transfers screen.
+ */
+function render_page(): void {
+	if ( ! current_user_can_approve() ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to decide group ownership transfers.', 'wordcamporg' ) );
+	}
+
+	$pending_rows = get_sites_with_pending_transfers();
+	$recent_rows  = get_recent_decided_transfers();
+	$updated      = isset( $_GET['updated'] ) ? sanitize_key( wp_unslash( $_GET['updated'] ) ) : '';
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Ownership Transfers', 'wordcamporg' ); ?></h1>
+
+		<?php if ( in_array( $updated, array( 'approved', 'rejected' ), true ) ) : ?>
+			<div class="notice notice-success is-dismissible"><p>
+				<?php
+				echo esc_html(
+					'approved' === $updated
+						? __( 'Transfer approved and completed.', 'wordcamporg' )
+						: __( 'Transfer rejected.', 'wordcamporg' )
+				);
+				?>
+			</p></div>
+		<?php endif; ?>
+
+		<p>
+			<?php esc_html_e( 'Group owners who want to hand off their group nominate a candidate, who must explicitly accept before a transfer lands here. Approving swaps the roles immediately; rejecting cancels the request.', 'wordcamporg' ); ?>
+		</p>
+
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Group', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Current owner', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Nominated owner', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Initiated', 'wordcamporg' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Action', 'wordcamporg' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( empty( $pending_rows ) ) : ?>
+					<tr><td colspan="5"><?php esc_html_e( 'No transfers are awaiting approval.', 'wordcamporg' ); ?></td></tr>
+				<?php else : ?>
+					<?php foreach ( $pending_rows as $row ) : ?>
+						<?php
+						$site_id      = (int) $row['site']->blog_id;
+						$pending      = $row['pending'];
+						$group_name   = get_blog_option( $site_id, 'blogname' );
+						$from_user    = get_userdata( (int) $pending['from_user_id'] );
+						$to_user      = get_userdata( (int) $pending['to_user_id'] );
+						$initiated_by = get_userdata( (int) $pending['initiated_by'] );
+						$awaiting     = STATUS_PENDING_ACCEPTANCE === $pending['status'];
+						?>
+						<tr>
+							<td>
+								<strong><?php echo esc_html( $group_name ?: $row['site']->domain . $row['site']->path ); ?></strong>
+								<br />
+								<a href="<?php echo esc_url( get_home_url( $site_id, '/' ) ); ?>"><?php echo esc_html( get_home_url( $site_id, '/' ) ); ?></a>
+							</td>
+							<td><?php echo esc_html( $from_user ? $from_user->display_name : __( '(deleted user)', 'wordcamporg' ) ); ?></td>
+							<td><?php echo esc_html( $to_user ? $to_user->display_name : __( '(deleted user)', 'wordcamporg' ) ); ?></td>
+							<td>
+								<?php
+								printf(
+									/* translators: 1: who initiated the transfer, 2: date initiated. */
+									esc_html__( 'by %1$s on %2$s', 'wordcamporg' ),
+									esc_html( $initiated_by ? $initiated_by->display_name : __( '(deleted user)', 'wordcamporg' ) ),
+									esc_html( wp_date( 'Y-m-d', (int) $pending['initiated_at'] ) )
+								);
+								?>
+								<br />
+								<em>
+									<?php
+									echo esc_html(
+										$awaiting
+											? __( 'Awaiting candidate acceptance.', 'wordcamporg' )
+											: __( 'Accepted — awaiting your approval.', 'wordcamporg' )
+									);
+									?>
+								</em>
+							</td>
+							<td>
+								<?php if ( $awaiting ) : ?>
+									<p class="description"><?php esc_html_e( 'Not yet accepted by the candidate.', 'wordcamporg' ); ?></p>
+								<?php else : ?>
+									<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;">
+										<input type="hidden" name="action" value="<?php echo esc_attr( DECIDE_ACTION ); ?>" />
+										<input type="hidden" name="site_id" value="<?php echo esc_attr( $site_id ); ?>" />
+										<input type="hidden" name="decision" value="approve" />
+										<?php wp_nonce_field( DECIDE_ACTION . '_' . $site_id ); ?>
+										<button
+											type="submit"
+											class="button button-primary"
+											onclick="return window.confirm( '<?php echo esc_js( __( 'Approve this transfer? Roles will be swapped immediately.', 'wordcamporg' ) ); ?>' );"
+										><?php esc_html_e( 'Approve', 'wordcamporg' ); ?></button>
+									</form>
+								<?php endif; ?>
+								<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;">
+									<input type="hidden" name="action" value="<?php echo esc_attr( DECIDE_ACTION ); ?>" />
+									<input type="hidden" name="site_id" value="<?php echo esc_attr( $site_id ); ?>" />
+									<input type="hidden" name="decision" value="reject" />
+									<?php wp_nonce_field( DECIDE_ACTION . '_' . $site_id ); ?>
+									<button
+										type="submit"
+										class="button button-link-delete"
+										onclick="return window.confirm( '<?php echo esc_js( __( 'Reject this transfer?', 'wordcamporg' ) ); ?>' );"
+									><?php esc_html_e( 'Reject', 'wordcamporg' ); ?></button>
+								</form>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+
+		<?php if ( ! empty( $recent_rows ) ) : ?>
+			<details style="margin-top: 2em;">
+				<summary><strong><?php esc_html_e( 'Recently decided transfers', 'wordcamporg' ); ?></strong></summary>
+				<table class="wp-list-table widefat fixed striped" style="margin-top: 1em;">
+					<thead>
+						<tr>
+							<th scope="col"><?php esc_html_e( 'Group', 'wordcamporg' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'From', 'wordcamporg' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'To', 'wordcamporg' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Outcome', 'wordcamporg' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Decided', 'wordcamporg' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $recent_rows as $row ) : ?>
+							<?php
+							$site_id   = (int) $row['site']->blog_id;
+							$entry     = $row['entry'];
+							$from_user = get_userdata( (int) $entry['from_user_id'] );
+							$to_user   = get_userdata( (int) $entry['to_user_id'] );
+							?>
+							<tr>
+								<td><?php echo esc_html( get_blog_option( $site_id, 'blogname' ) ?: $row['site']->domain . $row['site']->path ); ?></td>
+								<td><?php echo esc_html( $from_user ? $from_user->display_name : __( '(deleted user)', 'wordcamporg' ) ); ?></td>
+								<td><?php echo esc_html( $to_user ? $to_user->display_name : __( '(deleted user)', 'wordcamporg' ) ); ?></td>
+								<td><?php echo esc_html( $entry['final_status'] ?? '' ); ?></td>
+								<td><?php echo esc_html( ! empty( $entry['decided_at'] ) ? wp_date( 'Y-m-d', (int) $entry['decided_at'] ) : '' ); ?></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			</details>
+		<?php endif; ?>
+	</div>
+	<?php
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/bootstrap.php
@@ -36,6 +36,8 @@ function manually_load_plugin() {
 	require_once dirname( __DIR__ ) . '/wporg-groups-archive.php';
 	require_once dirname( __DIR__ ) . '/group-site-provisioning.php';
 	require_once dirname( __DIR__ ) . '/network-messaging.php';
+	require_once dirname( __DIR__ ) . '/group-ownership-transfer.php';
+	require_once dirname( __DIR__ ) . '/group-ownership-transfer-notifications.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer-notifications.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer-notifications.php
@@ -8,6 +8,7 @@ use function WordCamp\Groups\Ownership_Transfer\decline_transfer;
 use function WordCamp\Groups\Ownership_Transfer\execute_transfer;
 use function WordCamp\Groups\Ownership_Transfer\initiate_transfer;
 use function WordCamp\Groups\Ownership_Transfer\reject_transfer;
+use function WordCamp\Groups\Ownership_Transfer\Notifications\notify_candidate_nominated;
 
 defined( 'WPINC' ) || die();
 
@@ -285,6 +286,71 @@ class Test_Group_Ownership_Transfer_Notifications extends Groups_TestCase {
 		}
 
 		$this->assertNotNull( $captured, 'A failed notification send should have triggered a warning.' );
+		$this->assertSame( E_USER_WARNING, $captured[0] );
+	}
+
+	/**
+	 * A notification with nobody to send to is the same class of problem as
+	 * one that fails to send, and gets the same treatment. Silence here is
+	 * indistinguishable from a transfer nobody has got round to yet: the
+	 * candidate never finds out they were nominated.
+	 */
+	public function test_a_notification_with_no_usable_recipient_triggers_a_warning() {
+		$captured = null;
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional, test-only: capturing the warning under test, not debug code.
+			static function ( $errno, $errstr ) use ( &$captured ) {
+				$captured = array( $errno, $errstr );
+				return true;
+			}
+		);
+
+		try {
+			notify_candidate_nominated(
+				$this->group_site_id,
+				array(
+					'from_user_id' => self::factory()->user->create(),
+					'to_user_id'   => PHP_INT_MAX, // No such user.
+					'initiated_by' => 0,
+				)
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $this->sent_mail );
+		$this->assertNotNull( $captured, 'A notification with no recipient should have triggered a warning.' );
+		$this->assertSame( E_USER_WARNING, $captured[0] );
+	}
+
+	/**
+	 * Same, for the other end: a network with no reachable admins means an
+	 * accepted transfer sits waiting for an approval nobody was told about.
+	 */
+	public function test_an_acceptance_with_no_network_admins_triggers_a_warning() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		$this->sent_mail = array();
+
+		$GLOBALS['super_admins'] = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$captured = null;
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional, test-only: capturing the warning under test, not debug code.
+			static function ( $errno, $errstr ) use ( &$captured ) {
+				$captured = array( $errno, $errstr );
+				return true;
+			}
+		);
+
+		try {
+			accept_transfer( $this->group_site_id, $candidate_id );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $this->sent_mail );
+		$this->assertNotNull( $captured, 'An acceptance nobody can approve should have triggered a warning.' );
 		$this->assertSame( E_USER_WARNING, $captured[0] );
 	}
 }

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer-notifications.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer-notifications.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use function WordCamp\Groups\Ownership_Transfer\accept_transfer;
+use function WordCamp\Groups\Ownership_Transfer\cancel_transfer;
+use function WordCamp\Groups\Ownership_Transfer\decline_transfer;
+use function WordCamp\Groups\Ownership_Transfer\execute_transfer;
+use function WordCamp\Groups\Ownership_Transfer\initiate_transfer;
+use function WordCamp\Groups\Ownership_Transfer\reject_transfer;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group groups
+ *
+ * Covers `group-ownership-transfer-notifications.php`: that each transition
+ * hook emails exactly the intended parties, no one else. The hooks
+ * themselves are registered at file scope (loaded by `tests/bootstrap.php`),
+ * so driving the real `Transfer\*` functions exercises the real wiring
+ * rather than calling the `notify_*` callbacks directly.
+ */
+class Test_Group_Ownership_Transfer_Notifications extends Groups_TestCase {
+
+	/**
+	 * @var int
+	 */
+	private $group_site_id;
+
+	/**
+	 * Emails captured during the current test, via `pre_wp_mail`.
+	 *
+	 * @var array[]
+	 */
+	protected $sent_mail = array();
+
+	/**
+	 * Create a real group subsite and start intercepting outgoing mail.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->group_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/ownership-transfer-notifications-test/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		switch_to_blog( $this->group_site_id );
+		\GatherPress\Core\Setup::get_instance()->check_plugin_version();
+
+		$this->sent_mail = array();
+		add_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10, 2 );
+	}
+
+	/**
+	 * Remove the temporary group site, the mail interceptor, and any
+	 * super-admin override set by an individual test.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+		unset( $GLOBALS['super_admins'] );
+
+		restore_current_blog();
+		wp_delete_site( $this->group_site_id );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Record mail instead of sending it.
+	 *
+	 * @param null|bool $short_circuit Whether to short-circuit `wp_mail()`.
+	 * @param array     $atts          `wp_mail()` arguments.
+	 * @return bool
+	 */
+	public function capture_mail( $short_circuit, $atts ) {
+		$this->sent_mail[] = $atts;
+
+		return true;
+	}
+
+	/**
+	 * Grant `manage_sites` to a user via the `$GLOBALS['super_admins']`
+	 * override -- see `test-group-ownership-transfer.php::create_network_admin()`
+	 * for why this, rather than `update_site_option()`, is the reliable way
+	 * to do this in this test harness.
+	 *
+	 * @return int User ID.
+	 */
+	private function create_network_admin(): int {
+		$user_id = self::factory()->user->create();
+
+		$GLOBALS['super_admins'][] = get_userdata( $user_id )->user_login; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $user_id;
+	}
+
+	/**
+	 * The addresses actually mailed, lowercased for order-independent comparison.
+	 *
+	 * @return string[]
+	 */
+	private function mailed_addresses(): array {
+		return array_map(
+			static function ( array $atts ): string {
+				// `send_notification()` passes a single-element array,
+				// either "Name <email>" or a bare email.
+				$to = is_array( $atts['to'] ) ? $atts['to'][0] : $atts['to'];
+				preg_match( '/<([^>]+)>/', $to, $m );
+				return strtolower( $m[1] ?? $to );
+			},
+			$this->sent_mail
+		);
+	}
+
+	/**
+	 * Initiating only emails the nominated candidate.
+	 */
+	public function test_initiate_notifies_candidate_only() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+		$this->assertCount( 1, $this->sent_mail );
+		$this->assertSame(
+			array( strtolower( get_userdata( $candidate_id )->user_email ) ),
+			$this->mailed_addresses()
+		);
+	}
+
+	/**
+	 * Accepting only emails network admins, not the owner or the candidate.
+	 */
+	public function test_accept_notifies_network_admins_only() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$GLOBALS['super_admins'] = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$admin_one_id            = $this->create_network_admin();
+		$admin_two_id            = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		$this->sent_mail = array();
+
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		$this->assertCount( 2, $this->sent_mail );
+		$this->assertEqualsCanonicalizing(
+			array(
+				strtolower( get_userdata( $admin_one_id )->user_email ),
+				strtolower( get_userdata( $admin_two_id )->user_email ),
+			),
+			$this->mailed_addresses()
+		);
+
+		$mailed = $this->mailed_addresses();
+		$this->assertNotContains( strtolower( get_userdata( $owner_id )->user_email ), $mailed );
+		$this->assertNotContains( strtolower( get_userdata( $candidate_id )->user_email ), $mailed );
+	}
+
+	/**
+	 * Declining only emails whoever initiated the transfer.
+	 */
+	public function test_decline_notifies_initiator_only() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		$this->sent_mail = array();
+
+		decline_transfer( $this->group_site_id, $candidate_id );
+
+		$this->assertCount( 1, $this->sent_mail );
+		$this->assertSame(
+			array( strtolower( get_userdata( $owner_id )->user_email ) ),
+			$this->mailed_addresses()
+		);
+	}
+
+	/**
+	 * Cancelling only emails the nominated candidate.
+	 */
+	public function test_cancel_notifies_candidate_only() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		$this->sent_mail = array();
+
+		// `cancel_transfer()` authorizes off the *current* user, not the
+		// `$user_id` argument -- see `current_user_can_initiate()`.
+		wp_set_current_user( $owner_id );
+		cancel_transfer( $this->group_site_id, $owner_id );
+
+		$this->assertCount( 1, $this->sent_mail );
+		$this->assertSame(
+			array( strtolower( get_userdata( $candidate_id )->user_email ) ),
+			$this->mailed_addresses()
+		);
+	}
+
+	/**
+	 * Executing (approval) emails both the old and new owner, and no one else.
+	 */
+	public function test_execute_notifies_both_parties() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+		$this->sent_mail = array();
+
+		execute_transfer( $this->group_site_id, $admin_id );
+
+		$this->assertCount( 2, $this->sent_mail );
+		$this->assertEqualsCanonicalizing(
+			array(
+				strtolower( get_userdata( $owner_id )->user_email ),
+				strtolower( get_userdata( $candidate_id )->user_email ),
+			),
+			$this->mailed_addresses()
+		);
+	}
+
+	/**
+	 * Rejecting emails both parties, and the reason is included in the body.
+	 */
+	public function test_reject_notifies_both_parties_with_reason() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+		$this->sent_mail = array();
+
+		reject_transfer( $this->group_site_id, $admin_id, 'Suspicious request' );
+
+		$this->assertCount( 2, $this->sent_mail );
+		$this->assertEqualsCanonicalizing(
+			array(
+				strtolower( get_userdata( $owner_id )->user_email ),
+				strtolower( get_userdata( $candidate_id )->user_email ),
+			),
+			$this->mailed_addresses()
+		);
+
+		foreach ( $this->sent_mail as $atts ) {
+			$this->assertStringContainsString( 'Suspicious request', $atts['message'] );
+		}
+	}
+
+	/**
+	 * A `wp_mail()` failure surfaces as a warning rather than failing silently
+	 * -- matches `Notifications\schedule_new_event_notification()`'s own
+	 * precedent (`test-notifications.php`).
+	 */
+	public function test_mail_failure_triggers_warning() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		remove_filter( 'pre_wp_mail', array( $this, 'capture_mail' ), 10 );
+		add_filter( 'pre_wp_mail', '__return_false' );
+
+		$captured = null;
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional, test-only: capturing the warning under test, not debug code.
+			static function ( $errno, $errstr ) use ( &$captured ) {
+				$captured = array( $errno, $errstr );
+				return true;
+			}
+		);
+
+		try {
+			initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		} finally {
+			restore_error_handler();
+			remove_filter( 'pre_wp_mail', '__return_false' );
+		}
+
+		$this->assertNotNull( $captured, 'A failed notification send should have triggered a warning.' );
+		$this->assertSame( E_USER_WARNING, $captured[0] );
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
@@ -8,12 +8,17 @@ use function WordCamp\Groups\Ownership_Transfer\current_user_can_approve;
 use function WordCamp\Groups\Ownership_Transfer\current_user_can_initiate;
 use function WordCamp\Groups\Ownership_Transfer\decline_transfer;
 use function WordCamp\Groups\Ownership_Transfer\execute_transfer;
+use function WordCamp\Groups\Ownership_Transfer\get_final_status_label;
 use function WordCamp\Groups\Ownership_Transfer\get_pending_transfer;
+use function WordCamp\Groups\Ownership_Transfer\get_recent_decided_transfers;
+use function WordCamp\Groups\Ownership_Transfer\get_sites_with_pending_transfers;
 use function WordCamp\Groups\Ownership_Transfer\get_transfer_history;
 use function WordCamp\Groups\Ownership_Transfer\initiate_transfer;
 use function WordCamp\Groups\Ownership_Transfer\reject_transfer;
 use function WordCamp\Groups\Ownership_Transfer\validate_candidate;
 use const WordCamp\Groups\Ownership_Transfer\HISTORY_LIMIT;
+use const WordCamp\Groups\Ownership_Transfer\LOCK_GROUP;
+use const WordCamp\Groups\Ownership_Transfer\LOCK_TIMEOUT;
 use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_ACCEPTANCE;
 use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_APPROVAL;
 
@@ -216,6 +221,29 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	}
 
 	/**
+	 * Every transition is serialized per site: while another request holds
+	 * this group's lock, a concurrent transition is refused outright rather
+	 * than racing the read-then-write against site meta.
+	 */
+	public function test_concurrent_transition_is_refused_while_locked() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$lock_key = 'transfer_' . $this->group_site_id;
+		$this->assertTrue( wp_cache_add( $lock_key, 1, LOCK_GROUP, LOCK_TIMEOUT ) );
+
+		try {
+			$result = initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		} finally {
+			wp_cache_delete( $lock_key, LOCK_GROUP );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_busy', $result->get_error_code() );
+		$this->assertNull( get_pending_transfer( $this->group_site_id ), 'A refused initiate must not leave a partial record.' );
+	}
+
+	/**
 	 * Only the nominated candidate can accept or decline.
 	 */
 	public function test_only_the_candidate_can_accept_or_decline() {
@@ -308,6 +336,50 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 		$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
 		$this->assertWPError( $result );
 		$this->assertSame( 'transfer_not_awaiting_approval', $result->get_error_code() );
+	}
+
+	/**
+	 * `execute_transfer()` re-validates the candidate immediately before
+	 * mutating roles -- if they were removed from the group between
+	 * acceptance and approval, execution must refuse rather than silently
+	 * re-adding them to the site as a full administrator.
+	 */
+	public function test_cannot_execute_if_candidate_no_longer_a_member() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		remove_user_from_blog( $candidate_id, $this->group_site_id );
+
+		$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
+		$this->assertWPError( $result );
+		$this->assertSame( 'candidate_not_found', $result->get_error_code() );
+
+		$this->assertFalse( is_user_member_of_blog( $candidate_id, $this->group_site_id ) );
+	}
+
+	/**
+	 * Same, but for the old owner having already been demoted by someone
+	 * else in the meantime.
+	 */
+	public function test_cannot_execute_if_owner_no_longer_administrator() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		$owner = get_userdata( $owner_id );
+		$owner->set_role( 'editor' );
+
+		$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_owner_no_longer_administrator', $result->get_error_code() );
+
+		// The candidate must not have been promoted despite the rejection.
+		$this->assertNotContains( 'administrator', get_userdata( $candidate_id )->roles );
 	}
 
 	/**
@@ -419,5 +491,74 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 
 		// The most recently declined candidate is first.
 		$this->assertSame( $candidate_id, $history[0]['to_user_id'] );
+	}
+
+	/**
+	 * The Network Admin listing functions query for sites that actually
+	 * carry transfer meta, rather than iterating every group on the
+	 * network -- a site with no transfer activity must not show up in
+	 * either listing.
+	 */
+	public function test_listing_functions_only_include_sites_with_transfer_activity() {
+		$untouched_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/ownership-transfer-untouched/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		try {
+			$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+			$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+			initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+			$pending_site_ids = $this->site_ids_from_rows( get_sites_with_pending_transfers() );
+			$this->assertContains( $this->group_site_id, $pending_site_ids );
+			$this->assertNotContains( $untouched_site_id, $pending_site_ids );
+
+			decline_transfer( $this->group_site_id, $candidate_id );
+
+			$recent_site_ids = $this->site_ids_from_rows( get_recent_decided_transfers() );
+			$this->assertContains( $this->group_site_id, $recent_site_ids );
+			$this->assertNotContains( $untouched_site_id, $recent_site_ids );
+
+			// The now-declined transfer must no longer appear as pending.
+			$this->assertNotContains( $this->group_site_id, $this->site_ids_from_rows( get_sites_with_pending_transfers() ) );
+		} finally {
+			wp_delete_site( $untouched_site_id );
+		}
+	}
+
+	/**
+	 * Every `final_status` `finalize_transfer()` can write has a translated
+	 * label; anything unrecognised still shows the raw value rather than
+	 * going blank.
+	 */
+	public function test_get_final_status_label_covers_every_final_status() {
+		foreach ( array( 'declined', 'cancelled', 'completed', 'rejected' ) as $status ) {
+			$label = get_final_status_label( $status );
+			$this->assertNotSame( $status, $label );
+			$this->assertNotSame( '', $label );
+		}
+
+		$this->assertSame( 'something_new', get_final_status_label( 'something_new' ) );
+	}
+
+	/**
+	 * Pull `blog_id`s out of the `{site, pending|entry}` row shape both
+	 * listing functions return.
+	 *
+	 * @param array $rows Rows from `get_sites_with_pending_transfers()` or `get_recent_decided_transfers()`.
+	 * @return int[]
+	 */
+	private function site_ids_from_rows( array $rows ): array {
+		return array_map(
+			static function ( array $row ): int {
+				return (int) $row['site']->blog_id;
+			},
+			$rows
+		);
 	}
 }

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
@@ -2,6 +2,7 @@
 
 namespace WordCamp\Groups\Tests;
 
+use WPDieException;
 use function WordCamp\Groups\Ownership_Transfer\accept_transfer;
 use function WordCamp\Groups\Ownership_Transfer\cancel_transfer;
 use function WordCamp\Groups\Ownership_Transfer\current_user_can_approve;
@@ -9,16 +10,20 @@ use function WordCamp\Groups\Ownership_Transfer\current_user_can_initiate;
 use function WordCamp\Groups\Ownership_Transfer\decline_transfer;
 use function WordCamp\Groups\Ownership_Transfer\execute_transfer;
 use function WordCamp\Groups\Ownership_Transfer\get_final_status_label;
+use function WordCamp\Groups\Ownership_Transfer\get_group_sites_with_meta_key;
 use function WordCamp\Groups\Ownership_Transfer\get_pending_transfer;
 use function WordCamp\Groups\Ownership_Transfer\get_recent_decided_transfers;
 use function WordCamp\Groups\Ownership_Transfer\get_sites_with_pending_transfers;
 use function WordCamp\Groups\Ownership_Transfer\get_transfer_history;
+use function WordCamp\Groups\Ownership_Transfer\handle_decision;
 use function WordCamp\Groups\Ownership_Transfer\initiate_transfer;
 use function WordCamp\Groups\Ownership_Transfer\reject_transfer;
 use function WordCamp\Groups\Ownership_Transfer\validate_candidate;
+use const WordCamp\Groups\Ownership_Transfer\DECIDE_ACTION;
 use const WordCamp\Groups\Ownership_Transfer\HISTORY_LIMIT;
 use const WordCamp\Groups\Ownership_Transfer\LOCK_GROUP;
 use const WordCamp\Groups\Ownership_Transfer\LOCK_TIMEOUT;
+use const WordCamp\Groups\Ownership_Transfer\META_KEY_PENDING;
 use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_ACCEPTANCE;
 use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_APPROVAL;
 
@@ -35,6 +40,13 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	 * @var int
 	 */
 	private $group_site_id;
+
+	/**
+	 * `[errno, errstr]` pairs collected by `capture_warnings()`.
+	 *
+	 * @var array[]
+	 */
+	private $captured_warnings = array();
 
 	/**
 	 * Create a real group subsite for each test.
@@ -59,6 +71,12 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	 */
 	protected function tearDown(): void {
 		unset( $GLOBALS['super_admins'] );
+
+		// `handle_decision()` reads these directly; leaving them set would
+		// leak a nonce and a decision into whatever test runs next.
+		$_POST    = array();
+		$_REQUEST = array();
+
 		restore_current_blog();
 		wp_delete_site( $this->group_site_id );
 
@@ -249,6 +267,7 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	public function test_only_the_candidate_can_accept_or_decline() {
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
 		$bystander_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 
 		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
@@ -330,6 +349,7 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	public function test_cannot_execute_before_acceptance() {
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
 
 		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
 
@@ -347,6 +367,7 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	public function test_cannot_execute_if_candidate_no_longer_a_member() {
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
 
 		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
 		accept_transfer( $this->group_site_id, $candidate_id );
@@ -367,6 +388,7 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	public function test_cannot_execute_if_owner_no_longer_administrator() {
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
 
 		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
 		accept_transfer( $this->group_site_id, $candidate_id );
@@ -389,6 +411,7 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 	public function test_promotes_new_owner_before_demoting_old_owner() {
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
 
 		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
 		accept_transfer( $this->group_site_id, $candidate_id );
@@ -429,6 +452,7 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
 
 		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
 		accept_transfer( $this->group_site_id, $candidate_id );
@@ -544,6 +568,336 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 		}
 
 		$this->assertSame( 'something_new', get_final_status_label( 'something_new' ) );
+	}
+
+	/**
+	 * Declining is the candidate's half of the acceptance step. Once they've
+	 * accepted, the decision belongs to a network admin -- a stale panel (or a
+	 * second click) must not be able to pull an accepted transfer back out
+	 * from under the admin about to approve it.
+	 */
+	public function test_decline_is_refused_once_the_transfer_has_been_accepted() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		$result = decline_transfer( $this->group_site_id, $candidate_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_not_awaiting_acceptance', $result->get_error_code() );
+
+		// The accepted transfer is still there, waiting on its approval.
+		$pending = get_pending_transfer( $this->group_site_id );
+		$this->assertNotNull( $pending );
+		$this->assertSame( STATUS_PENDING_APPROVAL, $pending['status'] );
+		$this->assertSame( array(), get_transfer_history( $this->group_site_id ) );
+	}
+
+	/**
+	 * If the promotion doesn't land, the demotion must not run either -- in a
+	 * single-owner group, demoting on the assumption that `set_role()` worked
+	 * is what leaves the site with zero administrators.
+	 */
+	public function test_failed_promotion_does_not_demote_the_old_owner() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		// Stands in for anything that swallows the promotion -- another
+		// plugin's `set_user_role` handler, a failed write -- by putting the
+		// candidate straight back on `editor` as the promotion completes.
+		$undo = static function ( $user_id, $role ) use ( $candidate_id ) {
+			if ( $candidate_id === $user_id && 'administrator' === $role ) {
+				update_user_meta( $user_id, self::capabilities_meta_key(), array( 'editor' => true ) );
+			}
+		};
+		add_action( 'set_user_role', $undo, 10, 2 );
+
+		$demotions = array();
+		$recorder  = static function ( $user_id, $role ) use ( &$demotions, $owner_id ) {
+			if ( $owner_id === $user_id ) {
+				$demotions[] = $role;
+			}
+		};
+		add_action( 'set_user_role', $recorder, 10, 2 );
+
+		$this->capture_warnings();
+
+		try {
+			$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
+		} finally {
+			restore_error_handler();
+			remove_action( 'set_user_role', $undo, 10 );
+			remove_action( 'set_user_role', $recorder, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_promotion_failed', $result->get_error_code() );
+		$this->assertNotEmpty( $this->captured_warnings );
+
+		$this->assertSame( array(), $demotions, 'The old owner must not be touched once the promotion is known to have failed.' );
+		$this->assertContains( 'administrator', get_userdata( $owner_id )->roles );
+		$this->assertNotNull( get_pending_transfer( $this->group_site_id ), 'The transfer stays pending so it can simply be retried.' );
+	}
+
+	/**
+	 * A demotion that leaves the old owner with no roles at all is a failure,
+	 * not a success: "not an administrator any more" is satisfied by a user
+	 * locked out of the group entirely. Both parties are put back as they
+	 * were, so the decision can be retried rather than needing hand-repair.
+	 */
+	public function test_demotion_that_lands_nowhere_is_rolled_back() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		// Wipe the old owner's capabilities as their demotion completes,
+		// standing in for a concurrent write racing the same swap.
+		$wipe = static function ( $user_id, $role ) use ( $owner_id ) {
+			if ( $owner_id === $user_id && 'editor' === $role ) {
+				update_user_meta( $user_id, self::capabilities_meta_key(), array() );
+			}
+		};
+		add_action( 'set_user_role', $wipe, 10, 2 );
+
+		$this->capture_warnings();
+
+		try {
+			$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
+		} finally {
+			restore_error_handler();
+			remove_action( 'set_user_role', $wipe, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_execution_inconsistent', $result->get_error_code() );
+		$this->assertNotEmpty( $this->captured_warnings );
+
+		// Rolled back: the group has exactly the owner it started with, and
+		// the candidate wasn't left holding `administrator`, which would have
+		// made every retry fail on `candidate_already_administrator`.
+		$this->assertContains( 'administrator', get_userdata( $owner_id )->roles );
+		$this->assertNotContains( 'administrator', get_userdata( $candidate_id )->roles );
+		$this->assertContains( 'editor', get_userdata( $candidate_id )->roles );
+		$this->assertNotNull( get_pending_transfer( $this->group_site_id ) );
+	}
+
+	/**
+	 * A group that has been archived or marked as spam is out of circulation;
+	 * a transfer request made before that must not still be sitting on the
+	 * approvals screen with a live Approve button next to it.
+	 */
+	public function test_archived_and_spammed_groups_are_excluded_from_listings() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		$this->assertContains( $this->group_site_id, $this->site_ids_from_rows( get_sites_with_pending_transfers() ) );
+
+		foreach ( array( 'archived', 'spam' ) as $flag ) {
+			update_blog_status( $this->group_site_id, $flag, '1' );
+
+			$this->assertNotContains(
+				$this->group_site_id,
+				$this->site_ids_from_rows( get_sites_with_pending_transfers() ),
+				"A {$flag} group must not appear on the approvals screen."
+			);
+
+			update_blog_status( $this->group_site_id, $flag, '0' );
+		}
+
+		// ...and it comes back once the group does.
+		$this->assertContains( $this->group_site_id, $this->site_ids_from_rows( get_sites_with_pending_transfers() ) );
+	}
+
+	/**
+	 * A failed lookup must not be indistinguishable from "nothing to approve"
+	 * -- that is the one wrong answer this screen can give the people
+	 * responsible for acting on these requests.
+	 */
+	public function test_a_failed_lookup_is_reported_rather_than_read_as_empty() {
+		global $wpdb;
+
+		$break = static function ( $query ) {
+			return false !== strpos( $query, $GLOBALS['wpdb']->blogmeta ) ? 'SELECT * FROM a_table_that_is_not_there' : $query;
+		};
+
+		$suppressed = $wpdb->suppress_errors( true );
+		add_filter( 'query', $break );
+
+		$this->capture_warnings();
+
+		try {
+			$sites   = get_group_sites_with_meta_key( META_KEY_PENDING );
+			$pending = get_sites_with_pending_transfers();
+			$recent  = get_recent_decided_transfers();
+		} finally {
+			restore_error_handler();
+			remove_filter( 'query', $break );
+			$wpdb->suppress_errors( $suppressed );
+			$wpdb->last_error = '';
+		}
+
+		$this->assertWPError( $sites );
+		$this->assertSame( 'transfer_query_failed', $sites->get_error_code() );
+		$this->assertWPError( $pending );
+		$this->assertWPError( $recent );
+		$this->assertNotEmpty( $this->captured_warnings );
+	}
+
+	/**
+	 * A decision whose site-meta write doesn't land is reported, not reported
+	 * as done -- otherwise the transfer keeps showing up as awaiting a
+	 * decision that everyone has been told was already made.
+	 */
+	public function test_a_decision_that_cannot_be_saved_is_reported() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+		add_filter( 'update_blog_metadata', '__return_false' );
+
+		$this->capture_warnings();
+
+		try {
+			$result = reject_transfer( $this->group_site_id, $admin_id, 'Nope' );
+		} finally {
+			restore_error_handler();
+			remove_filter( 'update_blog_metadata', '__return_false' );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_not_recorded', $result->get_error_code() );
+		$this->assertNotEmpty( $this->captured_warnings );
+
+		// The pending record survives the failure, so the decision can be
+		// made again rather than the request disappearing unrecorded.
+		$this->assertNotNull( get_pending_transfer( $this->group_site_id ) );
+	}
+
+	/**
+	 * The Network Admin form handler is the only way to approve or reject, so
+	 * its own capability check and nonce are load-bearing rather than
+	 * decoration on top of a check further in: `execute_transfer()` and
+	 * `reject_transfer()` don't re-check who is asking.
+	 */
+	public function test_handle_decision_requires_manage_sites() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $owner_id );
+		$this->assertFalse( current_user_can_approve(), 'Precondition: a group owner is not a network admin.' );
+
+		$this->post_decision( $this->group_site_id, 'approve', true );
+
+		$this->expectException( WPDieException::class );
+
+		handle_decision();
+	}
+
+	/**
+	 * Same, for the nonce: a valid network admin session must not be enough
+	 * on its own to approve a transfer from a cross-site request.
+	 */
+	public function test_handle_decision_requires_a_valid_nonce() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		wp_set_current_user( $admin_id );
+		$this->post_decision( $this->group_site_id, 'approve', false );
+
+		try {
+			handle_decision();
+			$this->fail( 'handle_decision() should have died on the missing nonce.' );
+		} catch ( WPDieException $exception ) {
+			$this->assertNotNull( get_pending_transfer( $this->group_site_id ), 'No decision may be applied without a valid nonce.' );
+		}
+
+		$this->assertContains( 'administrator', get_userdata( $owner_id )->roles );
+		$this->assertNotContains( 'administrator', get_userdata( $candidate_id )->roles );
+	}
+
+	/**
+	 * Anything other than approve/reject is refused outright, rather than
+	 * falling through to the reject branch of the ternary that picks between them.
+	 */
+	public function test_handle_decision_rejects_an_unknown_decision() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+		wp_set_current_user( $admin_id );
+		$this->post_decision( $this->group_site_id, 'delete', true );
+
+		try {
+			handle_decision();
+			$this->fail( 'handle_decision() should have died on the unknown decision.' );
+		} catch ( WPDieException $exception ) {
+			$this->assertNotNull( get_pending_transfer( $this->group_site_id ) );
+			$this->assertSame( array(), get_transfer_history( $this->group_site_id ) );
+		}
+	}
+
+	/**
+	 * Populate the `$_POST`/`$_REQUEST` a `handle_decision()` call reads.
+	 * `tearDown()` clears them.
+	 *
+	 * @param int    $site_id  Group site being decided.
+	 * @param string $decision 'approve', 'reject', or something invalid.
+	 * @param bool   $nonce    Whether to include a valid nonce.
+	 */
+	private function post_decision( int $site_id, string $decision, bool $nonce ): void {
+		$_POST['site_id']  = (string) $site_id;
+		$_POST['decision'] = $decision;
+
+		if ( $nonce ) {
+			$_POST['_wpnonce'] = wp_create_nonce( DECIDE_ACTION . '_' . $site_id );
+		}
+
+		$_REQUEST = $_POST;
+	}
+
+	/**
+	 * Swap in an error handler that collects `trigger_error()` calls into
+	 * `$this->captured_warnings` instead of letting them surface. Callers
+	 * MUST `restore_error_handler()`.
+	 */
+	private function capture_warnings(): void {
+		$this->captured_warnings = array();
+
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional, test-only: capturing the warnings under test, not debug code.
+			function ( $errno, $errstr ) {
+				$this->captured_warnings[] = array( $errno, $errstr );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * The user-meta key holding a user's roles on the group site under test.
+	 *
+	 * @return string
+	 */
+	private static function capabilities_meta_key(): string {
+		global $wpdb;
+
+		return $wpdb->get_blog_prefix( get_current_blog_id() ) . 'capabilities';
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use function WordCamp\Groups\Ownership_Transfer\accept_transfer;
+use function WordCamp\Groups\Ownership_Transfer\cancel_transfer;
+use function WordCamp\Groups\Ownership_Transfer\current_user_can_approve;
+use function WordCamp\Groups\Ownership_Transfer\current_user_can_initiate;
+use function WordCamp\Groups\Ownership_Transfer\decline_transfer;
+use function WordCamp\Groups\Ownership_Transfer\execute_transfer;
+use function WordCamp\Groups\Ownership_Transfer\get_pending_transfer;
+use function WordCamp\Groups\Ownership_Transfer\get_transfer_history;
+use function WordCamp\Groups\Ownership_Transfer\initiate_transfer;
+use function WordCamp\Groups\Ownership_Transfer\reject_transfer;
+use function WordCamp\Groups\Ownership_Transfer\validate_candidate;
+use const WordCamp\Groups\Ownership_Transfer\HISTORY_LIMIT;
+use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_ACCEPTANCE;
+use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_APPROVAL;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
+
+/**
+ * @group groups
+ */
+class Test_Group_Ownership_Transfer extends Groups_TestCase {
+
+	/**
+	 * @var int
+	 */
+	private $group_site_id;
+
+	/**
+	 * Create a real group subsite for each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->group_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/ownership-transfer-test/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		switch_to_blog( $this->group_site_id );
+		\GatherPress\Core\Setup::get_instance()->check_plugin_version();
+	}
+
+	/**
+	 * Remove the temporary group site and restore the parent fixture.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['super_admins'] );
+		restore_current_blog();
+		wp_delete_site( $this->group_site_id );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Grant `manage_sites` to a user.
+	 *
+	 * `grant_super_admin()` reads `site_admins` out of `sitemeta`, which
+	 * `Database_TestCase` truncates; setting the global that
+	 * `get_super_admins()` checks first is the fixture-safe equivalent — see
+	 * `test-sponsors.php::act_as_network_admin()`'s identical use of this.
+	 * `tearDown()` clears it.
+	 *
+	 * @return int User ID.
+	 */
+	private function create_network_admin(): int {
+		$user_id = self::factory()->user->create();
+
+		$GLOBALS['super_admins'] = array( get_userdata( $user_id )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $user_id;
+	}
+
+	/**
+	 * Full happy-path: initiate -> accept -> approve/execute.
+	 */
+	public function test_full_happy_path_swaps_roles() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		wp_set_current_user( $owner_id );
+		$this->assertTrue( initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id ) );
+
+		$pending = get_pending_transfer( $this->group_site_id );
+		$this->assertSame( STATUS_PENDING_ACCEPTANCE, $pending['status'] );
+
+		$this->assertTrue( accept_transfer( $this->group_site_id, $candidate_id ) );
+		$pending = get_pending_transfer( $this->group_site_id );
+		$this->assertSame( STATUS_PENDING_APPROVAL, $pending['status'] );
+
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can_approve() );
+		$this->assertTrue( execute_transfer( $this->group_site_id, $admin_id ) );
+
+		$this->assertNull( get_pending_transfer( $this->group_site_id ) );
+
+		$this->assertContains( 'editor', get_userdata( $owner_id )->roles );
+		$this->assertNotContains( 'administrator', get_userdata( $owner_id )->roles );
+		$this->assertContains( 'administrator', get_userdata( $candidate_id )->roles );
+
+		$history = get_transfer_history( $this->group_site_id );
+		$this->assertCount( 1, $history );
+		$this->assertSame( 'completed', $history[0]['final_status'] );
+	}
+
+	/**
+	 * Only the site's own administrator, or a super admin, may initiate.
+	 */
+	public function test_only_owner_or_super_admin_can_initiate() {
+		$owner_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id  = $this->create_network_admin();
+
+		wp_set_current_user( $owner_id );
+		$this->assertTrue( current_user_can_initiate( $this->group_site_id ) );
+
+		wp_set_current_user( $editor_id );
+		$this->assertFalse( current_user_can_initiate( $this->group_site_id ) );
+
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can_initiate( $this->group_site_id ) );
+	}
+
+	/**
+	 * A network admin can initiate on behalf of an unresponsive owner —
+	 * the resolution to the issue's "abandoned group" open question. The
+	 * candidate must still accept and a network admin must still approve.
+	 */
+	public function test_network_admin_can_initiate_on_owners_behalf() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		wp_set_current_user( $admin_id );
+		$result = initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $admin_id );
+
+		$this->assertTrue( $result );
+
+		$pending = get_pending_transfer( $this->group_site_id );
+		$this->assertSame( $admin_id, $pending['initiated_by'] );
+		$this->assertSame( $owner_id, $pending['from_user_id'] );
+	}
+
+	/**
+	 * Only `manage_sites` holders (network admins by default) can approve.
+	 */
+	public function test_only_manage_sites_can_approve() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $owner_id );
+		$this->assertFalse( current_user_can_approve() );
+
+		$admin_id = $this->create_network_admin();
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can_approve() );
+	}
+
+	/**
+	 * Candidate validation rejects author/subscriber tiers, an already-admin
+	 * user, and the current owner transferring to themselves.
+	 */
+	public function test_validate_candidate_rejects_ineligible_targets() {
+		$owner_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$other_admin   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$author_id     = self::factory()->user->create( array( 'role' => 'author' ) );
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$self_result = validate_candidate( $owner_id, $owner_id, $this->group_site_id );
+		$this->assertWPError( $self_result );
+		$this->assertSame( 'cannot_transfer_to_self', $self_result->get_error_code() );
+
+		$admin_result = validate_candidate( $other_admin, $owner_id, $this->group_site_id );
+		$this->assertWPError( $admin_result );
+		$this->assertSame( 'candidate_already_administrator', $admin_result->get_error_code() );
+
+		$author_result = validate_candidate( $author_id, $owner_id, $this->group_site_id );
+		$this->assertWPError( $author_result );
+		$this->assertSame( 'candidate_not_eligible', $author_result->get_error_code() );
+
+		$subscriber_result = validate_candidate( $subscriber_id, $owner_id, $this->group_site_id );
+		$this->assertWPError( $subscriber_result );
+		$this->assertSame( 'candidate_not_eligible', $subscriber_result->get_error_code() );
+
+		// The factory defaults new users to `subscriber` on the current
+		// blog, so a genuinely non-member candidate has to be removed
+		// explicitly rather than just created without a `role` argument.
+		$non_member_id = self::factory()->user->create();
+		remove_user_from_blog( $non_member_id, $this->group_site_id );
+		$non_member_result = validate_candidate( $non_member_id, $owner_id, $this->group_site_id );
+		$this->assertWPError( $non_member_result );
+		$this->assertSame( 'candidate_not_found', $non_member_result->get_error_code() );
+	}
+
+	/**
+	 * A second initiate request is refused while one is already pending.
+	 */
+	public function test_cannot_initiate_while_one_already_pending() {
+		$owner_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$second_editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->assertTrue( initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id ) );
+
+		$result = initiate_transfer( $this->group_site_id, $owner_id, $second_editor, $owner_id );
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_already_pending', $result->get_error_code() );
+	}
+
+	/**
+	 * Only the nominated candidate can accept or decline.
+	 */
+	public function test_only_the_candidate_can_accept_or_decline() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$bystander_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+		$accept_result = accept_transfer( $this->group_site_id, $bystander_id );
+		$this->assertWPError( $accept_result );
+		$this->assertSame( 'not_the_candidate', $accept_result->get_error_code() );
+
+		$decline_result = decline_transfer( $this->group_site_id, $bystander_id );
+		$this->assertWPError( $decline_result );
+		$this->assertSame( 'not_the_candidate', $decline_result->get_error_code() );
+
+		$this->assertTrue( accept_transfer( $this->group_site_id, $candidate_id ) );
+	}
+
+	/**
+	 * A decline clears the pending record and records it in history.
+	 */
+	public function test_decline_finalizes_as_declined() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		$this->assertTrue( decline_transfer( $this->group_site_id, $candidate_id ) );
+
+		$this->assertNull( get_pending_transfer( $this->group_site_id ) );
+		$history = get_transfer_history( $this->group_site_id );
+		$this->assertSame( 'declined', $history[0]['final_status'] );
+	}
+
+	/**
+	 * Only the initiating audience (owner or super admin) can cancel; anyone
+	 * else, including the nominated candidate, cannot.
+	 */
+	public function test_only_initiating_audience_can_cancel() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+		wp_set_current_user( $candidate_id );
+		$result = cancel_transfer( $this->group_site_id, $candidate_id );
+		$this->assertWPError( $result );
+		$this->assertSame( 'cannot_cancel_transfer', $result->get_error_code() );
+
+		wp_set_current_user( $owner_id );
+		$this->assertTrue( cancel_transfer( $this->group_site_id, $owner_id ) );
+		$this->assertNull( get_pending_transfer( $this->group_site_id ) );
+		$this->assertSame( 'cancelled', get_transfer_history( $this->group_site_id )[0]['final_status'] );
+	}
+
+	/**
+	 * A network admin can reject at either pending stage, with a reason recorded.
+	 */
+	public function test_reject_finalizes_with_reason() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( reject_transfer( $this->group_site_id, $admin_id, 'Suspicious request' ) );
+
+		$this->assertNull( get_pending_transfer( $this->group_site_id ) );
+		$history = get_transfer_history( $this->group_site_id );
+		$this->assertSame( 'rejected', $history[0]['final_status'] );
+		$this->assertSame( 'Suspicious request', $history[0]['reason'] );
+
+		// Roles are untouched by a rejection.
+		$this->assertContains( 'administrator', get_userdata( $owner_id )->roles );
+		$this->assertContains( 'editor', get_userdata( $candidate_id )->roles );
+	}
+
+	/**
+	 * `execute_transfer()` refuses to run before the candidate has accepted.
+	 */
+	public function test_cannot_execute_before_acceptance() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+
+		$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_not_awaiting_approval', $result->get_error_code() );
+	}
+
+	/**
+	 * `execute_transfer()` promotes the new owner before demoting the old
+	 * one, so the site is never briefly without an administrator.
+	 */
+	public function test_promotes_new_owner_before_demoting_old_owner() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		// Created before the recorder is attached — the factory's own
+		// default-role assignment for this user would otherwise show up as
+		// a spurious third `set_user_role` firing.
+		$decided_by = self::factory()->user->create();
+
+		$order    = array();
+		$recorder = static function ( $user_id, $role ) use ( &$order ) {
+			$order[] = array( $user_id, $role );
+		};
+		add_action( 'set_user_role', $recorder, 10, 2 );
+
+		try {
+			$result = execute_transfer( $this->group_site_id, $decided_by );
+		} finally {
+			remove_action( 'set_user_role', $recorder, 10 );
+		}
+
+		$this->assertTrue( $result );
+		$this->assertCount( 2, $order );
+		$this->assertSame( array( $candidate_id, 'administrator' ), $order[0] );
+		$this->assertSame( array( $owner_id, 'editor' ), $order[1] );
+	}
+
+	/**
+	 * If the post-swap state isn't exactly one administrator, `execute_transfer()`
+	 * reports a `WP_Error` and a Slack-relayed warning instead of false success.
+	 *
+	 * Simulated by corrupting the old owner's stored roles, from a `set_user_role`
+	 * hook, right after their own demote call finishes — standing in for a
+	 * concurrent process racing the same swap.
+	 */
+	public function test_execute_transfer_reports_inconsistent_state() {
+		global $wpdb;
+
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		$meta_key = $wpdb->get_blog_prefix( $this->group_site_id ) . 'capabilities';
+
+		$corrupt = static function ( $user_id, $role ) use ( $owner_id, $meta_key ) {
+			if ( $owner_id === $user_id && 'editor' === $role ) {
+				update_user_meta(
+					$owner_id,
+					$meta_key,
+					array(
+						'editor'        => true,
+						'administrator' => true,
+					)
+				);
+			}
+		};
+		add_action( 'set_user_role', $corrupt, 10, 2 );
+
+		$captured = null;
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Intentional, test-only: capturing the warning under test, not debug code.
+			static function ( $errno, $errstr ) use ( &$captured ) {
+				$captured = array( $errno, $errstr );
+				return true;
+			}
+		);
+
+		try {
+			$result = execute_transfer( $this->group_site_id, self::factory()->user->create() );
+		} finally {
+			restore_error_handler();
+			remove_action( 'set_user_role', $corrupt, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'transfer_execution_inconsistent', $result->get_error_code() );
+		$this->assertNotNull( $captured, 'execute_transfer() should have triggered a warning.' );
+		$this->assertSame( E_USER_WARNING, $captured[0] );
+
+		// The pending record is left in place rather than silently finalized,
+		// so a network admin can retry after fixing the roles by hand.
+		$this->assertNotNull( get_pending_transfer( $this->group_site_id ) );
+	}
+
+	/**
+	 * History is capped at `HISTORY_LIMIT`, newest first.
+	 */
+	public function test_history_is_capped_and_newest_first() {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		for ( $i = 0; $i < HISTORY_LIMIT + 5; $i++ ) {
+			$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+			initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+			decline_transfer( $this->group_site_id, $candidate_id );
+		}
+
+		$history = get_transfer_history( $this->group_site_id );
+		$this->assertCount( HISTORY_LIMIT, $history );
+
+		// The most recently declined candidate is first.
+		$this->assertSame( $candidate_id, $history[0]['to_user_id'] );
+	}
+}

--- a/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-group-ownership-transfer.php
@@ -18,12 +18,15 @@ use function WordCamp\Groups\Ownership_Transfer\get_transfer_history;
 use function WordCamp\Groups\Ownership_Transfer\handle_decision;
 use function WordCamp\Groups\Ownership_Transfer\initiate_transfer;
 use function WordCamp\Groups\Ownership_Transfer\reject_transfer;
+use function WordCamp\Groups\Ownership_Transfer\render_page;
+use function WordCamp\Groups\Ownership_Transfer\sanitize_reason;
 use function WordCamp\Groups\Ownership_Transfer\validate_candidate;
 use const WordCamp\Groups\Ownership_Transfer\DECIDE_ACTION;
 use const WordCamp\Groups\Ownership_Transfer\HISTORY_LIMIT;
 use const WordCamp\Groups\Ownership_Transfer\LOCK_GROUP;
 use const WordCamp\Groups\Ownership_Transfer\LOCK_TIMEOUT;
 use const WordCamp\Groups\Ownership_Transfer\META_KEY_PENDING;
+use const WordCamp\Groups\Ownership_Transfer\REASON_MAX_LENGTH;
 use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_ACCEPTANCE;
 use const WordCamp\Groups\Ownership_Transfer\STATUS_PENDING_APPROVAL;
 
@@ -852,6 +855,73 @@ class Test_Group_Ownership_Transfer extends Groups_TestCase {
 			$this->assertNotNull( get_pending_transfer( $this->group_site_id ) );
 			$this->assertSame( array(), get_transfer_history( $this->group_site_id ) );
 		}
+	}
+
+	/**
+	 * The reject form has to actually collect a reason. `reject_transfer()`
+	 * stores one and the rejection email has a line for it, but neither can do
+	 * anything if the only screen that rejects transfers never asks.
+	 */
+	public function test_reject_form_collects_a_reason() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		wp_set_current_user( $admin_id );
+
+		ob_start();
+		render_page();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="reason"', $html );
+		$this->assertStringContainsString( 'id="wporg-transfer-reason-' . $this->group_site_id . '"', $html );
+
+		// Labelled, since it renders as a bare box in a table cell.
+		$this->assertStringContainsString( 'for="wporg-transfer-reason-' . $this->group_site_id . '"', $html );
+
+		// And it belongs to the reject form, not the approve one -- approving
+		// has no reason to give.
+		$reject_form = strstr( $html, 'value="reject"' );
+		$this->assertStringContainsString( 'name="reason"', $reject_form );
+		$this->assertStringNotContainsString( 'name="reason"', strstr( $html, 'value="reject"', true ) );
+	}
+
+	/**
+	 * A reason typed into that field survives the round trip into the history
+	 * entry the notification reads from.
+	 */
+	public function test_a_rejection_reason_is_recorded() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$admin_id     = $this->create_network_admin();
+
+		initiate_transfer( $this->group_site_id, $owner_id, $candidate_id, $owner_id );
+		accept_transfer( $this->group_site_id, $candidate_id );
+
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( reject_transfer( $this->group_site_id, $admin_id, 'Candidate asked us to hold off.' ) );
+
+		$this->assertSame( 'Candidate asked us to hold off.', get_transfer_history( $this->group_site_id )[0]['reason'] );
+	}
+
+	/**
+	 * `maxlength` on the input is a courtesy to whoever is typing; the POST can
+	 * carry any length regardless, so the cap is enforced server-side too.
+	 */
+	public function test_reason_is_capped_and_sanitized() {
+		$this->assertSame( REASON_MAX_LENGTH, mb_strlen( sanitize_reason( str_repeat( 'a', REASON_MAX_LENGTH * 2 ) ) ) );
+		$this->assertSame( 'ok', sanitize_reason( 'ok' ) );
+		$this->assertSame( '', sanitize_reason( '' ) );
+
+		// Counted in characters, not bytes -- a multibyte reason must not be
+		// cut mid-character.
+		$multibyte = str_repeat( 'é', REASON_MAX_LENGTH * 2 );
+		$this->assertSame( REASON_MAX_LENGTH, mb_strlen( sanitize_reason( $multibyte ) ) );
+
+		$this->assertStringNotContainsString( '<script>', sanitize_reason( 'nope <script>alert(1)</script>' ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
@@ -105,11 +105,19 @@ class Ownership_Transfer_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check shared by every route: must be logged in and a member
-	 * of this group. Identity/role-specific rules (is this the candidate? the
-	 * owner?) are enforced by the `Transfer\*` state functions themselves,
-	 * the same split `Members_Controller::update_member_role()` uses between
-	 * its permission callback and its handler.
+	 * Permission check shared by every route: must be logged in and either a
+	 * member of this group or a super admin. Identity/role-specific rules (is
+	 * this the candidate? the owner?) are enforced by the `Transfer\*` state
+	 * functions themselves, the same split `Members_Controller::update_member_role()`
+	 * uses between its permission callback and its handler.
+	 *
+	 * Super admins are exempt from the membership requirement so the
+	 * abandoned-group path (`Transfer\current_user_can_initiate()`'s
+	 * `is_super_admin()` branch) actually works for a network admin who
+	 * isn't personally a member of the group in question — otherwise this
+	 * check would 403 them before that override is ever consulted, on
+	 * every route including the initial `GET` the front-end panel needs
+	 * just to render the initiate form.
 	 *
 	 * @return true|WP_Error
 	 */
@@ -122,7 +130,7 @@ class Ownership_Transfer_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( ! is_user_member_of_blog() ) {
+		if ( ! is_super_admin() && ! is_user_member_of_blog() ) {
 			return new WP_Error(
 				'not_a_member',
 				__( 'You are not a member of this group.', 'wporg-groups-frontend' ),

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
@@ -32,6 +32,7 @@ use WP_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group_settings;
 
 defined( 'WPINC' ) || die();
 
@@ -105,11 +106,22 @@ class Ownership_Transfer_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Permission check shared by every route: must be logged in and either a
-	 * member of this group or a super admin. Identity/role-specific rules (is
-	 * this the candidate? the owner?) are enforced by the `Transfer\*` state
-	 * functions themselves, the same split `Members_Controller::update_member_role()`
-	 * uses between its permission callback and its handler.
+	 * Permission check shared by every route: must be logged in, a member of
+	 * this group, and able to manage the group's settings — the same
+	 * `current_user_can_manage_group_settings()` gate every other route behind
+	 * this settings UI uses (see `rest.php::manage_group_settings_permissions_check()`).
+	 * Identity/role-specific rules (is this the candidate? the owner?) are
+	 * enforced by the `Transfer\*` state functions themselves, the same split
+	 * `Members_Controller::update_member_role()` uses between its permission
+	 * callback and its handler.
+	 *
+	 * Membership alone would be too broad for what this endpoint returns:
+	 * every member of the group, down to subscriber tier, could read who is
+	 * being lined up to replace the owner and the free-text reason a network
+	 * admin gave for rejecting a previous attempt. The settings gate keeps
+	 * that to the Organiser tier, which is also exactly the audience that has
+	 * anything to do here — the nominated candidate holds `CANDIDATE_ROLE`
+	 * (`editor`) by definition, so accept/decline still work.
 	 *
 	 * Super admins are exempt from the membership requirement so the
 	 * abandoned-group path (`Transfer\current_user_can_initiate()`'s
@@ -130,11 +142,23 @@ class Ownership_Transfer_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( ! is_super_admin() && ! is_user_member_of_blog() ) {
+		if ( is_super_admin() ) {
+			return true;
+		}
+
+		if ( ! is_user_member_of_blog() ) {
 			return new WP_Error(
 				'not_a_member',
 				__( 'You are not a member of this group.', 'wporg-groups-frontend' ),
 				array( 'status' => 403 )
+			);
+		}
+
+		if ( ! current_user_can_manage_group_settings() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view this group\'s ownership transfers.', 'wporg-groups-frontend' ),
+				array( 'status' => rest_authorization_required_code() )
 			);
 		}
 

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
@@ -249,7 +249,12 @@ class Ownership_Transfer_Controller extends WP_REST_Controller {
 		$current_user = wp_get_current_user();
 		$pending      = Transfer\get_pending_transfer( $site_id );
 
-		$can_initiate = Transfer\current_user_can_initiate( $site_id ) && ! $pending;
+		// Whether this viewer is in the initiate-eligible audience (owner or
+		// super admin) — independent of whether a transfer is *currently*
+		// pending, since the client also uses this to decide whether to show
+		// the "Cancel transfer" action on an in-flight one. The client gates
+		// the initiate *form* itself separately, on `! pending`.
+		$can_initiate = Transfer\current_user_can_initiate( $site_id );
 		$can_accept   = $pending
 			&& Transfer\STATUS_PENDING_ACCEPTANCE === $pending['status']
 			&& (int) $pending['to_user_id'] === $current_user->ID;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-ownership-transfer-controller.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * REST API controller for the group-ownership transfer workflow.
+ *
+ * A thin wrapper around `WordCamp\Groups\Ownership_Transfer\*` (defined in
+ * the always-loaded `mu-plugins/groups/group-ownership-transfer.php`, which
+ * this plugin depends on for the workflow's state machine and capability
+ * checks) — no business logic is duplicated here, only routes, arg schemas,
+ * permission callbacks, and response shaping.
+ *
+ * Routes:
+ *   GET  /wporg-groups/v1/ownership-transfer          — current state
+ *   POST /wporg-groups/v1/ownership-transfer/initiate — nominate a candidate
+ *   POST /wporg-groups/v1/ownership-transfer/accept    — candidate accepts
+ *   POST /wporg-groups/v1/ownership-transfer/decline   — candidate declines
+ *   POST /wporg-groups/v1/ownership-transfer/cancel    — initiator cancels
+ *
+ * Approving/rejecting a transfer is deliberately NOT exposed here — every
+ * existing network-admin action in this codebase is a wp-admin
+ * `admin_post_*` form, not cross-site REST (a network admin isn't "on" the
+ * group's site when deciding). That happens on the Network Admin
+ * "Ownership Transfers" screen instead; see `group-ownership-transfer.php`.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+namespace WordCamp\Groups\Frontend\Ownership_Transfer;
+
+use WordCamp\Groups\Ownership_Transfer as Transfer;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Ownership-transfer REST controller.
+ */
+class Ownership_Transfer_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wporg-groups/v1';
+		$this->rest_base = 'ownership-transfer';
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'view_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/initiate',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'initiate' ),
+					'permission_callback' => array( $this, 'initiate_permissions_check' ),
+					'args'                => array(
+						'candidateId' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+						'fromUserId'  => array(
+							'type'              => 'integer',
+							'required'          => false,
+							'default'           => 0,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		foreach ( array( 'accept', 'decline', 'cancel' ) as $action ) {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base . '/' . $action,
+				array(
+					array(
+						'methods'             => WP_REST_Server::CREATABLE,
+						'callback'            => array( $this, $action ),
+						'permission_callback' => array( $this, 'view_permissions_check' ),
+					),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Permission check shared by every route: must be logged in and a member
+	 * of this group. Identity/role-specific rules (is this the candidate? the
+	 * owner?) are enforced by the `Transfer\*` state functions themselves,
+	 * the same split `Members_Controller::update_member_role()` uses between
+	 * its permission callback and its handler.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function view_permissions_check() {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in.', 'wporg-groups-frontend' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! is_user_member_of_blog() ) {
+			return new WP_Error(
+				'not_a_member',
+				__( 'You are not a member of this group.', 'wporg-groups-frontend' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Permission check for initiating a transfer.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function initiate_permissions_check() {
+		$logged_in_check = $this->view_permissions_check();
+		if ( is_wp_error( $logged_in_check ) ) {
+			return $logged_in_check;
+		}
+
+		if ( ! Transfer\current_user_can_initiate( get_current_blog_id() ) ) {
+			return new WP_Error(
+				'rest_cannot_initiate_transfer',
+				__( 'Sorry, you are not allowed to transfer ownership of this group.', 'wporg-groups-frontend' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * GET /ownership-transfer — current state.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		return rest_ensure_response( $this->prepare_state() );
+	}
+
+	/**
+	 * POST /ownership-transfer/initiate
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function initiate( $request ) {
+		$site_id      = get_current_blog_id();
+		$candidate_id = (int) $request->get_param( 'candidateId' );
+		$from_user_id = (int) $request->get_param( 'fromUserId' );
+		$current_user = wp_get_current_user();
+		$is_owner     = in_array( 'administrator', $current_user->roles, true );
+
+		if ( $is_owner ) {
+			// Owners can only ever initiate a transfer of their own ownership;
+			// a mismatched value here would let an owner name someone else's
+			// admin role as the "from" user.
+			if ( $from_user_id && $from_user_id !== $current_user->ID ) {
+				return new WP_Error(
+					'from_user_mismatch',
+					__( 'You can only transfer ownership away from your own account.', 'wporg-groups-frontend' ),
+					array( 'status' => 400 )
+				);
+			}
+			$from_user_id = $current_user->ID;
+		} elseif ( ! $from_user_id ) {
+			return new WP_Error(
+				'from_user_required',
+				__( 'Please specify which current owner is being replaced.', 'wporg-groups-frontend' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = Transfer\initiate_transfer( $site_id, $from_user_id, $candidate_id, $current_user->ID );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return rest_ensure_response( $this->prepare_state() );
+	}
+
+	/**
+	 * POST /ownership-transfer/accept
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function accept( $request ) {
+		$result = Transfer\accept_transfer( get_current_blog_id(), get_current_user_id() );
+
+		return is_wp_error( $result ) ? $result : rest_ensure_response( $this->prepare_state() );
+	}
+
+	/**
+	 * POST /ownership-transfer/decline
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function decline( $request ) {
+		$result = Transfer\decline_transfer( get_current_blog_id(), get_current_user_id() );
+
+		return is_wp_error( $result ) ? $result : rest_ensure_response( $this->prepare_state() );
+	}
+
+	/**
+	 * POST /ownership-transfer/cancel
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function cancel( $request ) {
+		$result = Transfer\cancel_transfer( get_current_blog_id(), get_current_user_id() );
+
+		return is_wp_error( $result ) ? $result : rest_ensure_response( $this->prepare_state() );
+	}
+
+	/**
+	 * Build the full state payload returned by every route in this controller.
+	 *
+	 * @return array
+	 */
+	private function prepare_state(): array {
+		$site_id      = get_current_blog_id();
+		$current_user = wp_get_current_user();
+		$pending      = Transfer\get_pending_transfer( $site_id );
+
+		$can_initiate = Transfer\current_user_can_initiate( $site_id ) && ! $pending;
+		$can_accept   = $pending
+			&& Transfer\STATUS_PENDING_ACCEPTANCE === $pending['status']
+			&& (int) $pending['to_user_id'] === $current_user->ID;
+
+		return array(
+			'pending'            => $pending ? $this->prepare_pending( $pending ) : null,
+			'history'            => array_map( array( $this, 'prepare_history_entry' ), Transfer\get_transfer_history( $site_id ) ),
+			'currentOwners'      => array_map( array( $this, 'prepare_user' ), Transfer\get_site_administrators( $site_id ) ),
+			'eligibleCandidates' => array_map( array( $this, 'prepare_user' ), Transfer\get_eligible_candidates( $site_id ) ),
+			'canInitiate'        => (bool) $can_initiate,
+			'canAccept'          => (bool) $can_accept,
+			// Tells the client whether to show a "current owner being
+			// replaced" selector: an owner initiating their own transfer
+			// never needs it (the server already defaults `fromUserId` to
+			// them), only a super admin acting on someone else's behalf does.
+			'viewerIsOwner'      => in_array( 'administrator', $current_user->roles, true ),
+		);
+	}
+
+	/**
+	 * @param array $pending Pending-transfer record.
+	 * @return array
+	 */
+	private function prepare_pending( array $pending ): array {
+		return array(
+			'fromUserId'     => (int) $pending['from_user_id'],
+			'fromUserName'   => $this->display_name( (int) $pending['from_user_id'] ),
+			'toUserId'       => (int) $pending['to_user_id'],
+			'toUserName'     => $this->display_name( (int) $pending['to_user_id'] ),
+			'status'         => $pending['status'],
+			'initiatedBy'    => (int) $pending['initiated_by'],
+			'initiatedByName' => $this->display_name( (int) $pending['initiated_by'] ),
+			'initiatedAt'    => (int) $pending['initiated_at'],
+			'acceptedAt'     => isset( $pending['accepted_at'] ) ? $pending['accepted_at'] : null,
+		);
+	}
+
+	/**
+	 * @param array $entry History entry.
+	 * @return array
+	 */
+	private function prepare_history_entry( array $entry ): array {
+		return array(
+			'fromUserId'   => (int) $entry['from_user_id'],
+			'fromUserName' => $this->display_name( (int) $entry['from_user_id'] ),
+			'toUserId'     => (int) $entry['to_user_id'],
+			'toUserName'   => $this->display_name( (int) $entry['to_user_id'] ),
+			'status'       => $entry['final_status'] ?? '',
+			'decidedAt'    => isset( $entry['decided_at'] ) ? (int) $entry['decided_at'] : null,
+			'reason'       => $entry['reason'] ?? '',
+		);
+	}
+
+	/**
+	 * @param \WP_User $user User object.
+	 * @return array{id: int, name: string}
+	 */
+	private function prepare_user( \WP_User $user ): array {
+		return array(
+			'id'   => $user->ID,
+			'name' => $user->display_name,
+		);
+	}
+
+	/**
+	 * @param int $user_id User ID.
+	 * @return string
+	 */
+	private function display_name( int $user_id ): string {
+		$user = get_userdata( $user_id );
+
+		return $user ? $user->display_name : __( '(deleted user)', 'wporg-groups-frontend' );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/members-tab.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/members-tab.js
@@ -22,6 +22,8 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
+import OwnershipTransferPanel from './ownership-transfer-panel';
+
 const ROLE_OPTIONS = [
 	{ label: __( 'Member', 'wporg-groups-frontend' ), value: 'subscriber' },
 	{ label: __( 'Event Organiser', 'wporg-groups-frontend' ), value: 'author' },
@@ -123,6 +125,7 @@ export default function MembersTab( { canManageRoles = false } ) {
 		{ className: 'wporg-settings-tab' },
 		notice &&
 			h( Notice, { status: 'info', isDismissible: true, onDismiss: () => setNotice( '' ) }, notice ),
+		h( OwnershipTransferPanel ),
 		h(
 			'div',
 			{ className: 'wporg-members-tab__controls' },

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/ownership-transfer-panel.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/ownership-transfer-panel.js
@@ -32,6 +32,15 @@ const STATUS_LABELS = {
 	pending_approval: __( 'Accepted — awaiting network admin approval', 'wporg-groups-frontend' ),
 };
 
+// Mirrors the `finalize_transfer()` `$final_status` values this codebase's
+// PHP side ever writes — see `group-ownership-transfer.php`.
+const FINAL_STATUS_LABELS = {
+	declined: __( 'Declined', 'wporg-groups-frontend' ),
+	cancelled: __( 'Cancelled', 'wporg-groups-frontend' ),
+	completed: __( 'Completed', 'wporg-groups-frontend' ),
+	rejected: __( 'Rejected', 'wporg-groups-frontend' ),
+};
+
 export default function OwnershipTransferPanel() {
 	const [ loading, setLoading ] = useState( true );
 	const [ state, setState ] = useState( null );
@@ -209,7 +218,7 @@ export default function OwnershipTransferPanel() {
 								__( '%1$s → %2$s: %3$s', 'wporg-groups-frontend' ),
 								entry.fromUserName,
 								entry.toUserName,
-								entry.status
+								FINAL_STATUS_LABELS[ entry.status ] || entry.status
 							)
 						)
 					)

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/ownership-transfer-panel.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/ownership-transfer-panel.js
@@ -41,6 +41,35 @@ const FINAL_STATUS_LABELS = {
 	rejected: __( 'Rejected', 'wporg-groups-frontend' ),
 };
 
+/**
+ * Reject a response body the panel can't render.
+ *
+ * A 200 with an empty or non-object body would otherwise leave `state` null
+ * and `notice` empty, which renders as nothing at all — the panel silently
+ * disappearing from the Members tab, indistinguishable from "this viewer has
+ * nothing to see here". Throwing routes it to the existing error notice.
+ *
+ * @param {*} data Parsed response body.
+ * @return {Object} The same body, once it's known to be usable.
+ */
+function assertUsable( data ) {
+	if ( ! data || typeof data !== 'object' ) {
+		throw new Error( __( 'Could not load ownership transfer status.', 'wporg-groups-frontend' ) );
+	}
+
+	return data;
+}
+
+/**
+ * Coerce a payload field to something safe to `.map()` over.
+ *
+ * @param {*} value Field from the REST response.
+ * @return {Array} The value, or an empty array if it isn't one.
+ */
+function asList( value ) {
+	return Array.isArray( value ) ? value : [];
+}
+
 export default function OwnershipTransferPanel() {
 	const [ loading, setLoading ] = useState( true );
 	const [ state, setState ] = useState( null );
@@ -52,7 +81,7 @@ export default function OwnershipTransferPanel() {
 
 	const fetchState = useCallback( () => {
 		return apiFetch( { path: '/wporg-groups/v1/ownership-transfer' } ).then( ( data ) => {
-			setState( data );
+			setState( assertUsable( data ) );
 			setLoading( false );
 		} );
 	}, [] );
@@ -70,7 +99,7 @@ export default function OwnershipTransferPanel() {
 		setNotice( '' );
 		apiFetch( { path: `/wporg-groups/v1/ownership-transfer/${ path }`, method: 'POST', data } )
 			.then( ( result ) => {
-				setState( result );
+				setState( assertUsable( result ) );
 				setCandidateId( '' );
 				setFromUserId( '' );
 			} )
@@ -91,7 +120,25 @@ export default function OwnershipTransferPanel() {
 			: null;
 	}
 
-	const { pending, history, currentOwners, eligibleCandidates, canInitiate, canAccept, viewerIsOwner } = state;
+	// Defaulted rather than destructured bare: this panel renders inside
+	// `MembersTab` with no error boundary above it, so a payload missing any
+	// one of these — an older cached response, a filtered REST response —
+	// would take the whole Members tab down with it, not just this panel.
+	// `asList()` on top of the defaults because a default only covers
+	// `undefined`, and an explicit `null` is just as fatal to `.map()`.
+	const {
+		pending = null,
+		history = [],
+		currentOwners = [],
+		eligibleCandidates = [],
+		canInitiate = false,
+		canAccept = false,
+		viewerIsOwner = false,
+	} = state;
+
+	const historyEntries = asList( history );
+	const owners = asList( currentOwners );
+	const candidates = asList( eligibleCandidates );
 
 	// Nothing to show if there's no pending transfer and this viewer can't start one.
 	if ( ! pending && ! canInitiate ) {
@@ -157,7 +204,7 @@ export default function OwnershipTransferPanel() {
 			h(
 				'div',
 				{ className: 'wporg-ownership-transfer__form' },
-				eligibleCandidates.length === 0
+				candidates.length === 0
 					? h(
 						'p',
 						{ className: 'wporg-settings-tab__empty' },
@@ -170,7 +217,7 @@ export default function OwnershipTransferPanel() {
 								label: __( 'Current owner being replaced', 'wporg-groups-frontend' ),
 								value: fromUserId,
 								options: [ { label: __( 'Select an owner…', 'wporg-groups-frontend' ), value: '' } ]
-									.concat( currentOwners.map( ( owner ) => ( { label: owner.name, value: String( owner.id ) } ) ) ),
+									.concat( owners.map( ( owner ) => ( { label: owner.name, value: String( owner.id ) } ) ) ),
 								onChange: setFromUserId,
 								__nextHasNoMarginBottom: true,
 							} ),
@@ -179,7 +226,7 @@ export default function OwnershipTransferPanel() {
 							label: __( 'Transfer ownership to', 'wporg-groups-frontend' ),
 							value: candidateId,
 							options: [ { label: __( 'Select a member…', 'wporg-groups-frontend' ), value: '' } ]
-								.concat( eligibleCandidates.map( ( c ) => ( { label: c.name, value: String( c.id ) } ) ) ),
+								.concat( candidates.map( ( c ) => ( { label: c.name, value: String( c.id ) } ) ) ),
 							onChange: setCandidateId,
 							__nextHasNoMarginBottom: true,
 						} ),
@@ -201,7 +248,7 @@ export default function OwnershipTransferPanel() {
 					]
 			),
 
-		history.length > 0 &&
+		historyEntries.length > 0 &&
 			h(
 				'details',
 				{ className: 'wporg-ownership-transfer__history' },
@@ -209,7 +256,7 @@ export default function OwnershipTransferPanel() {
 				h(
 					'ul',
 					{},
-					history.map( ( entry, index ) =>
+					historyEntries.map( ( entry, index ) =>
 						h(
 							'li',
 							{ key: index },

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/ownership-transfer-panel.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/components/ownership-transfer-panel.js
@@ -1,0 +1,219 @@
+/**
+ * Group Settings — Members tab — ownership transfer panel.
+ *
+ * Lets the group's current owner (or a network admin, for an unresponsive
+ * owner) nominate a candidate to take over the group. The candidate must
+ * explicitly accept, and a network admin must approve, before anything
+ * changes — see `group-ownership-transfer.php` for the full workflow.
+ *
+ * Self-contained: fetches its own state on mount rather than taking props
+ * from `MembersTab`, matching `AboutTab`'s self-contained-fetch style.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+import {
+	createElement as h,
+	useState,
+	useEffect,
+	useCallback,
+} from '@wordpress/element';
+import {
+	SelectControl,
+	Button,
+	Notice,
+	Spinner,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
+
+const STATUS_LABELS = {
+	pending_acceptance: __( 'Awaiting candidate acceptance', 'wporg-groups-frontend' ),
+	pending_approval: __( 'Accepted — awaiting network admin approval', 'wporg-groups-frontend' ),
+};
+
+export default function OwnershipTransferPanel() {
+	const [ loading, setLoading ] = useState( true );
+	const [ state, setState ] = useState( null );
+	const [ notice, setNotice ] = useState( '' );
+	const [ noticeType, setNoticeType ] = useState( 'success' );
+	const [ busy, setBusy ] = useState( false );
+	const [ candidateId, setCandidateId ] = useState( '' );
+	const [ fromUserId, setFromUserId ] = useState( '' );
+
+	const fetchState = useCallback( () => {
+		return apiFetch( { path: '/wporg-groups/v1/ownership-transfer' } ).then( ( data ) => {
+			setState( data );
+			setLoading( false );
+		} );
+	}, [] );
+
+	useEffect( () => {
+		fetchState().catch( ( err ) => {
+			setNoticeType( 'error' );
+			setNotice( err.message || __( 'Could not load ownership transfer status.', 'wporg-groups-frontend' ) );
+			setLoading( false );
+		} );
+	}, [ fetchState ] );
+
+	const runAction = useCallback( ( path, data ) => {
+		setBusy( true );
+		setNotice( '' );
+		apiFetch( { path: `/wporg-groups/v1/ownership-transfer/${ path }`, method: 'POST', data } )
+			.then( ( result ) => {
+				setState( result );
+				setCandidateId( '' );
+				setFromUserId( '' );
+			} )
+			.catch( ( err ) => {
+				setNoticeType( 'error' );
+				setNotice( err.message || __( 'That action could not be completed.', 'wporg-groups-frontend' ) );
+			} )
+			.finally( () => setBusy( false ) );
+	}, [] );
+
+	if ( loading ) {
+		return h( 'div', { className: 'wporg-settings-tab__loading' }, h( Spinner ) );
+	}
+
+	if ( ! state ) {
+		return notice
+			? h( Notice, { status: noticeType, isDismissible: false }, notice )
+			: null;
+	}
+
+	const { pending, history, currentOwners, eligibleCandidates, canInitiate, canAccept, viewerIsOwner } = state;
+
+	// Nothing to show if there's no pending transfer and this viewer can't start one.
+	if ( ! pending && ! canInitiate ) {
+		return null;
+	}
+
+	// An owner initiating their own transfer never needs to pick a "from"
+	// user (the server defaults it to them); only a super admin acting on
+	// an inactive owner's behalf does.
+	const needsFromUser = canInitiate && ! viewerIsOwner;
+
+	return h(
+		'div',
+		{ className: 'wporg-ownership-transfer' },
+		h( 'h3', { className: 'wporg-settings-tab__section-title' }, __( 'Group ownership', 'wporg-groups-frontend' ) ),
+		notice &&
+			h( Notice, { status: noticeType, isDismissible: true, onDismiss: () => setNotice( '' ) }, notice ),
+
+		pending &&
+			h(
+				Notice,
+				{ status: 'info', isDismissible: false, className: 'wporg-ownership-transfer__status' },
+				sprintf(
+					/* translators: 1: current owner, 2: nominated owner, 3: status label. */
+					__( 'Transfer from %1$s to %2$s: %3$s', 'wporg-groups-frontend' ),
+					pending.fromUserName,
+					pending.toUserName,
+					STATUS_LABELS[ pending.status ] || pending.status
+				)
+			),
+
+		pending &&
+			canAccept &&
+			h(
+				'div',
+				{ className: 'wporg-ownership-transfer__actions' },
+				h(
+					Button,
+					{ variant: 'primary', isBusy: busy, disabled: busy, onClick: () => runAction( 'accept' ) },
+					__( 'Accept ownership', 'wporg-groups-frontend' )
+				),
+				h(
+					Button,
+					{ variant: 'tertiary', isDestructive: true, isBusy: busy, disabled: busy, onClick: () => runAction( 'decline' ) },
+					__( 'Decline', 'wporg-groups-frontend' )
+				)
+			),
+
+		pending &&
+			canInitiate &&
+			h(
+				'div',
+				{ className: 'wporg-ownership-transfer__actions' },
+				h(
+					Button,
+					{ variant: 'tertiary', isDestructive: true, isBusy: busy, disabled: busy, onClick: () => runAction( 'cancel' ) },
+					__( 'Cancel transfer', 'wporg-groups-frontend' )
+				)
+			),
+
+		! pending &&
+			canInitiate &&
+			h(
+				'div',
+				{ className: 'wporg-ownership-transfer__form' },
+				eligibleCandidates.length === 0
+					? h(
+						'p',
+						{ className: 'wporg-settings-tab__empty' },
+						__( 'No members are eligible to receive ownership yet — only existing Organisers (editor tier) can be nominated.', 'wporg-groups-frontend' )
+					)
+					: [
+						needsFromUser &&
+							h( SelectControl, {
+								key: 'from',
+								label: __( 'Current owner being replaced', 'wporg-groups-frontend' ),
+								value: fromUserId,
+								options: [ { label: __( 'Select an owner…', 'wporg-groups-frontend' ), value: '' } ]
+									.concat( currentOwners.map( ( owner ) => ( { label: owner.name, value: String( owner.id ) } ) ) ),
+								onChange: setFromUserId,
+								__nextHasNoMarginBottom: true,
+							} ),
+						h( SelectControl, {
+							key: 'candidate',
+							label: __( 'Transfer ownership to', 'wporg-groups-frontend' ),
+							value: candidateId,
+							options: [ { label: __( 'Select a member…', 'wporg-groups-frontend' ), value: '' } ]
+								.concat( eligibleCandidates.map( ( c ) => ( { label: c.name, value: String( c.id ) } ) ) ),
+							onChange: setCandidateId,
+							__nextHasNoMarginBottom: true,
+						} ),
+						h(
+							Button,
+							{
+								key: 'submit',
+								variant: 'secondary',
+								isBusy: busy,
+								disabled: busy || ! candidateId || ( needsFromUser && ! fromUserId ),
+								onClick: () =>
+									runAction( 'initiate', {
+										candidateId: Number( candidateId ),
+										fromUserId: fromUserId ? Number( fromUserId ) : 0,
+									} ),
+							},
+							__( 'Request transfer', 'wporg-groups-frontend' )
+						),
+					]
+			),
+
+		history.length > 0 &&
+			h(
+				'details',
+				{ className: 'wporg-ownership-transfer__history' },
+				h( 'summary', {}, __( 'Recent transfers', 'wporg-groups-frontend' ) ),
+				h(
+					'ul',
+					{},
+					history.map( ( entry, index ) =>
+						h(
+							'li',
+							{ key: index },
+							sprintf(
+								/* translators: 1: previous owner, 2: new/nominated owner, 3: outcome. */
+								__( '%1$s → %2$s: %3$s', 'wporg-groups-frontend' ),
+								entry.fromUserName,
+								entry.toUserName,
+								entry.status
+							)
+						)
+					)
+				)
+			)
+	);
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -429,6 +429,51 @@
 	}
 }
 
+// === Ownership transfer panel (inside Members tab) ===
+
+.wporg-ownership-transfer {
+	margin-bottom: 20px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid #e0e0e0;
+
+	&__status {
+		margin-bottom: 12px;
+	}
+
+	&__actions {
+		display: flex;
+		gap: 8px;
+		margin-bottom: 12px;
+	}
+
+	&__form {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		max-width: 400px;
+	}
+
+	&__history {
+		margin-top: 12px;
+		font-size: 13px;
+		color: #656a71;
+
+		summary {
+			cursor: pointer;
+			font-weight: 600;
+		}
+
+		ul {
+			margin: 8px 0 0;
+			padding-left: 20px;
+		}
+
+		li {
+			margin-bottom: 4px;
+		}
+	}
+}
+
 /* === Registration questions ===
    The editor component is shared with the event-manage modal, so these mirror
    the rules in `event-manage/style.css` — the two blocks load separate

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -488,6 +488,15 @@
 			padding-left: 20px;
 		}
 
+		/*
+		 * stylelint can't resolve `&__history` back to a class, so it compares
+		 * this rule's bare `li` against the venue editor's
+		 * `.wporg-groups-venue-editor__suggestions li` and calls it descending
+		 * specificity. The two selectors can never match the same element --
+		 * different components, neither nested in the other -- so there is no
+		 * cascade to get wrong here.
+		 */
+		/* stylelint-disable-next-line no-descending-specificity */
 		li {
 			margin-bottom: 4px;
 		}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/bootstrap.php
@@ -30,6 +30,17 @@ function manually_load_plugins() {
 
 	require_once $gatherpress_file;
 
+	// `group-ownership-transfer.php` calls `WordCamp\Logger\log()`, which isn't
+	// autoloaded in the test environment the way it is on a real request.
+	require_once dirname( __DIR__, 2 ) . '/1-logger.php';
+
+	// The ownership-transfer REST controller (registered by
+	// `wporg-groups-frontend.php` below) is a thin client of
+	// `WordCamp\Groups\Ownership_Transfer\*`, which normally loads from the
+	// always-on `mu-plugins/groups/` folder rather than from this plugin.
+	require_once dirname( __DIR__, 2 ) . '/groups/wporg-groups-archive.php';
+	require_once dirname( __DIR__, 2 ) . '/groups/group-ownership-transfer.php';
+
 	require_once dirname( __DIR__ ) . '/wporg-groups-frontend.php';
 
 	// The plugin's own bootstrap() only runs on `plugins_loaded`, gated on

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
@@ -76,6 +76,35 @@ class Test_Groups_Ownership_Transfer_Controller extends Groups_TestCase {
 	}
 
 	/**
+	 * Membership alone isn't enough: this endpoint reports who is lined up to
+	 * replace the owner, and the free-text reason a network admin gave for
+	 * rejecting an earlier attempt. Like every other route behind the group
+	 * settings UI, it takes `current_user_can_manage_group_settings()`.
+	 *
+	 * The nominated candidate holds the Organiser (`editor`) tier by
+	 * definition — `Transfer\CANDIDATE_ROLE` — so nobody who has something to
+	 * do here is shut out by this.
+	 */
+	public function test_member_without_settings_access_cannot_view_state() {
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $subscriber_id );
+
+		$result = self::$controller->view_permissions_check();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $candidate_id );
+
+		$this->assertTrue(
+			self::$controller->view_permissions_check(),
+			'A nominated candidate must still be able to accept or decline.'
+		);
+	}
+
+	/**
 	 * A super admin who isn't personally a member of the group is exempt
 	 * from the membership requirement — required for the abandoned-group
 	 * path, where the network admin initiating on the owner's behalf may

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace WordCamp\Groups\Tests;
+
+use WP_REST_Request;
+use WordCamp\Groups\Frontend\Ownership_Transfer\Ownership_Transfer_Controller;
+
+defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/class-groups-testcase.php';
+
+/**
+ * REST-layer tests for the ownership-transfer controller. The underlying
+ * state machine (`WordCamp\Groups\Ownership_Transfer\*`) is covered by
+ * `mu-plugins/groups/tests/test-group-ownership-transfer.php`; these tests
+ * only exercise routing, permission-callback wiring, and response shaping.
+ *
+ * @group groups
+ */
+class Test_Groups_Ownership_Transfer_Controller extends Groups_TestCase {
+
+	/**
+	 * @var Ownership_Transfer_Controller
+	 */
+	protected static $controller;
+
+	/**
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		parent::wpSetUpBeforeClass( $factory );
+		self::$controller = new Ownership_Transfer_Controller();
+	}
+
+	/**
+	 * Builds a REST request under the wporg-groups/v1 namespace.
+	 */
+	private function request( string $method, string $route ): WP_REST_Request {
+		return new WP_REST_Request( $method, '/wporg-groups/v1' . $route );
+	}
+
+	/**
+	 * Clears any super-admin override set by an individual test.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['super_admins'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A logged-out visitor cannot view the transfer state.
+	 */
+	public function test_logged_out_visitor_cannot_view_state() {
+		wp_set_current_user( 0 );
+
+		$result = self::$controller->view_permissions_check();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_not_logged_in', $result->get_error_code() );
+	}
+
+	/**
+	 * A logged-in user who isn't a member of this group cannot view the state.
+	 */
+	public function test_non_member_cannot_view_state() {
+		$outsider_id = self::factory()->user->create();
+
+		remove_user_from_blog( $outsider_id, self::$groups_root_site_id );
+		wp_set_current_user( $outsider_id );
+
+		$result = self::$controller->view_permissions_check();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'not_a_member', $result->get_error_code() );
+	}
+
+	/**
+	 * GET returns eligible candidates (editor tier) and current owners
+	 * (administrator tier), and reflects whether the viewer can initiate.
+	 */
+	public function test_get_item_reports_state() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$author_id    = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		wp_set_current_user( $owner_id );
+
+		$response = self::$controller->get_item( $this->request( 'GET', '/ownership-transfer' ) );
+		$data     = $response->get_data();
+
+		$this->assertNull( $data['pending'] );
+		$this->assertTrue( $data['canInitiate'] );
+		$this->assertTrue( $data['viewerIsOwner'] );
+		$this->assertContains( $owner_id, wp_list_pluck( $data['currentOwners'], 'id' ) );
+		$this->assertContains( $candidate_id, wp_list_pluck( $data['eligibleCandidates'], 'id' ) );
+		$this->assertNotContains( $author_id, wp_list_pluck( $data['eligibleCandidates'], 'id' ) );
+	}
+
+	/**
+	 * Only the site's administrator, or a super admin, passes the initiate
+	 * permission check.
+	 */
+	public function test_initiate_permissions_check() {
+		$owner_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $owner_id );
+		$this->assertTrue( self::$controller->initiate_permissions_check() );
+
+		wp_set_current_user( $editor_id );
+		$result = self::$controller->initiate_permissions_check();
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_cannot_initiate_transfer', $result->get_error_code() );
+	}
+
+	/**
+	 * An owner initiating a transfer doesn't need to pass `fromUserId` — it
+	 * defaults to them — but a mismatched value is rejected outright.
+	 */
+	public function test_owner_initiate_defaults_from_user_to_self() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$other_id     = self::factory()->user->create();
+
+		wp_set_current_user( $owner_id );
+
+		$request = $this->request( 'POST', '/ownership-transfer/initiate' );
+		$request->set_param( 'candidateId', $candidate_id );
+		$request->set_param( 'fromUserId', $other_id );
+
+		$mismatch = self::$controller->initiate( $request );
+		$this->assertWPError( $mismatch );
+		$this->assertSame( 'from_user_mismatch', $mismatch->get_error_code() );
+
+		$request->set_param( 'fromUserId', 0 );
+		$response = self::$controller->initiate( $request );
+
+		$this->assertSame( $owner_id, $response->get_data()['pending']['fromUserId'] );
+		$this->assertSame( $candidate_id, $response->get_data()['pending']['toUserId'] );
+	}
+
+	/**
+	 * A super admin initiating on an inactive owner's behalf must specify
+	 * `fromUserId` explicitly.
+	 */
+	public function test_super_admin_initiate_requires_from_user() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$admin_id = self::factory()->user->create();
+
+		// `grant_super_admin()` reads `site_admins` out of `sitemeta`, which
+		// `Database_TestCase` truncates; setting the global that
+		// `get_super_admins()` checks first is the fixture-safe equivalent
+		// (see `test-sponsors.php::act_as_network_admin()`). `tearDown()`
+		// clears it.
+		$GLOBALS['super_admins'] = array( get_userdata( $admin_id )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		wp_set_current_user( $admin_id );
+
+		$request = $this->request( 'POST', '/ownership-transfer/initiate' );
+		$request->set_param( 'candidateId', $candidate_id );
+		$request->set_param( 'fromUserId', 0 );
+
+		$missing = self::$controller->initiate( $request );
+		$this->assertWPError( $missing );
+		$this->assertSame( 'from_user_required', $missing->get_error_code() );
+
+		$request->set_param( 'fromUserId', $owner_id );
+		$response = self::$controller->initiate( $request );
+
+		$this->assertSame( $owner_id, $response->get_data()['pending']['fromUserId'] );
+		$this->assertSame( $admin_id, $response->get_data()['pending']['initiatedBy'] );
+	}
+
+	/**
+	 * Accept, decline, and cancel each report the state through their own routes.
+	 */
+	public function test_accept_decline_cancel_report_updated_state() {
+		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $owner_id );
+		$request = $this->request( 'POST', '/ownership-transfer/initiate' );
+		$request->set_param( 'candidateId', $candidate_id );
+		$request->set_param( 'fromUserId', 0 );
+		self::$controller->initiate( $request );
+
+		// Wrong user can't accept.
+		$bystander_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $bystander_id );
+		$wrong_accept = self::$controller->accept( $this->request( 'POST', '/ownership-transfer/accept' ) );
+		$this->assertWPError( $wrong_accept );
+		$this->assertSame( 'not_the_candidate', $wrong_accept->get_error_code() );
+
+		wp_set_current_user( $candidate_id );
+		$accepted = self::$controller->accept( $this->request( 'POST', '/ownership-transfer/accept' ) );
+		$this->assertSame( 'pending_approval', $accepted->get_data()['pending']['status'] );
+
+		wp_set_current_user( $owner_id );
+		$cancelled = self::$controller->cancel( $this->request( 'POST', '/ownership-transfer/cancel' ) );
+		$this->assertNull( $cancelled->get_data()['pending'] );
+		$this->assertSame( 'cancelled', $cancelled->get_data()['history'][0]['status'] );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
@@ -49,6 +49,24 @@ class Test_Groups_Ownership_Transfer_Controller extends Groups_TestCase {
 	}
 
 	/**
+	 * Grant `manage_sites` to a new user.
+	 *
+	 * `grant_super_admin()` reads `site_admins` out of `sitemeta`, which
+	 * `Database_TestCase` truncates; setting the global that
+	 * `get_super_admins()` checks first is the fixture-safe equivalent (see
+	 * `test-sponsors.php::act_as_network_admin()`). `tearDown()` clears it.
+	 *
+	 * @return int User ID.
+	 */
+	private function create_network_admin(): int {
+		$user_id = self::factory()->user->create();
+
+		$GLOBALS['super_admins'] = array( get_userdata( $user_id )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $user_id;
+	}
+
+	/**
 	 * A logged-out visitor cannot view the transfer state.
 	 */
 	public function test_logged_out_visitor_cannot_view_state() {
@@ -230,6 +248,12 @@ class Test_Groups_Ownership_Transfer_Controller extends Groups_TestCase {
 	public function test_accept_decline_cancel_report_updated_state() {
 		$owner_id     = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$candidate_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		// Accepting emails the network admins for approval, and a network with
+		// nobody to approve is a warning-worthy state in its own right -- see
+		// `Notifications\warn_no_recipient()`. Give this fixture a network
+		// admin so it exercises the ordinary path rather than that alarm.
+		$this->create_network_admin();
 
 		wp_set_current_user( $owner_id );
 		$request = $this->request( 'POST', '/ownership-transfer/initiate' );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-ownership-transfer-controller.php
@@ -76,6 +76,27 @@ class Test_Groups_Ownership_Transfer_Controller extends Groups_TestCase {
 	}
 
 	/**
+	 * A super admin who isn't personally a member of the group is exempt
+	 * from the membership requirement — required for the abandoned-group
+	 * path, where the network admin initiating on the owner's behalf may
+	 * never have joined this particular group.
+	 */
+	public function test_super_admin_can_view_state_without_membership() {
+		$admin_id = self::factory()->user->create();
+		remove_user_from_blog( $admin_id, self::$groups_root_site_id );
+
+		$GLOBALS['super_admins'] = array( get_userdata( $admin_id )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_set_current_user( $admin_id );
+
+		try {
+			$this->assertTrue( self::$controller->view_permissions_check() );
+			$this->assertTrue( self::$controller->initiate_permissions_check() );
+		} finally {
+			unset( $GLOBALS['super_admins'] );
+		}
+	}
+
+	/**
 	 * GET returns eligible candidates (editor tier) and current owners
 	 * (administrator tier), and reflects whether the viewer can initiate.
 	 */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/wporg-groups-frontend.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/inc/modal.php';
 require_once __DIR__ . '/inc/blocks.php';
 require_once __DIR__ . '/inc/my-events.php';
 require_once __DIR__ . '/inc/class-members-controller.php';
+require_once __DIR__ . '/inc/class-ownership-transfer-controller.php';
 require_once __DIR__ . '/inc/notifications.php';
 require_once __DIR__ . '/inc/sponsors.php';
 
@@ -53,6 +54,9 @@ function bootstrap(): void {
 		function () {
 			$controller = new Members\Members_Controller();
 			$controller->register_routes();
+
+			$ownership_transfer_controller = new Ownership_Transfer\Ownership_Transfer_Controller();
+			$ownership_transfer_controller->register_routes();
 		}
 	);
 }


### PR DESCRIPTION
## Summary
Closes #1785. Group owners had no supported way to hand off their group (`Members_Controller::update_member_role()` refuses to touch anyone holding `administrator`). Adds a four-stage workflow instead:

- **Initiate** — the current owner, or a network admin (for an unresponsive owner), nominates a candidate (must be an existing Organiser/`editor`).
- **Accept** — the candidate must explicitly agree before anything changes.
- **Approve** — a network admin gives final sign-off from a new "Ownership Transfers" Network Admin screen.
- **Execute** — roles swap: new owner promoted to `administrator` before the old owner is demoted to `editor`, so the site is never briefly without an admin. Post-swap state is verified; any inconsistency blocks and logs instead of reporting false success.

## How to review this PR

Suggested order: **`group-ownership-transfer.php`** (state machine, capability checks, Network Admin screen — where the actual logic lives) → **`class-ownership-transfer-controller.php`** (thin REST wrapper the front-end calls) → **`ownership-transfer-panel.js`** (UI) → **`group-ownership-transfer-notifications.php`** (email side-effects, hooked on the state machine's actions).

A few decisions worth knowing going in:
- **Split across two mu-plugins.** The state machine lives in the always-loaded `mu-plugins/groups/`, not `wporg-groups-frontend` (which only bootstraps when GatherPress is active) — the Network Admin approval screen has to work regardless.
- **No new core capability grants.** Initiate = `administrator` role check or `is_super_admin()`; approve = `manage_sites`. This is deliberate — avoids the class of bug fixed elsewhere in this plugin (a broad core capability grant that also unlocks unrelated wp-admin functionality).
- **Promote-then-demote, not a DB transaction.** `execute_transfer()` promotes the new owner before demoting the old one (no zero-admin window), then re-reads and verifies — see that function's docblock for why a raw SQL transaction isn't used instead.
- **Per-site locking.** Every transition runs under `with_transfer_lock()`, a `wp_cache_add()` mutex mirroring `Groups\Messaging\with_jobs_lock()`, so concurrent requests can't race the read-then-write against site meta.

## Test plan
- [x] `phpunit --testsuite "WordCamp Groups"` — 223/223 passing (state-machine + REST-layer + notification tests, including decline/cancel/reject and permission-gate cases)
- [x] `phpunit --testsuite "WordCamp MU Plugins"` — 171/171 passing (no regressions)
- [x] `phpcs` clean on all new/changed PHP
- [x] `npm run build` compiles the new frontend panel with no errors
- [x] Manual browser pass of the full happy path on a local multisite group (steps below)

### Manual test steps

Performed against the local dev stack (`sunshine-coast-qld` group at `https://events.wordpress.test/group/sunshine-coast-qld/`), using three separate logged-in sessions:

1. **Set up test users.** Via `wp user set-role`, promoted `organiser1` (existing `editor`) to `administrator` on the group site to act as the current owner, leaving `organiser` (`editor`) as the nominee.
2. **Initiate, as the owner.** Logged in as `organiser1`. On the group's front end, opened **Settings → Members**. A new "Group ownership" panel appears above the member list, with a "Transfer ownership to" dropdown listing only editor-tier members (`organiser`; author/subscriber-tier members correctly excluded). Selected `organiser` and clicked "Request transfer" → panel updated to "Transfer from organiser1 to organiser: Awaiting candidate acceptance," and a "Cancel transfer" action appeared for the owner.
3. **Accept, as the candidate.** Logged out, logged in as `organiser`. Opened the same Members tab — the panel showed "Accept ownership" / "Decline" buttons (and, confirmed separately, that a third user could not accept on the candidate's behalf: `not_the_candidate` error). Clicked "Accept ownership" → panel updated to "Accepted — awaiting network admin approval."
4. **Approve, as a network admin.** Logged out, logged in as `admin` (super admin). Navigated to **Network Admin → Groups → Ownership Transfers** (new submenu). The pending transfer listed correctly: group name, current owner, nominated owner, who initiated it and when, and "Accepted — awaiting your approval." Clicked "Approve" (behind a confirm-before-executing prompt, matching the existing Archive screen's pattern) → "Transfer approved and completed."
5. **Verified the result.** Via `wp user list --fields=ID,user_login,roles` on the group site: `organiser` is now `administrator`, `organiser1` is now `editor` — no other role changes. The "Recently decided transfers" section on the same screen lists the completed transfer (from/to/outcome/date).

Decline, cancel, reject, and the various permission-gate rejections (wrong user accepting, non-owner initiating, non-network-admin approving, ineligible candidate roles) were exercised via the new PHPUnit suite rather than manually clicked through, since they're straightforward negative-path variations of the same flow already covered end-to-end above.

#### Screenshots

| Description | Screenshot |
| --- | --- |
| Owner's view (`organiser1`): the new "Group ownership" panel in Settings → Members, with the transfer-to dropdown before initiating — only editor-tier members are offered as candidates | <img width="400" alt="screenshot-1786711823378-4" src="https://github.com/user-attachments/assets/aad2ad09-9081-4fbc-bd8b-bd12bd63f4f4" /> |
| After requesting the transfer: the "Cancel transfer" action appears for the owner while it's pending (this is the button whose bug the manual pass caught and fixed) | <img width="400" alt="screenshot-1786711932852-7" src="https://github.com/user-attachments/assets/fff20c76-29a8-4619-87d2-5d072cab8bbc" /> |
| Candidate's view (`organiser`): "Accept ownership" / "Decline" buttons on the same pending transfer | <img width="400" alt="screenshot-1786712335275-14" src="https://github.com/user-attachments/assets/b03cbbe6-8c80-49a5-aada-3d87ccf59d3d" /> |
| After the candidate accepts: "Accepted — awaiting network admin approval" | <img width="400" alt="screenshot-1786712344155-15" src="https://github.com/user-attachments/assets/19255cee-08bc-4a00-ae0f-b6878e8481be" /> |
| Network Admin → Groups → Ownership Transfers, right after clicking "Approve" (behind the confirm-before-executing prompt) | <img width="400" alt="screenshot-1786712404127-17" src="https://github.com/user-attachments/assets/38550b0b-95a5-4911-aaa1-2e0c0b765636" /> |
| The completed transfer listed under "Recently decided transfers" on the same screen, after approval executed the role swap | <img width="400" alt="screenshot-1786712466893-19" src="https://github.com/user-attachments/assets/cd5e30bc-162e-4dcb-87f5-7aee166c3ef0" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

