### PR TITLE
WordCamp application: attribute the application to the submitting user

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-events/class-events-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-events/class-events-application.php
@@ -150,15 +150,16 @@ class Events_Application extends WordCamp_Application {
 	public function create_post( $data ) {
 		$wordcamp_user_id = get_user_by( 'email', 'support@wordcamp.org' )->ID;
 
-		// Create the post.
-		$user     = wcorg_get_user_by_canonical_names( $data['q_wporg_username'] );
-		$statuses = \WordCamp_Loader::get_post_statuses();
+		// `submit_application()` only reaches this method for a logged-in submitter, so the
+		// application is owned by that account. The username field is stored as meta below.
+		$author_id = get_current_user_id();
+		$statuses  = \WordCamp_Loader::get_post_statuses();
 
 		$post = array(
 			'post_type'   => self::get_event_type(),
 			'post_title'  => esc_html( $data['q_event_location'] ),
 			'post_status' => self::get_default_status(),
-			'post_author' => is_a( $user, 'WP_User' ) ? $user->ID : $wordcamp_user_id, // Set `wordcamp` as author if supplied username is not valid.
+			'post_author' => $author_id ?: $wordcamp_user_id,
 		);
 
 		$post_id = wp_insert_post( $post, true );

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -189,8 +189,11 @@ class WordCamp_Application extends Event_Application {
 	 * @return int|\WP_Error
 	 */
 	public function create_post( $data ) {
-		// Create the post.
-		$user      = wcorg_get_user_by_canonical_names( $data['q_4236565_wporg_username'] );
+		// `submit_application()` only reaches this method for a logged-in submitter, so the
+		// application is owned by the account that is submitting it. The WordPress.org
+		// username field is descriptive data for the Community Team (stored as meta below),
+		// not a claim of ownership.
+		$author_id = get_current_user_id();
 		$statues   = \WordCamp_Loader::get_post_statuses();
 		$countries = wcorg_get_countries();
 
@@ -198,7 +201,7 @@ class WordCamp_Application extends Event_Application {
 			'post_type'   => $this->get_event_type(),
 			'post_title'  => 'WordCamp ' . $data['q_1079103_wordcamp_location'],
 			'post_status' => WCPT_DEFAULT_STATUS,
-			'post_author' => is_a( $user, 'WP_User' ) ? $user->ID : 7694169, // Set `wordcamp` as author if supplied username is not valid.
+			'post_author' => $author_id ?: 7694169, // Fall back to the `wordcamp` account if there is somehow no current user.
 		);
 
 		$post_id = wp_insert_post( $post, true );
@@ -253,7 +256,7 @@ class WordCamp_Application extends Event_Application {
 			'_status_change',
 			array(
 				'timestamp' => time(),
-				'user_id'   => is_a( $user, 'WP_User' ) ? $user->ID : 0,
+				'user_id'   => $author_id,
 				'message'   => sprintf( '%s &rarr; %s', 'Application', $statues[ WCPT_DEFAULT_STATUS ] ),
 			)
 		);

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -190,9 +190,7 @@ class WordCamp_Application extends Event_Application {
 	 */
 	public function create_post( $data ) {
 		// `submit_application()` only reaches this method for a logged-in submitter, so the
-		// application is owned by the account that is submitting it. The WordPress.org
-		// username field is descriptive data for the Community Team (stored as meta below),
-		// not a claim of ownership.
+		// application is owned by that account. The username field is stored as meta below.
 		$author_id = get_current_user_id();
 		$statues   = \WordCamp_Loader::get_post_statuses();
 		$countries = wcorg_get_countries();


### PR DESCRIPTION
## Summary

`WordCamp_Application::create_post()` set the application's `post_author` from the submitted **WordPress.org Username** field (resolved via `wcorg_get_user_by_canonical_names()`). The application form is only reachable by a logged-in user — `Event_Application::submit_application()` requires `is_user_logged_in()` — so the account that submits the application is the natural owner.

This change attributes the new WordCamp application to the current (submitting) user and keeps the WordPress.org username field as application data for the Community Team to review, rather than using it to set the owner. The initial status-change entry is recorded against the same user. This matches how the Meetup converter attributes its applications and makes ownership predictable.

## Changes

- `post_author` is the current user (falling back to the `wordcamp` account only if there is somehow no current user).
- The WordPress.org username stays as the `WordPress.org Username` meta.
- `_status_change['user_id']` is the current user.

## Testing

1. Check out this branch on a local wordcamp.org multisite (Central site).
2. Log in as the admin account.
3. Open the organizer application form at `https://central.wordcamp.test/wordcamp-organizer-application/` and submit it. In the **WordPress.org Username** field, enter a *different* account's username than the one you're logged in as, e.g. `contributorrole`.
4. Find the application created on Central and confirm the author is the account you submitted with — not the one you typed in the username field:
   ```
   wp --url=https://central.wordcamp.test post list --post_type=wordcamp \
     --fields=ID,post_title,post_author --orderby=ID --order=desc --posts_per_page=1
   ```
   `post_author` should be your logged-in user's ID.
5. Confirm the typed username is still retained as data on the application:
   ```
   wp --url=https://central.wordcamp.test post meta get <application_id> "WordPress.org Username"
   ```
   It should echo back what you entered in step 3.
6. Confirm the initial status entry is attributed to the submitting user:
   ```
   wp --url=https://central.wordcamp.test post meta get <application_id> _status_change --format=json
   ```
   `user_id` should be your logged-in user's ID.
