### PR TITLE
Enables Jetpack wp.me shortlinks by default for new WordCamp sites

### DIFF
--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/modules.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/modules.php
@@ -48,6 +48,7 @@ function default_jetpack_modules( $modules ) {
 		'image-cdn',
 		'sharedaddy',
 		'shortcodes',
+		'shortlinks',
 		'subscriptions'
 	);
 


### PR DESCRIPTION
Default WordCamp site links are extraordinarily long, and in order to share WordCamp content on social platforms, we need shortlinks enabled. I've been enabling this option for all flagship WordCamps over the last few years, so it seems appropriate to enable it by default.

### Screenshots

<img width="1412" height="280" alt="CleanShot 2026-08-24 at 11 17 31@2x" src="https://github.com/user-attachments/assets/cb707200-14e1-468b-9aa5-b7038e0f8e53" />

### How to test the changes in this Pull Request:

1. Create a new WordCamp site
2. Visit `/wp-admin/admin.php?page=jetpack#/traffic`
3. Verify that the "Generate shortened URLs for simpler sharing." option is enabled