### PR TITLE
Payments: pass $escape explicitly to fputcsv()/fgetcsv()

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php
@@ -937,7 +937,7 @@ function process_import_request() {
 	$header  = array();
 	$results = array();
 
-	while ( ( $line = fgetcsv( $handle ) ) !== false ) {
+	while ( ( $line = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
 		// Skip first line.
 		if ( ++$count == 1 ) {
 			continue;

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -1466,7 +1466,7 @@ function _generate_payment_report_jpm_wires( $args ) {
 	$report = fopen( 'php://output', 'w' );
 
 	// JPM Header
-	fputcsv( $report, Utilities\Export_CSV::esc_csv( array( 'HEADER', gmdate( 'YmdHis' ), '1' ) ) );
+	fputcsv( $report, Utilities\Export_CSV::esc_csv( array( 'HEADER', gmdate( 'YmdHis' ), '1' ) ), ',', '"', '\\', "\n" );
 
 	$total = 0;
 	$count = 0;


### PR DESCRIPTION
## What

PHP 8.4 deprecates calling `fputcsv()` / `fgetcsv()` without an explicit `$escape` argument, because the default is scheduled to change from `"\\"` to `""`. Two call sites still relied on the default and were emitting

> `fputcsv(): the $escape parameter must be provided as its default value will change`

Both now pass the current default explicitly, so behaviour is unchanged today and stays unchanged when PHP flips it.

| File | Call |
| --- | --- |
| `wordcamp-payments/includes/reimbursement-request.php:1469` | The JPM wires `HEADER` row in `_generate_payment_report_jpm_wires()` |
| `wordcamp-payments-network/includes/wordcamp-budgets-dashboard.php:940` | The `fgetcsv()` loop in `process_import_request()` |

The `reimbursement-request.php` one was simply an inconsistency — its twin in `payment-request.php:1471` already passed the full argument list, and this brings the two functions back in line.

The `wordcamp-budgets-dashboard.php` one is the source of the warning volume: it sits in the import `while` loop, so it fired once per row of the uploaded CSV.

## Why these arguments

`fputcsv()` and `fgetcsv()` take `$escape` positionally (5th), so `','` and `'"'` have to be repeated even though they are already the defaults. The `"\n"` passed as `fputcsv()`'s 6th argument is likewise the default and a strict no-op; it is there so the call matches the six-argument form used at every other CSV call site in the repo — `payment-request.php`, `camptix.php`, `class-camptix-admin-tools.php` and `indesign-badges.php`.

## Scope

I tokenised every non-vendor `.php` file in the repo and counted top-level arguments at each `fputcsv` / `fgetcsv` / `str_getcsv` / `setCsvControl` call. These two were the only ones missing `$escape`; everything else already passes it. After the change the scan comes back empty.

One site is **not** covered here: `Utilities\Export_CSV` itself has two bare `fputcsv()` calls in its row-writing loop, but that class lives outside this repo, so it needs a separate patch.

## Testing

- `php -l` clean on both files.
- The argument-count scan re-run over the repo reports no remaining sites.
- Round-tripped both forms standalone on PHP 8.5 with `error_reporting( E_ALL )` — the header row writes and reads back identically, with no deprecation output.

Not run, and worth a reviewer's eye: the containing flows were not exercised end to end (no local environment for this pass), and `phpcs` was not run — only `phpcs.xml.dist` is present, with no local install. The changed lines are character-identical in style to the existing calls in the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
