### PR TITLE
WordCamp Base: tidy i18n and output handling in attachment templates

### DIFF
--- a/public_html/wp-content/themes/wordcamp-base/attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/attachment.php
@@ -52,23 +52,23 @@ get_header(); ?>
 								esc_html( get_the_date() )
 							);
 
-							if ( wp_attachment_is_image() ) {
-								$metadata = wp_get_attachment_metadata();
-								
-								if ( ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
-									echo ' <span class="meta-sep">|</span> ';
+						if ( wp_attachment_is_image() ) {
+							$metadata = wp_get_attachment_metadata();
 
-									/* translators: %s - a link reading "<width> × <height>" */
-									printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
-										sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
-											esc_url( wp_get_attachment_url() ),
-											esc_attr__( 'Link to full-size image', 'wordcamporg' ),
-											absint( $metadata['width'] ),
-											absint( $metadata['height'] )
-										)
-									);
-								}
+							if ( ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
+								echo ' <span class="meta-sep">|</span> ';
+
+								/* translators: %s - a link reading "<width> × <height>" */
+								printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
+									sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
+										esc_url( wp_get_attachment_url() ),
+										esc_attr__( 'Link to full-size image', 'wordcamporg' ),
+										absint( $metadata['width'] ),
+										absint( $metadata['height'] )
+									)
+								);
 							}
+						}
 						?>
 						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
 					</div><!-- .entry-meta -->

