### PR TITLE
Payments Network: batch the network-wide payment index aggregation

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -117,6 +117,13 @@ class Payment_Requests_Dashboard {
 	 *
 	 * Runs in batches of self-rescheduled single events to keep peak memory bounded, since a single request
 	 * iterating all sites was pushing peak memory usage above 90%.
+	 *
+	 * Each blog's rows are replaced as the run reaches that blog, rather than the whole table being emptied
+	 * up front. Spreading a rebuild over many requests rules out the empty-table approach: `generate_payment_report()`
+	 * builds the actual wire/SEPA payment files straight out of this index, so a run that emptied the table
+	 * and refilled it over the following minutes would let an export taken in that window silently come out
+	 * short -- or completely empty. Replacing per blog keeps the index continuously readable, and makes
+	 * indexing a blog idempotent, so a resumed batch can safely re-cover ground it already did.
 	 */
 	public static function aggregate( $after_blog_id = 0 ) {
 		global $wpdb, $wp_object_cache;
@@ -127,10 +134,10 @@ class Payment_Requests_Dashboard {
 		require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/payment-request.php';
 		WCP_Payment_Request::register_post_statuses();
 
-		// A fresh run is about to empty the index, which makes any continuation still queued from an
-		// earlier run that never finished stale: it would index its remaining blogs into a table it no
-		// longer owns, duplicating every row this run's own batches also insert. Retire those first,
-		// before this run claims the state option for itself.
+		// Retire any continuation still queued from an earlier run that never finished, before this run
+		// claims the state option for itself. Two chains walking the network at once would interleave
+		// their per-blog delete/insert pairs, and a delete landing between the other chain's delete and
+		// its inserts leaves that blog indexed twice.
 		if ( 0 === $after_blog_id ) {
 			self::abandon_stalled_chain();
 		}
@@ -140,11 +147,6 @@ class Payment_Requests_Dashboard {
 		// `watchdog()` to run it again. Without this, only the very last completed batch is recoverable,
 		// and a first batch that dies loses the whole run until the next daily event.
 		self::save_run_state( $after_blog_id );
-
-		// Only truncate at the start of a fresh run, not on every batch.
-		if ( 0 === $after_blog_id ) {
-			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name isn't user input, can't be a bound placeholder.
-		}
 
 		// `max( 1, ... )` so a filter returning 0 can't make every batch look "not full" while indexing
 		// nothing, which would schedule continuations forever.
@@ -164,6 +166,15 @@ class Payment_Requests_Dashboard {
 		) );
 
 		foreach ( $blogs as $blog_id ) {
+			$blog_id = (int) $blog_id;
+
+			// Clear this blog's slice of the index before rebuilding it, so that indexing a blog is
+			// idempotent. Without this the inserts below are additive, and every path that can cover the
+			// same blog twice -- a resumed batch, or `save_post()` having indexed a request while the run
+			// was still working its way toward that blog -- leaves a duplicate row behind. In an export,
+			// a duplicated row is a duplicated payment.
+			$wpdb->delete( self::get_table_name(), array( 'blog_id' => $blog_id ), array( '%d' ) );
+
 			switch_to_blog( $blog_id );
 
 			$paged = 1;
@@ -195,8 +206,32 @@ class Payment_Requests_Dashboard {
 			self::save_run_state( $next_cursor );
 			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $next_cursor ) );
 		} else {
+			// The run has covered every blog, so anything still indexed against a blog that no longer
+			// exists belongs to a site deleted since the last run. Dropping the whole table up front used
+			// to take care of these implicitly; now that each blog is refreshed in place, a site that is
+			// gone is never visited and has to be cleaned up explicitly.
+			self::prune_orphaned_rows();
+
 			delete_site_option( self::AGGREGATE_RUN_OPTION );
 		}
+	}
+
+	/**
+	 * Removes index rows belonging to blogs that are no longer in the network.
+	 */
+	protected static function prune_orphaned_rows() {
+		global $wpdb;
+
+		$table = self::get_table_name();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names aren't user input, and there isn't a good way to escape them yet, see https://core.trac.wordpress.org/ticket/52506.
+		$wpdb->query( "
+			DELETE payments_index
+			FROM `{$table}` AS payments_index
+			LEFT JOIN `{$wpdb->blogs}` AS blogs ON payments_index.blog_id = blogs.blog_id
+			WHERE blogs.blog_id IS NULL
+		" );
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -107,6 +107,8 @@ class Payment_Requests_Dashboard {
 	public static function aggregate( $after_blog_id = 0 ) {
 		global $wpdb, $wp_object_cache;
 
+		$after_blog_id = (int) $after_blog_id;
+
 		// Register the custom payment statuses so that we can filter posts to include only them, in order to exclude trashed posts.
 		require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/payment-request.php';
 		WCP_Payment_Request::register_post_statuses();
@@ -116,7 +118,7 @@ class Payment_Requests_Dashboard {
 			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name isn't user input, can't be a bound placeholder.
 		}
 
-		$batch_size = apply_filters( 'wordcamp_payments_aggregate_batch_size', self::AGGREGATE_BATCH_SIZE );
+		$batch_size = (int) apply_filters( 'wordcamp_payments_aggregate_batch_size', self::AGGREGATE_BATCH_SIZE );
 
 		// Keyset pagination on `blog_id` rather than LIMIT/OFFSET on `last_updated`, since `last_updated`
 		// changes constantly as sites get traffic, which would shift rows across the offset boundary
@@ -156,7 +158,10 @@ class Payment_Requests_Dashboard {
 		// and persist the cursor so `watchdog()` can resume the chain if that scheduling call is ever lost to
 		// WordPress core's unsynchronized read-modify-write of the shared `cron` option.
 		if ( count( $blogs ) === $batch_size ) {
-			$next_cursor = end( $blogs );
+			// Cast to int: `get_col()` returns strings, and cron identifies an event by
+			// `md5( serialize( $args ) )`, so a string cursor here wouldn't match the int one
+			// `watchdog()` looks up -- leaving it to schedule a duplicate run every hour.
+			$next_cursor = (int) end( $blogs );
 			update_site_option( self::AGGREGATE_CURSOR_OPTION, $next_cursor );
 			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $next_cursor ) );
 		} else {

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -234,10 +234,13 @@ class Payment_Requests_Dashboard {
 	 * @param int $cursor The `blog_id` to resume after. `0` restarts the run from the beginning.
 	 */
 	protected static function save_run_state( $cursor ) {
-		update_site_option( self::AGGREGATE_RUN_OPTION, array(
-			'cursor'  => (int) $cursor,
-			'updated' => time(),
-		) );
+		update_site_option(
+			self::AGGREGATE_RUN_OPTION,
+			array(
+				'cursor'  => (int) $cursor,
+				'updated' => time(),
+			)
+		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -4,6 +4,8 @@ class Payment_Requests_Dashboard {
 	public static $list_table;
 	public static $db_version = 7;
 
+	const AGGREGATE_BATCH_SIZE = 250;
+
 	/**
 	 * Runs during plugins_loaded, doh.
 	 */
@@ -16,7 +18,7 @@ class Payment_Requests_Dashboard {
 				wp_schedule_event( time(), 'daily', 'wordcamp_payments_aggregate' );
 			}
 
-			add_action( 'wordcamp_payments_aggregate', array( __CLASS__, 'aggregate' ) );
+			add_action( 'wordcamp_payments_aggregate', array( __CLASS__, 'aggregate' ), 10, 1 );
 		}
 
 		add_action( 'network_admin_menu', array( __CLASS__, 'network_admin_menu' ) );
@@ -90,24 +92,29 @@ class Payment_Requests_Dashboard {
 	 * This is a backup for the diff-based updates in `save_post()` / `delete_post()`. Those are fast but have the
 	 * chance of getting out of sync over time if an error occurs, etc. This is slow but more likely to be accurate.
 	 * The diff-based updates keep things up to date in-between the full updates done here.
+	 *
+	 * Runs in batches of self-rescheduled single events to keep peak memory bounded, since a single request
+	 * iterating all sites was pushing peak memory usage above 90%.
 	 */
-	public static function aggregate() {
+	public static function aggregate( $offset = 0 ) {
 		global $wpdb, $wp_object_cache;
 
 		// Register the custom payment statuses so that we can filter posts to include only them, in order to exclude trashed posts.
 		require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/payment-request.php';
 		WCP_Payment_Request::register_post_statuses();
 
-		// Truncate existing table.
-		$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() );
+		// Only truncate at the start of a fresh run, not on every batch.
+		if ( 0 === $offset ) {
+			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() );
+		}
 
-		// This may need to be refactored in the future to use batching to avoid out-of-memory-issues.
 		$blogs = $wpdb->get_col( $wpdb->prepare( "
 			SELECT blog_id
 			FROM `{$wpdb->blogs}`
 			ORDER BY last_updated DESC
-			LIMIT %d;",
-			3000
+			LIMIT %d OFFSET %d;",
+			self::AGGREGATE_BATCH_SIZE,
+			$offset
 		) );
 
 		foreach ( $blogs as $blog_id ) {
@@ -129,6 +136,11 @@ class Payment_Requests_Dashboard {
 			$wp_object_cache->delete( 'alloptions', 'options' );
 
 			restore_current_blog();
+		}
+
+		// More blogs left? Schedule the next batch as a separate request instead of looping further in this one.
+		if ( count( $blogs ) === self::AGGREGATE_BATCH_SIZE ) {
+			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $offset + self::AGGREGATE_BATCH_SIZE ) );
 		}
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -96,7 +96,7 @@ class Payment_Requests_Dashboard {
 	 * Runs in batches of self-rescheduled single events to keep peak memory bounded, since a single request
 	 * iterating all sites was pushing peak memory usage above 90%.
 	 */
-	public static function aggregate( $offset = 0 ) {
+	public static function aggregate( $after_blog_id = 0 ) {
 		global $wpdb, $wp_object_cache;
 
 		// Register the custom payment statuses so that we can filter posts to include only them, in order to exclude trashed posts.
@@ -104,17 +104,21 @@ class Payment_Requests_Dashboard {
 		WCP_Payment_Request::register_post_statuses();
 
 		// Only truncate at the start of a fresh run, not on every batch.
-		if ( 0 === $offset ) {
-			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() );
+		if ( 0 === $after_blog_id ) {
+			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name isn't user input, can't be a bound placeholder.
 		}
 
+		// Keyset pagination on `blog_id` rather than LIMIT/OFFSET on `last_updated`, since `last_updated`
+		// changes constantly as sites get traffic, which would shift rows across the offset boundary
+		// mid-run and cause blogs to be skipped or double-processed.
 		$blogs = $wpdb->get_col( $wpdb->prepare( "
 			SELECT blog_id
 			FROM `{$wpdb->blogs}`
-			ORDER BY last_updated DESC
-			LIMIT %d OFFSET %d;",
-			self::AGGREGATE_BATCH_SIZE,
-			$offset
+			WHERE blog_id > %d
+			ORDER BY blog_id ASC
+			LIMIT %d;",
+			$after_blog_id,
+			self::AGGREGATE_BATCH_SIZE
 		) );
 
 		foreach ( $blogs as $blog_id ) {
@@ -140,7 +144,7 @@ class Payment_Requests_Dashboard {
 
 		// More blogs left? Schedule the next batch as a separate request instead of looping further in this one.
 		if ( count( $blogs ) === self::AGGREGATE_BATCH_SIZE ) {
-			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $offset + self::AGGREGATE_BATCH_SIZE ) );
+			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( end( $blogs ) ) );
 		}
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -5,6 +5,7 @@ class Payment_Requests_Dashboard {
 	public static $db_version = 7;
 
 	const AGGREGATE_BATCH_SIZE = 250;
+	const AGGREGATE_CURSOR_OPTION = 'wcp_network_aggregate_cursor';
 
 	/**
 	 * Runs during plugins_loaded, doh.
@@ -18,7 +19,14 @@ class Payment_Requests_Dashboard {
 				wp_schedule_event( time(), 'daily', 'wordcamp_payments_aggregate' );
 			}
 
+			// Resumes a batch chain within the hour if a `wordcamp_payments_aggregate` continuation
+			// ever fails to schedule -- see `watchdog()`.
+			if ( get_current_blog_id() == $current_site->blog_id && ! wp_next_scheduled( 'wordcamp_payments_aggregate_watchdog' ) ) {
+				wp_schedule_event( time(), 'hourly', 'wordcamp_payments_aggregate_watchdog' );
+			}
+
 			add_action( 'wordcamp_payments_aggregate', array( __CLASS__, 'aggregate' ), 10, 1 );
+			add_action( 'wordcamp_payments_aggregate_watchdog', array( __CLASS__, 'watchdog' ) );
 		}
 
 		add_action( 'network_admin_menu', array( __CLASS__, 'network_admin_menu' ) );
@@ -108,6 +116,8 @@ class Payment_Requests_Dashboard {
 			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name isn't user input, can't be a bound placeholder.
 		}
 
+		$batch_size = apply_filters( 'wordcamp_payments_aggregate_batch_size', self::AGGREGATE_BATCH_SIZE );
+
 		// Keyset pagination on `blog_id` rather than LIMIT/OFFSET on `last_updated`, since `last_updated`
 		// changes constantly as sites get traffic, which would shift rows across the offset boundary
 		// mid-run and cause blogs to be skipped or double-processed.
@@ -118,7 +128,7 @@ class Payment_Requests_Dashboard {
 			ORDER BY blog_id ASC
 			LIMIT %d;",
 			$after_blog_id,
-			self::AGGREGATE_BATCH_SIZE
+			$batch_size
 		) );
 
 		foreach ( $blogs as $blog_id ) {
@@ -142,9 +152,31 @@ class Payment_Requests_Dashboard {
 			restore_current_blog();
 		}
 
-		// More blogs left? Schedule the next batch as a separate request instead of looping further in this one.
-		if ( count( $blogs ) === self::AGGREGATE_BATCH_SIZE ) {
-			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( end( $blogs ) ) );
+		// More blogs left? Schedule the next batch as a separate request instead of looping further in this one,
+		// and persist the cursor so `watchdog()` can resume the chain if that scheduling call is ever lost to
+		// WordPress core's unsynchronized read-modify-write of the shared `cron` option.
+		if ( count( $blogs ) === $batch_size ) {
+			$next_cursor = end( $blogs );
+			update_site_option( self::AGGREGATE_CURSOR_OPTION, $next_cursor );
+			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $next_cursor ) );
+		} else {
+			delete_site_option( self::AGGREGATE_CURSOR_OPTION );
+		}
+	}
+
+	/**
+	 * Resumes an aggregate() batch chain if its next scheduled continuation was lost.
+	 *
+	 * `wp_schedule_single_event()` writes into the same site-wide `cron` option that every other cron
+	 * call on the network writes to, unsynchronized -- so a concurrent scheduling call elsewhere can
+	 * clobber the continuation aggregate() just scheduled for itself. Runs hourly; harmless no-op when
+	 * there's no run in progress or the continuation is already scheduled.
+	 */
+	public static function watchdog() {
+		$cursor = (int) get_site_option( self::AGGREGATE_CURSOR_OPTION, 0 );
+
+		if ( $cursor > 0 && ! wp_next_scheduled( 'wordcamp_payments_aggregate', array( $cursor ) ) ) {
+			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $cursor ) );
 		}
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/payment-requests-dashboard.php
@@ -5,7 +5,21 @@ class Payment_Requests_Dashboard {
 	public static $db_version = 7;
 
 	const AGGREGATE_BATCH_SIZE = 250;
-	const AGGREGATE_CURSOR_OPTION = 'wcp_network_aggregate_cursor';
+
+	/**
+	 * Durable state of an in-progress `aggregate()` run: `array( 'cursor' => int, 'updated' => int )`.
+	 * Absent when no run is in progress. See `watchdog()`.
+	 */
+	const AGGREGATE_RUN_OPTION = 'wcp_network_aggregate_run';
+
+	/**
+	 * How long a run's state may go untouched before `watchdog()` treats the run as dead and resumes it.
+	 *
+	 * Has to be comfortably longer than a single batch takes, because a batch that is running right now
+	 * looks identical to one that died: cron deletes a single event before firing it, so in both cases
+	 * the state names a cursor with no event scheduled for it.
+	 */
+	const AGGREGATE_STALL_TIMEOUT = HOUR_IN_SECONDS;
 
 	/**
 	 * Runs during plugins_loaded, doh.
@@ -19,8 +33,8 @@ class Payment_Requests_Dashboard {
 				wp_schedule_event( time(), 'daily', 'wordcamp_payments_aggregate' );
 			}
 
-			// Resumes a batch chain within the hour if a `wordcamp_payments_aggregate` continuation
-			// ever fails to schedule -- see `watchdog()`.
+			// Resumes an `aggregate()` run that stopped making progress, whether because a continuation
+			// failed to schedule or because a batch died mid-request -- see `watchdog()`.
 			if ( get_current_blog_id() == $current_site->blog_id && ! wp_next_scheduled( 'wordcamp_payments_aggregate_watchdog' ) ) {
 				wp_schedule_event( time(), 'hourly', 'wordcamp_payments_aggregate_watchdog' );
 			}
@@ -113,12 +127,28 @@ class Payment_Requests_Dashboard {
 		require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/payment-request.php';
 		WCP_Payment_Request::register_post_statuses();
 
+		// A fresh run is about to empty the index, which makes any continuation still queued from an
+		// earlier run that never finished stale: it would index its remaining blogs into a table it no
+		// longer owns, duplicating every row this run's own batches also insert. Retire those first,
+		// before this run claims the state option for itself.
+		if ( 0 === $after_blog_id ) {
+			self::abandon_stalled_chain();
+		}
+
+		// Record where this batch starts *before* doing any of its work, so that a batch which dies partway
+		// through -- OOM, request timeout, deploy mid-flight -- still leaves behind enough state for
+		// `watchdog()` to run it again. Without this, only the very last completed batch is recoverable,
+		// and a first batch that dies loses the whole run until the next daily event.
+		self::save_run_state( $after_blog_id );
+
 		// Only truncate at the start of a fresh run, not on every batch.
 		if ( 0 === $after_blog_id ) {
 			$wpdb->query( 'TRUNCATE TABLE ' . self::get_table_name() ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name isn't user input, can't be a bound placeholder.
 		}
 
-		$batch_size = (int) apply_filters( 'wordcamp_payments_aggregate_batch_size', self::AGGREGATE_BATCH_SIZE );
+		// `max( 1, ... )` so a filter returning 0 can't make every batch look "not full" while indexing
+		// nothing, which would schedule continuations forever.
+		$batch_size = max( 1, (int) apply_filters( 'wordcamp_payments_aggregate_batch_size', self::AGGREGATE_BATCH_SIZE ) );
 
 		// Keyset pagination on `blog_id` rather than LIMIT/OFFSET on `last_updated`, since `last_updated`
 		// changes constantly as sites get traffic, which would shift rows across the offset boundary
@@ -155,34 +185,95 @@ class Payment_Requests_Dashboard {
 		}
 
 		// More blogs left? Schedule the next batch as a separate request instead of looping further in this one,
-		// and persist the cursor so `watchdog()` can resume the chain if that scheduling call is ever lost to
-		// WordPress core's unsynchronized read-modify-write of the shared `cron` option.
+		// and advance the persisted cursor so `watchdog()` can resume the chain if that scheduling call is
+		// ever lost to WordPress core's unsynchronized read-modify-write of the shared `cron` option.
 		if ( count( $blogs ) === $batch_size ) {
 			// Cast to int: `get_col()` returns strings, and cron identifies an event by
 			// `md5( serialize( $args ) )`, so a string cursor here wouldn't match the int one
 			// `watchdog()` looks up -- leaving it to schedule a duplicate run every hour.
 			$next_cursor = (int) end( $blogs );
-			update_site_option( self::AGGREGATE_CURSOR_OPTION, $next_cursor );
+			self::save_run_state( $next_cursor );
 			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $next_cursor ) );
 		} else {
-			delete_site_option( self::AGGREGATE_CURSOR_OPTION );
+			delete_site_option( self::AGGREGATE_RUN_OPTION );
 		}
 	}
 
 	/**
-	 * Resumes an aggregate() batch chain if its next scheduled continuation was lost.
+	 * Discards everything left over from a run that never reached its final batch.
 	 *
-	 * `wp_schedule_single_event()` writes into the same site-wide `cron` option that every other cron
-	 * call on the network writes to, unsynchronized -- so a concurrent scheduling call elsewhere can
-	 * clobber the continuation aggregate() just scheduled for itself. Runs hourly; harmless no-op when
-	 * there's no run in progress or the continuation is already scheduled.
+	 * Sweeps the queue rather than only unscheduling the continuation named by the run state, so that an
+	 * orphaned event is still cleared when the state itself was lost -- the two are written separately and
+	 * either one can go missing on its own.
+	 *
+	 * The recurring daily event is left alone: it's the one `wordcamp_payments_aggregate` event with no
+	 * arguments, and it's what starts a run rather than continuing one.
+	 */
+	protected static function abandon_stalled_chain() {
+		$crons = _get_cron_array();
+
+		if ( is_array( $crons ) ) {
+			foreach ( $crons as $timestamp => $hooks ) {
+				foreach ( $hooks['wordcamp_payments_aggregate'] ?? array() as $event ) {
+					if ( ! empty( $event['args'] ) ) {
+						wp_unschedule_event( $timestamp, 'wordcamp_payments_aggregate', $event['args'] );
+					}
+				}
+			}
+		}
+
+		delete_site_option( self::AGGREGATE_RUN_OPTION );
+	}
+
+	/**
+	 * Records the point an `aggregate()` run can be resumed from.
+	 *
+	 * The timestamp is a heartbeat, not just bookkeeping -- `watchdog()` uses it to tell a batch that is
+	 * still running from one that died.
+	 *
+	 * @param int $cursor The `blog_id` to resume after. `0` restarts the run from the beginning.
+	 */
+	protected static function save_run_state( $cursor ) {
+		update_site_option( self::AGGREGATE_RUN_OPTION, array(
+			'cursor'  => (int) $cursor,
+			'updated' => time(),
+		) );
+	}
+
+	/**
+	 * Resumes an aggregate() run that stopped making progress.
+	 *
+	 * The run state in `AGGREGATE_RUN_OPTION` -- not the queued cron event -- is the durable record of
+	 * progress, because `wp_schedule_single_event()` writes into the same site-wide `cron` option that
+	 * every other cron call on the network writes to, unsynchronized: a concurrent scheduling call
+	 * elsewhere can clobber the continuation `aggregate()` just scheduled for itself. The state also
+	 * survives a batch dying mid-request, which no cron entry would.
+	 *
+	 * Runs hourly; a no-op unless a run is genuinely stuck.
 	 */
 	public static function watchdog() {
-		$cursor = (int) get_site_option( self::AGGREGATE_CURSOR_OPTION, 0 );
+		$run = get_site_option( self::AGGREGATE_RUN_OPTION );
 
-		if ( $cursor > 0 && ! wp_next_scheduled( 'wordcamp_payments_aggregate', array( $cursor ) ) ) {
-			wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $cursor ) );
+		// No run in progress.
+		if ( ! is_array( $run ) || ! isset( $run['cursor'], $run['updated'] ) ) {
+			return;
 		}
+
+		$cursor = (int) $run['cursor'];
+
+		// The continuation is queued and will fire on its own.
+		if ( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $cursor ) ) ) {
+			return;
+		}
+
+		// Nothing queued, but the state was touched recently, so that batch is most likely executing right
+		// now -- cron deletes a single event before firing it. Resuming here would run a second chain
+		// alongside it and index every remaining blog twice.
+		if ( time() - (int) $run['updated'] < self::AGGREGATE_STALL_TIMEOUT ) {
+			return;
+		}
+
+		wp_schedule_single_event( time(), 'wordcamp_payments_aggregate', array( $cursor ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -108,6 +108,49 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Counts the index rows for one payment request.
+	 */
+	private function count_rows_for( int $blog_id, int $post_id ): int {
+		global $wpdb;
+
+		$table = Payment_Requests_Dashboard::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name isn't user input, can't be a bound placeholder.
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $table WHERE blog_id = %d AND post_id = %d", $blog_id, $post_id ) );
+	}
+
+	/**
+	 * Creates a site with a single approved payment request on it.
+	 *
+	 * @return array{0: int, 1: int} The new `blog_id` and the request's `post_id`.
+	 */
+	private function create_blog_with_payment_request( string $invoice ): array {
+		$blog_id = self::factory()->blog->create();
+
+		switch_to_blog( $blog_id );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$post_id = self::factory()->post->create( array(
+			'post_type'   => 'wcp_payment_request',
+			'post_status' => 'wcb-approved',
+			'meta_input'  => array(
+				'_wcb_updated_timestamp'         => strtotime( 'Yesterday 10am' ),
+				'_camppayments_description'      => 'Batch Test Request',
+				'_camppayments_due_by'           => strtotime( 'Next Tuesday' ),
+				'_camppayments_payment_amount'   => '100',
+				'_camppayments_currency'         => 'USD',
+				'_camppayments_payment_method'   => 'Wire',
+				'_camppayments_invoice_number'   => $invoice,
+				'_camppayments_payment_category' => 'audio-visual',
+			),
+		) );
+
+		restore_current_blog();
+
+		return array( $blog_id, $post_id );
+	}
+
+	/**
 	 * Backdates the run state's heartbeat past the stall timeout, so watchdog() sees a dead run.
 	 */
 	private function stall_run_state(): void {
@@ -255,8 +298,8 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A fresh run truncates the index, so a continuation left queued by a run that never finished would
-	 * index its remaining blogs a second time, on top of what this run inserts for the same blogs.
+	 * Two chains walking the network at once interleave their per-blog delete/insert pairs, so a fresh run
+	 * has to retire a continuation left queued by a run that never finished.
 	 *
 	 * @covers Payment_Requests_Dashboard::aggregate
 	 */
@@ -287,7 +330,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 
 		$this->assertFalse(
 			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $stale_cursor ) ),
-			'A fresh run must retire the previous run\'s continuation, or it will index into the table this run just truncated.'
+			'A fresh run must retire the previous run\'s continuation, or the two chains will race over the same blogs.'
 		);
 		$this->assertNotFalse(
 			wp_next_scheduled( 'wordcamp_payments_aggregate' ),
@@ -296,14 +339,138 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 
 		// This network is smaller than a batch, so the run finished and cleared its own state too.
 		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION ) );
+	}
 
-		// This is the only test that exercises a *fresh* run, so it's the only one that reaches the
-		// TRUNCATE. That's DDL: MySQL commits it implicitly and won't roll it back with the rest of this
-		// test, while the rows aggregate() re-inserted afterwards *would* be rolled back -- leaving the
-		// index empty for every test below, which reads it via generate_payment_report(). Commit the
-		// rebuilt index instead, once this test's own cron entries are cleared so they don't leak with it.
-		wp_unschedule_hook( 'wordcamp_payments_aggregate' );
-		self::commit_transaction();
+	/**
+	 * Resuming uses the cursor recorded at the *start* of a batch, so a batch that died partway is re-run
+	 * over blogs it had already indexed. Indexing a blog therefore has to be idempotent.
+	 *
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 */
+	public function test_re_running_a_batch_does_not_duplicate_rows(): void {
+		list( $blog_id, $post_id ) = $this->create_blog_with_payment_request( 'Resumed Batch' );
+
+		Payment_Requests_Dashboard::aggregate( $blog_id - 1 );
+		$this->assertSame( 1, $this->count_rows_for( $blog_id, $post_id ), 'Precondition: the batch indexed the request once.' );
+
+		// What watchdog() does after that batch dies: run it again from the same resume point.
+		Payment_Requests_Dashboard::aggregate( $blog_id - 1 );
+
+		$this->assertSame(
+			1,
+			$this->count_rows_for( $blog_id, $post_id ),
+			'Resuming a batch must not index a request it had already covered a second time -- in an export, a duplicated row is a duplicated payment.'
+		);
+	}
+
+	/**
+	 * A run spans many requests, so organizers keep editing payment requests while it is in flight.
+	 * `save_post()` indexes those immediately; the batch that later reaches that blog must not add a
+	 * second row for the same request.
+	 *
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 * @covers Payment_Requests_Dashboard::save_post
+	 */
+	public function test_a_request_saved_mid_run_is_not_indexed_twice(): void {
+		list( $blog_id, $post_id ) = $this->create_blog_with_payment_request( 'Saved Mid Run' );
+
+		// An organizer saves the request while the run is still working its way toward this blog.
+		switch_to_blog( $blog_id );
+		Payment_Requests_Dashboard::save_post( $post_id );
+		restore_current_blog();
+
+		$this->assertSame( 1, $this->count_rows_for( $blog_id, $post_id ), 'Precondition: save_post() indexed the request once.' );
+
+		// The run now reaches that blog.
+		Payment_Requests_Dashboard::aggregate( $blog_id - 1 );
+
+		$this->assertSame(
+			1,
+			$this->count_rows_for( $blog_id, $post_id ),
+			'A request already indexed by save_post() must be replaced, not duplicated, when the run reaches its blog.'
+		);
+	}
+
+	/**
+	 * `generate_payment_report()` builds the wire and SEPA payment files straight out of this index, and a
+	 * run now spans many requests. So the index has to stay readable throughout -- a run that emptied it up
+	 * front would let an export taken mid-run come out short, or empty, with nothing to signal it.
+	 *
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 */
+	public function test_the_index_stays_complete_during_a_run(): void {
+		// One blog per batch, so the run below stops after its first batch with most blogs still to go.
+		add_filter(
+			'wordcamp_payments_aggregate_batch_size',
+			function () {
+				return 1;
+			}
+		);
+
+		$rows_before = $this->count_index_rows();
+		$this->assertGreaterThan( 0, $rows_before, 'Precondition: the fixture is indexed.' );
+
+		// The first batch of a fresh run.
+		Payment_Requests_Dashboard::aggregate();
+
+		$this->assertGreaterThanOrEqual(
+			$rows_before,
+			$this->count_index_rows(),
+			'A run in progress must never leave the index with fewer rows than it started with.'
+		);
+
+		$report = generate_payment_report( array(
+			'status'      => 'wcb-approved',
+			'start_date'  => strtotime( '3 days ago' ),
+			'end_date'    => time(),
+			'post_type'   => 'wcp_payment_request',
+
+			'export_type' => array(
+				'label'     => 'JP Morgan Access - Wire Payments',
+				'mime_type' => 'text/csv',
+				'callback'  => 'WordCamp\Budgets_Dashboard\_generate_payment_report_jpm_wires',
+				'filename'  => 'wordcamp-payments-%s-%s-jpm-wires.csv',
+			),
+		) );
+
+		$this->assertStringContainsString(
+			'Invoice 1234',
+			$report,
+			'An export generated while a run is in flight must not silently omit approved payments.'
+		);
+	}
+
+	/**
+	 * Refreshing each blog in place means a site deleted since the last run is never visited, so its rows
+	 * have to be cleaned up explicitly once the run has covered the whole network.
+	 *
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 */
+	public function test_a_completed_run_prunes_rows_for_deleted_sites(): void {
+		global $wpdb;
+
+		// Past the end of the network, so it stands in for a site deleted since the last run.
+		$deleted_blog_id = (int) $wpdb->get_var( "SELECT MAX(blog_id) FROM $wpdb->blogs" ) + 1000;
+
+		$wpdb->insert(
+			Payment_Requests_Dashboard::get_table_name(),
+			array(
+				'blog_id' => $deleted_blog_id,
+				'post_id' => 1,
+				'status'  => 'wcb-approved',
+			)
+		);
+
+		$this->assertSame( 1, $this->count_rows_for( $deleted_blog_id, 1 ), 'Precondition: the orphaned row is indexed.' );
+
+		// This network is smaller than a batch, so one call covers it and completes the run.
+		Payment_Requests_Dashboard::aggregate();
+
+		$this->assertSame(
+			0,
+			$this->count_rows_for( $deleted_blog_id, 1 ),
+			'A completed run must drop rows belonging to sites that no longer exist.'
+		);
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -87,6 +87,101 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 * @covers Payment_Requests_Dashboard::watchdog
+	 */
+	public function test_aggregate_batches_across_multiple_sites(): void {
+		global $wpdb;
+
+		// Force one blog per batch, so two new sites are enough to exercise a multi-batch chain.
+		add_filter( 'wordcamp_payments_aggregate_batch_size', function () {
+			return 1;
+		} );
+
+		$start_blog_id = (int) $wpdb->get_var( "SELECT MAX(blog_id) FROM $wpdb->blogs" );
+		$blog_a        = self::factory()->blog->create();
+		$blog_b        = self::factory()->blog->create();
+
+		foreach ( array( $blog_a, $blog_b ) as $blog_id ) {
+			switch_to_blog( $blog_id );
+			wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+			self::factory()->post->create( array(
+				'post_type'   => 'wcp_payment_request',
+				'post_status' => 'wcb-approved',
+				'meta_input'  => array(
+					'_wcb_updated_timestamp'         => strtotime( 'Yesterday 10am' ),
+					'_camppayments_description'      => 'Batch Test Request',
+					'_camppayments_due_by'           => strtotime( 'Next Tuesday' ),
+					'_camppayments_payment_amount'   => '100',
+					'_camppayments_currency'         => 'USD',
+					'_camppayments_payment_method'   => 'Wire',
+					'_camppayments_invoice_number'   => 'Batch Invoice',
+					'_camppayments_payment_category' => 'audio-visual',
+				),
+			) );
+			restore_current_blog();
+		}
+
+		$table       = Payment_Requests_Dashboard::get_table_name();
+		$rows_before = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$this->assertGreaterThan( 0, $rows_before, 'The wpSetUpBeforeClass fixture should already have indexed rows.' );
+
+		// Batch 1: starting the cursor at $start_blog_id skips every pre-existing blog, so this batch
+		// should pick up exactly $blog_a and schedule a continuation for it.
+		Payment_Requests_Dashboard::aggregate( $start_blog_id );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ),
+			'A full batch should schedule a continuation for the next blog_id.'
+		);
+		$this->assertSame( $blog_a, (int) get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
+
+		$rows_after_batch_1 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$this->assertSame(
+			$rows_before + 1,
+			$rows_after_batch_1,
+			'A mid-chain batch must add rows, not truncate the ones earlier batches already indexed.'
+		);
+
+		// Simulate the batch 1 continuation getting lost to a clobbered `cron` option (the race
+		// `watchdog()` exists to recover from), instead of ever firing.
+		wp_unschedule_event( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ), 'wordcamp_payments_aggregate', array( $blog_a ) );
+		$this->assertFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ), 'Precondition: the continuation is now lost.' );
+
+		Payment_Requests_Dashboard::watchdog();
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ),
+			'watchdog() should resume the chain from the persisted cursor when a continuation goes missing.'
+		);
+
+		// Consume the (re-)scheduled batch 2: picks up $blog_b, and since that still fills the
+		// batch, schedules one more (empty) check before the chain can be considered done.
+		wp_unschedule_event( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ), 'wordcamp_payments_aggregate', array( $blog_a ) );
+		Payment_Requests_Dashboard::aggregate( $blog_a );
+
+		$this->assertNotFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ) );
+		$this->assertSame( $blog_b, (int) get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
+
+		$rows_after_batch_2 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$this->assertSame( $rows_after_batch_1 + 1, $rows_after_batch_2, 'Batch 2 should have indexed blog_b, on top of batch 1.' );
+
+		// Batch 3: $blog_b was the last blog in the network, so this finds nothing -- the chain
+		// ends here, with no further continuation and the cursor cleared.
+		wp_unschedule_event( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ), 'wordcamp_payments_aggregate', array( $blog_b ) );
+		Payment_Requests_Dashboard::aggregate( $blog_b );
+
+		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
+
+		$rows_after_batch_3 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$this->assertSame( $rows_after_batch_2, $rows_after_batch_3, 'The empty final batch must not truncate or duplicate prior rows.' );
+
+		// watchdog() must be a no-op once the chain has already completed cleanly.
+		Payment_Requests_Dashboard::watchdog();
+		$this->assertFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ) );
+	}
+
+	/**
 	 * @covers WordCamp\Budgets_Dashboard\generate_payment_report
 	 * @covers WordCamp\Budgets_Dashboard\_generate_payment_report_jpm_wires
 	 * @covers WCP_Payment_Request::_generate_payment_report_jpm_wires

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -87,6 +87,18 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Counts the rows currently in the payment index table.
+	 */
+	private function count_index_rows(): int {
+		global $wpdb;
+
+		$table = Payment_Requests_Dashboard::get_table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name isn't user input, can't be a bound placeholder.
+		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+	}
+
+	/**
 	 * @covers Payment_Requests_Dashboard::aggregate
 	 * @covers Payment_Requests_Dashboard::watchdog
 	 */
