### PR TITLE
Jetpack: normalize meta values on the Unified Importer routes

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/import-meta.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/import-meta.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Normalize the post meta the Jetpack Unified Importer receives.
+ *
+ * The importer recreates post meta from an export and runs `maybe_unserialize()` on each value so
+ * that values a WXR export stored serialized are restored. Imported meta is always plain data
+ * (scalars and arrays), so we decode any serialized value ourselves -- without instantiating
+ * classes -- and hand the plain result back to the importer. Normal imports keep working, and the
+ * importer only ever receives plain data from the request.
+ *
+ * @package WordCamp\Jetpack_Tweaks
+ */
+
+namespace WordCamp\Jetpack_Tweaks\Import_Meta;
+
+use WP_REST_Request;
+
+defined( 'WPINC' ) || die();
+
+add_filter( 'rest_request_before_callbacks', __NAMESPACE__ . '\normalize_import_meta', 10, 3 );
+
+/**
+ * Replace serialized meta values on the Jetpack import routes with plain, object-free values.
+ *
+ * @param mixed $response The response so far. Returned unchanged.
+ * @param array $handler  The matched route handler.
+ * @param mixed $request  The current request object.
+ *
+ * @return mixed The unchanged $response.
+ */
+function normalize_import_meta( $response, $handler, $request ) {
+	if ( ! $request instanceof WP_REST_Request ) {
+		return $response;
+	}
+
+	$route = $request->get_route();
+
+	if ( ! is_string( $route ) || 0 !== strpos( $route, '/jetpack/v4/import/' ) ) {
+		return $response;
+	}
+
+	$metas = $request->get_param( 'meta' );
+
+	if ( ! is_array( $metas ) ) {
+		return $response;
+	}
+
+	$changed = false;
+
+	foreach ( $metas as $key => $value ) {
+		$clean = decode_without_objects( $value );
+
+		if ( $clean !== $value ) {
+			$metas[ $key ] = $clean;
+			$changed       = true;
+		}
+	}
+
+	if ( $changed ) {
+		$request->set_param( 'meta', $metas );
+	}
+
+	return $response;
+}
+
+/**
+ * Decode a possibly-serialized value without instantiating any class.
+ *
+ * Values that aren't serialized strings are returned untouched. Serialized values are decoded with
+ * class instantiation disabled and any leftover objects removed, so callers receive plain data only.
+ *
+ * @param mixed $value Raw value from the request.
+ *
+ * @return mixed A plain (object-free) value.
+ */
+function decode_without_objects( $value ) {
+	if ( ! is_string( $value ) || ! is_serialized( $value ) ) {
+		return $value;
+	}
+
+	// Decoding with `allowed_classes => false` is exactly what keeps this safe: no class is ever instantiated.
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+	$decoded = @unserialize( trim( $value ), array( 'allowed_classes' => false ) );
+
+	// `b:0;` legitimately decodes to false; anything else that fails to decode is dropped.
+	if ( false === $decoded && 'b:0;' !== trim( $value ) ) {
+		return '';
+	}
+
+	return strip_objects( $decoded );
+}
+
+/**
+ * Recursively remove any objects from a decoded value.
+ *
+ * @param mixed $value Decoded value.
+ *
+ * @return mixed The value with any objects replaced by null.
+ */
+function strip_objects( $value ) {
+	if ( is_object( $value ) ) {
+		return null;
+	}
+
+	if ( is_array( $value ) ) {
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = strip_objects( $item );
+		}
+	}
+
+	return $value;
+}

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -34,6 +34,7 @@ function manually_load_plugins() {
 	require_once dirname( __DIR__ ) . '/trusted-deputy-capabilities.php';
 	require_once dirname( __DIR__ ) . '/wcorg-subroles.php';
 	require_once dirname( __DIR__ ) . '/wcorg-network-theme-control.php';
+	require_once dirname( __DIR__ ) . '/jetpack-tweaks/import-meta.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/mu-plugins/tests/test-jetpack-import-meta.php
+++ b/public_html/wp-content/mu-plugins/tests/test-jetpack-import-meta.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+use WP_REST_Request;
+use function WordCamp\Jetpack_Tweaks\Import_Meta\normalize_import_meta;
+use function WordCamp\Jetpack_Tweaks\Import_Meta\decode_without_objects;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_Jetpack_Import_Meta
+ *
+ * @group mu-plugins
+ * @group jetpack-tweaks
+ * @group jetpack-import
+ *
+ * @package WordCamp\Tests
+ */
+class Test_Jetpack_Import_Meta extends WP_UnitTestCase {
+
+	/**
+	 * Build a request for the given route with the given `meta` param, and run it through the filter.
+	 *
+	 * @param string $route The REST route.
+	 * @param array  $meta  The meta param.
+	 *
+	 * @return array The meta param after filtering.
+	 */
+	private function filter_meta( $route, $meta ) {
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'meta', $meta );
+
+		normalize_import_meta( null, array(), $request );
+
+		return $request->get_param( 'meta' );
+	}
+
+	/**
+	 * A serialized object in a meta value must not survive as an object.
+	 */
+	public function test_serialized_object_is_neutralized() {
+		$payload = 'O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}';
+
+		$meta = $this->filter_meta( '/jetpack/v4/import/posts', array( 'x' => $payload ) );
+
+		$this->assertObjectFree( $meta['x'] );
+		// The importer runs maybe_unserialize() next; confirm that still yields no object.
+		$this->assertObjectFree( maybe_unserialize( $meta['x'] ) );
+	}
+
+	/**
+	 * An object nested inside a serialized array must also be removed.
+	 */
+	public function test_nested_serialized_object_is_neutralized() {
+		$payload = 'a:2:{s:4:"safe";s:2:"ok";s:3:"bad";O:8:"stdClass":0:{}}';
+
+		$meta  = $this->filter_meta( '/jetpack/v4/import/posts', array( 'x' => $payload ) );
+		$value = maybe_unserialize( $meta['x'] );
+
+		$this->assertIsArray( $value );
+		$this->assertSame( 'ok', $value['safe'] );
+		$this->assertObjectFree( $value );
+	}
+
+	/**
+	 * A legitimately-serialized array of scalars must round-trip unchanged.
+	 */
+	public function test_serialized_array_round_trips() {
+		$original = array(
+			'width'  => 1024,
+			'height' => 768,
+			'sizes'  => array( 'thumbnail', 'medium' ),
+		);
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Building a fixture of the exact WXR-style serialized value the importer receives.
+		$serialized = serialize( $original );
+		$meta       = $this->filter_meta( '/jetpack/v4/import/posts', array( '_wp_attachment_metadata' => $serialized ) );
+		$value      = maybe_unserialize( $meta['_wp_attachment_metadata'] );
+
+		$this->assertSame( $original, $value );
+	}
+
+	/**
+	 * Plain (non-serialized) values must be left untouched.
+	 */
+	public function test_plain_values_untouched() {
+		$meta = $this->filter_meta(
+			'/jetpack/v4/import/posts',
+			array(
+				'_edit_last' => '1',
+				'note'       => 'a plain string',
+			)
+		);
+
+		$this->assertSame( '1', $meta['_edit_last'] );
+		$this->assertSame( 'a plain string', $meta['note'] );
+	}
+
+	/**
+	 * Requests to routes outside the import namespace must not be modified.
+	 */
+	public function test_non_import_routes_untouched() {
+		$payload = 'O:8:"stdClass":0:{}';
+
+		$meta = $this->filter_meta( '/wp/v2/posts', array( 'x' => $payload ) );
+
+		$this->assertSame( $payload, $meta['x'] );
+	}
+
+	/**
+	 * The pages route is covered as well as posts.
+	 */
+	public function test_pages_route_is_covered() {
+		$payload = 'O:8:"stdClass":0:{}';
+
+		$meta = $this->filter_meta( '/jetpack/v4/import/pages', array( 'x' => $payload ) );
+
+		$this->assertObjectFree( maybe_unserialize( $meta['x'] ) );
+	}
+
+	/**
+	 * Scalars and arrays of scalars are left alone by decode_without_objects().
+	 */
+	public function test_decode_without_objects_passthrough() {
+		$this->assertSame( 'draft', decode_without_objects( 'draft' ) );
+		$this->assertSame( 5, decode_without_objects( 5 ) );
+		$this->assertSame( array( 'a' => 'b' ), decode_without_objects( array( 'a' => 'b' ) ) );
+	}
+
+	/**
+	 * Assert that a value contains no objects at any depth.
+	 *
+	 * @param mixed $value The value to check.
+	 */
+	private function assertObjectFree( $value ) {
+		if ( is_object( $value ) ) {
+			$this->fail( 'Value is an object: ' . get_class( $value ) );
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				$this->assertObjectFree( $item );
+			}
+		}
+
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
Jetpack's Unified Importer restores post meta from an import and runs `maybe_unserialize()` on caller-supplied values. Decode serialized meta values ourselves first — as plain data only, never as objects — before Jetpack processes them, so imports keep working exactly as before.

### How to test the changes in this Pull Request:

1. Import posts via the Jetpack importer as normal (e.g. attachment metadata, `_edit_last`, other serialized meta) and confirm everything round-trips unchanged.
2. Run the new PHPUnit suite: `Test_Jetpack_Import_Meta` in `wp-content/mu-plugins/tests/test-jetpack-import-meta.php`.
