### PR TITLE
Groups: wire stylelint into CI for GatherPress-migration code

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -85,6 +85,17 @@ jobs:
         npm run lint:js --workspaces --if-present
         npm run lint:css --workspaces --if-present
 
+    - name: Lint styles not covered by an npm workspace
+      # `groups-site` and `gatherpress-recurring-events` are plain CSS with
+      # no other build/lint tooling need, so they're not registered as npm
+      # workspaces — the step above never reaches them. `stylelint` itself
+      # is still available here, hoisted to the root node_modules by one of
+      # the actual workspaces' `@wordpress/scripts` dependency.
+      run: |
+        npx stylelint \
+          'public_html/wp-content/themes/groups-site/assets/css/*.css' \
+          'public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/*.css'
+
     - name: Lint PHP
       run: |
         BASE_REF=${{ github.base_ref }} php .github/bin/phpcs-branch.php

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/package.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/package.json
@@ -4,7 +4,8 @@
 	"scripts": {
 		"build": "wp-scripts build --webpack-src-dir=src/blocks --output-path=build/blocks --experimental-modules",
 		"start": "wp-scripts start --webpack-src-dir=src/blocks --output-path=build/blocks --experimental-modules",
-		"test": "wp-scripts test-unit-js"
+		"test": "wp-scripts test-unit-js",
+		"lint:css": "wp-scripts lint-style 'src/**/*.css' 'src/**/*.scss'"
 	},
 	"devDependencies": {
 		"@wordpress/interactivity": "6.48.0",

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-manage/style.css
@@ -2,8 +2,8 @@
  * WPorg Groups Frontend — event manage block + modal styles.
  */
 
-@import '../../components/recurrence-controls.css';
-@import '../../components/component-accents.css';
+@import "../../components/recurrence-controls.css";
+@import "../../components/component-accents.css";
 
 /* === Message members modal === */
 
@@ -40,8 +40,10 @@
 
 /* === Modal — override wp-components Modal defaults === */
 
+/* Prevent modal body scroll leak when editor is focused. */
 .wporg-groups-event-modal .components-modal__content {
 	padding: 24px 32px 32px;
+	overscroll-behavior: contain;
 }
 
 .wporg-groups-event-modal {
@@ -93,6 +95,7 @@
 }
 
 @media (max-width: 600px) {
+
 	.wporg-groups-event-modal__row {
 		grid-template-columns: 1fr;
 	}
@@ -270,11 +273,6 @@
 
 .wporg-groups-event-modal__editor li {
 	margin-block: 0.35em;
-}
-
-/* Prevent modal body scroll leak when editor is focused. */
-.wporg-groups-event-modal .components-modal__content {
-	overscroll-behavior: contain;
 }
 
 /* === Venue editor overlay === */

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
@@ -5,10 +5,10 @@
  */
 
 /* === Summary (avatar stack + count) ===
-   The button under the RSVP button that opens the attendee modal. `inline-flex`
-   keeps the avatars and the "N attending" label on a single row, and shrinks the
-   button to the width of that row instead of the full column, so the clickable
-   area matches the visible content. */
+   The button under the RSVP button that opens the attendee modal.
+   `inline-flex` keeps the avatars and the "N attending" label on a single
+   row, and shrinks the button to the width of that row instead of the full
+   column, so the clickable area matches the visible content. */
 .wporg-event-rsvp__summary {
 	display: inline-flex;
 	align-items: center;
@@ -374,6 +374,7 @@
 /* === Responsive === */
 
 @media (max-width: 600px) {
+
 	.wporg-event-rsvp__modal {
 		padding: 0;
 	}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-location/style.css
@@ -8,5 +8,5 @@
 	width: 1em;
 	height: 1em;
 	flex: 0 0 auto;
-	fill: currentColor;
+	fill: currentcolor;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
@@ -6,7 +6,7 @@
  * follows the shared card spec.
  */
 
-@import '../../components/section-heading.css';
+@import "../../components/section-heading.css";
 
 .wporg-group-members__grid {
 	display: grid;
@@ -18,6 +18,7 @@
 	display: flex;
 	align-items: flex-start;
 	gap: var(--wp--preset--spacing--20);
+
 	/* 20px rather than 24px: an avatar-plus-two-lines row is a compact card,
 	   the same call made for `.wporg-my-events__card`. */
 	padding: var(--wp--preset--spacing--20);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-news/style.css
@@ -6,7 +6,7 @@
  * the sidebar gets the Inter 16px/600 utility heading.
  */
 
-@import '../../components/section-heading.css';
+@import "../../components/section-heading.css";
 
 .wporg-group-news__list {
 	border-top: 1px solid var(--wp--preset--color--light-grey-1);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -4,12 +4,13 @@
  * Uses SCSS for nesting and maintainability.
  */
 
-@import '../../components/recurrence-controls.css';
-@import '../../components/component-accents.css';
+@import "../../components/recurrence-controls.css";
+@import "../../components/component-accents.css";
 
 // === Trigger button ===
 
 .wporg-group-settings-block {
+
 	.dashicons {
 		font-size: 16px;
 		width: 16px;
@@ -207,10 +208,23 @@
 			padding: 12px 16px;
 		}
 
-		ul, ol { padding-inline-start: 1.5em; margin-block: 1em; }
-		ul { list-style: disc outside; }
-		ol { list-style: decimal outside; }
-		li { margin-block: 0.35em; }
+		ul,
+		ol {
+			padding-inline-start: 1.5em;
+			margin-block: 1em;
+		}
+
+		ul {
+			list-style: disc outside;
+		}
+
+		ol {
+			list-style: decimal outside;
+		}
+
+		li {
+			margin-block: 0.35em;
+		}
 	}
 
 	&__editor-toolbar {
@@ -293,6 +307,7 @@
 // === Inline venue editor (no overlay) ===
 
 .wporg-groups-venue-editor--inline {
+
 	.wporg-groups-venue-editor__inner {
 		max-width: 640px;
 	}
@@ -352,7 +367,8 @@
 			cursor: pointer;
 			font-size: 14px;
 
-			&:hover, &:focus {
+			&:hover,
+			&:focus {
 				background: #f0f0f0;
 			}
 		}
@@ -362,6 +378,7 @@
 // === Members tab ===
 
 .wporg-members-tab {
+
 	&__controls {
 		display: flex;
 		align-items: center;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/my-events/style.css
@@ -8,7 +8,7 @@
  * Kept in step with `.groups-site-event-card` in the theme's custom.css.
  */
 
-@import '../../components/section-heading.css';
+@import "../../components/section-heading.css";
 
 /*
  * One card per row, full width of the column, so the serif title fits on one
@@ -27,6 +27,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--wp--preset--spacing--10);
+
 	/*
 	 * 20px all round rather than the 24px card spec — the same compact-card
 	 * value `.wporg-group-members__card` uses, for the same reason: the card
@@ -36,14 +37,17 @@
 	background: var(--wp--preset--color--white);
 	border: 1px solid var(--wp--preset--color--light-grey-1);
 	border-radius: 4px;
-	transition: border-color 0.18s ease, box-shadow 0.18s ease,
+	transition:
+		border-color 0.18s ease,
+		box-shadow 0.18s ease,
 		transform 0.18s ease;
 }
 
 .wporg-my-events__card:hover,
 .wporg-my-events__card:has(a:focus-visible) {
 	border-color: var(--wp--preset--color--blueberry-1);
-	box-shadow: 0 18px 36px -16px rgba(56, 88, 233, 0.22),
+	box-shadow:
+		0 18px 36px -16px rgba(56, 88, 233, 0.22),
 		0 4px 12px rgba(30, 30, 30, 0.04);
 	transform: translateY(-2px);
 }
@@ -55,6 +59,7 @@
  * without that the link keeps the global ring rather than losing it.
  */
 @supports selector(:has(*)) {
+
 	.wporg-my-events__card:has(a:focus-visible) {
 		outline: 2px solid var(--wp--preset--color--blueberry-1);
 		outline-offset: 2px;
@@ -86,6 +91,7 @@
 	color: var(--wp--preset--color--blueberry-1);
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
+
 	/* "Wednesday, September 13, 2026 · 6:00 PM" is wider than the card at
 	   320px, and uppercase with tracking is wider still. */
 	overflow-wrap: break-word;
@@ -107,13 +113,13 @@
 
 /* Stretch the title's link over the whole card. */
 .wporg-my-events__title a::after {
-	content: '';
+	content: "";
 	position: absolute;
 	inset: 0;
 }
 
-.wporg-my-events__card:hover .wporg-my-events__title a,
-.wporg-my-events__title a:focus-visible {
+.wporg-my-events__title a:focus-visible,
+.wporg-my-events__card:hover .wporg-my-events__title a {
 	color: var(--wp--preset--color--blueberry-1);
 	text-decoration: none;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/sponsors/style.css
@@ -8,7 +8,7 @@
  * the list used to have inside the card's own.
  */
 
-@import '../../components/section-heading.css';
+@import "../../components/section-heading.css";
 
 .wporg-sponsors {
 	padding: 24px;
@@ -139,6 +139,7 @@ a.wporg-sponsors__link:hover .wporg-sponsors__external {
  * sponsor name still get a usable measure between them.
  */
 @media (max-width: 480px) {
+
 	.wporg-sponsors__link {
 		grid-template-columns: 64px 1fr auto;
 		gap: var(--wp--preset--spacing--10);
@@ -146,6 +147,7 @@ a.wporg-sponsors__link:hover .wporg-sponsors__external {
 }
 
 @media (max-width: 380px) {
+
 	.wporg-sponsors {
 		padding: var(--wp--preset--spacing--20);
 	}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/recurrence-controls.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/recurrence-controls.css
@@ -35,6 +35,7 @@
 }
 
 @media (max-width: 600px) {
+
 	.wporg-event-recurrence__row {
 		align-items: stretch;
 		flex-direction: column;

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -89,6 +89,7 @@ body.error404 .site-content-container h1 {
  * `[class*="wp-block"].is-style-outline .wp-block-button__link:hover`, which
  * would otherwise repaint a disabled button on hover from equal weight.
  */
+
 .wp-block-button > .wp-block-button__link.wp-element-button:disabled,
 .wp-block-button.is-style-outline > .wp-block-button__link.wp-element-button:disabled {
 	background-color: var(--wp--preset--color--light-grey-2);
@@ -105,9 +106,11 @@ body.error404 .site-content-container h1 {
  * `disabled`. The label stays put: replacing it with a spinner would reflow
  * the row and drop the accessible name mid-action.
  */
+
 /* Second selector only exists to outweigh the parent theme's
    `[class*="wp-block"] .wp-block-button__link { cursor: pointer }`, which
    ties with the first on specificity and wins on source order. */
+
 .wp-element-button[aria-busy="true"],
 .wp-block-button > .wp-block-button__link.wp-element-button[aria-busy="true"] {
 	cursor: progress;
@@ -151,6 +154,7 @@ body.error404 .site-content-container h1 {
 
 /* The nav bar above already carries the group name — this row stays on the
    page background and closes with a hairline instead of a second slab. */
+
 .groups-site-identity {
 	border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
 }
@@ -165,6 +169,14 @@ body.error404 .site-content-container h1 {
 
 .groups-site-home-layout {
 	align-items: flex-start !important;
+}
+
+.groups-site-sidebar-column {
+	order: 2;
+}
+
+.groups-site-main-column-wrapper {
+	order: 1;
 }
 
 .groups-site-sidebar {
@@ -197,6 +209,7 @@ body.error404 .site-content-container h1 {
  * serif; a 36px serif in a 26%-wide rail would outrank the section it
  * labels. Sponsors is listed because it renders in both places.
  */
+
 .groups-site-sidebar .wporg-sponsors__heading,
 .groups-site-event-sidebar .wporg-sponsors__heading,
 .groups-site-sidebar .wporg-group-membership__heading,
@@ -236,74 +249,16 @@ body.error404 .site-content-container h1 {
 }
 
 /* ==========================================================================
-   Front-page content and sidebar
-   ========================================================================== */
-
-.groups-site-home-layout {
-	align-items: flex-start !important;
-}
-
-.groups-site-sidebar-column {
-	order: 2;
-}
-
-.groups-site-main-column-wrapper {
-	order: 1;
-}
-
-.groups-site-sidebar {
-	box-sizing: border-box;
-	width: 100%;
-	padding-left: var(--wp--preset--spacing--40);
-	border-left: 1px solid var(--wp--preset--color--light-grey-1);
-}
-
-.groups-site-sidebar .wporg-event-manage,
-.groups-site-sidebar .wporg-group-settings-block,
-.groups-site-sidebar .wporg-group-membership {
-	width: 100%;
-}
-
-.groups-site-sidebar .wporg-event-manage,
-.groups-site-sidebar .wporg-group-membership {
-	flex-direction: column;
-	align-items: flex-start;
-}
-
-.groups-site-sidebar .wporg-event-manage {
-	gap: 12px;
-}
-
-.groups-site-sidebar .wporg-group-membership__heading,
-.groups-site-sidebar .wporg-group-membership__preference-heading {
-	box-sizing: border-box;
-	width: 100%;
-	padding: 0;
-	margin: 0 !important;
-	font-family: var(--wp--preset--font-family--inter);
-	font-size: var(--wp--preset--font-size--normal);
-	font-weight: 600;
-	line-height: 1.4;
-	color: var(--wp--preset--color--charcoal-1);
-}
-
-.groups-site-sidebar:has(.wporg-event-manage) .groups-site-sidebar-preference {
-	margin-top: var(--wp--preset--spacing--10) !important;
-	padding-top: var(--wp--preset--spacing--20);
-	border-top: 1px solid var(--wp--preset--color--light-grey-1);
-}
-
-.groups-site-main-column {
-	min-width: 0;
-}
-
-/* ==========================================================================
    Query Loop event cards — make the entire card clickable via the
    post-title link and add hover state.
    ========================================================================== */
 
+/* Card is clickable everywhere via the stretched title link below, so it
+   shows a pointer cursor everywhere too. */
+
 .wp-block-post-template .wp-block-group.has-border-color {
 	position: relative;
+	cursor: pointer;
 	transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 
@@ -323,12 +278,6 @@ body.error404 .site-content-container h1 {
 
 .wp-block-post-template .wp-block-post-title a {
 	text-decoration: none;
-}
-
-
-/* Make the card show a pointer cursor everywhere. */
-.wp-block-post-template .wp-block-group.has-border-color {
-	cursor: pointer;
 }
 
 .gatherpress-event-query .wp-block-post-template .wp-block-group.has-border-color {
@@ -360,6 +309,7 @@ body.error404 .site-content-container h1 {
  * group never chose, and it competes with the real photography in the cards
  * beside it.
  */
+
 .groups-site-featured-placeholder {
 	aspect-ratio: 16 / 9;
 	background: var(--wp--preset--color--blueberry-4);
@@ -414,7 +364,6 @@ body.error404 .site-content-container h1 {
 }
 
 /* ----------  Venue extras (description + access) ---------- */
-
 .wporg-venue-extra {
 	margin-top: 12px;
 	font-size: var(--wp--preset--font-size--small);
@@ -426,7 +375,6 @@ body.error404 .site-content-container h1 {
 }
 
 /* ----------  Event info card  ---------- */
-
 .groups-site-event-info-card {
 	box-shadow: 0 1px 2px rgba(30, 30, 30, 0.04),
 		0 2px 8px rgba(30, 30, 30, 0.04);
@@ -447,6 +395,7 @@ body.error404 .site-content-container h1 {
  * Generous, symmetric room (more than the 20px `blockGap` used *within* a
  * zone) so it reads as a hard boundary rather than another item in the list.
  */
+
 .groups-site-event-info-card > .groups-site-event-zone {
 	margin-top: 32px;
 	border-top: 1px solid var(--wp--preset--color--light-grey-1);
@@ -456,6 +405,7 @@ body.error404 .site-content-container h1 {
 /* GatherPress's wrapper-`<div>` blocks seed their inner blocks in the editor,
    so one rendered from a theme template can arrive as an empty wrapper rather
    than as no element at all. Hiding the zone takes its border with it. */
+
 .groups-site-event-info-card > .groups-site-event-zone:empty {
 	display: none;
 }
@@ -469,6 +419,7 @@ body.error404 .site-content-container h1 {
  * event title and the main-column card headings. The three sizes live on
  * the blocks in single-event.html; only the label's tracking needs CSS.
  */
+
 .groups-site-event-info-card .groups-site-event-label {
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
@@ -483,6 +434,7 @@ body.error404 .site-content-container h1 {
  * One muted tone for all of them, so they don't compete with the blue links
  * beside them.
  */
+
 .groups-site-event-info-card .gatherpress--has-venue-address .wp-block-icon,
 .groups-site-event-info-card .gatherpress--has-venue-phone .wp-block-icon,
 .groups-site-event-info-card .gatherpress--has-venue-website .wp-block-icon,
@@ -494,12 +446,14 @@ body.error404 .site-content-container h1 {
 /* GatherPress renders the address in an <address>, which every browser
    italicises by default — next to the upright phone and website lines it
    read as a pull quote rather than the third fact in the list. */
+
 .groups-site-event-info-card .gatherpress-venue-detail__address {
 	font-style: normal;
 }
 
 /* A wrapping address puts the pin halfway down the block if it stays
    centred, so anchor it to the first line instead. */
+
 .groups-site-event-info-card .gatherpress--has-venue-address {
 	align-items: flex-start;
 }
@@ -512,6 +466,7 @@ body.error404 .site-content-container h1 {
    block markup splits them across two groups, which lets the wrap push
    phone flush under the address and leave the website adrift below —
    force one rhythm over the three regardless of how they break. */
+
 .groups-site-event-info-card .groups-site-venue-contact {
 	flex-direction: column;
 	align-items: flex-start;
@@ -685,6 +640,7 @@ body.error404 .site-content-container h1 {
 
 /* An About page is prose, not a layout — hold it to a comfortable measure
    rather than letting it run the full 860px of the main column. */
+
 .groups-site-about p {
 	max-width: 68ch;
 	text-wrap: pretty;
@@ -692,6 +648,7 @@ body.error404 .site-content-container h1 {
 
 /* Organizer-only affordance. Deliberately quiet: it's a maintenance link on
    someone else's reading experience, not a call to action. */
+
 .wporg-page-content__edit {
 	margin: var(--wp--preset--spacing--20) 0 0;
 	font-size: var(--wp--preset--font-size--small);
@@ -713,6 +670,7 @@ body.error404 .site-content-container h1 {
  * one indicator that did pass. The global `:focus-visible` outline now
  * does that job; this just confirms the field is the active one.
  */
+
 .wp-block-search__input:focus {
 	border-color: var(--wp--preset--color--blueberry-1) !important;
 }
@@ -748,6 +706,7 @@ body.error404 .site-content-container h1 {
    radius of its own — only the `is-style-rounded` variation adds one, and
    that isn't registered here — so the comment avatars were the one square
    set among the RSVP, speaker, and member stacks. */
+
 .wp-block-avatar img {
 	border-radius: 9999px;
 }
@@ -763,6 +722,7 @@ body.error404 .site-content-container h1 {
 
 /* Suppress the auto "Leave a Reply" heading and any logged-in-as boilerplate
    that core might re-inject despite our comment_form_defaults filter. */
+
 .wp-block-post-comments-form .comment-reply-title,
 .wp-block-post-comments-form #reply-title,
 .wp-block-post-comments-form .logged-in-as,
@@ -823,6 +783,7 @@ body.error404 .site-content-container h1 {
 /* Hide the author/email/url fields that core injects for guests — keep the
    composer minimal. Logged-out users still see the "you must be logged in"
    notice from core in place of the textarea. */
+
 .wp-block-post-comments-form .comment-form-author,
 .wp-block-post-comments-form .comment-form-email,
 .wp-block-post-comments-form .comment-form-url,
@@ -839,6 +800,7 @@ body.error404 .site-content-container h1 {
 /* Compact size — see the note in the Buttons section. The composer is a
    16px textarea in a 16px-padded well; a 32px-padded submit under it would
    outweigh the thing it submits. */
+
 .wp-block-post-comments-form .form-submit .submit {
 	padding: 10px 20px;
 	background: var(--wp--preset--color--blueberry-1);
@@ -996,6 +958,7 @@ body.error404 .site-content-container h1 {
 	*::after {
 		transition-duration: 0.01ms !important;
 		animation-duration: 0.01ms !important;
+
 		/* Without this, a looping animation doesn't stop — it just loops
 		   0.01ms at a time, which is worse than the motion it replaced. */
 		animation-iteration-count: 1 !important;

--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -10,6 +10,7 @@
    applied to every `img` on the site: UI chrome (avatars, logos) sets its own
    dimensions, and a global rule fights those instead of helping them.
    Editor-inserted images and featured images are already handled by core. */
+
 :where(.wp-block-post-content, .wp-block-comment-content, .wp-block-wporg-page-content)
 	:where(img, video, iframe) {
 	max-width: 100%;
@@ -19,6 +20,7 @@
 @media (max-width: 960px) {
 	.groups-site-home-layout {
 		flex-wrap: wrap !important;
+
 		/* Columns only carry `blockGap.left`, which becomes `column-gap` —
 		   once they wrap there is nothing holding the two apart vertically. */
 		row-gap: var(--wp--preset--spacing--60);
@@ -30,6 +32,7 @@
 
 	/* The sidebar is second in the source, so wrapping puts it *below* the
 	   main column — its divider belongs on the leading edge. */
+
 	.groups-site-sidebar {
 		padding-left: 0;
 		padding-top: var(--wp--preset--spacing--40);
@@ -118,6 +121,7 @@
    ========================================================================== */
 
 @media (min-width: 1024px) {
+
 	/*
 	 * Stick the event sidebar to the top while scrolling.
 	 *
@@ -127,6 +131,7 @@
 	 * it. `align-self` stops the column stretching to the row's full height,
 	 * which would leave `sticky` no room to travel in.
 	 */
+
 	.groups-site-event-sidebar {
 		position: sticky;
 		top: 96px;


### PR DESCRIPTION
## Summary

Closes #1907.

`wporg-groups-frontend` is registered as an npm workspace but, unlike every other workspace in the repo, its `package.json` has no `lint:css` script — CI's `npm run lint:css --workspaces --if-present` silently no-ops on it instead of failing. `groups-site` (theme) and `gatherpress-recurring-events` (mu-plugin) aren't npm workspaces at all, so their plain CSS isn't reachable by any lint mechanism regardless.

- Added `"lint:css": "wp-scripts lint-style 'src/**/*.css' 'src/**/*.scss'"` to `wporg-groups-frontend/package.json`, matching the pattern already used by every other workspace.
- Added a second step to `.github/workflows/linter.yml` that runs `stylelint` directly against `groups-site` and `gatherpress-recurring-events` — `stylelint` itself is already available at the repo root, hoisted there by one of the workspaces' `@wordpress/scripts` dependency, so no new devDependency or workspace registration was needed.
- Fixed everything both checks found, so the gate goes in green:
  - Mechanical formatting (quote style, blank lines, selector-list line breaks) — auto-fixed via `--fix`, no behavior change.
  - **A real bug**: `custom.css` had an entire "Front-page content and sidebar" section duplicated near-verbatim (~60 lines). The later, duplicate copy silently won the cascade for one property — the sidebar's `.wporg-event-manage` gap was hardcoded `12px` there instead of the design token (`var(--wp--preset--spacing--10)`, 10px) used by the original. Merged the two rules the later copy uniquely added (`.groups-site-sidebar-column`, `.groups-site-main-column-wrapper`) into the first copy and removed the redundant rest — restores the token-driven 10px gap.
  - Two smaller duplicate-selector merges (the event-manage modal's content padding/overscroll, the event-cards cursor rule) — pure consolidation, no behavior change.

## Test plan

- [x] `npm run lint:css --workspaces --if-present` — clean (0 errors) across all workspaces including the newly-covered one
- [x] `npx stylelint` against `groups-site` and `gatherpress-recurring-events` paths directly (the exact command the new CI step runs) — clean (0 errors)
- [x] `npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend` — compiles successfully
- [x] Brace-balance / basic syntax check on both theme CSS files after the manual merges
- [x] `curl` the group front page — 200 OK, no PHP fatals, both rules the merge preserved (`.groups-site-sidebar-column`, `.groups-site-main-column-wrapper`) still present in rendered markup
- [x] Manual browser click-through, logged in as an organizer: front page and single-event page both render correctly (sidebar order, "Membership"/"Settings"/event-manage widgets, RSVP card, recurring-event date-picker chips). Confirmed via computed styles that `.wporg-event-manage`'s gap is now `10px` (the token value) rather than the previously-winning hardcoded `12px`.

No PHP was touched, so this doesn't affect PHPUnit; I did try to run the `WordCamp Groups` suite as an extra sanity check but hit an unrelated local docker environment issue (the phpunit container's `mu-plugins-private` mount going stale) — pre-existing, not caused by this branch.