@@ -94,9 +106,12 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		global $wpdb;
 
 		// Force one blog per batch, so two new sites are enough to exercise a multi-batch chain.
-		add_filter( 'wordcamp_payments_aggregate_batch_size', function () {
-			return 1;
-		} );
+		add_filter(
+			'wordcamp_payments_aggregate_batch_size',
+			function () {
+				return 1;
+			}
+		);
 
 		$start_blog_id = (int) $wpdb->get_var( "SELECT MAX(blog_id) FROM $wpdb->blogs" );
 		$blog_a        = self::factory()->blog->create();
@@ -122,8 +137,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 			restore_current_blog();
 		}
 
-		$table       = Payment_Requests_Dashboard::get_table_name();
-		$rows_before = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$rows_before = $this->count_index_rows();
 		$this->assertGreaterThan( 0, $rows_before, 'The wpSetUpBeforeClass fixture should already have indexed rows.' );
 
 		// Batch 1: starting the cursor at $start_blog_id skips every pre-existing blog, so this batch
@@ -136,7 +150,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		);
 		$this->assertSame( $blog_a, (int) get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
 
-		$rows_after_batch_1 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$rows_after_batch_1 = $this->count_index_rows();
 		$this->assertSame(
 			$rows_before + 1,
 			$rows_after_batch_1,
@@ -163,7 +177,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		$this->assertNotFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ) );
 		$this->assertSame( $blog_b, (int) get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
 
-		$rows_after_batch_2 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$rows_after_batch_2 = $this->count_index_rows();
 		$this->assertSame( $rows_after_batch_1 + 1, $rows_after_batch_2, 'Batch 2 should have indexed blog_b, on top of batch 1.' );
 
 		// Batch 3: $blog_b was the last blog in the network, so this finds nothing -- the chain
@@ -173,7 +187,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 
 		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
 
-		$rows_after_batch_3 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $table" );
+		$rows_after_batch_3 = $this->count_index_rows();
 		$this->assertSame( $rows_after_batch_2, $rows_after_batch_3, 'The empty final batch must not truncate or duplicate prior rows.' );
 
 		// watchdog() must be a no-op once the chain has already completed cleanly.

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -99,6 +99,26 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Returns the `blog_id` the persisted run state would resume after, or `null` if no run is in progress.
+	 */
+	private function get_run_cursor(): ?int {
+		$run = get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION );
+
+		return is_array( $run ) && isset( $run['cursor'] ) ? (int) $run['cursor'] : null;
+	}
+
+	/**
+	 * Backdates the run state's heartbeat past the stall timeout, so watchdog() sees a dead run.
+	 */
+	private function stall_run_state(): void {
+		$run = get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION );
+
+		$run['updated'] = time() - Payment_Requests_Dashboard::AGGREGATE_STALL_TIMEOUT - 1;
+
+		update_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION, $run );
+	}
+
+	/**
 	 * @covers Payment_Requests_Dashboard::aggregate
 	 * @covers Payment_Requests_Dashboard::watchdog
 	 */
