### PR TITLE
WC Payments: limit non-network-admins to pre-approval request statuses

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/bootstrap.php
@@ -14,12 +14,19 @@ function manually_load_plugin() {
 
 	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/wordcamp-budgets.php';
 	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/payment-request.php';
+	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/reimbursement-request.php';
+	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/sponsor-invoice.php';
 	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/encryption.php';
 
 	// Registers the `wcp_payment_request` post type on `init`. Without this,
 	// the dashboard tests create posts of that type before it's registered,
-	// which trips a "map_meta_cap called incorrectly" notice.
-	new \WCP_Payment_Request();
+	// which trips a "map_meta_cap called incorrectly" notice. Store it in the
+	// same global the plugin uses at runtime so tests can invoke its methods.
+	//
+	// `reimbursement-request.php` and `sponsor-invoice.php` register their post
+	// types and status filters on `require`, so tests can exercise all three
+	// budget CPTs.
+	$GLOBALS['wcp_payment_request'] = new \WCP_Payment_Request();
 
 	require_once dirname( __DIR__ )  . '/includes/payment-requests-dashboard.php';
 	require_once dirname( __DIR__ )  . '/includes/wordcamp-budgets-dashboard.php';

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-status-permissions.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-status-permissions.php
@@ -99,8 +99,14 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 		$draft = $this->create_draft( 'wcb_reimbursement' );
 
 		$result = set_request_status(
-			array( 'post_type' => 'wcb_reimbursement', 'post_status' => 'wcb-approved' ),
-			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+			array(
+				'post_type'   => 'wcb_reimbursement',
+				'post_status' => 'wcb-approved',
+			),
+			array(
+				'ID'          => $draft,
+				'post_status' => 'wcb-approved',
+			)
 		);
 
 		$this->assertSame( 'wcb-pending-approval', $result['post_status'] );
@@ -114,8 +120,15 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 		$draft = $this->create_draft( 'wcb_reimbursement' );
 
 		$result = set_request_status(
-			array( 'post_type' => 'wcb_reimbursement', 'post_status' => 'draft' ),
-			array( 'ID' => $draft, 'post_status' => 'draft', 'wcb-update' => 'Submit for Review' )
+			array(
+				'post_type'   => 'wcb_reimbursement',
+				'post_status' => 'draft',
+			),
+			array(
+				'ID'          => $draft,
+				'post_status' => 'draft',
+				'wcb-update'  => 'Submit for Review',
+			)
 		);
 
 		$this->assertSame( 'wcb-pending-approval', $result['post_status'] );
@@ -129,8 +142,14 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 		$draft = $this->create_draft( 'wcb_reimbursement' );
 
 		$result = set_request_status(
-			array( 'post_type' => 'wcb_reimbursement', 'post_status' => 'wcb-approved' ),
-			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+			array(
+				'post_type'   => 'wcb_reimbursement',
+				'post_status' => 'wcb-approved',
+			),
+			array(
+				'ID'          => $draft,
+				'post_status' => 'wcb-approved',
+			)
 		);
 
 		$this->assertSame( 'wcb-approved', $result['post_status'] );
@@ -152,7 +171,10 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 				'post_date'     => '2020-01-01 00:00:00',
 				'post_date_gmt' => '2020-01-01 00:00:00',
 			),
-			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+			array(
+				'ID'          => $draft,
+				'post_status' => 'wcb-approved',
+			)
 		);
 
 		$this->assertSame( 'wcb-pending-approval', $result['post_status'] );
@@ -172,7 +194,10 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 				'post_date'     => '2020-01-01 00:00:00',
 				'post_date_gmt' => '2020-01-01 00:00:00',
 			),
-			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+			array(
+				'ID'          => $draft,
+				'post_status' => 'wcb-approved',
+			)
 		);
 
 		$this->assertSame( 'wcb-approved', $result['post_status'] );
@@ -189,9 +214,15 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 		$draft   = $this->create_draft( 'wcb_sponsor_invoice' );
 
 		$result = set_invoice_status(
-			array( 'post_type' => 'wcb_sponsor_invoice', 'post_status' => 'wcbsi_approved' ),
+			array(
+				'post_type'   => 'wcb_sponsor_invoice',
+				'post_status' => 'wcbsi_approved',
+			),
 			array_merge(
-				array( 'ID' => $draft, 'post_status' => 'wcbsi_approved' ),
+				array(
+					'ID'          => $draft,
+					'post_status' => 'wcbsi_approved',
+				),
 				$this->complete_invoice_fields( $sponsor )
 			)
 		);
