### PR TITLE
Events: align post status registration with the public status set

### DIFF
--- a/public_html/wp-content/mu-plugins/events/jetpack-form-to-wcpt-application.php
+++ b/public_html/wp-content/mu-plugins/events/jetpack-form-to-wcpt-application.php
@@ -82,16 +82,21 @@ function create_campus_connect_tracker( $post_id, $fields, $is_spam, $entry_valu
 	 * registering the `wordcamp` statuses, so they have to be registered before the
 	 * check or the query filters on statuses that cannot match and the cap never trips.
 	 */
+	$viewable = \WordCamp_Loader::get_publicly_viewable_post_statuses();
+
 	foreach ( \WordCamp_Loader::get_post_statuses() as $status => $label ) {
 		if ( ! get_post_status_object( $status ) ) {
-			// `public` to match how `Event_Loader::register_post_statuses()` registers
-			// them on the central site. Left to the defaults these would come out
-			// `internal`, which is a different status on one network to the other.
+			// `public` / `protected` to match how `Event_Loader::register_post_statuses()`
+			// registers them on the central site. Left to the defaults these would come
+			// out `internal`, which is a different status on one network to the other.
+			$is_viewable = in_array( $status, $viewable, true );
+
 			register_post_status(
 				$status,
 				array(
-					'label'  => $label,
-					'public' => true,
+					'label'     => $label,
+					'public'    => $is_viewable,
+					'protected' => ! $is_viewable,
 				)
 			);
 		}

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-event/test-event-status-visibility.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-event/test-event-status-visibility.php
@@ -1,0 +1,422 @@
+<?php
+
+namespace WordCamp\WCPT\Tests;
+
+use WP_UnitTestCase;
+use WP_Query;
+use WordCamp_Loader;
+use Meetup_Loader;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for which event post statuses expose a public single view.
+ *
+ * @group wcpt
+ */
+class Test_Event_Status_Visibility extends WP_UnitTestCase {
+
+	/**
+	 * A `wordcamp` post in an application status, created per test.
+	 *
+	 * @var int
+	 */
+	protected $application_id;
+
+	/**
+	 * Create an application that no public surface links to.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->application_id = self::factory()->post->create(
+			array(
+				'post_type'   => WCPT_POST_TYPE_ID,
+				'post_status' => 'wcpt-rejected',
+				'post_title'  => 'WordCamp Nowhere',
+			)
+		);
+	}
+
+	/**
+	 * Subroles are a global rather than user meta, so they have to be cleared by hand.
+	 * So does the screen, since this suite otherwise runs with `is_admin()` true.
+	 */
+	public function tear_down() {
+		$GLOBALS['wcorg_subroles'] = array();
+		unset( $GLOBALS['current_screen'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Grant a user the WordCamp Wrangler subrole.
+	 *
+	 * `WP_User::add_cap()` is not usable here: `WordCamp\SubRoles\omit_usermeta_caps()`
+	 * strips any capability stored in user meta, on purpose. Production grants these
+	 * through `$wcorg_subroles` in `.config/capes.php`, so the tests do too.
+	 *
+	 * @param int $user_id
+	 */
+	protected function make_wrangler( $user_id ) {
+		$GLOBALS['wcorg_subroles'][ $user_id ] = array( 'wordcamp_wrangler' );
+	}
+
+	/**
+	 * Run the query a request for a camp's permalink produces.
+	 *
+	 * Queried by name rather than through `$this->go_to( get_permalink() )`, because that
+	 * depends on rewrite rules and `$_SERVER` globals that other suites in this run leave
+	 * modified, which made these tests pass alone and fail in the full suite. A `name`
+	 * query sets `is_single`, which is all the status check in `WP_Query::get_posts()`
+	 * needs.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return WP_Query
+	 */
+	protected function query_single( $post_id ) {
+		set_current_screen( 'front' );
+
+		return new WP_Query(
+			array(
+				'post_type' => WCPT_POST_TYPE_ID,
+				'name'      => get_post_field( 'post_name', $post_id ),
+			)
+		);
+	}
+
+	/**
+	 * The two statuses public surfaces list stay `public`.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_listed_statuses_are_public() {
+		foreach ( WordCamp_Loader::get_public_post_statuses() as $status ) {
+			$object = get_post_status_object( $status );
+
+			$this->assertNotNull( $object, "$status is not registered" );
+			$this->assertTrue( $object->public, "$status should be public" );
+			$this->assertFalse( $object->protected, "$status should not be protected" );
+		}
+	}
+
+	/**
+	 * Application statuses lose their public single view.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_application_statuses_are_protected() {
+		$expected = array(
+			'wcpt-needs-vetting',
+			'wcpt-needs-orientati',
+			'wcpt-more-info-reque',
+			'wcpt-interview-sched',
+			'wcpt-rejected',
+			'wcpt-approved-pre-pl',
+			'wcpt-needs-email',
+			'wcpt-needs-site',
+			'wcpt-needs-pre-plann',
+			'wcpt-needs-action',
+		);
+
+		foreach ( $expected as $status ) {
+			$object = get_post_status_object( $status );
+
+			$this->assertNotNull( $object, "$status is not registered" );
+			$this->assertFalse( $object->public, "$status should not be public" );
+			$this->assertTrue( $object->protected, "$status should be protected" );
+			$this->assertFalse( $object->publicly_queryable, "$status should not be publicly queryable" );
+		}
+	}
+
+	/**
+	 * Cancelled and pre-planning camps keep resolving, for the reasons in
+	 * `WordCamp_Loader::get_publicly_viewable_post_statuses()`.
+	 *
+	 * @covers WordCamp_Loader::get_publicly_viewable_post_statuses
+	 */
+	public function test_deferred_statuses_still_resolve() {
+		$deferred = array_merge(
+			array( 'wcpt-cancelled' ),
+			WordCamp_Loader::get_pre_planning_post_statuses()
+		);
+
+		foreach ( $deferred as $status ) {
+			$this->assertTrue(
+				get_post_status_object( $status )->public,
+				"$status should still be public"
+			);
+		}
+	}
+
+	/**
+	 * `exclude_from_search` governs `post_status => 'any'`, which `get_wordcamps()` and
+	 * `get_wordcamp_post()` depend on. It has to stay false for every status.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_no_status_is_excluded_from_search() {
+		$statuses = array_merge(
+			array_keys( WordCamp_Loader::get_post_statuses() ),
+			array_keys( Meetup_Loader::get_post_statuses() )
+		);
+
+		foreach ( $statuses as $status ) {
+			$this->assertFalse(
+				get_post_status_object( $status )->exclude_from_search,
+				"$status must not be excluded from search"
+			);
+		}
+	}
+
+	/**
+	 * The regression the previous test guards, stated as behaviour rather than as a flag.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_any_status_query_still_returns_applications() {
+		$found = get_posts(
+			array(
+				'post_type'   => WCPT_POST_TYPE_ID,
+				'post_status' => 'any',
+				'fields'      => 'ids',
+			)
+		);
+
+		$this->assertContains( $this->application_id, $found );
+	}
+
+	/**
+	 * A query that doesn't name a status must not pick up applications.
+	 *
+	 * `WP_Query` rather than `get_posts()`, because `get_posts()` substitutes
+	 * `post_status => 'publish'` and would never exercise the default status set.
+	 * `wcpt_has_wordcamps()`, which the Central theme calls, uses `WP_Query`.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_default_status_query_omits_applications() {
+		// This suite runs with `is_admin()` true, and WP_Query deliberately widens the
+		// default status set in admin context. Pin the front end explicitly.
+		set_current_screen( 'front' );
+
+		$listed = $this->create_listed_camp();
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => WCPT_POST_TYPE_ID,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		$this->assertContains( $listed, $query->posts );
+		$this->assertNotContains( $this->application_id, $query->posts );
+	}
+
+	/**
+	 * The other half of the previous test. Wranglers triage from the list table, so the
+	 * admin has to keep seeing what the front end no longer does.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_default_status_query_keeps_applications_in_the_admin() {
+		set_current_screen( 'edit-wordcamp' );
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => WCPT_POST_TYPE_ID,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		$this->assertTrue( is_admin(), 'this test needs admin context to mean anything' );
+		$this->assertContains( $this->application_id, $query->posts );
+	}
+
+	/**
+	 * A camp in a status public surfaces list.
+	 *
+	 * `wcpt-closed` rather than `wcpt-scheduled`, because WordCamp_Admin fires a Slack
+	 * notification on the transition to scheduled and it fatals on PHP 8 when the camp
+	 * has no `Start Date` meta.
+	 *
+	 * @return int
+	 */
+	protected function create_listed_camp() {
+		return self::factory()->post->create(
+			array(
+				'post_type'   => WCPT_POST_TYPE_ID,
+				'post_status' => 'wcpt-closed',
+			)
+		);
+	}
+
+	/**
+	 * The disclosure itself: a logged out visitor gets nothing from the permalink.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_single_view_is_empty_for_anonymous_visitors() {
+		wp_set_current_user( 0 );
+
+		$this->assertEmpty( $this->query_single( $this->application_id )->posts );
+	}
+
+	/**
+	 * A Wrangler clicking "View" on an application still gets the page. This is the
+	 * workflow that ruled out registering the statuses as plain non-public.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_single_view_resolves_for_users_who_can_edit() {
+		$wrangler = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->make_wrangler( $wrangler );
+
+		wp_set_current_user( $wrangler );
+
+		$this->assertTrue(
+			current_user_can( 'edit_post', $this->application_id ),
+			'the fixture did not actually grant edit rights'
+		);
+
+		$query = $this->query_single( $this->application_id );
+
+		$this->assertCount( 1, $query->posts );
+		$this->assertSame( $this->application_id, $query->posts[0]->ID );
+		$this->assertTrue( $query->is_preview, 'the wrangler should get a preview' );
+	}
+
+	/**
+	 * Mentors reach `edit_post` through a different branch of `map_subrole_caps()` than
+	 * Wranglers do, mapping to plain `edit_posts`. They process applications too, so the
+	 * preview has to work for them as well.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_mentor_can_preview_their_own_mentee_camp() {
+		$mentor = self::factory()->user->create(
+			array(
+				'role'       => 'contributor',
+				'user_login' => 'mentor_of_nowhere',
+			)
+		);
+
+		update_post_meta( $this->application_id, 'Mentor WordPress.org User Name', 'mentor_of_nowhere' );
+		wp_set_current_user( $mentor );
+
+		$query = $this->query_single( $this->application_id );
+
+		$this->assertCount( 1, $query->posts );
+		$this->assertSame( $this->application_id, $query->posts[0]->ID );
+	}
+
+	/**
+	 * Being a mentor somewhere does not open every application.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_mentor_cannot_preview_a_camp_they_do_not_mentor() {
+		$mentor = self::factory()->user->create(
+			array(
+				'role'       => 'contributor',
+				'user_login' => 'mentor_of_elsewhere',
+			)
+		);
+
+		update_post_meta( $this->application_id, 'Mentor WordPress.org User Name', 'somebody_else' );
+		wp_set_current_user( $mentor );
+
+		$this->assertEmpty( $this->query_single( $this->application_id )->posts );
+	}
+
+	/**
+	 * The mentor branch maps to `edit_posts`, which resolves to `edit_wordcamps`, which
+	 * `register_post_capabilities()` only grants to Contributor and above. A mentor who
+	 * is a Subscriber on Central therefore loses the preview.
+	 *
+	 * Pinned as the current boundary rather than as desired behaviour. The mapping in
+	 * `wcorg-subroles.php` says it "assumes mentors already have contributor+ access",
+	 * and nothing enforces that.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_subscriber_mentor_does_not_get_the_preview() {
+		$mentor = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'mentor_without_caps',
+			)
+		);
+
+		update_post_meta( $this->application_id, 'Mentor WordPress.org User Name', 'mentor_without_caps' );
+		wp_set_current_user( $mentor );
+
+		$this->assertEmpty( $this->query_single( $this->application_id )->posts );
+	}
+
+	/**
+	 * A logged in user without edit rights is treated the same as a logged out one.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_single_view_is_empty_for_subscribers() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertEmpty( $this->query_single( $this->application_id )->posts );
+	}
+
+	/**
+	 * A cancelled camp keeps resolving for everyone, so the v2 REST API keeps serving it.
+	 *
+	 * @covers WordCamp_Loader::get_publicly_viewable_post_statuses
+	 */
+	public function test_cancelled_single_view_still_resolves_for_anonymous_visitors() {
+		$cancelled = self::factory()->post->create(
+			array(
+				'post_type'   => WCPT_POST_TYPE_ID,
+				'post_status' => 'wcpt-cancelled',
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$this->assertCount( 1, $this->query_single( $cancelled )->posts );
+	}
+
+	/**
+	 * Meetups inherit the same treatment, against their own public set. `wcpt-mtp-nds-vet`
+	 * is deliberately public there, unlike the WordCamp equivalent.
+	 *
+	 * @covers Event_Loader::get_publicly_viewable_post_statuses
+	 */
+	public function test_meetup_statuses_follow_the_meetup_public_set() {
+		foreach ( Meetup_Loader::get_public_post_statuses() as $status ) {
+			$this->assertTrue(
+				get_post_status_object( $status )->public,
+				"$status should be public"
+			);
+		}
+
+		$this->assertTrue( get_post_status_object( 'wcpt-mtp-nds-vet' )->public );
+		$this->assertFalse( get_post_status_object( 'wcpt-mtp-rejected' )->public );
+		$this->assertTrue( get_post_status_object( 'wcpt-mtp-rejected' )->protected );
+	}
+
+	/**
+	 * The admin list table shows every status under "All", which relies on protected
+	 * statuses opting in to that list.
+	 *
+	 * @covers Event_Loader::register_post_statuses
+	 */
+	public function test_protected_statuses_stay_in_the_admin_lists() {
+		foreach ( array_keys( WordCamp_Loader::get_post_statuses() ) as $status ) {
+			$object = get_post_status_object( $status );
+
+			$this->assertTrue( $object->show_in_admin_all_list, "$status missing from the admin All list" );
+			$this->assertTrue( $object->show_in_admin_status_list, "$status missing from the admin status links" );
+		}
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-event/class-event-loader.php
@@ -46,15 +46,47 @@ abstract class Event_Loader {
 	abstract public static function get_post_statuses();
 
 	/**
+	 * Statuses whose single view resolves for everyone.
+	 *
+	 * Defaults to the statuses that public surfaces already list. Subclasses widen it for
+	 * statuses that aren't listed but whose permalink is still linked from somewhere.
+	 *
+	 * @return array
+	 */
+	public static function get_publicly_viewable_post_statuses() {
+		return static::get_public_post_statuses();
+	}
+
+	/**
 	 * Register post statuses for this event type.
 	 */
 	public function register_post_statuses() {
+		$viewable = static::get_publicly_viewable_post_statuses();
+
 		foreach ( $this->get_post_statuses() as $key => $label ) {
+			$is_viewable = in_array( $key, $viewable, true );
+
 			register_post_status(
 				$key, array(
-					'label'       => $label,
-					'public'      => true,
-					'label_count' => _nx_noop(
+					'label'               => $label,
+					'public'              => $is_viewable,
+
+					/*
+					 * `protected` rather than plain non-public, so WP_Query still resolves the
+					 * single view for users who can edit the post. Wranglers and mentors open
+					 * applications they're processing that way. Everyone else gets a 404.
+					 */
+					'protected'           => ! $is_viewable,
+
+					/*
+					 * Deliberately false for every status. This governs `post_status => 'any'`,
+					 * not the default status set, and `get_wordcamps()` / `get_wordcamp_post()`
+					 * both rely on 'any' meaning all of them. Setting it true would also break
+					 * asymmetrically, since these statuses are only registered on Central.
+					 */
+					'exclude_from_search' => false,
+
+					'label_count'         => _nx_noop(
 						sprintf( '%s <span class="count">(%s)</span>', $label, '%s' ),
 						sprintf( '%s <span class="count">(%s)</span>', $label, '%s' ),
 						'wordcamporg'

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-loader.php
@@ -232,6 +232,31 @@ class WordCamp_Loader extends Event_Loader {
 	}
 
 	/**
+	 * Statuses whose single view resolves for everyone.
+	 *
+	 * Wider than `get_public_post_statuses()` because two groups aren't listed on the
+	 * schedule but are still reached by URL:
+	 *
+	 * - `wcpt-cancelled` is served over the v2 REST API to unauthenticated clients, so
+	 *   Official WordPress Events can drop cancelled camps from the events widget. That
+	 *   works via the `public` flag, through the parent `check_read_permission()`.
+	 * - Pre-planning camps usually have no site of their own yet, so the map markers link
+	 *   their Central permalink through `WordCamp_Central_Theme::get_best_wordcamp_url()`.
+	 *
+	 * Both are addressable, but each needs its own change first. Until then they keep
+	 * resolving.
+	 *
+	 * @return array Post status names.
+	 */
+	public static function get_publicly_viewable_post_statuses() {
+		return array_merge(
+			self::get_public_post_statuses(),
+			array( 'wcpt-cancelled' ),
+			self::get_pre_planning_post_statuses()
+		);
+	}
+
+	/**
 	 * Get post statuses for WordCamps on pre-planning schedule.
 	 *
 	 * @return array Post status names.


### PR DESCRIPTION
## Why

`Event_Loader::register_post_statuses()` passes `'public' => true` for every status it registers. `WordCamp_Loader::get_public_post_statuses()` names two of the nineteen, and `Meetup_Application::get_public_post_statuses()` names three of the fourteen. The two have disagreed since both were added, in the same commit, in April 2016.

The archive query has compensated since two days after that, in `Event_Loader::query_public_statuses_on_archives()`, but only for archives and feeds. The single view was never covered, so an event post resolves at its permalink in any status, including statuses no public surface links to.

On Central that is 1,096 of 2,589 `wordcamp` posts. This PR moves 642 of them. The remaining 454 are held back deliberately, see below.

The registration also means `get_post_stati( array( 'public' => true ) )` reports application statuses as public, so any query that does not name its statuses picks them up. There is one such query on the front end today, `WordCamp_Central_Theme::get_sessions()`, which only ever wanted scheduled camps.

## What changed

- Statuses in the event type's public set register `public`, as before.
- Statuses outside it register `protected`. `WP_Query` resolves a protected single view for users who pass `edit_post` on the post and returns nothing to everyone else, which is how core already treats drafts. Wranglers keep the front-end view they use while processing an application, and so do mentors for the camps they mentor, as long as they hold Contributor or above on Central. That is what the mentor branch in `wcorg-subroles.php` already assumes, in a comment, without enforcing it.
- `exclude_from_search` is now passed explicitly as `false`, with a comment saying why it must stay that way. It governs `post_status => 'any'`, which `get_wordcamps()` and `get_wordcamp_post()` both default to. It would also behave differently depending on which site a request started from, because these statuses only register on Central.
- Meetups follow the same rule against their own public set. `wcpt-mtp-nds-vet` stays public there, unlike the WordCamp equivalent, since the meetup tracker lists it. `wp_meetup` is registered `'public' => false` anyway, so this only affects which statuses default queries return.
- `mu-plugins/events/jetpack-form-to-wcpt-application.php` registers the same statuses on the events network, where `init` never does, so the rate limit's status count can match. It hardcoded `'public' => true` to mirror Central, so it now derives the flags from `get_publicly_viewable_post_statuses()` instead of drifting. No behaviour change there: the count it exists for uses `get_post_stati()`, which returns every registered status regardless of these flags.

## Deliberately unchanged

Two groups keep the old registration, each because something else depends on the `public` flag and needs its own change first.

- **`wcpt-cancelled`, 424 posts.** `WordCamp_REST_WordCamps_Controller::check_read_permission()` allowlists it so Official WordPress Events can drop cancelled camps from the events widget, then defers to the parent, which returns true only because the status is `public`. Moving it would silently close that endpoint. Fixing it means having the controller answer from its own allowlist instead of deferring.
- **The six pre-planning statuses, 30 posts.** `WordCamp_Central_Theme::get_best_wordcamp_url()` falls back to the Central permalink when a camp has no `URL` meta, and pre-planning camps usually have no site yet, so the map markers link exactly these permalinks.

## Testing

16 new tests in `tests/wcpt-event/test-event-status-visibility.php` covering the registered flags for both event types, the default and `'any'` query paths, and the single view for a logged out visitor, a Wrangler, a mentor on their own mentee, a mentor on someone else's camp, a Subscriber mentor and a plain Subscriber.

The existing `Test_Event_Application_Rate_Limit` covers the events-network registration described above and still passes, since the count it guards reads every registered status.

Suite on this branch is 786 tests, 9 failures, 6 skipped. Clean `production` in the same environment is 770 tests with the **same 9** failures (all `Test_Groups_Blocks`, caused by stale built assets in the test environment) and the same 6 skips. So this adds 16 tests and no failures. `phpcs` reports no new violations, and the new file is clean.

Compatibility, checked because it is the part that would fail quietly:

- `get_wordcamp_post()` resolves an application-status camp identically before and after, called both from a camp site, where these statuses are not registered at all, and from Central, where they are.
- `get_wordcamps( array( 'post_status' => 'any' ) )` returns the same set.
- The mentors dashboard query returns the same statuses and the same camps.
- `/wordcamps/`, its feed, `/schedule/`, `/about/`, `calendar.ics` and site search are byte identical before and after.
- REST collection, cancelled single and application-status single are all unchanged.
- The admin list keeps every status, its counts and its status links. The "View" row action stays but its href becomes the plain permalink form, since `wp_force_plain_post_permalink()` does that for protected statuses unless `$sample` is set. Both forms open for someone who can edit the post.

## How to review this locally

Check out the branch and restart the container so opcache cannot serve the old bytecode:

```
git checkout claude/event-status-visibility
docker restart wordcamptest-wordcamp.test-1
```

Make a camp in an application status:

```
docker exec wordcamptest-wordcamp.test-1 wp --url=central.wordcamp.test --allow-root \
  post create --post_type=wordcamp --post_status=wcpt-rejected \
  --post_title="WordCamp Reviewtown" --post_name=wc-reviewtown --porcelain
```

**A logged out visitor should not reach it.** This should print `302`, and following the redirect should land on the Central home page with none of the camp's data on it:

```
docker exec wordcamptest-wordcamp.test-1 sh -c \
  "curl -sk 'https://central.wordcamp.test/wordcamps/wc-reviewtown/' -o /dev/null -w '%{http_code}\n'"
```

**Someone who can edit it should still reach it.** Log in as an admin in the browser and open the same URL. You should get the camp page. The "View" link on `/wp-admin/edit.php?post_type=wordcamp` should also open it, at a `?post_type=wordcamp&p=<id>` URL rather than the pretty one.

**Nothing listed should have moved.** `/wordcamps/`, `/wordcamps/feed/`, `/schedule/`, `/about/` and `/calendar.ics` should be unchanged, and a camp at `wcpt-cancelled` or `wcpt-closed` should still resolve for a logged out visitor.

**The admin should be untouched.** `/wp-admin/edit.php?post_type=wordcamp` should still list every camp with its status label and status links.

**REST should be untouched.** A cancelled camp should still return 200 and an application-status camp should still return 401:

```
docker exec wordcamptest-wordcamp.test-1 sh -c \
  "curl -sk 'https://central.wordcamp.test/wp-json/wp/v2/wordcamps/<id>' -o /dev/null -w '%{http_code}\n'"
```

Tests:

```
docker compose -f docker-compose.phpunit.yml run --rm phpunit_wp \
  phpunit -c phpunit.xml.dist --filter Test_Event_Status_Visibility
```

## Note for deploy

WP Super Cache is on in production with `$cache_max_time = 3600`. Pages already cached for application-status camps keep being served to logged out visitors until they expire, so the change is not fully in effect until the cache turns over or is purged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
