### PR TITLE
Forms to Drafts: gate the login requirement on the form's authenticated source

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -114,6 +114,7 @@ require_once SUT_WPMU_PLUGIN_DIR . '/wporg-groups-frontend/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/gatherpress-recurring-events/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/groups/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-coming-soon-page/tests/bootstrap.php';
+require_once WP_PLUGIN_DIR . '/wordcamp-forms-to-drafts/tests/bootstrap.php';
 
 /*
  * GatherPress hooks `send_headers` to set a novelty HTTP header ("Go

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -68,6 +68,12 @@
 			</directory>
 		</testsuite>
 
+		<testsuite name="WordCamp Forms to Drafts">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="WordCamp Groups">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WordCamp\Forms_To_Drafts\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugins that we'll need to be active for the tests.
+ *
+ * The gate reads the JWT-signed source through Jetpack's contact-form classes,
+ * so Jetpack has to be loaded before the plugin under test.
+ */
+function manually_load_plugins() {
+	require_once dirname( dirname( __DIR__ ) ) . '/jetpack/jetpack.php';
+	require_once dirname( __DIR__ ) . '/wordcamp-forms-to-drafts.php';
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-prevent-form-submission.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-prevent-form-submission.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace WordCamp\Forms_To_Drafts\Tests;
+
+use WP_UnitTestCase;
+use WordCamp_Forms_To_Drafts;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the login gate in `WordCamp_Forms_To_Drafts::prevent_form_submission()`.
+ *
+ * The gate keys on the form source Jetpack has authenticated in the signed JWT,
+ * not on the request-supplied `contact-form-id`. These cover that a gated form
+ * (`call-for-speakers`) stays behind the login requirement for a logged-out
+ * visitor, while ungated forms and logged-in visitors are left alone.
+ *
+ * @group wordcamp-forms-to-drafts
+ */
+class Test_Prevent_Form_Submission extends WP_UnitTestCase {
+	/**
+	 * The plugin instance under test.
+	 *
+	 * @var WordCamp_Forms_To_Drafts
+	 */
+	protected $plugin;
+
+	/**
+	 * ID of a page holding the login-gated Call for Speakers form.
+	 *
+	 * @var int
+	 */
+	protected $gated_page_id;
+
+	/**
+	 * ID of a page holding an ungated Call for Volunteers form.
+	 *
+	 * @var int
+	 */
+	protected $ungated_page_id;
+
+	/**
+	 * Set up a gated and an ungated form page, logged out by default.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! class_exists( Contact_Form::class ) ) {
+			$this->markTestSkipped( 'Jetpack contact-form classes are not loaded.' );
+		}
+
+		$this->plugin = $GLOBALS['wordcamp_forms_to_drafts'];
+
+		$this->gated_page_id   = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$this->ungated_page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		update_post_meta( $this->gated_page_id, 'wcfd-key', 'call-for-speakers' );
+		update_post_meta( $this->ungated_page_id, 'wcfd-key', 'call-for-volunteers' );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Reset the request superglobal and queried post touched by the gate.
+	 */
+	public function tear_down() {
+		unset(
+			$_POST['contact-form-id'],
+			$_POST['jetpack_contact_form_jwt'],
+			$GLOBALS['post']
+		);
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a genuine signed JWT whose source is the given post.
+	 *
+	 * Jetpack derives the source from the post in scope while the form renders,
+	 * so setting the global post is enough to bind the token to it.
+	 *
+	 * @param int $source_id Post the form lives on.
+	 *
+	 * @return string The signed JWT.
+	 */
+	protected function jwt_for_source( $source_id ) {
+		global $post;
+
+		$post = get_post( $source_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$form = new Contact_Form( array(), '[contact-field label="Name" type="name"/]' );
+
+		return $form->get_jwt();
+	}
+
+	/**
+	 * A logged-out visitor cannot submit the gated form. The posted
+	 * `contact-form-id` does not influence the decision.
+	 */
+	public function test_blocks_gated_form_for_logged_out_visitor() {
+		$_POST['jetpack_contact_form_jwt'] = $this->jwt_for_source( $this->gated_page_id );
+		$_POST['contact-form-id']          = '0';
+
+		$result = $this->plugin->prevent_form_submission( false );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'spam', $result->get_error_code() );
+	}
+
+	/**
+	 * The gate ignores a posted `contact-form-id` that points somewhere other
+	 * than the signed source; the signed source still decides.
+	 */
+	public function test_blocks_gated_form_regardless_of_posted_id() {
+		$_POST['jetpack_contact_form_jwt'] = $this->jwt_for_source( $this->gated_page_id );
+		$_POST['contact-form-id']          = (string) $this->ungated_page_id;
+
+		$result = $this->plugin->prevent_form_submission( false );
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * An ungated form is left alone for a logged-out visitor.
+	 */
+	public function test_allows_ungated_form_for_logged_out_visitor() {
+		$_POST['jetpack_contact_form_jwt'] = $this->jwt_for_source( $this->ungated_page_id );
+		$_POST['contact-form-id']          = '0';
+
+		$this->assertFalse( $this->plugin->prevent_form_submission( false ) );
+	}
+
+	/**
+	 * A logged-in visitor may submit the gated form.
+	 */
+	public function test_allows_gated_form_for_logged_in_visitor() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$_POST['jetpack_contact_form_jwt'] = $this->jwt_for_source( $this->gated_page_id );
+		$_POST['contact-form-id']          = '0';
+
+		$this->assertFalse( $this->plugin->prevent_form_submission( false ) );
+	}
+
+	/**
+	 * A submission already flagged as spam is passed through untouched.
+	 */
+	public function test_passes_through_when_already_spam() {
+		$_POST['jetpack_contact_form_jwt'] = $this->jwt_for_source( $this->gated_page_id );
+
+		$this->assertTrue( $this->plugin->prevent_form_submission( true ) );
+	}
+
+	/**
+	 * Legacy submissions without a JWT still gate on the posted `contact-form-id`,
+	 * which Jetpack validates against the current post before processing.
+	 */
+	public function test_falls_back_to_posted_id_without_jwt() {
+		$_POST['contact-form-id'] = (string) $this->gated_page_id;
+
+		$result = $this->plugin->prevent_form_submission( false );
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * An unverifiable token resolves to no known form, so the gate does not flag
+	 * it. Jetpack rejects the same token before storing anything.
+	 */
+	public function test_allows_unverifiable_jwt() {
+		$_POST['jetpack_contact_form_jwt'] = 'not.a.valid-token';
+		$_POST['contact-form-id']          = '0';
+
+		$this->assertFalse( $this->plugin->prevent_form_submission( false ) );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -209,17 +209,19 @@ class WordCamp_Forms_To_Drafts {
 	 * NOTE: This accepts submissions and marks as spam, it does not inform the submitter.
 	 */
 	public function prevent_form_submission( $is_spam ) {
-		global $post;
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$contact_form_post_id = absint( $_POST['contact-form-id'] ?? 0 );
-
-		// Already marked as spam, no form known, or user is already logged in..
-		if ( $is_spam || ! $contact_form_post_id || is_user_logged_in() ) {
+		// Already flagged, or the user is signed in and allowed to submit.
+		if ( $is_spam || is_user_logged_in() ) {
 			return $is_spam;
 		}
 
-		$form_id = get_post_meta( $contact_form_post_id, 'wcfd-key', true );
+		// Identify the form from the source Jetpack has authenticated (the signed
+		// JWT), rather than the request-supplied `contact-form-id`. When a token
+		// is present Jetpack routes and stores the submission by the token's
+		// source, and does not require `contact-form-id` to match it, so the
+		// gate has to look at the same source Jetpack does.
+		$source_id = $this->get_verified_form_source_id();
+
+		$form_id = $source_id ? get_post_meta( $source_id, 'wcfd-key', true ) : '';
 
 		if ( $this->form_requires_login( $form_id ) ) {
 			// String not shown when logged out.
@@ -227,6 +229,44 @@ class WordCamp_Forms_To_Drafts {
 		}
 
 		return $is_spam;
+	}
+
+	/**
+	 * Resolve the post ID of the form being submitted, from an authenticated source.
+	 *
+	 * When Jetpack renders a form it embeds a signed JWT describing the form and the
+	 * post it lives on. That signed source is the identity Jetpack uses to store the
+	 * feedback and route it, so it is the value our login gate must key on too. The
+	 * `contact-form-id` request field is not bound to that signed source and must not
+	 * drive an access-control decision.
+	 *
+	 * For legacy submissions with no JWT, Jetpack itself validates `contact-form-id`
+	 * against the current post before processing, so it is safe to fall back to.
+	 *
+	 * @return int Post ID of the form's source, or 0 when it cannot be determined.
+	 */
+	protected function get_verified_form_source_id() {
+		$contact_form_class = '\Automattic\Jetpack\Forms\ContactForm\Contact_Form';
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Jetpack verifies the token below.
+		if ( isset( $_POST['jetpack_contact_form_jwt'] ) && class_exists( $contact_form_class ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$jwt = sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) );
+
+			try {
+				$form = $contact_form_class::get_instance_from_jwt( $jwt );
+			} catch ( \Exception $e ) {
+				$form = null;
+			}
+
+			// An unverifiable token resolves to no source, so the gate does not
+			// treat it as a known form. Jetpack rejects the same token before it
+			// stores anything, so nothing is created for it downstream either.
+			return $form ? (int) $form->get_source()->get_id() : 0;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return absint( $_POST['contact-form-id'] ?? 0 );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
The Call for Speakers login requirement was decided from the request's `contact-form-id`. When a form carries a signed Jetpack JWT, Jetpack routes and stores the submission by the token's source and does not require the posted id to match it, so the two could diverge. This keys the login requirement on the same authenticated source Jetpack uses, and keeps the posted-id path only as a fallback for legacy submissions with no token (which Jetpack validates against the current post itself).

## How to review this PR
- The whole change is in `wordcamp-forms-to-drafts.php`: `prevent_form_submission()` and the new `get_verified_form_source_id()` helper.
- Key idea: the login gate now reads the form identity from the **JWT-verified source** (`Contact_Form::get_instance_from_jwt()` → `get_source()->get_id()`) instead of `$_POST['contact-form-id']`. The old fail-open early return on a zero/empty id is gone.
- Fallback: when no JWT is present (legacy forms), we still use the posted id — safe because Jetpack itself validates it against the current post when `has_verified_jwt === false`.
- Worth a sanity check: the downstream draft routing (`get_form_key()` → feedback parent) already uses the authenticated source, so it's unchanged — only the gate moved onto the same source.

## Test plan
- [x] phpunit — new **WordCamp Forms to Drafts** suite, 7/7 passing; confirmed the two gate assertions fail without the code change
- [x] phpcs clean on changed files
- [x] Regression — Remote CSS (8/8) and Coming Soon Page (9/9) suites green
- [x] Manual (HTTP) — see steps below

### Manual test steps
1. Publish a Call for Speakers page (a page with `wcfd-key = call-for-speakers`) and grab the anonymous rendered form's signed JWT + `contact-form-hash`.
2. **Logged out**, POST the form to the front end with the honest `contact-form-id` → expect the login-required error and **no** Speaker/Session drafts (unchanged).
3. **Logged out**, POST the same signed JWT but with `contact-form-id=0` (or any mismatched id) → **now blocked**, no drafts created. (Before this change, `0` skipped the gate and created drafts.)
4. **Logged out**, submit an ungated form (Call for Volunteers) → still accepted, draft created (no regression).
5. Confirm via DB: `wp post list --post_type=wcb_session --post_status=draft` shows nothing created by the blocked submissions.

> Note: verification was via direct HTTP to the submission endpoint (server-side, pre-render gate) rather than a browser form click — the local seed site has no active theme to render the form UI. Automated tests cover the logged-in path.
