### PR TITLE
WC Post Types: consistent output escaping in the schedule grid

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
@@ -26,6 +26,20 @@ class Test_Schedule_Shortcode extends WP_UnitTestCase {
 	const TRACK_NAME = 'Main Hall" data-extra="1';
 
 	/**
+	 * A session title holding markup that survives `wp_filter_kses()`.
+	 *
+	 * `title_save_pre` runs post titles through kses, not through an entity
+	 * encoder, so any tag in the small `$allowedtags` set (`em`, `code`, `a`,
+	 * ...) is stored as-is and reaches the renderer intact.
+	 */
+	const SESSION_TITLE = 'Opening <em>Remarks</em>';
+
+	/**
+	 * A speaker name holding the same kses-permitted markup.
+	 */
+	const SPEAKER_NAME = 'Ada <em>Lovelace</em>';
+
+	/**
 	 * Track term ID.
 	 *
 	 * @var int
@@ -40,19 +54,32 @@ class Test_Schedule_Shortcode extends WP_UnitTestCase {
 	protected static $session_id;
 
 	/**
-	 * Create one track and one scheduled session on it.
+	 * Speaker post ID.
+	 *
+	 * @var int
+	 */
+	protected static $speaker_id;
+
+	/**
+	 * Create one track, one speaker, and one scheduled session joining them.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
 		$track = wp_insert_term( self::TRACK_NAME, 'wcb_track', array( 'slug' => 'main-hall' ) );
 
 		self::$track_id = $track['term_id'];
 
+		self::$speaker_id = $factory->post->create( array(
+			'post_type'  => 'wcb_speaker',
+			'post_title' => self::SPEAKER_NAME,
+		) );
+
 		self::$session_id = $factory->post->create( array(
 			'post_type'  => 'wcb_session',
-			'post_title' => 'Opening Remarks',
+			'post_title' => self::SESSION_TITLE,
 			'meta_input' => array(
 				'_wcpt_session_time' => 1786788000,
 				'_wcpt_session_type' => 'session',
+				'_wcpt_speaker_id'   => self::$speaker_id,
 			),
 		) );
 
@@ -99,6 +126,64 @@ class Test_Schedule_Shortcode extends WP_UnitTestCase {
 		$this->assertStringContainsString(
 			'<span class="wcpt-track-name">' . esc_html( self::TRACK_NAME ) . '</span>',
 			$html
+		);
+	}
+
+	/**
+	 * The session title is displayed as text, both in the cell and in the
+	 * favorite-session button's screen-reader label.
+	 *
+	 * @covers WordCamp_Post_Types_Plugin::shortcode_schedule
+	 */
+	public function test_session_title_is_escaped(): void {
+		$html = $this->render_schedule();
+
+		$this->assertStringContainsString( esc_html( self::SESSION_TITLE ), $html );
+		$this->assertStringContainsString(
+			sprintf( 'Favorite session: %s', esc_html( self::SESSION_TITLE ) ),
+			$html
+		);
+		$this->assertStringNotContainsString( '<em>', $html );
+	}
+
+	/**
+	 * The session title is displayed as text in the `session_link="none"`
+	 * variant too, which uses a `<span>` instead of an anchor.
+	 *
+	 * @covers WordCamp_Post_Types_Plugin::shortcode_schedule
+	 */
+	public function test_session_title_is_escaped_without_a_link(): void {
+		$html = $this->render_schedule( array( 'session_link' => 'none' ) );
+
+		$this->assertStringContainsString(
+			'<span class="wcpt-session-title">' . esc_html( self::SESSION_TITLE ) . '</span>',
+			$html
+		);
+		$this->assertStringNotContainsString( '<em>', $html );
+	}
+
+	/**
+	 * Speaker names are displayed as text whether or not they are wrapped in a
+	 * link, so the escaping can't live in the linked branch alone.
+	 *
+	 * @covers WordCamp_Post_Types_Plugin::shortcode_schedule
+	 *
+	 * @dataProvider data_speaker_link_variants
+	 */
+	public function test_speaker_name_is_escaped( string $speaker_link ): void {
+		$html = $this->render_schedule( array( 'speaker_link' => $speaker_link ) );
+
+		$this->assertStringContainsString( esc_html( self::SPEAKER_NAME ), $html );
+		$this->assertStringNotContainsString( '<em>', $html );
+	}
+
+	/**
+	 * Test cases for test_speaker_name_is_escaped().
+	 */
+	public function data_speaker_link_variants(): array {
+		return array(
+			'linked names'   => array( 'permalink' ),
+			'unlinked names' => array( 'none' ),
 		);
 	}
 }

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace WordCamp\WC_Post_Types\Tests;
+
+use WP_UnitTestCase, WP_UnitTest_Factory;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the markup that `[schedule]` builds.
+ *
+ * The grid is assembled by hand with `sprintf()` rather than by a template, so
+ * these cover that each value taken from user-entered content -- track names,
+ * session titles and speaker names -- is escaped for the position it lands in.
+ *
+ * @group wc-post-types
+ */
+class Test_Schedule_Shortcode extends WP_UnitTestCase {
+	/**
+	 * A track name holding the characters that matter in an attribute value.
+	 *
+	 * Term names keep double quotes verbatim: core's `pre_term_name` filters
+	 * run `_wp_specialchars()` with the default `ENT_NOQUOTES`, so `<` and `>`
+	 * are encoded on save but `"` is not.
+	 */
+	const TRACK_NAME = 'Main Hall" data-extra="1';
+
+	/**
+	 * Track term ID.
+	 *
+	 * @var int
+	 */
+	protected static $track_id;
+
+	/**
+	 * Session post ID.
+	 *
+	 * @var int
+	 */
+	protected static $session_id;
+
+	/**
+	 * Create one track and one scheduled session on it.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		$track = wp_insert_term( self::TRACK_NAME, 'wcb_track', array( 'slug' => 'main-hall' ) );
+
+		self::$track_id = $track['term_id'];
+
+		self::$session_id = $factory->post->create( array(
+			'post_type'  => 'wcb_session',
+			'post_title' => 'Opening Remarks',
+			'meta_input' => array(
+				'_wcpt_session_time' => 1786788000,
+				'_wcpt_session_type' => 'session',
+			),
+		) );
+
+		wp_set_object_terms( self::$session_id, array( self::$track_id ), 'wcb_track' );
+	}
+
+	/**
+	 * Render the schedule grid.
+	 *
+	 * @param array $attributes Shortcode attributes to override.
+	 */
+	protected function render_schedule( array $attributes = array() ): string {
+		return $GLOBALS['wcpt_plugin']->shortcode_schedule( $attributes, '' );
+	}
+
+	/**
+	 * The track name lands in the `data-track-title` attribute, so a double
+	 * quote in it has to be encoded rather than closing the attribute early.
+	 *
+	 * @covers WordCamp_Post_Types_Plugin::shortcode_schedule
+	 */
+	public function test_track_name_is_escaped_in_the_cell_attribute(): void {
+		$html = $this->render_schedule();
+
+		$this->assertStringContainsString(
+			'data-track-title="' . esc_attr( self::TRACK_NAME ) . '"',
+			$html
+		);
+
+		// With the quote encoded, the rest of the name stays inside the value
+		// instead of becoming a second attribute on the cell.
+		$this->assertStringNotContainsString( 'data-extra="1"', $html );
+	}
+
+	/**
+	 * The same track name is displayed as text in the column heading, where it
+	 * was already escaped -- kept as a regression guard on the pair.
+	 *
+	 * @covers WordCamp_Post_Types_Plugin::shortcode_schedule
+	 */
+	public function test_track_name_is_escaped_in_the_column_heading(): void {
+		$html = $this->render_schedule();
+
+		$this->assertStringContainsString(
+			'<span class="wcpt-track-name">' . esc_html( self::TRACK_NAME ) . '</span>',
+			$html
+		);
+	}
+}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -572,18 +572,19 @@ class WordCamp_Post_Types_Plugin {
 
 				// Determine the session title.
 				if ( 'permalink' === $attr['session_link'] && 'session' === $session_type ) {
-					$session_title_html = sprintf( '<a class="wcpt-session-title" href="%s">%s</a>', esc_url( get_permalink( $session->ID ) ), $session_title );
+					$session_title_html = sprintf( '<a class="wcpt-session-title" href="%s">%s</a>', esc_url( get_permalink( $session->ID ) ), esc_html( $session_title ) );
 				} elseif ( 'anchor' === $attr['session_link'] && 'session' === $session_type ) {
-					$session_title_html = sprintf( '<a class="wcpt-session-title" href="%s">%s</a>', esc_url( $this->get_wcpt_anchor_permalink( $session->ID ) ), $session_title );
+					$session_title_html = sprintf( '<a class="wcpt-session-title" href="%s">%s</a>', esc_url( $this->get_wcpt_anchor_permalink( $session->ID ) ), esc_html( $session_title ) );
 				} else {
-					$session_title_html = sprintf( '<span class="wcpt-session-title">%s</span>', $session_title );
+					$session_title_html = sprintf( '<span class="wcpt-session-title">%s</span>', esc_html( $session_title ) );
 				}
 
 				$content .= $session_title_html;
 
 				$speakers_names = array();
 				foreach ( $speakers as $speaker ) {
-					$speaker_name = apply_filters( 'the_title', $speaker->post_title );
+					$speaker_name      = esc_html( apply_filters( 'the_title', $speaker->post_title ) );
+					$speaker_permalink = '';
 
 					if ( 'anchor' === $attr['speaker_link'] ) {
 						// speakers/#wcorg-speaker-slug.
@@ -597,7 +598,7 @@ class WordCamp_Post_Types_Plugin {
 					}
 
 					if ( ! empty( $speaker_permalink ) ) {
-						$speaker_name = sprintf( '<a href="%s">%s</a>', esc_url( $speaker_permalink ), esc_html( $speaker_name ) );
+						$speaker_name = sprintf( '<a href="%s">%s</a>', esc_url( $speaker_permalink ), $speaker_name );
 					}
 
 					$speakers_names[] = $speaker_name;
@@ -615,7 +616,7 @@ class WordCamp_Post_Types_Plugin {
 				if ( 'session' === $session_type ) {
 					$content .= '<div class="wcb-session-favourite-icon">';
 					$content .= '<a href="#" role="button" class="fav-session-button" aria-pressed="false"><span class="screen-reader-text">';
-					$content .= sprintf( esc_html__( 'Favorite session: %s', 'wordcamporg' ), $session_title );
+					$content .= sprintf( esc_html__( 'Favorite session: %s', 'wordcamporg' ), esc_html( $session_title ) );
 					$content .= '</span><span class="dashicons dashicons-star-filled"></span></a></div>';
 				}
 

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -637,7 +637,7 @@ class WordCamp_Post_Types_Plugin {
 					}
 				}
 
-				$columns_html .= sprintf( '<td colspan="%d" class="%s" data-track-title="%s" data-session-id="%s">%s</td>', $colspan, esc_attr( implode( ' ', $classes ) ), $session_track_titles, esc_attr( $session->ID ), $content );
+				$columns_html .= sprintf( '<td colspan="%d" class="%s" data-track-title="%s" data-session-id="%s">%s</td>', (int) $colspan, esc_attr( implode( ' ', $classes ) ), esc_attr( $session_track_titles ), esc_attr( $session->ID ), $content );
 			}
 
 			$global_session      = count( $columns ) === $colspan ? ' global-session' : '';


### PR DESCRIPTION
## Summary

`shortcode_schedule()` builds the schedule grid by hand with `sprintf()` rather than through a template, and a few of the values it interpolates were missing an escaper. This makes the escaping consistent across the function.

- `data-track-title` was the only value in the cell's `sprintf()` not passed through `esc_attr()` — `class` and `data-session-id` on either side of it already were. Track names keep double quotes verbatim on save (`_wp_specialchars()` runs with `ENT_NOQUOTES` on `pre_term_name`), so an unescaped quote ends the attribute early and the rest of the name is parsed as further attributes on the `<td>`.
- Session titles were interpolated as-is into the cell anchor, the no-link `<span>` variant, and the favourite button's screen-reader label. `title_save_pre` runs post titles through kses rather than an entity encoder, so any tag in the small `$allowedtags` set (`em`, `code`, `a`, …) survives the save and renders as markup in the grid.
- Speaker names were escaped only inside the branch that wraps them in a link, so `speaker_link="none"` emitted them raw. The escaping now happens once where the name is built.
- `$speaker_permalink` wasn't reset between loop iterations, so a speaker whose `get_permalink()` came back empty inherited the previous speaker's URL.
- `colspan` is cast to int while we're on that line.

The same values are already escaped elsewhere in the function — the track name in the column heading uses `esc_html()`, and speaker names in the linked branch did too — so this brings the outliers in line rather than introducing a new convention.

## Test plan

- [x] phpcs clean on both changed files (remaining warnings in `wc-post-types.php` are pre-existing and on untouched lines)
- [x] `php -l` clean
- [x] phpunit — new `Test_Schedule_Shortcode` suite, running in CI on this PR
- [x] Manual browser pass (steps below)

New test file `tests/test-schedule-shortcode.php` covers the cell attribute, the column heading that renders the same track name as text, the session title in both link variants and in the screen-reader label, and speaker names with and without links.

### Manual test steps

Verified by hand on a local multisite camp site. The local phpunit container wouldn't finish building, so the automated suite is running in CI here rather than locally — everything below was exercised in a real browser.

1. As an Editor on a camp site, create a session track whose name contains a double quote followed by something that looks like another attribute, e.g. `Main Hall" data-extra="1`.
<img width="294" height="155" alt="Edit_Session_“Session_1”_‹_WordCamp_Seattle_2023_—_WordPress" src="https://github.com/user-attachments/assets/2d5df721-88bf-481e-af63-fe480239d1a7" />

2. Create a published session, assign it to that track, and set a session time in the Session metabox so the grid renders it.
3. Put `[schedule]` on a published page and load that page while logged out.
4. Inspect the rendered `<td>`: before this change the quote closed `data-track-title` and everything after it became real attributes on the cell; after it, the whole name stays inside the attribute value and the cell has only the four attributes it's meant to have.

| Before | After |
| --- | --- |
| <img width="746" height="327" alt="Schedule__shortcode____WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/9416fad1-1040-4954-bc5e-1915c9c8301f" /> | <img width="736" height="304" alt="Schedule__shortcode____WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/583b2b1b-c910-4bf2-973a-7bf471a5c6e2" /> |

5. Set a session title containing kses-permitted markup via a path that doesn't pre-encode it — e.g. wp post update <id> --post_title="Session <em>1</em>", or a REST POST to /wp-json/wp/v2/sessions/<id>. Typing it into the block editor's title field will not work: that field encodes </> on input, so the title arrives already entity-encoded and renders as text either way. Reload the schedule and confirm the markup shows as visible text in the cell, the speaker list, and the favourite button's screen-reader label.

| Before | After |
| --- | --- |
| <img width="752" height="390" alt="Schedule__shortcode____WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/ffc82fe1-6f2c-4f0a-9150-ffd8795e9296" /> | <img width="781" height="446" alt="Schedule__shortcode____WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/74b10a33-ffe6-4da1-ad86-5f177ae899de" /> |

6. Repeat step 5 with `[schedule speaker_link="none"]` and `[schedule session_link="none"]` to cover the unlinked branches.