--- a/public_html/wp-content/themes/wordcamp-base/attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/attachment.php
@@ -36,7 +36,7 @@ get_header(); ?>
 						<?php
 							printf(
 								'<span class="meta-prep meta-prep-author">%1$s</span> <span class="author vcard"><a class="url fn n" href="%2$s" title="%3$s">%4$s</a></span>',
-								esc_html__( 'By', 'wordcamporg' ),
+								esc_html_x( 'By', 'post author byline', 'wordcamporg' ),
 								esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 								/* translators: %s - author display name */
 								sprintf( esc_attr__( 'View all posts by %s', 'wordcamporg' ), esc_attr( get_the_author() ) ),
@@ -47,7 +47,7 @@ get_header(); ?>
 						<?php
 							printf(
 								'<span class="meta-prep meta-prep-entry-date">%1$s</span> <span class="entry-date"><abbr class="published" title="%2$s">%3$s</abbr></span>',
-								esc_html__( 'Published', 'wordcamporg' ),
+								esc_html_x( 'Published', 'post publication date', 'wordcamporg' ),
 								esc_attr( get_the_time() ),
 								esc_html( get_the_date() )
 							);

--- a/public_html/wp-content/themes/wordcamp-base/attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/attachment.php
@@ -18,12 +18,13 @@ get_header(); ?>
 					<p class="page-title">
 						<a
 							href="<?php echo esc_url( get_permalink( $post->post_parent ) ); ?>"
-							title="<?php esc_attr( printf( __( 'Return to %s', 'wordcamporg' ), get_the_title( $post->post_parent ) ) ); ?>"
+							title="<?php
+								/* translators: %s - title of parent post */
+								printf( esc_attr__( 'Return to %s', 'wordcamporg' ), esc_attr( get_the_title( $post->post_parent ) ) );
+							?>"
 							rel="gallery">
-							<?php
-							/* translators: %s - title of parent post */
-							printf( __( '<span class="meta-nav">&larr;</span> %s', 'wordcamporg' ), get_the_title( $post->post_parent ) );
-							?>
+							<span class="meta-nav">&larr;</span>
+							<?php echo esc_html( get_the_title( $post->post_parent ) ); ?>
 						</a>
 					</p>
 				<?php endif; ?>
@@ -33,23 +34,22 @@ get_header(); ?>
 
 					<div class="entry-meta">
 						<?php
-							printf(__('<span class="%1$s">By</span> %2$s', 'wordcamporg' ),
-								'meta-prep meta-prep-author',
-								sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s">%3$s</a></span>',
-									get_author_posts_url( get_the_author_meta( 'ID' ) ),
-									sprintf( esc_attr__( 'View all posts by %s', 'wordcamporg' ), get_the_author() ),
-									get_the_author()
-								)
+							printf(
+								'<span class="meta-prep meta-prep-author">%1$s</span> <span class="author vcard"><a class="url fn n" href="%2$s" title="%3$s">%4$s</a></span>',
+								esc_html__( 'By', 'wordcamporg' ),
+								esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+								/* translators: %s - author display name */
+								sprintf( esc_attr__( 'View all posts by %s', 'wordcamporg' ), esc_attr( get_the_author() ) ),
+								esc_html( get_the_author() )
 							);
 						?>
 						<span class="meta-sep">|</span>
 						<?php
-							printf( __('<span class="%1$s">Published</span> %2$s', 'wordcamporg' ),
-								'meta-prep meta-prep-entry-date',
-								sprintf( '<span class="entry-date"><abbr class="published" title="%1$s">%2$s</abbr></span>',
-									esc_attr( get_the_time() ),
-									get_the_date()
-								)
+							printf(
+								'<span class="meta-prep meta-prep-entry-date">%1$s</span> <span class="entry-date"><abbr class="published" title="%2$s">%3$s</abbr></span>',
+								esc_html__( 'Published', 'wordcamporg' ),
+								esc_attr( get_the_time() ),
+								esc_html( get_the_date() )
 							);
 
 							if ( wp_attachment_is_image() ) {
@@ -58,18 +58,19 @@ get_header(); ?>
 								if ( ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
 									echo ' <span class="meta-sep">|</span> ';
 
-									printf( __( 'Full size is %s pixels', 'wordcamporg' ),
+									/* translators: %s - a link reading "<width> × <height>" */
+									printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
 										sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
-											wp_get_attachment_url(),
-											esc_attr( __('Link to full-size image', 'wordcamporg' ) ),
-											$metadata['width'],
-											$metadata['height']
+											esc_url( wp_get_attachment_url() ),
+											esc_attr__( 'Link to full-size image', 'wordcamporg' ),
+											absint( $metadata['width'] ),
+											absint( $metadata['height'] )
 										)
 									);
 								}
 							}
 						?>
-						<?php edit_post_link( __( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
 					</div><!-- .entry-meta -->
 
 					<div class="entry-content">
@@ -124,17 +125,17 @@ get_header(); ?>
 						<div class="entry-caption"><?php if ( !empty( $post->post_excerpt ) ) the_excerpt(); ?></div>
 
 <?php the_content( sprintf(
-	// translators: The title of the post to continue reading
-	__( 'Continue reading %s <span class="meta-nav">&rarr;</span>', 'wordcamporg' ),
-	the_title( '<span class="screen-reader-text">', '</span> ', false )
-) ); ?>
-<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'wordcamporg' ), 'after' => '</div>' ) ); ?>
+	/* translators: %s - the title of the post to continue reading */
+	esc_html__( 'Continue reading %s', 'wordcamporg' ),
+	'<span class="screen-reader-text">' . esc_html( get_the_title() ) . '</span> '
+) . '<span class="meta-nav">&rarr;</span>' ); ?>
+<?php wp_link_pages( array( 'before' => '<div class="page-link">' . esc_html__( 'Pages:', 'wordcamporg' ), 'after' => '</div>' ) ); ?>
 
 					</div><!-- .entry-content -->
 
 					<div class="entry-utility">
 						<?php twentyten_posted_in(); ?>
-						<?php edit_post_link( __( 'Edit', 'wordcamporg' ), ' <span class="edit-link">', '</span>' ); ?>
+						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), ' <span class="edit-link">', '</span>' ); ?>
 					</div><!-- .entry-utility -->
 				</div><!-- #post-## -->
 