@@ -148,7 +168,7 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ),
 			'A full batch should schedule a continuation for the next blog_id.'
 		);
-		$this->assertSame( $blog_a, (int) get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
+		$this->assertSame( $blog_a, $this->get_run_cursor() );
 
 		$rows_after_batch_1 = $this->count_index_rows();
 		$this->assertSame(
@@ -162,11 +182,20 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		wp_unschedule_event( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ), 'wordcamp_payments_aggregate', array( $blog_a ) );
 		$this->assertFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ), 'Precondition: the continuation is now lost.' );
 
+		// A missing continuation alone isn't enough to resume on: that's also what an in-flight batch
+		// looks like, since cron deletes a single event before firing it.
+		Payment_Requests_Dashboard::watchdog();
+		$this->assertFalse(
+			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ),
+			'watchdog() must not resume a run whose heartbeat is still fresh -- that batch may be running right now.'
+		);
+
+		$this->stall_run_state();
 		Payment_Requests_Dashboard::watchdog();
 
 		$this->assertNotFalse(
 			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_a ) ),
-			'watchdog() should resume the chain from the persisted cursor when a continuation goes missing.'
+			'watchdog() should resume the chain from the persisted cursor once the run has stopped making progress.'
 		);
 
 		// Consume the (re-)scheduled batch 2: picks up $blog_b, and since that still fills the
