### PR TITLE
Groups: keep the block inserter below the event modal header

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-settings/style.scss
@@ -21,7 +21,8 @@
 // === Full-screen modal ===
 
 .wporg-group-settings-modal {
-	// Accent tokens come from `components/component-accents.css`.
+	// Accent tokens and the header stacking fix come from
+	// `components/component-accents.css`.
 
 	.components-modal__content {
 		padding: 0;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
@@ -21,8 +21,11 @@
 	--wp-components-color-accent-inverted: var(--wp--preset--color--white, #fff);
 }
 
-/*
- * Fix form elements overlapping form header.
+/**
+ * The block editor's inserter popover (`.block-editor-block-popover`,
+ * position: absolute, z-index: 31) draws over the modal header when the
+ * content scrolls, because the upstream header is z-index: 10 with no
+ * background. Opaque and one above the popover keeps the header on top.
  */
 .wporg-groups-modal-accent .components-modal__header {
 	background: var(--wp--preset--color--white, #fff);

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/component-accents.css
@@ -20,3 +20,11 @@
 	--wp-components-color-accent-darker-20: var(--wp--preset--color--dark-blueberry, #1d35b4);
 	--wp-components-color-accent-inverted: var(--wp--preset--color--white, #fff);
 }
+
+/*
+ * Fix form elements overlapping form header.
+ */
+.wporg-groups-modal-accent .components-modal__header {
+	background: var(--wp--preset--color--white, #fff);
+	z-index: 32;
+}


### PR DESCRIPTION
Updates the event modal header's background and stacking order so Description editor controls no longer render above it while scrolling.

Fixes #1937

Props vanyukov

### Screenshots

Before:
<img width="1280" height="900" alt="before-modal-inserter" src="https://github.com/user-attachments/assets/ed7768d7-3fb5-4594-bc64-40c78cd95501" />

After:
<img width="1280" height="900" alt="after-modal-inserter" src="https://github.com/user-attachments/assets/ac2b36a5-a4bd-43a3-b730-59a9b7ef2108" />

### How to test the changes in this Pull Request:

1. Build the Groups frontend:
   `npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend`
2. As an Organiser, open **+ Create event**, focus the Description editor, and scroll the modal.
3. Confirm the `+` inserter stays below the header and the header controls remain visible.