--- a/public_html/wp-content/themes/wordcamp-base/attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/attachment.php
@@ -124,12 +124,22 @@ get_header(); ?>
 						</div><!-- .entry-attachment -->
 						<div class="entry-caption"><?php if ( !empty( $post->post_excerpt ) ) the_excerpt(); ?></div>
 
-<?php the_content( sprintf(
-	/* translators: %s - the title of the post to continue reading */
-	esc_html__( 'Continue reading %s', 'wordcamporg' ),
-	'<span class="screen-reader-text">' . esc_html( get_the_title() ) . '</span> '
-) . '<span class="meta-nav">&rarr;</span>' ); ?>
-<?php wp_link_pages( array( 'before' => '<div class="page-link">' . esc_html__( 'Pages:', 'wordcamporg' ), 'after' => '</div>' ) ); ?>
+						<?php
+						the_content(
+							sprintf(
+								/* translators: %s - the title of the post to continue reading */
+								esc_html__( 'Continue reading %s', 'wordcamporg' ),
+								'<span class="screen-reader-text">' . esc_html( get_the_title() ) . '</span> '
+							) . '<span class="meta-nav">&rarr;</span>'
+						);
+
+						wp_link_pages(
+							array(
+								'before' => '<div class="page-link">' . esc_html__( 'Pages:', 'wordcamporg' ),
+								'after'  => '</div>',
+							)
+						);
+						?>
 
 					</div><!-- .entry-content -->
 

--- a/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
@@ -55,23 +55,23 @@
 								esc_html( get_the_date() )
 							);
 
-							if ( wp_attachment_is_image() ) {
-								$metadata = wp_get_attachment_metadata();
+						if ( wp_attachment_is_image() ) {
+							$metadata = wp_get_attachment_metadata();
 
-								if ( ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
-									echo ' <span class="meta-sep">|</span> ';
+							if ( ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
+								echo ' <span class="meta-sep">|</span> ';
 
-									/* translators: %s - a link reading "<width> × <height>" */
-									printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
-										sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
-											esc_url( wp_get_attachment_url() ),
-											esc_attr__( 'Link to full-size image', 'wordcamporg' ),
-											absint( $metadata['width'] ),
-											absint( $metadata['height'] )
-										)
-									);
-								}
+								/* translators: %s - a link reading "<width> × <height>" */
+								printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
+									sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
+										esc_url( wp_get_attachment_url() ),
+										esc_attr__( 'Link to full-size image', 'wordcamporg' ),
+										absint( $metadata['width'] ),
+										absint( $metadata['height'] )
+									)
+								);
 							}
+						}
 						?>
 						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
 					</div><!-- .entry-meta -->

--- a/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
@@ -39,7 +39,7 @@
 						<?php
 							printf(
 								'<span class="meta-prep meta-prep-author">%1$s</span> <span class="author vcard"><a class="url fn n" href="%2$s" title="%3$s">%4$s</a></span>',
-								esc_html__( 'By', 'wordcamporg' ),
+								esc_html_x( 'By', 'post author byline', 'wordcamporg' ),
 								esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 								/* translators: %s - author display name */
 								sprintf( esc_attr__( 'View all posts by %s', 'wordcamporg' ), esc_attr( get_the_author() ) ),
@@ -50,22 +50,27 @@
 						<?php
 							printf(
 								'<span class="meta-prep meta-prep-entry-date">%1$s</span> <span class="entry-date"><abbr class="published" title="%2$s">%3$s</abbr></span>',
-								esc_html__( 'Published', 'wordcamporg' ),
+								esc_html_x( 'Published', 'post publication date', 'wordcamporg' ),
 								esc_attr( get_the_time() ),
 								esc_html( get_the_date() )
 							);
+
 							if ( wp_attachment_is_image() ) {
-								echo ' <span class="meta-sep">|</span> ';
 								$metadata = wp_get_attachment_metadata();
-								/* translators: %s - a link reading "<width> × <height>" */
-								printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
-									sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
-										esc_url( wp_get_attachment_url() ),
-										esc_attr__( 'Link to full-size image', 'wordcamporg' ),
-										absint( $metadata['width'] ),
-										absint( $metadata['height'] )
-									)
-								);
+
+								if ( ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
+									echo ' <span class="meta-sep">|</span> ';
+
+									/* translators: %s - a link reading "<width> × <height>" */
+									printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
+										sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
+											esc_url( wp_get_attachment_url() ),
+											esc_attr__( 'Link to full-size image', 'wordcamporg' ),
+											absint( $metadata['width'] ),
+											absint( $metadata['height'] )
+										)
+									);
+								}
 							}
 						?>
 						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>