@@ -175,17 +204,17 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		Payment_Requests_Dashboard::aggregate( $blog_a );
 
 		$this->assertNotFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ) );
-		$this->assertSame( $blog_b, (int) get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
+		$this->assertSame( $blog_b, $this->get_run_cursor() );
 
 		$rows_after_batch_2 = $this->count_index_rows();
 		$this->assertSame( $rows_after_batch_1 + 1, $rows_after_batch_2, 'Batch 2 should have indexed blog_b, on top of batch 1.' );
 
 		// Batch 3: $blog_b was the last blog in the network, so this finds nothing -- the chain
-		// ends here, with no further continuation and the cursor cleared.
+		// ends here, with no further continuation and the run state cleared.
 		wp_unschedule_event( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ), 'wordcamp_payments_aggregate', array( $blog_b ) );
 		Payment_Requests_Dashboard::aggregate( $blog_b );
 
-		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_CURSOR_OPTION ) );
+		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION ) );
 
 		$rows_after_batch_3 = $this->count_index_rows();
 		$this->assertSame( $rows_after_batch_2, $rows_after_batch_3, 'The empty final batch must not truncate or duplicate prior rows.' );
@@ -193,6 +222,77 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 		// watchdog() must be a no-op once the chain has already completed cleanly.
 		Payment_Requests_Dashboard::watchdog();
 		$this->assertFalse( wp_next_scheduled( 'wordcamp_payments_aggregate', array( $blog_b ) ) );
