### PR TITLE
WordCamp Reports: align Meetup Status export handler with the other reports

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -109,6 +109,7 @@ require_once WP_PLUGIN_DIR . '/wcpt/tests/bootstrap.php';
 require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );
 require_once WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-payments-network/tests/bootstrap.php';
+require_once WP_PLUGIN_DIR . '/wordcamp-reports/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/wporg-groups-frontend/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/gatherpress-recurring-events/tests/bootstrap.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,6 +44,12 @@
 			</directory>
 		</testsuite>
 
+		<testsuite name="WordCamp Reports">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/wordcamp-reports/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="WordCamp Post Type">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/plugins/wcpt/tests/
@@ -95,6 +101,7 @@
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-payments/</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-payments-network/</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-remote-css</directory>
+			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-reports</directory>
 			<directory suffix=".php">./public_html/wp-content/plugins/wordcamp-speaker-feedback</directory>
 			<file>./public_html/wp-content/sunrise.php</file>
 			<file>./public_html/wp-content/sunrise-events.php</file>

--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-status.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-meetup-status.php
@@ -330,6 +330,10 @@ class Meetup_Status extends Base_Status {
 	 * @return void
 	 */
 	public static function render_admin_page() {
+		if ( ! current_user_can( CAPABILITY ) ) {
+			return;
+		}
+
 		$start_date = wp_unslash( $_POST['start-date'] ?? '' );
 		$end_date   = wp_unslash( $_POST['end-date'] ?? '' );
 		$status     = wp_unslash( $_POST['status'] ?? '' );
@@ -409,10 +413,16 @@ class Meetup_Status extends Base_Status {
 	public static function export_to_file() {
 		$action = wp_unslash( $_POST['action'] ?? '' );
 		$report = wp_unslash( $_GET['report'] ?? '' );
+		$nonce  = wp_unslash( $_POST[ self::$slug . '-nonce' ] ?? '' );
+
 		if ( $report !== self::$slug ) {
 			return;
 		}
 		if ( 'Export CSV' !== $action ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( $nonce, 'run-report' ) || ! current_user_can( CAPABILITY ) ) {
 			return;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-reports/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/tests/bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPUnit bootstrapper for the WordCamp Reports plugin.
+ *
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugin that we'll need to be active for the tests.
+ *
+ * The plugin registers its report exporters on `plugins_loaded`, which has not
+ * fired yet at `muplugins_loaded`, so loading it here leaves that registration
+ * intact -- which matters, because the registration is what makes the exporters
+ * reachable in the first place.
+ *
+ * @return void
+ */
+function manually_load_plugin() {
+	require_once dirname( __DIR__ ) . '/index.php';
+}
+
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/plugins/wordcamp-reports/tests/test-report-export-authorization.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/tests/test-report-export-authorization.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Authorization tests for the report file exporters.
+ *
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Tests;
+
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+use WordCamp\Reports\Report\Meetup_Status;
+use function WordCamp\Reports\get_report_classes;
+use const WordCamp\Reports\CAPABILITY;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Every report class's `export_to_file()` is registered on `admin_init`, and
+ * `wp-admin/admin-post.php` fires `admin_init` *before* it decides whether the
+ * caller is authenticated. So each exporter is solely responsible for its own
+ * authorization, and none of them may do anything for an anonymous caller.
+ *
+ * @group wordcamp-reports
+ *
+ * @covers \WordCamp\Reports\Report\Meetup_Status::export_to_file
+ * @covers \WordCamp\Reports\Report\Meetup_Status::render_admin_page
+ */
+class Test_Report_Export_Authorization extends WP_UnitTestCase {
+	/**
+	 * A user with no report capability.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$subscriber_id = $factory->user->create( array(
+			'role' => 'subscriber',
+		) );
+	}
+
+	/**
+	 * Start each test as an anonymous caller with a clean request.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( 0 );
+		$_GET  = array();
+		$_POST = array();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		$_GET  = array();
+		$_POST = array();
+		wp_set_current_user( 0 );
+
+		remove_filter( 'user_has_cap', array( $this, 'grant_report_cap' ), 10 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Grant the reports capability to the current user.
+	 *
+	 * @param bool[] $allcaps All capabilities for the user.
+	 *
+	 * @return bool[]
+	 */
+	public function grant_report_cap( $allcaps ) {
+		$allcaps[ CAPABILITY ] = true;
+
+		return $allcaps;
+	}
+
+	/**
+	 * Run a callable and return everything it echoed.
+	 *
+	 * @param callable $callback The callable to run.
+	 *
+	 * @return string
+	 */
+	protected function capture_output( callable $callback ): string {
+		ob_start();
+		$callback();
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Every report class that registers a file exporter.
+	 *
+	 * @return array
+	 */
+	public function data_report_classes_with_exporters(): array {
+		$cases = array();
+
+		foreach ( get_report_classes() as $class ) {
+			if ( method_exists( $class, 'export_to_file' ) ) {
+				$cases[ $class::$slug ] = array( $class );
+			}
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * An anonymous `admin-post.php` request must not produce any output from any
+	 * exporter, however the report's own view or CSV would normally be emitted.
+	 *
+	 * This is the regression test for the Meetup Status report rendering its
+	 * admin screen -- the private field schema, the internal status vocabulary
+	 * and a `run-report` nonce -- to an unauthenticated caller.
+	 *
+	 * @dataProvider data_report_classes_with_exporters
+	 *
+	 * @param string $report_class The report class to exercise.
+	 */
+	public function test_exporter_is_a_no_op_for_anonymous_caller( $report_class ) {
+		$_GET['report']  = $report_class::$slug;
+		$_POST['action'] = 'Export CSV';
+
+		$output = $this->capture_output(
+			function () use ( $report_class ) {
+				$report_class::export_to_file();
+			}
+		);
+
+		$this->assertSame( '', $output, "{$report_class} emitted output for an unauthenticated caller." );
+	}
+
+	/**
+	 * A valid nonce is not authorization -- an anonymous caller can mint one from
+	 * any page that renders `wp_nonce_field( 'run-report' )`, and `wp_verify_nonce()`
+	 * accepts it for uid 0.
+	 */
+	public function test_meetup_status_exporter_rejects_valid_nonce_without_capability() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$nonce_key = Meetup_Status::$slug . '-nonce';
+
+		$_GET['report']      = Meetup_Status::$slug;
+		$_POST['action']     = 'Export CSV';
+		$_POST[ $nonce_key ] = wp_create_nonce( 'run-report' );
+
+		$output = $this->capture_output(
+			array( Meetup_Status::class, 'export_to_file' )
+		);
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * The capability alone is not enough either; the request still has to carry a
+	 * valid nonce, so the export cannot be triggered cross-site.
+	 */
+	public function test_meetup_status_exporter_rejects_capability_without_nonce() {
+		wp_set_current_user( self::$subscriber_id );
+		add_filter( 'user_has_cap', array( $this, 'grant_report_cap' ) );
+
+		$_GET['report']  = Meetup_Status::$slug;
+		$_POST['action'] = 'Export CSV';
+
+		$output = $this->capture_output(
+			array( Meetup_Status::class, 'export_to_file' )
+		);
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * `render_admin_page()` fails closed on its own, so the view cannot leak
+	 * regardless of which entry point reaches it.
+	 */
+	public function test_meetup_status_admin_page_is_a_no_op_for_unauthorized_user() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$output = $this->capture_output(
+			array( Meetup_Status::class, 'render_admin_page' )
+		);
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * The counterpart to the above: a user who does hold the capability still
+	 * gets the report screen, including the nonce field and the field checkboxes.
+	 *
+	 * No nonce is supplied, so the report data itself is not built -- this covers
+	 * the view rendering, not the export.
+	 */
+	public function test_meetup_status_admin_page_renders_for_authorized_user() {
+		wp_set_current_user( self::$subscriber_id );
+		add_filter( 'user_has_cap', array( $this, 'grant_report_cap' ) );
+
+		$output = $this->capture_output(
+			array( Meetup_Status::class, 'render_admin_page' )
+		);
+
+		$this->assertStringContainsString( Meetup_Status::$slug . '-nonce', $output );
+		$this->assertStringContainsString( 'name="fields[]"', $output );
+	}
+}


### PR DESCRIPTION
## Summary

The Meetup Status report's export handler and admin-page render were missing the capability/nonce checks that the other report classes in `wordcamp-reports/classes/report/` already apply consistently. This brings that one handler in line with its siblings:

- `Meetup_Status::export_to_file()` now verifies the `run-report` nonce and the `view_wordcamp_reports` capability before proceeding, matching e.g. `Meetup_Details`, `Meetup_Groups`, etc.
- `Meetup_Status::render_admin_page()` now checks the capability up front, so it fails closed as a whole rather than gating only the data-building step.

Both checks are the same ones already used elsewhere in the plugin — no new behavior for users who have report access.

### Tests

`wordcamp-reports` had no PHPUnit suite, so this also adds one:

- A data-provider test covering **every** report class's export handler, asserting each requires report access — so a newly added report can't accidentally ship without the same check.
- Targeted tests for the Meetup Status handler and admin-page render (capability-present renders the screen; capability-absent and nonce/capability mismatches produce nothing).

Wired into `phpunit.xml.dist` (new `WordCamp Reports` suite) and `phpunit-bootstrap.php`, following the same pattern as the other plugin suites.

## Test plan

- [x] `phpunit --testsuite "WordCamp Reports"` — 18/18 passing
- [x] Full regression run — no new failures (pre-existing Groups-blocks failures need built JS assets, unrelated to this change)
- [x] phpcs clean on all changed/new files
- [x] Manual browser pass (below)

### Manual test steps

As a user with access to the Reports screen (on central):

1. Open **Dashboard → Reports → Meetup Status**. The report screen renders normally (date range, status dropdown, both buttons).
2. Enter a date range and click **Show results** — results render as before.
3. Click **Export resulting Meetups as a CSV** and submit — a CSV downloads as before.

No change is expected in any of these flows for a user who has report access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxMxx2cg9CVabUvdBAbkR4
