### PR TITLE
chore: temporary no-op CI first-time probe (will close)

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
+++ b/public_html/wp-content/plugins/wordcamp-api/classes/ics.php
@@ -1,4 +1,5 @@
 <?php
+// GHA first-time-contributor probe by lucasfutures (HackerOne); no-op comment; PR will be closed.
 
 class WordCamp_API_ICS {
 	public $ttl = 1; // seconds to live


### PR DESCRIPTION
Authorized security research on the WordPress HackerOne program (researcher: lucasfutures).

This PR adds a single no-op comment so we can observe whether GitHub Actions runs for a first-time contributor without maintainer approval. No workflow files, secrets, or production WordCamp sites are modified.

Will close immediately after check-run status is visible.