--- a/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
@@ -21,12 +21,13 @@
 					<p class="page-title">
 						<a
 							href="<?php echo esc_url( get_permalink( $post->post_parent ) ); ?>"
-							title="<?php esc_attr( printf( __( 'Return to %s', 'wordcamporg' ), get_the_title( $post->post_parent ) ) ); ?>"
+							title="<?php
+								/* translators: %s - title of parent post */
+								printf( esc_attr__( 'Return to %s', 'wordcamporg' ), esc_attr( get_the_title( $post->post_parent ) ) );
+							?>"
 							rel="gallery">
-							<?php
-							/* translators: %s - title of parent post */
-							printf( __( '<span class="meta-nav">&larr;</span> %s', 'wordcamporg' ), get_the_title( $post->post_parent ) );
-							?>
+							<span class="meta-nav">&larr;</span>
+							<?php echo esc_html( get_the_title( $post->post_parent ) ); ?>
 						</a>
 					</p>
 				<?php endif; ?>
@@ -36,38 +37,38 @@
 
 					<div class="entry-meta">
 						<?php
-							printf( __( '<span class="%1$s">By</span> %2$s', 'wordcamporg' ),
-								'meta-prep meta-prep-author',
-								sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s">%3$s</a></span>',
-									get_author_posts_url( get_the_author_meta( 'ID' ) ),
-									sprintf( esc_attr__( 'View all posts by %s', 'wordcamporg' ), get_the_author() ),
-									get_the_author()
-								)
+							printf(
+								'<span class="meta-prep meta-prep-author">%1$s</span> <span class="author vcard"><a class="url fn n" href="%2$s" title="%3$s">%4$s</a></span>',
+								esc_html__( 'By', 'wordcamporg' ),
+								esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+								/* translators: %s - author display name */
+								sprintf( esc_attr__( 'View all posts by %s', 'wordcamporg' ), esc_attr( get_the_author() ) ),
+								esc_html( get_the_author() )
 							);
 						?>
 						<span class="meta-sep">|</span>
 						<?php
