### PR TITLE
Groups: fix two mobile overflow/overlap bugs from #1858 feedback

### DIFF
--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/style.css
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/style.css
@@ -1,6 +1,7 @@
 .gpre-occurrence-selector {
 	position: relative;
 	margin-block: 0 2rem;
+
 	/* The scroll strip's negative margin (below) intentionally bleeds past
 	   this container so its content lines up flush with the container's own
 	   edges once the matching padding is subtracted back out. Without
@@ -21,6 +22,7 @@
    showed up worst on narrow viewports, where fewer chips fit and the
    overlapped one is more likely to be a chip the user hasn't scrolled past
    yet, but the underlying mismatch exists at any width. */
+
 nav.gpre-occurrence-selector > ul {
 	display: flex;
 	gap: 0.75rem;

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/style.css
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/style.css
@@ -1,6 +1,16 @@
 .gpre-occurrence-selector {
 	position: relative;
 	margin-block: 0 2rem;
+	/* The scroll strip's negative margin (below) intentionally bleeds past
+	   this container so its content lines up flush with the container's own
+	   edges once the matching padding is subtracted back out. Without
+	   clipping that bleed here, nothing else in the page does either — every
+	   ancestor up to <body> is `overflow: visible` — so it was propagating
+	   into page-level horizontal scroll on any viewport narrower than the
+	   bleed amount. The prev/next controls stay visible: they're positioned
+	   relative to this element, not the bled-out list, and sit well inside
+	   its box on every side. */
+	overflow: hidden;
 }
 
 /* The fade zone and scroll padding match the prev/next control's full

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/style.css
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/style.css
@@ -3,22 +3,30 @@
 	margin-block: 0 2rem;
 }
 
+/* The fade zone and scroll padding match the prev/next control's full
+   footprint (0.25rem offset + 2.5rem width = 2.75rem from each edge), not
+   just its offset — otherwise the control's near edge lands past where the
+   content has faded out, so it visually overlaps a still-fully-opaque chip
+   instead of one that's already faded to transparent underneath it. This
+   showed up worst on narrow viewports, where fewer chips fit and the
+   overlapped one is more likely to be a chip the user hasn't scrolled past
+   yet, but the underlying mismatch exists at any width. */
 nav.gpre-occurrence-selector > ul {
 	display: flex;
 	gap: 0.75rem;
-	margin: 0 -1.25rem;
+	margin: 0 -2.75rem;
 	overflow-x: auto;
-	padding: 0 1.25rem;
+	padding: 0 2.75rem;
 	list-style: none;
 	-webkit-mask-image: linear-gradient(
 		to right,
 		transparent,
-		#000 1.25rem,
-		#000 calc(100% - 1.25rem),
+		#000 2.75rem,
+		#000 calc(100% - 2.75rem),
 		transparent
 	);
-	mask-image: linear-gradient(to right, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
-	scroll-padding-inline: 1.25rem;
+	mask-image: linear-gradient(to right, transparent, #000 2.75rem, #000 calc(100% - 2.75rem), transparent);
+	scroll-padding-inline: 2.75rem;
 	scroll-snap-type: x proximity;
 	scrollbar-width: none;
 }

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -10,6 +10,7 @@
    applied to every `img` on the site: UI chrome (avatars, logos) sets its own
    dimensions, and a global rule fights those instead of helping them.
    Editor-inserted images and featured images are already handled by core. */
+
 :where(.wp-block-post-content, .wp-block-comment-content, .wp-block-wporg-page-content)
 	:where(img, video, iframe) {
 	max-width: 100%;
@@ -19,6 +20,7 @@
 @media (max-width: 960px) {
 	.groups-site-home-layout {
 		flex-wrap: wrap !important;
+
 		/* Columns only carry `blockGap.left`, which becomes `column-gap` —
 		   once they wrap there is nothing holding the two apart vertically. */
 		row-gap: var(--wp--preset--spacing--60);
@@ -30,6 +32,7 @@
 
 	/* The sidebar is second in the source, so wrapping puts it *below* the
 	   main column — its divider belongs on the leading edge. */
+
 	.groups-site-sidebar {
 		padding-left: 0;
 		padding-top: var(--wp--preset--spacing--40);
@@ -104,11 +107,13 @@
    ========================================================================== */
 
 @media (min-width: 481px) and (max-width: 781px) {
+
 	/* `minmax(0, 1fr)` rather than a bare `1fr` — a plain `1fr` track's
 	   implicit `min-width: auto` sizes it to its content's min-content
 	   width, which for a member/event card is wider than half the viewport
 	   at this breakpoint and forces the grid to overflow horizontally
 	   instead of letting the card's own content wrap. */
+
 	.wp-block-post-template.is-layout-grid {
 		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
 	}
@@ -123,6 +128,7 @@
    ========================================================================== */
 
 @media (min-width: 1024px) {
+
 	/*
 	 * Stick the event sidebar to the top while scrolling.
 	 *
@@ -132,6 +138,7 @@
 	 * it. `align-self` stops the column stretching to the row's full height,
 	 * which would leave `sticky` no room to travel in.
 	 */
+
 	.groups-site-event-sidebar {
 		position: sticky;
 		top: 96px;

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -104,12 +104,17 @@
    ========================================================================== */
 
 @media (min-width: 481px) and (max-width: 781px) {
+	/* `minmax(0, 1fr)` rather than a bare `1fr` — a plain `1fr` track's
+	   implicit `min-width: auto` sizes it to its content's min-content
+	   width, which for a member/event card is wider than half the viewport
+	   at this breakpoint and forces the grid to overflow horizontally
+	   instead of letting the card's own content wrap. */
 	.wp-block-post-template.is-layout-grid {
-		grid-template-columns: 1fr 1fr !important;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
 	}
 
 	.wporg-group-members__grid {
-		grid-template-columns: 1fr 1fr !important;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes three mobile-specific bugs from the design feedback on #1858 that were still open after #1884 merged:

- Members grid (and the event-cards query loop) overflowed horizontally at 481–781px viewport widths. The two-column breakpoint used bare `1fr` tracks, whose implicit `min-width: auto` sizes them to the card's min-content width instead of shrinking to fit — the same pattern this file already guards against elsewhere (`.groups-site-event-layout` at line 47), just missed here. Switched both to `minmax(0, 1fr)`.
- The recurring-event date-picker's prev/next arrows overlapped fully-opaque chip text instead of the intended faded edge, worst on narrow viewports where fewer chips are visible so the overlapped one is more likely unfaded. The scroll strip's mask fade zone and scroll padding only matched the arrow control's *offset* (0.25rem) from the edge, not its full footprint (offset + 2.5rem width = 2.75rem). Widened both to match.
- **Follow-up commit:** that same widened negative margin was already bleeding the scroll strip past its own container, which has no clipping — every ancestor up to `<body>` is `overflow: visible` — so it was propagating into page-level horizontal scroll on narrow viewports, and widening it in the first commit made that worse rather than fixing it. Clipped the bleed at its own container instead. This was caught by re-testing after the first commit, not by the original manual pass — see the corrected test plan below.

## Test plan

- [x] CSS syntax validated (brace-balance check on both changed files; no build step for either — plain enqueued CSS, cache-busted via `filemtime()`)
- [x] Manual browser pass (steps below) — no automated test coverage applies here (pure CSS, no PHP/JS logic touched)

### Manual test steps

1. Members grid: loaded `/members/` at a 600px viewport (inside the previously-broken 481–781px range) — confirmed `document.documentElement.scrollWidth` no longer exceeds `innerWidth`, and the two card columns render evenly at ~262px each with no clipped content.
2. Recurring event: created a weekly-recurring test event via the front-end "Create event" modal, opened it at the same mobile width, and confirmed the date-chip text now fades to transparent as it approaches both the previous and next arrow controls (instead of being abruptly cut off under an opaque button), while the arrows remain clickable and correctly advance/rewind the shown occurrence.
3. Page-level overflow: after the first commit, `document.documentElement.scrollWidth - window.innerWidth` on the recurring event page was still `+9`, i.e. still scrolling horizontally — the first commit fixed the visual overlap but not the underlying overflow. Traced it to the scroll strip's negative margin bleeding past its unclipped container (confirmed via `getBoundingClientRect()` on the container and each ancestor — all `overflow: visible`, all correctly width-constrained except the bled-out `<ul>`). After the second commit, the same measurement is `-15` (i.e. content is narrower than the viewport, no overflow) on both the recurring-event page and the front page, and the prev/next controls remain fully visible and clickable (`getBoundingClientRect()` confirms they sit well inside the now-clipped container's box on every side, since they're positioned relative to the container, not the bled-out list).

Screenshots from this pass are saved locally (not attached here) — happy to add them to the PR description if useful, or you're welcome to attach your own from a click-through.
