### PR TITLE
WCPT, Themes: Escape template tag output

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
@@ -153,7 +153,7 @@ function wcpt_get_wordcamp_id() {
  * @uses wcpt_get_wordcamp_permalink()
  */
 function wcpt_wordcamp_permalink( $wordcamp_id = 0 ) {
-	echo wcpt_get_wordcamp_permalink( $wordcamp_id );
+	echo esc_url( wcpt_get_wordcamp_permalink( $wordcamp_id ) );
 }
 
 /**
@@ -460,7 +460,7 @@ function wcpt_get_wordcamp_venue_name( $wordcamp_id = 0 ) {
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_url( $wordcamp_id = 0 ) {
-	echo wcpt_get_wordcamp_url( $wordcamp_id );
+	echo esc_url( wcpt_get_wordcamp_url( $wordcamp_id ) );
 }
 
 /**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
@@ -143,7 +143,7 @@ function wcpt_get_wordcamp_id() {
 /**
  * wcpt_wordcamp_permalink ()
  *
- * Output the link to the WordCamp in the WordCamp loop
+ * Output the link to the WordCamp in the WordCamp loop, escaped for an attribute
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
@@ -151,6 +151,7 @@ function wcpt_get_wordcamp_id() {
  *
  * @param int $wordcamp_id optional
  * @uses wcpt_get_wordcamp_permalink()
+ * @uses esc_url()
  */
 function wcpt_wordcamp_permalink( $wordcamp_id = 0 ) {
 	echo esc_url( wcpt_get_wordcamp_permalink( $wordcamp_id ) );
@@ -342,13 +343,14 @@ function wcpt_get_wordcamp_end_date( $wordcamp_id = 0, $format = 'F j, Y' ) {
 /**
  * wcpt_wordcamp_location ()
  *
- * Output the WordCamps location
+ * Output the WordCamps location, escaped for element text
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
  * @since WordCamp Post Type (0.1)
  *
  * @uses wcpt_get_wordcamp_location()
+ * @uses esc_html()
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_location( $wordcamp_id = 0 ) {
@@ -378,13 +380,14 @@ function wcpt_get_wordcamp_location( $wordcamp_id = 0 ) {
 /**
  * wcpt_wordcamp_organizer_name ()
  *
- * Output the WordCamps organizer
+ * Output the WordCamps organizer name, escaped for element text
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
  * @since WordCamp Post Type (0.1)
  *
  * @uses wcpt_get_wordcamp_organizer_name()
+ * @uses esc_html()
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_organizer_name( $wordcamp_id = 0 ) {
@@ -413,7 +416,7 @@ function wcpt_get_wordcamp_organizer_name( $wordcamp_id = 0 ) {
 
 /**
  * wcpt_wordcamp_venue_name ()
- *
+ * Output the WordCamps venue name, escaped for element text
  * Output the WordCamps organizer
  *
  * @package WordCamp Post Type
@@ -421,6 +424,7 @@ function wcpt_get_wordcamp_organizer_name( $wordcamp_id = 0 ) {
  * @since WordCamp Post Type (0.1)
  *
  * @uses wcpt_get_wordcamp_venue_name()
+ * @uses esc_html()
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_venue_name( $wordcamp_id = 0 ) {
@@ -450,13 +454,14 @@ function wcpt_get_wordcamp_venue_name( $wordcamp_id = 0 ) {
 /**
  * wcpt_wordcamp_url ()
  *
- * Output the WordCamps URL
+ * Output the WordCamps URL, escaped for an attribute
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
  * @since WordCamp Post Type (0.1)
  *
  * @uses wcpt_get_wordcamp_url()
+ * @uses esc_url()
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_url( $wordcamp_id = 0 ) {

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
@@ -416,8 +416,8 @@ function wcpt_get_wordcamp_organizer_name( $wordcamp_id = 0 ) {
 
 /**
  * wcpt_wordcamp_venue_name ()
+ *
  * Output the WordCamps venue name, escaped for element text
- * Output the WordCamps organizer
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
@@ -434,7 +434,7 @@ function wcpt_wordcamp_venue_name( $wordcamp_id = 0 ) {
 /**
  * wcpt_get_wordcamp_venue_name ()
  *
- * Return the WordCamps organizer
+ * Return the WordCamps venue name
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
@@ -491,16 +491,17 @@ function wcpt_get_wordcamp_url( $wordcamp_id = 0 ) {
 /**
  * wcpt_wordcamp_pagination_count ()
  *
- * Output the pagination count
+ * Output the pagination count, escaped for element text
  *
  * @package WordCamp Post Type
  * @subpackage Template Tags
  * @since WordCamp Post Type (0.1)
  *
  * @global WP_Query $wcpt_template
+ * @uses esc_html()
  */
 function wcpt_wordcamp_pagination_count() {
-	echo wcpt_get_wordcamp_pagination_count();
+	echo esc_html( wcpt_get_wordcamp_pagination_count() );
 }
 
 /**

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-template.php
@@ -352,7 +352,7 @@ function wcpt_get_wordcamp_end_date( $wordcamp_id = 0, $format = 'F j, Y' ) {
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_location( $wordcamp_id = 0 ) {
-	echo wcpt_get_wordcamp_location( $wordcamp_id );
+	echo esc_html( wcpt_get_wordcamp_location( $wordcamp_id ) );
 }
 
 /**
@@ -388,7 +388,7 @@ function wcpt_get_wordcamp_location( $wordcamp_id = 0 ) {
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_organizer_name( $wordcamp_id = 0 ) {
-	echo wcpt_get_wordcamp_organizer_name( $wordcamp_id );
+	echo esc_html( wcpt_get_wordcamp_organizer_name( $wordcamp_id ) );
 }
 
 /**
@@ -424,7 +424,7 @@ function wcpt_get_wordcamp_organizer_name( $wordcamp_id = 0 ) {
  * @param int $wordcamp_id optional
  */
 function wcpt_wordcamp_venue_name( $wordcamp_id = 0 ) {
-	echo wcpt_get_wordcamp_venue_name( $wordcamp_id );
+	echo esc_html( wcpt_get_wordcamp_venue_name( $wordcamp_id ) );
 }
 
 /**

--- a/public_html/wp-content/themes/wordcamp-base/lib/options/class-wcb-options.php
+++ b/public_html/wp-content/themes/wordcamp-base/lib/options/class-wcb-options.php
@@ -184,7 +184,7 @@ class WCB_Options extends WCB_Loader {
 
 				</table>
 				<p class="submit">
-					<input type="submit" class="button-primary" value="<?php _e( 'Save Options', 'wordcamporg' ); ?>" />
+					<input type="submit" class="button-primary" value="<?php esc_attr_e( 'Save Options', 'wordcamporg' ); ?>" />
 				</p>
 			</form>
 		</div>

--- a/public_html/wp-content/themes/wordcamp-base/lib/options/class-wcb-options.php
+++ b/public_html/wp-content/themes/wordcamp-base/lib/options/class-wcb-options.php
@@ -142,15 +142,15 @@ class WCB_Options extends WCB_Loader {
 
 		?>
 		<div class="wrap">
-			<h1><?php _e( 'WordCamp Base Theme Options', 'wordcamporg' ); ?></h1>
+			<h1><?php esc_html_e( 'WordCamp Base Theme Options', 'wordcamporg' ); ?></h1>
 
 			<?php if ( false !== $_REQUEST['updated'] ) : ?>
-				<div class="updated fade"><p><strong><?php _e( 'Options saved', 'wordcamporg' ); ?></strong></p></div>
+				<div class="updated fade"><p><strong><?php esc_html_e( 'Options saved', 'wordcamporg' ); ?></strong></p></div>
 			<?php endif; ?>
 
 			<form method="post" action="options.php">
 				<?php settings_fields( 'wcb_theme_options' ); ?>
-				<h3><?php _e('General Options', 'wordcamporg'); ?></h3>
+				<h3><?php esc_html_e( 'General Options', 'wordcamporg' ); ?></h3>
 				<table class="form-table">
 					<?php
 					$this->options['grid']->render();
@@ -159,7 +159,7 @@ class WCB_Options extends WCB_Loader {
 					?>
 				</table>
 
-				<h3><?php _e('Theme Layout', 'wordcamporg'); ?></h3>
+				<h3><?php esc_html_e( 'Theme Layout', 'wordcamporg' ); ?></h3>
 				<table class="form-table">
 					<?php
 					$rows = array( 'after_header', 'before_content', 'content', 'after_content', 'before_footer' ); ?>

--- a/public_html/wp-content/themes/wordcamp-central-2012/loop-attachment.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/loop-attachment.php
@@ -99,7 +99,7 @@ if ( have_posts() )
 								}
 							?>
 							<p class="attachment">
-								<a href="<?php echo esc_url( $next_attachment_url ); ?>" title="<?php esc_attr( the_title_attribute( array( 'echo' => false ) ) ); ?>" rel="attachment">
+								<a href="<?php echo esc_url( $next_attachment_url ); ?>" title="<?php the_title_attribute(); ?>" rel="attachment">
 									<?php
 									$attachment_width  = apply_filters( 'twentyten_attachment_size', 900 );
 									$attachment_height = apply_filters( 'twentyten_attachment_height', 900 );
@@ -113,7 +113,7 @@ if ( have_posts() )
 								<div class="nav-next"><?php next_image_link( false ); ?></div>
 							</div><!-- #nav-below -->
 	<?php else : ?>
-							<a href="<?php echo esc_url( wp_get_attachment_url() ); ?>" title="<?php esc_attr( the_title_attribute( array( 'echo' => false ) ) ); ?>" rel="attachment">
+							<a href="<?php echo esc_url( wp_get_attachment_url() ); ?>" title="<?php the_title_attribute(); ?>" rel="attachment">
 								<?php echo esc_html( basename( get_permalink() ) ); ?>
 							</a>
 <?php endif; ?>

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-past-wordcamps.php
@@ -65,7 +65,7 @@ get_header(); ?>
 										<?php if ( has_post_thumbnail() ) : ?>
 											<?php the_post_thumbnail( 'wccentral-thumbnail-past', array( 'class' => 'wc-image' ) ); ?>
 										<?php else : ?>
-											<div class="wc-image wp-post-image past-wordcamp-placeholder-thumb" title="<?php the_title(); ?>"></div>
+											<div class="wc-image wp-post-image past-wordcamp-placeholder-thumb" title="<?php the_title_attribute(); ?>"></div>
 										<?php endif; ?>
 
 										<h2 class="wc-title"><?php wcpt_wordcamp_title(); ?></h2>

--- a/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
+++ b/public_html/wp-content/themes/wordcamp-central-2012/template-schedule.php
@@ -68,7 +68,7 @@ get_header(); ?>
 										<?php if ( has_post_thumbnail() ) : ?>
 											<?php the_post_thumbnail( 'wccentral-thumbnail-small', array( 'class' => 'wc-image' ) ); ?>
 										<?php else : ?>
-											<div class="wc-image wp-post-image wordcamp-placeholder-thumb" title="<?php the_title(); ?>"></div>
+											<div class="wc-image wp-post-image wordcamp-placeholder-thumb" title="<?php the_title_attribute(); ?>"></div>
 										<?php endif; ?>
 
 										<h2 class="wc-title"><?php wcpt_wordcamp_title(); ?></h2>


### PR DESCRIPTION
### Why

A handful of template tags echo their value without escaping it for the context it lands in, and two more apply an escaper to something that never reaches the page. The shape is easy to miss in review, because the line contains no `$variable` for a scanner to flag.

`phpcs` already reports most of them under `WordPress.Security.EscapeOutput`.

### What changed

- `template-past-wordcamps.php:68` and `template-schedule.php:71` call `the_title_attribute()` instead of `the_title()` for the placeholder thumbnail's `title` attribute, which is the element rendered for any camp with no featured image. The output filters are not a substitute for escaping there: `wptexturize()` leaves the contents of `pre`, `code`, `kbd`, `style`, `script` and `tt` alone (`wp-includes/formatting.php:106`), and `code` is one of the tags kses permits in a post title (`wp-includes/kses.php:126`, wired to `title_save_pre` at `:2548`). `the_title_attribute()` applies `esc_attr( strip_tags() )` after the same filter chain, so a title carrying inline markup renders as its text content rather than as tags.
- `wcpt_wordcamp_url()` and `wcpt_wordcamp_permalink()` wrap their output in `esc_url()`. The first echoed the `URL` post meta straight into an `href`.
- `wcpt_wordcamp_venue_name()`, `wcpt_wordcamp_location()` and `wcpt_wordcamp_organizer_name()` wrap their output in `esc_html()`. Every call site is element-text, and `wordcamp-admin.php` already escapes the same getters for its list table.
- `wcpt_wordcamp_pagination_count()` wraps its output in `esc_html()`. It echoed a translated string raw, and has no callers in the tree today.
- The Base theme's options screen uses `esc_attr_e()` for its submit button label and `esc_html_e()` for the four remaining `_e()` calls in the same method. None of those msgids contain markup, so nothing about the rendered screen changes, and the method already used `esc_html_e()` two lines further down. Translations here are written by locale editors through translate.wordpress.org, who hold no capability on the site.
- `loop-attachment.php:102` and `:116` wrapped `the_title_attribute( 'echo' => false )` in `esc_attr()` and threw the return away, so both rendered an empty `title`. They call `the_title_attribute()` directly, which already escapes.

The six `wcpt_*` tags escape inside the function rather than at the call site, which is where core puts it for an echoing tag (`the_permalink()` is `echo esc_url( … )`). That is invisible to anyone reading the template, so their docblocks now name the context the value is escaped for and list the escaper under `@uses`.

The `wcpt_get_*` getters stay raw on purpose. `wp_parse_url()`, `urlencode()` and `make_clickable()` all consume them, and `wordcamp-admin.php` escapes them for itself, so escaping in the getter would double-encode. Call sites that use a getter and escape it themselves, like `sidebar-schedule.php:46`, are left as they are.

Untouched in the same file: `wcpt_wordcamp_id()` (an integer), `wcpt_wordcamp_start_date()` and `wcpt_wordcamp_end_date()` (formatted through `date()`), `wcpt_wordcamp_title()` (matches core's `the_title()`, which permits the same inline tags), and `wcpt_wordcamp_link()` and `wcpt_wordcamp_pagination_links()`, which build markup and escape as they build it.

### Testing

- `php -l` passes on all five changed files.
- `phpcs` against `phpcs.xml.dist`: the two central-theme listing templates hold steady at 20 errors and 1 warning, and `loop-attachment.php` at 28 and 3, all pre-existing and none on the changed lines. `wordcamp-template.php` and `class-wcb-options.php` drop from 119 errors to 108, six of the eleven being `WordPress.Security.EscapeOutput.OutputNotEscaped` and the other five `WordPress.Security.EscapeOutput.UnsafePrintingFunction` for the `_e()` calls.
- Swept `themes/`, `plugins/` and `mu-plugins/` for a PHP tag opening a quoted attribute value, in both quote styles. Everything remaining either escapes, or emits a generated URL or date.
- Checked against the local Docker environment, with a title and a venue name carrying a `code` element planted on one camp. On `/schedule/past-wordcamps/` the placeholder rendered as `title="Test <code>` beforehand, the attribute ending early and the rest of the title becoming attributes on the `div`; afterwards it is one intact `title="Test &quot; data-probe=&quot;1 Camp"`. On the single camp page the venue name rendered a live `code` element beforehand and literal text afterwards, and the camp URL is unchanged.
- `/schedule/` and the central home page both return 200 but do not exercise a changed line locally, because the seed data has no upcoming camps for the loop to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