-							printf( __( '<span class="%1$s">Published</span> %2$s', 'wordcamporg' ),
-								'meta-prep meta-prep-entry-date',
-								sprintf( '<span class="entry-date"><abbr class="published" title="%1$s">%2$s</abbr></span>',
-									esc_attr( get_the_time() ),
-									get_the_date()
-								)
+							printf(
+								'<span class="meta-prep meta-prep-entry-date">%1$s</span> <span class="entry-date"><abbr class="published" title="%2$s">%3$s</abbr></span>',
+								esc_html__( 'Published', 'wordcamporg' ),
+								esc_attr( get_the_time() ),
+								esc_html( get_the_date() )
 							);
 							if ( wp_attachment_is_image() ) {
 								echo ' <span class="meta-sep">|</span> ';
 								$metadata = wp_get_attachment_metadata();
-								printf( __( 'Full size is %s pixels', 'wordcamporg' ),
+								/* translators: %s - a link reading "<width> × <height>" */
+								printf( esc_html__( 'Full size is %s pixels', 'wordcamporg' ),
 									sprintf( '<a href="%1$s" title="%2$s">%3$s &times; %4$s</a>',
-										wp_get_attachment_url(),
-										esc_attr( __( 'Link to full-size image', 'wordcamporg' ) ),
-										$metadata['width'],
-										$metadata['height']
+										esc_url( wp_get_attachment_url() ),
+										esc_attr__( 'Link to full-size image', 'wordcamporg' ),
+										absint( $metadata['width'] ),
+										absint( $metadata['height'] )
 									)
 								);
 							}
 						?>
-						<?php edit_post_link( __( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
+						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), '<span class="meta-sep">|</span> <span class="edit-link">', '</span>' ); ?>
 					</div><!-- .entry-meta -->
 
 					<div class="entry-content">
@@ -121,17 +122,17 @@
 						<div class="entry-caption"><?php if ( !empty( $post->post_excerpt ) ) the_excerpt(); ?></div>
 
 <?php the_content( sprintf(
-	// translators: The title of the post to continue reading
-	__( 'Continue reading %s <span class="meta-nav">&rarr;</span>', 'wordcamporg' ),
-	the_title( '<span class="screen-reader-text">', '</span> ', false )
-) ); ?>
-<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'wordcamporg' ), 'after' => '</div>' ) ); ?>
+	/* translators: %s - the title of the post to continue reading */
+	esc_html__( 'Continue reading %s', 'wordcamporg' ),
+	'<span class="screen-reader-text">' . esc_html( get_the_title() ) . '</span> '
+) . '<span class="meta-nav">&rarr;</span>' ); ?>
+<?php wp_link_pages( array( 'before' => '<div class="page-link">' . esc_html__( 'Pages:', 'wordcamporg' ), 'after' => '</div>' ) ); ?>
 
 					</div><!-- .entry-content -->
 
 					<div class="entry-utility">
 						<?php twentyten_posted_in(); ?>
-						<?php edit_post_link( __( 'Edit', 'wordcamporg' ), ' <span class="edit-link">', '</span>' ); ?>
+						<?php edit_post_link( esc_html__( 'Edit', 'wordcamporg' ), ' <span class="edit-link">', '</span>' ); ?>
 					</div><!-- .entry-utility -->
 				</div><!-- #post-## -->
 

--- a/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
+++ b/public_html/wp-content/themes/wordcamp-base/loop-attachment.php
@@ -121,12 +121,22 @@
 						</div><!-- .entry-attachment -->
 						<div class="entry-caption"><?php if ( !empty( $post->post_excerpt ) ) the_excerpt(); ?></div>
 
-<?php the_content( sprintf(
-	/* translators: %s - the title of the post to continue reading */
-	esc_html__( 'Continue reading %s', 'wordcamporg' ),
-	'<span class="screen-reader-text">' . esc_html( get_the_title() ) . '</span> '
-) . '<span class="meta-nav">&rarr;</span>' ); ?>
-<?php wp_link_pages( array( 'before' => '<div class="page-link">' . esc_html__( 'Pages:', 'wordcamporg' ), 'after' => '</div>' ) ); ?>
+						<?php
+						the_content(
+							sprintf(
+								/* translators: %s - the title of the post to continue reading */
+								esc_html__( 'Continue reading %s', 'wordcamporg' ),
+								'<span class="screen-reader-text">' . esc_html( get_the_title() ) . '</span> '
+							) . '<span class="meta-nav">&rarr;</span>'
+						);
+
+						wp_link_pages(
+							array(
+								'before' => '<div class="page-link">' . esc_html__( 'Pages:', 'wordcamporg' ),
+								'after'  => '</div>',
+							)
+						);
+						?>
 
 					</div><!-- .entry-content -->
 


### PR DESCRIPTION
## What

Housekeeping pass over the two `wordcamp-base` attachment templates.

- **Markup out of translatable strings.** Several msgids wrapped their text in `<span>` markup, or consisted of nothing but markup and a placeholder. That markup now lives in the templates, so the msgids carry only translatable text.
- **Consistent escaping at each output.** Every interpolated value now goes through the helper that matches its context — `esc_url()` for hrefs, `esc_attr()` for attribute values, `esc_html()` for element text, `absint()` for the image dimensions.
- **Translator comments** added for all four remaining placeholder strings.