+	}
+
+	/**
+	 * A batch that dies partway through leaves nothing scheduled, so the run state has to be written
+	 * before the batch does any work -- otherwise there'd be nothing for watchdog() to resume from.
+	 *
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 */
+	public function test_aggregate_records_resume_point_before_doing_any_work(): void {
+		global $wpdb;
+
+		$start_blog_id  = (int) $wpdb->get_var( "SELECT MAX(blog_id) FROM $wpdb->blogs" );
+		$state_at_start = null;
+
+		// This filter is read after the run state is saved but before any blog is indexed, so it's a
+		// stand-in for "the batch died here".
+		add_filter(
+			'wordcamp_payments_aggregate_batch_size',
+			function ( $batch_size ) use ( &$state_at_start ) {
+				$state_at_start = get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION );
+
+				return $batch_size;
+			}
+		);
+
+		Payment_Requests_Dashboard::aggregate( $start_blog_id );
+
+		$this->assertIsArray( $state_at_start, 'The run state should already be persisted when the batch begins work.' );
+		$this->assertSame( $start_blog_id, (int) $state_at_start['cursor'] );
+		$this->assertLessThanOrEqual( time(), (int) $state_at_start['updated'] );
+	}
+
+	/**
+	 * A fresh run truncates the index, so a continuation left queued by a run that never finished would
+	 * index its remaining blogs a second time, on top of what this run inserts for the same blogs.
+	 *
+	 * @covers Payment_Requests_Dashboard::aggregate
+	 */
+	public function test_a_fresh_run_retires_a_stalled_chain(): void {
+		$stale_cursor = PHP_INT_MAX - 1;
+
+		// A run that got as far as $stale_cursor and then stopped, leaving its continuation queued.
+		wp_schedule_single_event( time() + HOUR_IN_SECONDS, 'wordcamp_payments_aggregate', array( $stale_cursor ) );
+		update_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION, array(
+			'cursor'  => $stale_cursor,
+			'updated' => time() - Payment_Requests_Dashboard::AGGREGATE_STALL_TIMEOUT - 1,
+		) );
+
+		// The recurring event that *starts* a run, which must survive the cleanup.
+		if ( ! wp_next_scheduled( 'wordcamp_payments_aggregate' ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'wordcamp_payments_aggregate' );
+		}
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $stale_cursor ) ),
+			'Precondition: the stalled run left a continuation queued.'
+		);
+
+		Payment_Requests_Dashboard::aggregate();
+
+		$this->assertFalse(
+			wp_next_scheduled( 'wordcamp_payments_aggregate', array( $stale_cursor ) ),
+			'A fresh run must retire the previous run\'s continuation, or it will index into the table this run just truncated.'
+		);
+		$this->assertNotFalse(
+			wp_next_scheduled( 'wordcamp_payments_aggregate' ),
+			'The recurring daily event must not be swept up along with the stale continuations.'
+		);
+
+		// This network is smaller than a batch, so the run finished and cleared its own state too.
+		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -265,10 +265,13 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 
 		// A run that got as far as $stale_cursor and then stopped, leaving its continuation queued.
 		wp_schedule_single_event( time() + HOUR_IN_SECONDS, 'wordcamp_payments_aggregate', array( $stale_cursor ) );
