### PR TITLE
WC Post Types, Blocks: List only what the viewer can read

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -40,6 +40,29 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// The ids come straight from post meta, so check them before dereferencing.
+	// Mirrors WP_REST_Posts_Controller::check_read_permission(): published posts
+	// are readable by everyone, including logged out visitors, who hold no
+	// capabilities at all. The post type check keeps a stray id from printing
+	// unrelated content.
+	$speaker_ids = array_filter(
+		$speaker_ids,
+		function ( $speaker_id ) {
+			$speaker = get_post( $speaker_id );
+
+			if ( ! $speaker instanceof \WP_Post || 'wcb_speaker' !== $speaker->post_type ) {
+				return false;
+			}
+
+			return 'publish' === $speaker->post_status
+				|| current_user_can( 'read_post', $speaker->ID );
+		}
+	);
+
+	if ( empty( $speaker_ids ) ) {
+		return '';
+	}
+
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
 	$classes = array_filter( array(
 		isset( $attributes['textAlign'] ) ? 'has-text-align-' . $attributes['textAlign'] : false,

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -40,9 +40,8 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// Resolve the ids through a query, the way add_speaker_info_to_session_posts()
-	// does for the classic themes, so that the post type is enforced and the
-	// posts are fetched together rather than one lookup at a time.
+	// Resolve the ids the way add_speaker_info_to_session_posts() does, so the
+	// post type is enforced in SQL and the posts are fetched in one query.
 	$speakers = get_posts( array(
 		'post_type'      => 'wcb_speaker',
 		'post__in'       => array_map( 'absint', $speaker_ids ),
@@ -55,9 +54,8 @@ function render( $attributes, $content, $block ) {
 		'update_post_term_cache' => false,
 	) );
 
-	// Mirrors WP_REST_Posts_Controller::check_read_permission(): published posts
-	// are readable by everyone, including logged out visitors, who hold no
-	// capabilities at all.
+	// Mirrors WP_REST_Posts_Controller::check_read_permission(). Logged out
+	// visitors hold no capabilities, so published has to be allowed for first.
 	$speakers = array_filter(
 		$speakers,
 		function ( $speaker ) {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -40,26 +40,34 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// The ids come straight from post meta, so check them before dereferencing.
+	// Resolve the ids through a query, the way add_speaker_info_to_session_posts()
+	// does for the classic themes, so that the post type is enforced and the
+	// posts are fetched together rather than one lookup at a time.
+	$speakers = get_posts( array(
+		'post_type'      => 'wcb_speaker',
+		'post__in'       => array_map( 'absint', $speaker_ids ),
+		'post_status'    => 'any',
+		'posts_per_page' => -1,
+		'orderby'        => 'post__in',
+		'no_found_rows'  => true,
+		// Only the title, slug, permalink and status are used below.
+		'update_post_meta_cache' => false,
+		'update_post_term_cache' => false,
+	) );
+
 	// Mirrors WP_REST_Posts_Controller::check_read_permission(): published posts
 	// are readable by everyone, including logged out visitors, who hold no
-	// capabilities at all. The post type check keeps a stray id from printing
-	// unrelated content.
-	$speaker_ids = array_filter(
-		$speaker_ids,
-		function ( $speaker_id ) {
-			$speaker = get_post( $speaker_id );
-
-			if ( ! $speaker instanceof \WP_Post || 'wcb_speaker' !== $speaker->post_type ) {
-				return false;
-			}
-
+	// capabilities at all.
+	$speakers = array_filter(
+		$speakers,
+		function ( $speaker ) {
 			return 'publish' === $speaker->post_status
 				|| current_user_can( 'read_post', $speaker->ID );
 		}
 	);
 
-	if ( empty( $speaker_ids ) ) {
+	// Session has no speakers this viewer can read.
+	if ( empty( $speakers ) ) {
 		return '';
 	}
 
@@ -73,12 +81,12 @@ function render( $attributes, $content, $block ) {
 		$content .= '<span class="wp-block-wordcamp-session-speakers__byline">' . wp_kses_post( $byline ) . '</span>';
 	}
 
-	foreach ( $speaker_ids as $speaker_id ) {
+	foreach ( $speakers as $speaker ) {
 		$content .= '<span class="wp-block-wordcamp-session-speakers__name">';
 		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-			$content .= sprintf( '<a href="%1$s">%2$s</a>', get_the_permalink( $speaker_id ), get_the_title( $speaker_id ) );
+			$content .= sprintf( '<a href="%1$s">%2$s</a>', get_the_permalink( $speaker->ID ), get_the_title( $speaker->ID ) );
 		} else {
-			$content .= get_the_title( $speaker_id );
+			$content .= get_the_title( $speaker->ID );
 		}
 		$content .= '</span>';
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -22,6 +22,28 @@ add_action( 'init', __NAMESPACE__ . '\init' );
 
 
 /**
+ * Get the session statuses the current user is allowed to see.
+ *
+ * Note that get_posts() passes no `perm` to WP_Query, and without it WP_Query
+ * skips the read_private_posts test entirely, so asking for `private` returns
+ * private sessions to everyone. Passing `perm => 'readable'` is not enough
+ * either: it falls back to matching on post_author, and a session with no
+ * author (0) matches a logged-out visitor (also 0).
+ *
+ * @return array
+ */
+function get_readable_session_statuses() {
+	$statuses  = array( 'publish' );
+	$post_type = get_post_type_object( 'wcb_session' );
+
+	if ( $post_type && current_user_can( $post_type->cap->read_private_posts ) ) {
+		$statuses[] = 'private';
+	}
+
+	return $statuses;
+}
+
+/**
  * Renders the block on the server.
  *
  * @param array    $attributes Block attributes.
@@ -46,10 +68,21 @@ function render( $attributes, $content, $block ) {
 		'meta_value'     => $post_ID,
 		'orderby'        => 'title',
 		'order'          => 'asc',
-		'post_status'    => array( 'publish', 'private' ),
+		'post_status'    => get_readable_session_statuses(),
 	);
 
 	$sessions = get_posts( $session_args );
+
+	// Second pass, mirroring WP_REST_Posts_Controller::check_read_permission().
+	// Published posts are readable by everyone, including logged-out visitors,
+	// who hold no capabilities at all.
+	$sessions = array_filter(
+		$sessions,
+		function ( $session ) {
+			return 'publish' === $session->post_status
+				|| current_user_can( 'read_post', $session->ID );
+		}
+	);
 
 	if ( ! isset( $sessions ) || count( $sessions ) < 1 ) {
 		return '';

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -24,11 +24,10 @@ add_action( 'init', __NAMESPACE__ . '\init' );
 /**
  * Get the session statuses the current user is allowed to see.
  *
- * Note that get_posts() passes no `perm` to WP_Query, and without it WP_Query
- * skips the read_private_posts test entirely, so asking for `private` returns
- * private sessions to everyone. Passing `perm => 'readable'` is not enough
- * either: it falls back to matching on post_author, and a session with no
- * author (0) matches a logged-out visitor (also 0).
+ * WP_Query skips the read_private_posts test unless `perm` is set, and
+ * get_posts() never sets it. `perm => 'readable'` doesn't fix it either: it
+ * falls back to post_author, and a session with no author (0) matches a
+ * logged out visitor (also 0).
  *
  * @return array
  */
@@ -73,9 +72,8 @@ function render( $attributes, $content, $block ) {
 
 	$sessions = get_posts( $session_args );
 
-	// Second pass, mirroring WP_REST_Posts_Controller::check_read_permission().
-	// Published posts are readable by everyone, including logged-out visitors,
-	// who hold no capabilities at all.
+	// Mirrors WP_REST_Posts_Controller::check_read_permission(). Logged out
+	// visitors hold no capabilities, so published has to be allowed for first.
 	$sessions = array_filter(
 		$sessions,
 		function ( $session ) {

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-session-speakers.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-session-speakers.php
@@ -148,6 +148,27 @@ class Test_Session_Speakers_Block extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a session with nothing readable renders nothing at all.
+	 *
+	 * The byline is emitted before the speaker names, so returning early matters:
+	 * otherwise the page shows "Presented by" followed by no one.
+	 */
+	public function test_logged_out_gets_nothing_when_no_speaker_is_readable() {
+		$speaker_ids = get_post_meta( $this->session_id, '_wcpt_speaker_id', false );
+
+		foreach ( $speaker_ids as $speaker_id ) {
+			wp_update_post( array(
+				'ID'          => $speaker_id,
+				'post_status' => 'draft',
+			) );
+		}
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame( '', $this->render_block() );
+	}
+
+	/**
 	 * Test that a user who can read the speakers still sees all of them.
 	 */
 	public function test_editor_sees_every_speaker() {

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-session-speakers.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-session-speakers.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_Block;
+use WP_Block_Type_Registry;
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/blocks/source/blocks/session-speakers/controller.php';
+
+/**
+ * Tests for the speakers the Session Speakers block lists.
+ *
+ * The block runs on the network's default `single-wcb_session` template, so
+ * whatever it dereferences out of `_wcpt_speaker_id` is published on a public
+ * page. Speaker records come from the public Call for Speakers form as drafts.
+ *
+ * @group blocks
+ */
+class Test_Session_Speakers_Block extends WP_UnitTestCase {
+	/**
+	 * The session the block renders for.
+	 *
+	 * @var int
+	 */
+	protected $session_id;
+
+	/**
+	 * Register the block, so that rendering it resolves its context and supports.
+	 */
+	public static function wpSetUpBeforeClass(): void {
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'wordcamp/session-speakers' ) ) {
+			\WordCamp\Blocks\SessionSpeakers\init();
+		}
+	}
+
+	/**
+	 * Create a session and attach one speaker of each status to it.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->session_id = wp_insert_post( array(
+			'post_type'   => 'wcb_session',
+			'post_title'  => 'Test Session',
+			'post_status' => 'publish',
+			'post_author' => $author_id,
+		) );
+
+		$this->attach_speaker( 'Published speaker', 'publish', $author_id );
+		$this->attach_speaker( 'Draft speaker', 'draft', $author_id );
+		$this->attach_speaker( 'Private speaker', 'private', $author_id );
+
+		// The meta holds bare post ids, so a stray one should not be printed
+		// just because it exists.
+		$unrelated_id = wp_insert_post( array(
+			'post_type'   => 'post',
+			'post_title'  => 'Unrelated draft post',
+			'post_status' => 'draft',
+			'post_author' => $author_id,
+		) );
+		add_post_meta( $this->session_id, '_wcpt_speaker_id', $unrelated_id );
+	}
+
+	/**
+	 * Create a speaker and attach it to the test session.
+	 *
+	 * @param string $title  Speaker title.
+	 * @param string $status Post status.
+	 * @param int    $author Post author ID.
+	 *
+	 * @return int
+	 */
+	protected function attach_speaker( string $title, string $status, int $author ): int {
+		$speaker_id = wp_insert_post( array(
+			'post_type'   => 'wcb_speaker',
+			'post_title'  => $title,
+			'post_status' => $status,
+			'post_author' => $author,
+		) );
+
+		add_post_meta( $this->session_id, '_wcpt_speaker_id', $speaker_id );
+
+		return $speaker_id;
+	}
+
+	/**
+	 * Render the block for the test session, the way the template does.
+	 *
+	 * @return string
+	 */
+	protected function render_block(): string {
+		$block = new WP_Block(
+			array(
+				'blockName'    => 'wordcamp/session-speakers',
+				'attrs'        => array(
+					'byline' => 'Presented by',
+					'isLink' => true,
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			),
+			array( 'postId' => $this->session_id )
+		);
+
+		return $block->render();
+	}
+
+	/**
+	 * Test that published speakers are still listed for a logged out visitor.
+	 */
+	public function test_logged_out_sees_published_speaker() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringContainsString( 'Published speaker', $this->render_block() );
+	}
+
+	/**
+	 * Test that draft speakers are not listed for a logged out visitor.
+	 */
+	public function test_logged_out_does_not_see_draft_speaker() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringNotContainsString( 'Draft speaker', $this->render_block() );
+	}
+
+	/**
+	 * Test that private speakers are not listed for a logged out visitor.
+	 */
+	public function test_logged_out_does_not_see_private_speaker() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringNotContainsString( 'Private speaker', $this->render_block() );
+	}
+
+	/**
+	 * Test that an id naming something other than a speaker is not printed.
+	 */
+	public function test_logged_out_does_not_see_unrelated_post_type() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringNotContainsString( 'Unrelated draft post', $this->render_block() );
+	}
+
+	/**
+	 * Test that a user who can read the speakers still sees all of them.
+	 */
+	public function test_editor_sees_every_speaker() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$rendered = $this->render_block();
+
+		$this->assertStringContainsString( 'Published speaker', $rendered );
+		$this->assertStringContainsString( 'Draft speaker', $rendered );
+		$this->assertStringContainsString( 'Private speaker', $rendered );
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-speaker-sessions.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-speaker-sessions.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_Block;
+use WP_Block_Type_Registry;
+use WP_UnitTestCase;
+use function WordCamp\Blocks\SpeakerSessions\get_readable_session_statuses;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/blocks/source/blocks/speaker-sessions/controller.php';
+
+/**
+ * Tests for the sessions the Speaker Sessions block lists.
+ *
+ * The block runs on the network's default `single-wcb_speaker` template, so
+ * whatever its query returns is published on a public page.
+ *
+ * @group blocks
+ */
+class Test_Speaker_Sessions_Block extends WP_UnitTestCase {
+	/**
+	 * A speaker for the sessions to hang off.
+	 *
+	 * @var int
+	 */
+	protected $speaker_id;
+
+	/**
+	 * Register the block, so that rendering it resolves its context and supports.
+	 */
+	public static function wpSetUpBeforeClass(): void {
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'wordcamp/speaker-sessions' ) ) {
+			\WordCamp\Blocks\SpeakerSessions\init();
+		}
+	}
+
+	/**
+	 * Create a speaker and attach one session of each status to it.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->speaker_id = wp_insert_post( array(
+			'post_type'   => 'wcb_speaker',
+			'post_title'  => 'Test Speaker',
+			'post_status' => 'publish',
+			'post_author' => $author_id,
+		) );
+
+		$this->add_session( 'Published session', 'publish', $author_id );
+		$this->add_session( 'Private session', 'private', $author_id );
+
+		// A session nobody owns. `perm => 'readable'` scopes private posts by
+		// post_author, and 0 matches a logged out visitor, so this is the case
+		// an author-based check lets through.
+		$this->add_session( 'Unowned private session', 'private', 0 );
+	}
+
+	/**
+	 * Create a session attached to the test speaker.
+	 *
+	 * @param string $title  Session title.
+	 * @param string $status Post status.
+	 * @param int    $author Post author ID.
+	 *
+	 * @return int
+	 */
+	protected function add_session( string $title, string $status, int $author ): int {
+		$session_id = wp_insert_post( array(
+			'post_type'   => 'wcb_session',
+			'post_title'  => $title,
+			'post_status' => $status,
+			'post_author' => $author,
+		) );
+
+		add_post_meta( $session_id, '_wcpt_speaker_id', $this->speaker_id );
+
+		return $session_id;
+	}
+
+	/**
+	 * Render the block for the test speaker, the way the template does.
+	 *
+	 * @return string
+	 */
+	protected function render_block(): string {
+		$block = new WP_Block(
+			array(
+				'blockName'    => 'wordcamp/speaker-sessions',
+				'attrs'        => array(
+					'hasSessionDetails' => true,
+					'isLink'            => true,
+				),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			),
+			array( 'postId' => $this->speaker_id )
+		);
+
+		return $block->render();
+	}
+
+	/**
+	 * Test that a logged out visitor is only asked about published sessions.
+	 */
+	public function test_logged_out_gets_published_status_only() {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( array( 'publish' ), get_readable_session_statuses() );
+	}
+
+	/**
+	 * Test that a user with read_private_posts is asked about private sessions too.
+	 */
+	public function test_editor_gets_private_status() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertContains( 'private', get_readable_session_statuses() );
+	}
+
+	/**
+	 * Test that published sessions are still listed for a logged out visitor.
+	 *
+	 * Logged out visitors hold no capabilities at all, so a per-post
+	 * `current_user_can( 'read_post' )` check drops published sessions unless
+	 * the published status is allowed for first.
+	 */
+	public function test_logged_out_sees_published_session() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringContainsString( 'Published session', $this->render_block() );
+	}
+
+	/**
+	 * Test that private sessions are not listed for a logged out visitor.
+	 */
+	public function test_logged_out_does_not_see_private_session() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringNotContainsString( 'Private session', $this->render_block() );
+	}
+
+	/**
+	 * Test that a private session with no author is not listed either.
+	 */
+	public function test_logged_out_does_not_see_unowned_private_session() {
+		wp_set_current_user( 0 );
+
+		$this->assertStringNotContainsString( 'Unowned private session', $this->render_block() );
+	}
+
+	/**
+	 * Test that a user with read_private_posts still sees every session.
+	 */
+	public function test_editor_sees_all_sessions() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$rendered = $this->render_block();
+
+		$this->assertStringContainsString( 'Published session', $rendered );
+		$this->assertStringContainsString( 'Private session', $rendered );
+		$this->assertStringContainsString( 'Unowned private session', $rendered );
+	}
+}

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -519,15 +519,26 @@ function register_additional_rest_fields() {
 				foreach ( $speaker_ids as $speaker_id ) {
 					$speaker = get_post( $speaker_id );
 
-					// Make sure the speaker post hasn't been deleted.
-					if ( $speaker instanceof WP_Post ) {
-						$speakers[] = array(
-							'id'   => $speaker_id,
-							'slug' => $speaker->post_name,
-							'name' => get_the_title( $speaker_id ),
-							'link' => get_permalink( $speaker_id ),
-						);
+					// Make sure the speaker post hasn't been deleted, and that the
+					// id names a speaker rather than whatever else the meta holds.
+					if ( ! $speaker instanceof WP_Post || 'wcb_speaker' !== $speaker->post_type ) {
+						continue;
 					}
+
+					// This field is served in the anonymous `view` context, and the
+					// controller's own read check covers the session, not the posts
+					// this dereferences. Published posts are readable by everyone,
+					// including logged out callers, who hold no capabilities at all.
+					if ( 'publish' !== $speaker->post_status && ! current_user_can( 'read_post', $speaker->ID ) ) {
+						continue;
+					}
+
+					$speakers[] = array(
+						'id'   => $speaker_id,
+						'slug' => $speaker->post_name,
+						'name' => get_the_title( $speaker_id ),
+						'link' => get_permalink( $speaker_id ),
+					);
 				}
 
 				return $speakers;

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -514,17 +514,28 @@ function register_additional_rest_fields() {
 		array(
 			'get_callback' => function ( $post ) {
 				$speaker_ids = get_post_meta( $post['id'], '_wcpt_speaker_id', false );
-				$speakers = array();
+				$speakers    = array();
 
-				foreach ( $speaker_ids as $speaker_id ) {
-					$speaker = get_post( $speaker_id );
+				if ( empty( $speaker_ids ) ) {
+					return $speakers;
+				}
 
-					// Make sure the speaker post hasn't been deleted, and that the
-					// id names a speaker rather than whatever else the meta holds.
-					if ( ! $speaker instanceof WP_Post || 'wcb_speaker' !== $speaker->post_type ) {
-						continue;
-					}
+				// Resolve the ids through a query so that the post type is enforced
+				// and the posts are fetched together. This runs for every session in
+				// a collection response, so a lookup per speaker adds up.
+				$speaker_posts = get_posts( array(
+					'post_type'      => 'wcb_speaker',
+					'post__in'       => array_map( 'absint', $speaker_ids ),
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+					'orderby'        => 'post__in',
+					'no_found_rows'  => true,
+					// Only the title, slug, permalink and status are used below.
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				) );
 
+				foreach ( $speaker_posts as $speaker ) {
 					// This field is served in the anonymous `view` context, and the
 					// controller's own read check covers the session, not the posts
 					// this dereferences. Published posts are readable by everyone,
@@ -534,10 +545,12 @@ function register_additional_rest_fields() {
 					}
 
 					$speakers[] = array(
-						'id'   => $speaker_id,
+						// Emitted as the stored meta string since this field was added;
+						// left alone here so the response shape does not change.
+						'id'   => (string) $speaker->ID,
 						'slug' => $speaker->post_name,
-						'name' => get_the_title( $speaker_id ),
-						'link' => get_permalink( $speaker_id ),
+						'name' => get_the_title( $speaker->ID ),
+						'link' => get_permalink( $speaker->ID ),
 					);
 				}
 

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -520,9 +520,8 @@ function register_additional_rest_fields() {
 					return $speakers;
 				}
 
-				// Resolve the ids through a query so that the post type is enforced
-				// and the posts are fetched together. This runs for every session in
-				// a collection response, so a lookup per speaker adds up.
+				// One query rather than a lookup per speaker: this runs for every
+				// session in a collection response.
 				$speaker_posts = get_posts( array(
 					'post_type'      => 'wcb_speaker',
 					'post__in'       => array_map( 'absint', $speaker_ids ),
@@ -536,17 +535,14 @@ function register_additional_rest_fields() {
 				) );
 
 				foreach ( $speaker_posts as $speaker ) {
-					// This field is served in the anonymous `view` context, and the
-					// controller's own read check covers the session, not the posts
-					// this dereferences. Published posts are readable by everyone,
-					// including logged out callers, who hold no capabilities at all.
+					// Served in the anonymous `view` context, and the controller's own
+					// read check covers the session, not the posts dereferenced here.
 					if ( 'publish' !== $speaker->post_status && ! current_user_can( 'read_post', $speaker->ID ) ) {
 						continue;
 					}
 
 					$speakers[] = array(
-						// Emitted as the stored meta string since this field was added;
-						// left alone here so the response shape does not change.
+						// Kept as the stored meta string so the response shape is unchanged.
 						'id'   => (string) $speaker->ID,
 						'slug' => $speaker->post_name,
 						'name' => get_the_title( $speaker->ID ),
@@ -642,9 +638,8 @@ function prepare_session_query_args( $args, $request ) {
 		$args['orderby']  = 'meta_value_num';
 	}
 
-	// The controller drops unreadable posts from the response body, but they are
-	// still counted in found_posts, so an unprivileged caller gets an X-WP-Total
-	// (and page count) that includes private sessions it never receives.
+	// The controller drops unreadable posts from the body but still counts them
+	// in found_posts, so X-WP-Total would include what the caller never receives.
 	$args['post_status'] = array( 'publish' );
 
 	$post_type = get_post_type_object( 'wcb_session' );

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -618,7 +618,15 @@ function prepare_session_query_args( $args, $request ) {
 		$args['orderby']  = 'meta_value_num';
 	}
 
-	$args['post_status'] = array( 'publish', 'private' );
+	// The controller drops unreadable posts from the response body, but they are
+	// still counted in found_posts, so an unprivileged caller gets an X-WP-Total
+	// (and page count) that includes private sessions it never receives.
+	$args['post_status'] = array( 'publish' );
+
+	$post_type = get_post_type_object( 'wcb_session' );
+	if ( $post_type && current_user_can( $post_type->cap->read_private_posts ) ) {
+		$args['post_status'][] = 'private';
+	}
 
 	return $args;
 }

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-rest-api-session-speakers.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-rest-api-session-speakers.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace WordCamp\WC_Post_Types\Tests;
+
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the speakers the `session_speakers` REST field exposes.
+ *
+ * The field is served in the anonymous `view` context. Core's per-item read
+ * check covers the session being listed, not the speaker posts this field
+ * dereferences out of `_wcpt_speaker_id`.
+ *
+ * @group wc-post-types
+ * @group rest-api
+ */
+class Test_Session_Speakers_Field extends WP_UnitTestCase {
+	/**
+	 * The session whose field is under test.
+	 *
+	 * @var int
+	 */
+	protected $session_id;
+
+	/**
+	 * Register the REST fields before the routes are queried.
+	 */
+	public static function wpSetUpBeforeClass(): void {
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Create a session and attach one speaker of each status to it.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->session_id = wp_insert_post( array(
+			'post_type'   => 'wcb_session',
+			'post_title'  => 'Test Session',
+			'post_status' => 'publish',
+			'post_author' => $author_id,
+		) );
+
+		$this->attach_speaker( 'Published speaker', 'publish', $author_id );
+		$this->attach_speaker( 'Draft speaker', 'draft', $author_id );
+		$this->attach_speaker( 'Private speaker', 'private', $author_id );
+
+		// The meta holds bare post ids, so a stray one should not be returned
+		// just because it exists.
+		$unrelated_id = wp_insert_post( array(
+			'post_type'   => 'post',
+			'post_title'  => 'Unrelated draft post',
+			'post_status' => 'draft',
+			'post_author' => $author_id,
+		) );
+		add_post_meta( $this->session_id, '_wcpt_speaker_id', $unrelated_id );
+	}
+
+	/**
+	 * Create a speaker and attach it to the test session.
+	 *
+	 * @param string $title  Speaker title.
+	 * @param string $status Post status.
+	 * @param int    $author Post author ID.
+	 *
+	 * @return int
+	 */
+	protected function attach_speaker( string $title, string $status, int $author ): int {
+		$speaker_id = wp_insert_post( array(
+			'post_type'   => 'wcb_speaker',
+			'post_title'  => $title,
+			'post_status' => $status,
+			'post_author' => $author,
+		) );
+
+		add_post_meta( $this->session_id, '_wcpt_speaker_id', $speaker_id );
+
+		return $speaker_id;
+	}
+
+	/**
+	 * Run the field's get_callback the way the REST controller does.
+	 *
+	 * `register_rest_field()` stores the callback in `$wp_rest_additional_fields`,
+	 * which is where the controller reads it from when preparing a response. The
+	 * full route is not exercised here because `rest_prepare_wcb_session` reaches
+	 * into the theme-templates mu-plugin, which this suite does not load.
+	 *
+	 * @return array
+	 */
+	protected function get_speaker_names(): array {
+		global $wp_rest_additional_fields;
+
+		$callback = $wp_rest_additional_fields['wcb_session']['session_speakers']['get_callback'] ?? null;
+
+		if ( ! $callback ) {
+			$this->fail( 'Could not find the get_callback for the session_speakers field.' );
+		}
+
+		$speakers = call_user_func( $callback, array( 'id' => $this->session_id ), 'session_speakers', null );
+
+		return wp_list_pluck( $speakers, 'name' );
+	}
+
+	/**
+	 * Test that published speakers are still returned to a logged out caller.
+	 */
+	public function test_logged_out_gets_published_speaker() {
+		wp_set_current_user( 0 );
+
+		$this->assertContains( 'Published speaker', $this->get_speaker_names() );
+	}
+
+	/**
+	 * Test that a logged out caller gets nothing it cannot read.
+	 */
+	public function test_logged_out_gets_only_the_published_speaker() {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( array( 'Published speaker' ), $this->get_speaker_names() );
+	}
+
+	/**
+	 * Test that a user who can read the speakers still gets all of them.
+	 */
+	public function test_editor_gets_every_speaker() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$names = $this->get_speaker_names();
+
+		$this->assertContains( 'Published speaker', $names );
+		$this->assertContains( 'Draft speaker', $names );
+		$this->assertContains( 'Private speaker', $names );
+	}
+
+	/**
+	 * Test that an id naming something other than a speaker is never returned.
+	 */
+	public function test_unrelated_post_type_is_never_returned() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertNotContains( 'Unrelated draft post', $this->get_speaker_names() );
+	}
+}

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-rest-api-session-statuses.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-rest-api-session-statuses.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace WordCamp\WC_Post_Types\Tests;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use function WordCamp\Post_Types\REST_API\prepare_session_query_args;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the post statuses `prepare_session_query_args()` asks WP_Query for.
+ *
+ * The REST controller filters unreadable posts out of the response body, but
+ * `found_posts` is taken from the query, so a status the caller can't read
+ * still lands in `X-WP-Total` and the reported page count.
+ *
+ * @group wc-post-types
+ * @group rest-api
+ */
+class Test_Session_Query_Statuses extends WP_UnitTestCase {
+	/**
+	 * Run the filter the way the REST controller does, and return the statuses.
+	 *
+	 * @return array
+	 */
+	private function get_query_statuses(): array {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sessions' );
+		$args    = prepare_session_query_args( array(), $request );
+
+		return (array) $args['post_status'];
+	}
+
+	/**
+	 * Test that a logged out caller is only asked about published sessions.
+	 */
+	public function test_logged_out_gets_published_only(): void {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( array( 'publish' ), $this->get_query_statuses() );
+	}
+
+	/**
+	 * Test that a user without read_private_posts is only asked about published sessions.
+	 */
+	public function test_subscriber_gets_published_only(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertSame( array( 'publish' ), $this->get_query_statuses() );
+	}
+
+	/**
+	 * Test that a user with read_private_posts is asked about private sessions too.
+	 */
+	public function test_editor_gets_private_sessions(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertContains( 'private', $this->get_query_statuses() );
+	}
+}


### PR DESCRIPTION
## Why

Four places in the session and speaker listings print content the viewer cannot read. Each turns stored ids or a status list into titles and permalinks without the check a query or a REST controller would apply.

**The session listings ask for a status they don't check.** The Speaker Sessions block and the `wcb_session` REST collection query for `publish` and `private` without passing `perm`, and `get_posts()` doesn't set one, so `WP_Query` folds the private-status branch into the readable one and unsets it before the `read_private_posts` test runs.

In the REST collection that surfaces as pagination that doesn't add up: the controller filters unreadable posts out of the body, but `found_posts` comes from the unfiltered query, so a logged out request to a camp with one published and one private session returns `X-WP-Total: 2` next to a single-item body. The block has no per-item filter at all, so it lists private sessions with their times and a link to each.

**The speaker listings don't resolve their ids at all.** The Session Speakers block and the `session_speakers` REST field read `_wcpt_speaker_id` and pass each id straight to `get_the_title()` and `get_permalink()`. No query, so no status defaults, and no post type check. Speaker records come from the Call for Speakers form as drafts, so a published session pointing at an unpublished speaker is ordinary while a schedule is being built. Both are public output: the block is on the network's default `single-wcb_session` template with `isLink` on, and the field is served in the anonymous `view` context. Doing it one id at a time is also expensive: 151 queries for one collection request over 30 sessions and 90 speakers.

The four sibling controllers that read this data correctly all hard-code `'publish'` (`speakers/controller.php:141`, `sessions/controller.php:217`, `organizers/controller.php:94`, `sponsors/controller.php:92`), and the classic-theme path already uses a single `post__in` query. None of this needs an organiser to opt in: `theme-templates/bootstrap.php` injects both templates for any camp on a block theme, and new camps get `twentytwentyfour` (`wordcamp-new-site.php:692`).

## What changed

**Session statuses are gated on capability.** The block and `prepare_session_query_args()` add `private` only when the viewer holds the post type's `read_private_posts`. That also settles the REST counting, so `X-WP-Total` and the page count agree with the body.

**Speaker ids are resolved through a query and then checked.** Both use `post__in` the way `add_speaker_info_to_session_posts()` already does, which enforces the post type in SQL, then skip what the viewer cannot read. Meta and term caches are not primed, since only the title, slug, permalink and status are read. That took the field from 151 queries to 91, mostly by not priming caches nothing reads rather than by the batching.

**All four use the same check** that `WP_REST_Posts_Controller::check_read_permission()` applies: published posts are readable by everyone, `read_post` decides the rest. Published has to come first, since logged out visitors hold no capabilities and a bare `current_user_can( 'read_post', … )` drops published posts too.

**Smaller things:** the Session Speakers block returns early when nothing is readable, so it no longer renders a byline with no names under it, and `post_status => 'any'` leaves out trashed speakers that `get_post()` would have printed. Note that `perm => 'readable'` is not sufficient for the session half, since it falls back to matching `post_author` and a session with no author (0) matches a logged out visitor (also 0).

## Testing

None of these four paths had coverage. This adds 19 tests across four files: the statuses the session query asks for, and the output of each listing path.

Four guard mistakes that are easy to make here, each failing against a version of this patch that made it: scoping by `post_author` lists a session with no author, checking `read_post` without allowing for published first drops published posts, checking only the status prints a stray non-speaker id, and skipping the early return leaves the byline behind. Against the pre-change code the session tests fail for the logged out and subscriber cases, and the speaker tests fail with draft speakers, private speakers and an unrelated draft post in the output. Full suite is 650 tests, with two `Test_Error_Handling` failures a macOS temp path produces locally and CI doesn't.

Also verified by hand on a local network install over HTTPS. Logged out, each listing returns only what is published, with `X-WP-Total` matching the body; as an administrator all of it comes back, so organisers keep the visibility #994 added. The private session's permalink and the draft speaker's both still 404. I haven't measured how many private sessions or unpublished speakers exist across the network, so that rests on these cases rather than on production counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)