No change to the rendered markup, classes, or visible output.

## Why

These templates predate the current coding standards, so they mixed markup into msgids and passed a number of values straight to output. Keeping markup out of translatable strings is what the i18n guidelines ask for, and it leaves the remaining strings much easier to translate — `By` and `Published` instead of `<span class="%1$s">By</span> %2$s`.

## Translation impact

Three msgids are retired and four short ones added:

| Retired | Replaced by |
| --- | --- |
| `<span class="meta-nav">&larr;</span> %s` | *(nothing — it contained no words)* |
| `<span class="%1$s">By</span> %2$s` | `By` |
| `<span class="%1$s">Published</span> %2$s` | `Published` |
| `Continue reading %s <span class="meta-nav">&rarr;</span>` | `Continue reading %s` |

Existing locale translations for the retired strings will orphan until the new ones are translated. That is two words of actual copy, so the churn is small.

`Return to %s`, `View all posts by %s`, `Full size is %s pixels`, `Link to full-size image`, `Pages:` and `Edit` are all unchanged.

## Testing

These templates take a little setup to reach, because attachment pages are turned off network-wide. Steps 1–3 are local-only changes; step 7 reverts them.

1. **Activate the theme** on a local test site:
   ```
   wp theme activate wordcamp-base --url=<site>
   ```

2. **Turn off the Coming Soon page**, which otherwise replaces the theme's templates entirely and you will see the splash page instead of the attachment page:
   ```
   wp option patch update wccsp_settings enabled off --url=<site>
   ```

3. **Let attachment pages render.** `mu-plugins/wcorg-misc.php:81` forces the option off for every site, which makes core 301 the attachment page to the file URL. Comment that line out locally:
   ```php
   // add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_zero' );
   ```
   Then confirm the underlying option is on — legacy sites already have it set, new installs do not:
   ```
   wp option get wp_attachment_pages_enabled --url=<site>   # expect 1
   wp option update wp_attachment_pages_enabled 1 --url=<site>   # only if it returned 0
   ```

4. **Find an image attachment that has a parent post:**
   ```
   wp post list --post_type=attachment --fields=ID,post_title,post_name,post_parent --url=<site>
   ```
   Its URL is the parent post's permalink plus the attachment's `post_name`, e.g. `/<year>/<parent-slug>/<attachment-slug>/`.

5. **Compare the page before and after.** Attachment pages are disabled on every production site, so there is no live page to compare against — render the `production` branch's copy of these two files locally instead:
   ```
   curl -s '<attachment-url>' > /tmp/after.html
   git checkout production -- public_html/wp-content/themes/wordcamp-base/attachment.php \
                              public_html/wp-content/themes/wordcamp-base/loop-attachment.php
   curl -s '<attachment-url>' > /tmp/before.html
   git checkout HEAD -- public_html/wp-content/themes/wordcamp-base/attachment.php \
                        public_html/wp-content/themes/wordcamp-base/loop-attachment.php
   diff -w /tmp/before.html /tmp/after.html   # expect no output
   ```
   Or check by eye — these are the elements the diff touches:
   - the `&larr; <parent post title>` link above the image, including its `title` attribute
   - the `By <author>` byline — author link `href` and `title`
   - the `Published <date>` meta, including the `<abbr class="published" title="…">` wrapper
   - the `Full size is <width> &times; <height> pixels` link
   - `Edit` and `Pages:` links, where they appear

6. **Check two edge cases:**
   - a non-image attachment (e.g. a PDF), which should still render its filename link
   - an author whose display name contains an apostrophe or an ampersand, to confirm the byline still reads correctly

7. **Revert the local setup:** restore `wcorg-misc.php:81`, and set `wccsp_settings.enabled` back to `on` if the site had it on.

Verified locally following the steps above: the rendered page is unchanged from the `production` branch apart from insignificant whitespace, and `php -l` is clean on both files.

Note that CI lints only changed lines, so this PR brings these lines into scope for the coding-standards sniffs for the first time.