-		update_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION, array(
-			'cursor'  => $stale_cursor,
-			'updated' => time() - Payment_Requests_Dashboard::AGGREGATE_STALL_TIMEOUT - 1,
-		) );
+		update_site_option(
+			Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION,
+			array(
+				'cursor'  => $stale_cursor,
+				'updated' => time() - Payment_Requests_Dashboard::AGGREGATE_STALL_TIMEOUT - 1,
+			)
+		);
 
 		// The recurring event that *starts* a run, which must survive the cleanup.
 		if ( ! wp_next_scheduled( 'wordcamp_payments_aggregate' ) ) {

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-wordcamp-budgets-dashboard.php
@@ -296,6 +296,14 @@ class Test_Budgets_Dashboard extends WP_UnitTestCase {
 
 		// This network is smaller than a batch, so the run finished and cleared its own state too.
 		$this->assertFalse( get_site_option( Payment_Requests_Dashboard::AGGREGATE_RUN_OPTION ) );
+
+		// This is the only test that exercises a *fresh* run, so it's the only one that reaches the
+		// TRUNCATE. That's DDL: MySQL commits it implicitly and won't roll it back with the rest of this
+		// test, while the rows aggregate() re-inserted afterwards *would* be rolled back -- leaving the
+		// index empty for every test below, which reads it via generate_payment_report(). Commit the
+		// rebuilt index instead, once this test's own cron entries are cleared so they don't leak with it.
+		wp_unschedule_hook( 'wordcamp_payments_aggregate' );
+		self::commit_transaction();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`Payment_Requests_Dashboard::aggregate()` (run daily via the `wordcamp_payments_aggregate` cron event) iterates all ~3000 sites on the network via `switch_to_blog()` in a single request to rebuild the payments index table. This has been showing up in prod as `E_USER_WARNING: Peak memory usage at 90.6%` / `92.2%`, with `current_action() === 'switch_blog'`, e.g.:

```
Peak memory usage at 90.6%. Current action/filter: switch_blog.
Stack Trace: do_action_ref_array('wordcamp_payments_aggregate'), ... Payment_Requests_Dashboard::aggregate, switch_to_blog, do_action('switch_blog'), ...
```

The code already had a comment flagging this ("This may need to be refactored in the future to use batching to avoid out-of-memory-issues").

- Split the run into batches of 250 blogs (`LIMIT`/`OFFSET`), tracked via an `$offset` arg.
- When a batch is full, self-reschedule the next batch via `wp_schedule_single_event( time(), ... )` instead of continuing the loop in the same process — the next batch runs as its own `wp-cron.php` request, so peak memory per request stays bounded.
- Only truncate the index table on the first batch (`$offset === 0`), not on every batch.

## Test plan

- [ ] `php -l` passes on the changed file (done locally).
- [ ] No existing test coverage for this class; none added, consistent with existing scope.
- [ ] Manually trigger `?wcp-debug-network` (or `do_action('wordcamp_payments_aggregate')` via WP-CLI) on a multisite install with several dozen+ sites and confirm:
  - the index table is truncated once, not per batch
  - all blogs eventually get indexed across multiple batches
  - a follow-up single event is scheduled/consumed correctly until done