@@ -208,9 +239,15 @@ class Test_Status_Permissions extends WP_UnitTestCase {
 		$draft   = $this->create_draft( 'wcb_sponsor_invoice' );
 
 		$result = set_invoice_status(
-			array( 'post_type' => 'wcb_sponsor_invoice', 'post_status' => 'wcbsi_approved' ),
+			array(
+				'post_type'   => 'wcb_sponsor_invoice',
+				'post_status' => 'wcbsi_approved',
+			),
 			array_merge(
-				array( 'ID' => $draft, 'post_status' => 'wcbsi_approved' ),
+				array(
+					'ID'          => $draft,
+					'post_status' => 'wcbsi_approved',
+				),
 				$this->complete_invoice_fields( $sponsor )
 			)
 		);

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-status-permissions.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-status-permissions.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace WordCamp\Budgets_Dashboard\Tests;
+
+use WP_UnitTestCase;
+use function WordCamp\Budgets\Reimbursement_Requests\set_request_status;
+use function WordCamp\Budgets\Sponsor_Invoices\set_invoice_status;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Who may set which status on the budget CPTs.
+ *
+ * Each of the three budget CPTs normalises `post_status` in a `wp_insert_post_data` filter as a request is
+ * saved. Statuses past pending approval/submission (approval, payment, etc.) are reserved for network
+ * admins; a non-network-admin editing their own request/invoice keeps a status within the requester-settable
+ * set. These tests exercise those filters directly against a real, stored draft.
+ *
+ * @group budgets-dashboard
+ */
+class Test_Status_Permissions extends WP_UnitTestCase {
+	/**
+	 * A subsite administrator: authors requests, but is not a network admin.
+	 *
+	 * @var int
+	 */
+	protected static $requester_id;
+
+	/**
+	 * A network administrator: may approve requests.
+	 *
+	 * @var int
+	 */
+	protected static $network_admin_id;
+
+	/**
+	 * Create the shared users.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$requester_id     = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$network_admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		grant_super_admin( self::$network_admin_id );
+	}
+
+	/**
+	 * Exercise the `wp_insert_post_data` status filters in isolation.
+	 *
+	 * The filters read the current user's caps and the raw POST, so keep both predictable. The `save_post`
+	 * handlers are detached so creating the stored draft fixtures doesn't run their nonce checks (which
+	 * `wp_die()` outside a real request), and restored in `tear_down()` so other suites are unaffected.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$_POST    = array();
+		$_REQUEST = array();
+
+		remove_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10 );
+		remove_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10 );
+		remove_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10 );
+	}
+
+	/**
+	 * Re-attach the `save_post` handlers detached in `set_up()`.
+	 */
+	public function tear_down() {
+		add_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10, 2 );
+		add_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10, 2 );
+		add_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10, 2 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a stored draft post of the given budget CPT, authored by the requester.
+	 *
+	 * @param string $post_type
+	 *
+	 * @return int
+	 */
+	protected function create_draft( $post_type ) {
+		return self::factory()->post->create( array(
+			'post_type'   => $post_type,
+			'post_status' => 'draft',
+			'post_author' => self::$requester_id,
+		) );
+	}
+
+	// -- Reimbursement requests -------------------------------------------------------------------------
+
+	/**
+	 * A non-network-admin submitting `wcb-approved` on their own draft is kept at pending approval.
+	 */
+	public function test_non_network_admin_cannot_set_approved_reimbursement() {
+		wp_set_current_user( self::$requester_id );
+		$draft = $this->create_draft( 'wcb_reimbursement' );
+
+		$result = set_request_status(
+			array( 'post_type' => 'wcb_reimbursement', 'post_status' => 'wcb-approved' ),
+			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+		);
+
+		$this->assertSame( 'wcb-pending-approval', $result['post_status'] );
+	}
+
+	/**
+	 * The "Submit for Review" path still promotes a draft to pending approval.
+	 */
+	public function test_requester_submit_promotes_reimbursement_to_pending() {
+		wp_set_current_user( self::$requester_id );
+		$draft = $this->create_draft( 'wcb_reimbursement' );
+
+		$result = set_request_status(
+			array( 'post_type' => 'wcb_reimbursement', 'post_status' => 'draft' ),
+			array( 'ID' => $draft, 'post_status' => 'draft', 'wcb-update' => 'Submit for Review' )
+		);
+
+		$this->assertSame( 'wcb-pending-approval', $result['post_status'] );
+	}
+
+	/**
+	 * A network admin may approve a reimbursement.
+	 */
+	public function test_network_admin_can_approve_reimbursement() {
+		wp_set_current_user( self::$network_admin_id );
+		$draft = $this->create_draft( 'wcb_reimbursement' );
+
+		$result = set_request_status(
+			array( 'post_type' => 'wcb_reimbursement', 'post_status' => 'wcb-approved' ),
+			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+		);
+
+		$this->assertSame( 'wcb-approved', $result['post_status'] );
+	}
+
+	// -- Vendor payment requests ------------------------------------------------------------------------
+
+	/**
+	 * A non-network-admin submitting `wcb-approved` on their own draft payment is kept at pending approval.
+	 */
+	public function test_non_network_admin_cannot_set_approved_payment() {
+		wp_set_current_user( self::$requester_id );
+		$draft = $this->create_draft( 'wcp_payment_request' );
+
+		$result = $GLOBALS['wcp_payment_request']->wp_insert_post_data(
+			array(
+				'post_type'     => 'wcp_payment_request',
+				'post_status'   => 'wcb-approved',
+				'post_date'     => '2020-01-01 00:00:00',
+				'post_date_gmt' => '2020-01-01 00:00:00',
+			),
+			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+		);
+
+		$this->assertSame( 'wcb-pending-approval', $result['post_status'] );
+	}
+
+	/**
+	 * A network admin may approve a vendor payment.
+	 */
+	public function test_network_admin_can_approve_payment() {
+		wp_set_current_user( self::$network_admin_id );
+		$draft = $this->create_draft( 'wcp_payment_request' );
+
+		$result = $GLOBALS['wcp_payment_request']->wp_insert_post_data(
+			array(
+				'post_type'     => 'wcp_payment_request',
+				'post_status'   => 'wcb-approved',
+				'post_date'     => '2020-01-01 00:00:00',
+				'post_date_gmt' => '2020-01-01 00:00:00',
+			),
+			array( 'ID' => $draft, 'post_status' => 'wcb-approved' )
+		);
+
+		$this->assertSame( 'wcb-approved', $result['post_status'] );
+	}
+
+	// -- Sponsor invoices -------------------------------------------------------------------------------
+
+	/**
+	 * A non-network-admin submitting `wcbsi_approved` on their own draft invoice is kept at draft.
+	 */
+	public function test_non_network_admin_cannot_set_approved_invoice() {
+		wp_set_current_user( self::$requester_id );
+		$sponsor = $this->create_complete_sponsor();
+		$draft   = $this->create_draft( 'wcb_sponsor_invoice' );
+
+		$result = set_invoice_status(
+			array( 'post_type' => 'wcb_sponsor_invoice', 'post_status' => 'wcbsi_approved' ),
+			array_merge(
+				array( 'ID' => $draft, 'post_status' => 'wcbsi_approved' ),
+				$this->complete_invoice_fields( $sponsor )
+			)
+		);
+
+		$this->assertSame( 'draft', $result['post_status'] );
+	}
+
+	/**
+	 * A network admin may approve a sponsor invoice.
+	 */
+	public function test_network_admin_can_approve_invoice() {
+		wp_set_current_user( self::$network_admin_id );
+		$sponsor = $this->create_complete_sponsor();
+		$draft   = $this->create_draft( 'wcb_sponsor_invoice' );
+
+		$result = set_invoice_status(
+			array( 'post_type' => 'wcb_sponsor_invoice', 'post_status' => 'wcbsi_approved' ),
+			array_merge(
+				array( 'ID' => $draft, 'post_status' => 'wcbsi_approved' ),
+				$this->complete_invoice_fields( $sponsor )
+			)
+		);
+
+		$this->assertSame( 'wcbsi_approved', $result['post_status'] );
+	}
+
+	/**
+	 * Create a sponsor whose required contact fields are all filled, so an invoice referencing it is
+	 * considered "complete" and the status rule -- not the missing-fields fallback -- is what applies.
+	 *
+	 * @return int Sponsor post ID.
+	 */
+	protected function create_complete_sponsor() {
+		$sponsor = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+		) );
+
+		$fields = array(
+			'company_name'    => 'ACME Corp',
+			'first_name'      => 'Jane',
+			'last_name'       => 'Doe',
+			'email_address'   => 'jane@example.org',
+			'phone_number'    => '555-1212',
+			'street_address1' => '1 Main St',
+			'city'            => 'Seattle',
+			'state'           => 'WA',
+			'zip_code'        => '98101',
+			'country'         => 'US',
+		);
+
+		foreach ( $fields as $key => $value ) {
+			update_post_meta( $sponsor, "_wcpt_sponsor_$key", $value );
+		}
+
+		return $sponsor;
+	}
+
+	/**
+	 * The set of invoice fields that `set_invoice_status()` treats as required.
+	 *
+	 * @param int $sponsor_id
+	 *
+	 * @return array
+	 */
+	protected function complete_invoice_fields( $sponsor_id ) {
+		return array(
+			'_wcbsi_sponsor_id'   => (string) $sponsor_id,
+			'_wcbsi_description'  => 'Gold sponsorship',
+			'_wcbsi_currency'     => 'USD',
+			'_wcbsi_amount'       => '5000',
+			'_wcbsi_qbo_class_id' => '42',
+		);
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -615,7 +615,22 @@ class WCP_Payment_Request {
 		// Submit for Review button was clicked.
 		if ( ! current_user_can( 'manage_network' ) ) {
 			$editable_statuses = self::get_editable_statuses();
-			if ( ! empty( $post_data_raw['wcb-update'] ) && in_array( $post_data['post_status'], $editable_statuses ) ) {
+			if ( ! empty( $post_data_raw['wcb-update'] ) && in_array( $post_data['post_status'], $editable_statuses, true ) ) {
+				$post_data['post_status'] = 'wcb-pending-approval';
+			}
+
+			/*
+			 * Statuses past pending approval (approval, payment, etc.) are reserved for network admins. For
+			 * everyone else, keep the status within the set a requester can set, defaulting to pending
+			 * approval.
+			 *
+			 * Keyed on the stored status, so this only applies while the request is still requester-editable
+			 * (draft/incomplete). Status changes made once it's further along, and the initial insert of a
+			 * new post, are left as-is.
+			 */
+			$stored_status      = isset( $post_data_raw['ID'] ) ? get_post_status( (int) $post_data_raw['ID'] ) : false;
+			$requester_statuses = array_merge( $editable_statuses, array( 'wcb-pending-approval' ) );
+			if ( in_array( $stored_status, $editable_statuses, true ) && ! in_array( $post_data['post_status'], $requester_statuses, true ) ) {
 				$post_data['post_status'] = 'wcb-pending-approval';
 			}
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -502,7 +502,21 @@ function set_request_status( $post_data, $post_data_raw ) {
 	// Requesting to submit/update the post
 	if ( ! current_user_can( 'manage_network' ) ) {
 		$editable_statuses = array( 'auto-draft', 'draft', 'wcb-incomplete' );
-		if ( ! empty( $post_data_raw['wcb-update'] ) && in_array( $post_data['post_status'], $editable_statuses ) ) {
+		if ( ! empty( $post_data_raw['wcb-update'] ) && in_array( $post_data['post_status'], $editable_statuses, true ) ) {
+			$post_data['post_status'] = 'wcb-pending-approval';
+		}
+
+		/*
+		 * Statuses past pending approval (approval, payment, etc.) are reserved for network admins. For
+		 * everyone else, keep the status within the set a requester can set, defaulting to pending approval.
+		 *
+		 * Keyed on the stored status, so this only applies while the request is still requester-editable
+		 * (draft/incomplete). Status changes made once it's further along, and the initial insert of a new
+		 * post, are left as-is.
+		 */
+		$stored_status      = isset( $post_data_raw['ID'] ) ? get_post_status( (int) $post_data_raw['ID'] ) : false;
+		$requester_statuses = array( 'auto-draft', 'draft', 'wcb-incomplete', 'wcb-pending-approval' );
+		if ( in_array( $stored_status, $editable_statuses, true ) && ! in_array( $post_data['post_status'], $requester_statuses, true ) ) {
 			$post_data['post_status'] = 'wcb-pending-approval';
 		}
 	}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -436,6 +436,24 @@ function set_invoice_status( $post_data, $post_data_raw ) {
 		$post_data['post_status'] = 'wcbsi_submitted';
 	}
 
+	/*
+	 * Statuses past submission (approval, payment, etc.) are reserved for network admins. For everyone
+	 * else, keep the status within the set a requester can set, defaulting to draft.
+	 *
+	 * Keyed on the stored status, so this only applies while the invoice is still requester-editable
+	 * (draft). Status changes made once it's further along, and the initial insert of a new invoice, are
+	 * left as-is.
+	 */
+	if ( ! current_user_can( 'manage_network' ) ) {
+		$requester_editable_statuses = array( 'auto-draft', 'draft' );
+		$requester_statuses          = array( 'auto-draft', 'draft', 'wcbsi_submitted' );
+		$stored_status               = isset( $post_data_raw['ID'] ) ? get_post_status( (int) $post_data_raw['ID'] ) : false;
+
+		if ( in_array( $stored_status, $requester_editable_statuses, true ) && ! in_array( $post_data['post_status'], $requester_statuses, true ) ) {
+			$post_data['post_status'] = 'draft';
+		}
+	}
+
 	return $post_data;
 }
 


### PR DESCRIPTION
Only network admins can move vendor payment, reimbursement, and sponsor-invoice requests to approval/payment statuses. For everyone else, the status stays within the set a requester can set (defaulting to pending approval, or draft for invoices). This is decided from the request's stored status, so it applies only while a request is still requester-editable — network-admin and programmatic status changes are unaffected, as is the normal "Submit for Review" promotion to pending approval.

### Testing
- New unit tests cover who may set each status across the three budget CPTs (a network admin can approve; otherwise the status stays pre-approval; the submit-for-review path still promotes a draft to pending approval).
- `phpunit --testsuite "WordCamp Budgets Dashboard"` — 14/14 passing.
- Manually confirmed a network admin can still approve a reimbursement through the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
