### PR TITLE
Applications: keep submitted form values as text in posts

### DIFF
--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -426,7 +426,10 @@ function wcorg_sanitize_plain_text( $value ) {
 		return '';
 	}
 
+	// `strip_tags()` deletes from an unterminated `<` to the end of the string, so encode that
+	// case first -- `Rated <A best` should keep its text, not become `Rated`.
 	$value = wp_check_invalid_utf8( (string) $value );
+	$value = wp_pre_kses_less_than( $value );
 	$value = wp_strip_all_tags( $value, true );
 
 	return str_replace( '<', '&lt;', $value );

--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -397,3 +397,42 @@ function wcorg_json_encode_attr_i18n( $raw_value ) {
 		true
 	);
 }
+
+/**
+ * Reduce a submitted value to text that stays text once WordPress saves it.
+ *
+ * `sanitize_text_field()` and `wp_kses()` disagree about what opens a tag: `strip_tags()`, which the
+ * former is built on, needs a letter, `/`, `!` or `?` after the `<`, while kses also accepts whitespace.
+ * A value like `< code >` therefore passes the sanitiser untouched, and the `wp_filter_kses()` that core
+ * puts on `title_save_pre` and `content_save_pre` then rebuilds it into a real element -- so a handler
+ * that meant to store text ends up storing markup. Encoding the `<` that survives settles the
+ * disagreement, and leaves the character visible to readers.
+ *
+ * `wp_kses( $value, array() )` is not a substitute: it drops whole `<...>` spans, turning
+ * `Hall < 100 > seats` into `Hall  seats`, and rewrites every `&`.
+ *
+ * The result is encoded for HTML. Decode it before using it in a plain-text medium such as an email
+ * body or a CSV column.
+ *
+ * @param string|array $value            The submitted value. Arrays are handled recursively; keys are
+ *                                       left alone.
+ * @param bool         $keep_line_breaks Whether to keep newlines, as `sanitize_textarea_field()` does.
+ *
+ * @return string|array A string, or an array of strings when `$value` is an array.
+ */
+function wcorg_sanitize_plain_text( $value, $keep_line_breaks = false ) {
+	if ( is_array( $value ) ) {
+		return array_map(
+			function ( $item ) use ( $keep_line_breaks ) {
+				return wcorg_sanitize_plain_text( $item, $keep_line_breaks );
+			},
+			$value
+		);
+	}
+
+	$value = $keep_line_breaks
+		? sanitize_textarea_field( (string) $value )
+		: sanitize_text_field( (string) $value );
+
+	return str_replace( '<', '&lt;', $value );
+}

--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -410,7 +410,8 @@ function wcorg_json_encode_attr_i18n( $raw_value ) {
  * percent-encoded URLs; `wp_kses( $value, array() )` drops whole `<...>` spans, turning
  * `Hall < 100 > seats` into `Hall  seats`.
  *
- * The result is HTML-encoded. Decode it for a plain-text medium such as an email body or a CSV column.
+ * The result is HTML-encoded. Decode it for a plain-text medium -- the organizer reminder mails
+ * (`wcor-mailer.php`) are the case already in the tree.
  *
  * @param mixed $value Arrays are handled recursively, with keys left alone. Anything neither array nor
  *                     scalar becomes `''`, as `sanitize_text_field()` does.

--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -401,24 +401,19 @@ function wcorg_json_encode_attr_i18n( $raw_value ) {
 /**
  * Reduce a submitted value to text that stays text once WordPress saves it.
  *
- * `sanitize_text_field()` and `wp_kses()` disagree about what opens a tag: `strip_tags()`, which the
- * former is built on, needs a letter, `/`, `!` or `?` after the `<`, while kses also accepts whitespace.
- * A value like `< code >` therefore passes the sanitiser untouched, and the `wp_filter_kses()` that core
- * puts on `title_save_pre` then rebuilds it into a real element -- so a handler that meant to store text
- * ends up storing markup. Encoding the `<` that survives settles the disagreement, and leaves the
- * character visible to readers.
+ * `strip_tags()` wants a letter, `/`, `!` or `?` after a `<` before it counts as a tag, but `wp_kses()`
+ * also accepts whitespace. So `< code >` survives `sanitize_text_field()`, and the `wp_filter_kses()`
+ * core puts on `title_save_pre` then rebuilds it into a real element. Encoding the surviving `<` settles
+ * that, and still reads as `<` to a human.
  *
- * This deliberately does not call `sanitize_text_field()`, which would also delete every `%[a-f0-9]{2}`
- * sequence and so quietly break a percent-encoded URL. `wp_kses( $value, array() )` is not usable either:
- * it drops whole `<...>` spans rather than neutralising them, turning `Hall < 100 > seats` into
- * `Hall  seats`, and rewrites every `&`.
+ * Two near-misses to avoid: `sanitize_text_field()` also deletes every `%[a-f0-9]{2}`, which breaks
+ * percent-encoded URLs; `wp_kses( $value, array() )` drops whole `<...>` spans, turning
+ * `Hall < 100 > seats` into `Hall  seats`.
  *
- * The result is encoded for HTML. Decode it before using it in a plain-text medium such as an email
- * body or a CSV column.
+ * The result is HTML-encoded. Decode it for a plain-text medium such as an email body or a CSV column.
  *
- * @param mixed $value The submitted value. Arrays are handled recursively; array keys are left alone,
- *                     and anything that is neither an array nor a scalar becomes an empty string, as
- *                     `sanitize_text_field()` does.
+ * @param mixed $value Arrays are handled recursively, with keys left alone. Anything neither array nor
+ *                     scalar becomes `''`, as `sanitize_text_field()` does.
  *
  * @return string|array A string, or an array of strings when `$value` is an array.
  */

--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -404,35 +404,35 @@ function wcorg_json_encode_attr_i18n( $raw_value ) {
  * `sanitize_text_field()` and `wp_kses()` disagree about what opens a tag: `strip_tags()`, which the
  * former is built on, needs a letter, `/`, `!` or `?` after the `<`, while kses also accepts whitespace.
  * A value like `< code >` therefore passes the sanitiser untouched, and the `wp_filter_kses()` that core
- * puts on `title_save_pre` and `content_save_pre` then rebuilds it into a real element -- so a handler
- * that meant to store text ends up storing markup. Encoding the `<` that survives settles the
- * disagreement, and leaves the character visible to readers.
+ * puts on `title_save_pre` then rebuilds it into a real element -- so a handler that meant to store text
+ * ends up storing markup. Encoding the `<` that survives settles the disagreement, and leaves the
+ * character visible to readers.
  *
- * `wp_kses( $value, array() )` is not a substitute: it drops whole `<...>` spans, turning
- * `Hall < 100 > seats` into `Hall  seats`, and rewrites every `&`.
+ * This deliberately does not call `sanitize_text_field()`, which would also delete every `%[a-f0-9]{2}`
+ * sequence and so quietly break a percent-encoded URL. `wp_kses( $value, array() )` is not usable either:
+ * it drops whole `<...>` spans rather than neutralising them, turning `Hall < 100 > seats` into
+ * `Hall  seats`, and rewrites every `&`.
  *
  * The result is encoded for HTML. Decode it before using it in a plain-text medium such as an email
  * body or a CSV column.
  *
- * @param string|array $value            The submitted value. Arrays are handled recursively; keys are
- *                                       left alone.
- * @param bool         $keep_line_breaks Whether to keep newlines, as `sanitize_textarea_field()` does.
+ * @param mixed $value The submitted value. Arrays are handled recursively; array keys are left alone,
+ *                     and anything that is neither an array nor a scalar becomes an empty string, as
+ *                     `sanitize_text_field()` does.
  *
  * @return string|array A string, or an array of strings when `$value` is an array.
  */
-function wcorg_sanitize_plain_text( $value, $keep_line_breaks = false ) {
+function wcorg_sanitize_plain_text( $value ) {
 	if ( is_array( $value ) ) {
-		return array_map(
-			function ( $item ) use ( $keep_line_breaks ) {
-				return wcorg_sanitize_plain_text( $item, $keep_line_breaks );
-			},
-			$value
-		);
+		return array_map( 'wcorg_sanitize_plain_text', $value );
 	}
 
-	$value = $keep_line_breaks
-		? sanitize_textarea_field( (string) $value )
-		: sanitize_text_field( (string) $value );
+	if ( ! is_scalar( $value ) ) {
+		return '';
+	}
+
+	$value = wp_check_invalid_utf8( (string) $value );
+	$value = wp_strip_all_tags( $value, true );
 
 	return str_replace( '<', '&lt;', $value );
 }

--- a/public_html/wp-content/mu-plugins/events/jetpack-form-to-wcpt-application.php
+++ b/public_html/wp-content/mu-plugins/events/jetpack-form-to-wcpt-application.php
@@ -119,8 +119,8 @@ function create_campus_connect_tracker( $post_id, $fields, $is_spam, $entry_valu
 		return;
 	}
 
-	// Jetpack only puts these through `sanitize_textarea_field()`, which is not enough on its own
-	// to keep the title text. See `wcorg_sanitize_plain_text()`.
+	// `find_first_field_matching_label()` applies `sanitize_text_field()`, which is not enough on
+	// its own to keep the title text. See `wcorg_sanitize_plain_text()`.
 	$post = array(
 		'post_type'   => 'wordcamp',
 		'post_title'  => 'WordPress Campus Connect ' . wcorg_sanitize_plain_text( $campus ?: trim( "$city, $country", ', ' ) ),

--- a/public_html/wp-content/mu-plugins/events/jetpack-form-to-wcpt-application.php
+++ b/public_html/wp-content/mu-plugins/events/jetpack-form-to-wcpt-application.php
@@ -119,9 +119,11 @@ function create_campus_connect_tracker( $post_id, $fields, $is_spam, $entry_valu
 		return;
 	}
 
+	// Jetpack only puts these through `sanitize_textarea_field()`, which is not enough on its own
+	// to keep the title text. See `wcorg_sanitize_plain_text()`.
 	$post = array(
 		'post_type'   => 'wordcamp',
-		'post_title'  => 'WordPress Campus Connect ' . ( $campus ?: trim( "$city, $country", ', ' ) ),
+		'post_title'  => 'WordPress Campus Connect ' . wcorg_sanitize_plain_text( $campus ?: trim( "$city, $country", ', ' ) ),
 		'post_status' => WCPT_DEFAULT_STATUS,
 		'post_author' => $service_account, // Public submission: owned by the service account.
 	);

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -27,6 +27,7 @@ function manually_load_plugins() {
 	require_once dirname( dirname( __DIR__ ) ) . '/sunrise.php';
 	require_once dirname( dirname( __DIR__ ) ) . '/sunrise-events.php';
 
+	require_once dirname( __DIR__ ) . '/3-helpers-misc.php';
 	require_once dirname( __DIR__ ) . '/site-url-history.php';
 	require_once dirname( __DIR__ ) . '/0-error-handling.php';
 	require_once dirname( __DIR__ ) . '/wordcamp/lets-encrypt-helper.php';

--- a/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
@@ -25,8 +25,8 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wcorg_sanitize_plain_text
 	 */
-	public function test_wcorg_sanitize_plain_text( $value, $keep_line_breaks, $expected ) {
-		$this->assertSame( $expected, wcorg_sanitize_plain_text( $value, $keep_line_breaks ) );
+	public function test_wcorg_sanitize_plain_text( $value, $expected ) {
+		$this->assertSame( $expected, wcorg_sanitize_plain_text( $value ) );
 	}
 
 	/**
@@ -38,64 +38,49 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 		return array(
 			'ordinary text is untouched' => array(
 				'WordCamp Narnia',
-				false,
 				'WordCamp Narnia',
 			),
 
 			'real elements are stripped' => array(
 				'<code>Narnia</code>',
-				false,
 				'Narnia',
 			),
 
 			'a space after the angle bracket does not carry an element through' => array(
 				self::SPACED_TAG,
-				false,
 				'Portland&lt; code >" data-x="&lt; /code >Oregon',
 			),
 
 			'an element outside the kses allow-list is handled the same way' => array(
 				'< pre >Narnia< /pre >',
-				false,
 				'&lt; pre >Narnia&lt; /pre >',
 			),
 
 			// `wp_kses( $value, array() )` deletes the whole `<...>` span here, returning `Hall  seats`.
 			'an angle bracket pair does not swallow the text between it' => array(
 				'Hall < 100 > seats',
-				false,
 				'Hall &lt; 100 > seats',
 			),
 
 			// Already-encoded input must not be decoded back into something kses can rebuild.
 			'entity-encoded angle brackets are left encoded' => array(
 				'&lt; code &gt;Narnia',
-				false,
 				'&lt; code &gt;Narnia',
 			),
 
 			'numeric character references are not decoded' => array(
 				'&#60; code >Narnia',
-				false,
 				'&#60; code >Narnia',
 			),
 
 			'ampersands are left for the kses pass to normalize' => array(
 				'Smith & Sons Hall',
-				false,
 				'Smith & Sons Hall',
 			),
 
 			'line breaks are collapsed by default' => array(
 				"Narnia\nHall",
-				false,
 				'Narnia Hall',
-			),
-
-			'line breaks are kept when asked for' => array(
-				"Narnia\nHall",
-				true,
-				"Narnia\nHall",
 			),
 
 			'arrays are sanitized recursively' => array(
@@ -103,7 +88,6 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 					'a' => '< code >x',
 					'b' => array( '< code >y' ),
 				),
-				false,
 				array(
 					'a' => '&lt; code >x',
 					'b' => array( '&lt; code >y' ),
@@ -112,8 +96,19 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 
 			'non-string scalars are cast' => array(
 				42,
-				false,
 				'42',
+			),
+
+			// `sanitize_text_field()` would delete these, quietly breaking a pasted URL.
+			'percent-encoded sequences are preserved' => array(
+				'See https://example.org/My%20Notes.pdf',
+				'See https://example.org/My%20Notes.pdf',
+			),
+
+			// The wrapper is no less forgiving than the `sanitize_*_field()` it replaces.
+			'a value that is neither array nor scalar becomes an empty string' => array(
+				new \stdClass(),
+				'',
 			),
 		);
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
@@ -78,7 +78,7 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 				'Smith & Sons Hall',
 			),
 
-			'line breaks are collapsed by default' => array(
+			'line breaks are collapsed' => array(
 				"Narnia\nHall",
 				'Narnia Hall',
 			),
@@ -97,6 +97,12 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 			'non-string scalars are cast' => array(
 				42,
 				'42',
+			),
+
+			// `strip_tags()` alone deletes from an unterminated `<` to the end of the string.
+			'an unterminated angle bracket does not truncate the value' => array(
+				'Rated <A best',
+				'Rated &lt;A best',
 			),
 
 			// `sanitize_text_field()` would delete these, quietly breaking a pasted URL.

--- a/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace WordCamp\Helpers\Misc\Tests;
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group mu-plugins
+ * @group helpers
+ * @group helpers-misc
+ */
+class Test_Helpers_Misc extends WP_UnitTestCase {
+	/**
+	 * A value that `sanitize_text_field()` leaves alone but `wp_kses()` would read as an element.
+	 *
+	 * The space after `<` is the point: `strip_tags()` wants a letter, `/`, `!` or `?` there, kses
+	 * does not. The quotes are in it because `wptexturize()` skips the contents of a `code` element,
+	 * so they would otherwise reach the page uncurled.
+	 */
+	const SPACED_TAG = 'Portland< code >" data-x="< /code >Oregon';
+
+	/**
+	 * @covers ::wcorg_sanitize_plain_text
+	 *
+	 * @dataProvider data_wcorg_sanitize_plain_text
+	 */
+	public function test_wcorg_sanitize_plain_text( $value, $keep_line_breaks, $expected ) {
+		$this->assertSame( $expected, wcorg_sanitize_plain_text( $value, $keep_line_breaks ) );
+	}
+
+	/**
+	 * Test cases for test_wcorg_sanitize_plain_text().
+	 *
+	 * @return array
+	 */
+	public function data_wcorg_sanitize_plain_text() {
+		return array(
+			'ordinary text is untouched' => array(
+				'WordCamp Narnia',
+				false,
+				'WordCamp Narnia',
+			),
+
+			'real elements are stripped' => array(
+				'<code>Narnia</code>',
+				false,
+				'Narnia',
+			),
+
+			'a space after the angle bracket does not carry an element through' => array(
+				self::SPACED_TAG,
+				false,
+				'Portland&lt; code >" data-x="&lt; /code >Oregon',
+			),
+
+			'an element outside the kses allow-list is handled the same way' => array(
+				'< pre >Narnia< /pre >',
+				false,
+				'&lt; pre >Narnia&lt; /pre >',
+			),
+
+			// `wp_kses( $value, array() )` deletes the whole `<...>` span here, returning `Hall  seats`.
+			'an angle bracket pair does not swallow the text between it' => array(
+				'Hall < 100 > seats',
+				false,
+				'Hall &lt; 100 > seats',
+			),
+
+			// Already-encoded input must not be decoded back into something kses can rebuild.
+			'entity-encoded angle brackets are left encoded' => array(
+				'&lt; code &gt;Narnia',
+				false,
+				'&lt; code &gt;Narnia',
+			),
+
+			'numeric character references are not decoded' => array(
+				'&#60; code >Narnia',
+				false,
+				'&#60; code >Narnia',
+			),
+
+			'ampersands are left for the kses pass to normalize' => array(
+				'Smith & Sons Hall',
+				false,
+				'Smith & Sons Hall',
+			),
+
+			'line breaks are collapsed by default' => array(
+				"Narnia\nHall",
+				false,
+				'Narnia Hall',
+			),
+
+			'line breaks are kept when asked for' => array(
+				"Narnia\nHall",
+				true,
+				"Narnia\nHall",
+			),
+
+			'arrays are sanitized recursively' => array(
+				array(
+					'a' => '< code >x',
+					'b' => array( '< code >y' ),
+				),
+				false,
+				array(
+					'a' => '&lt; code >x',
+					'b' => array( '&lt; code >y' ),
+				),
+			),
+
+			'non-string scalars are cast' => array(
+				42,
+				false,
+				'42',
+			),
+		);
+	}
+
+	/**
+	 * Sanitizing an already-sanitized value must not change it again.
+	 *
+	 * @covers ::wcorg_sanitize_plain_text
+	 */
+	public function test_wcorg_sanitize_plain_text_is_idempotent() {
+		$once = wcorg_sanitize_plain_text( self::SPACED_TAG );
+
+		$this->assertSame( $once, wcorg_sanitize_plain_text( $once ) );
+	}
+
+	/**
+	 * The point of the helper: nothing comes out that `wp_kses()` can read back as an element.
+	 *
+	 * `wp_filter_kses()` is what core registers on `title_save_pre` for users without
+	 * `unfiltered_html`, so this is the transformation a stored title actually goes through.
+	 *
+	 * @covers ::wcorg_sanitize_plain_text
+	 */
+	public function test_wcorg_sanitize_plain_text_survives_the_kses_pass() {
+		$values = array(
+			self::SPACED_TAG,
+			'< pre >Narnia< /pre >',
+			'< a href="https://example.org" >Narnia< /a >',
+
+			// Pre-encoded forms, in case anything upstream encodes before this runs.
+			'&lt; code &gt;Narnia',
+			'&#60; code >Narnia',
+			'&amp;lt; code >Narnia',
+
+			// A NUL between the bracket and the tag name.
+			"< \0code >Narnia",
+		);
+
+		foreach ( $values as $value ) {
+			$stored = wp_filter_kses( wcorg_sanitize_plain_text( $value ) );
+
+			$this->assertFalse(
+				( new \WP_HTML_Tag_Processor( $stored ) )->next_tag(),
+				"Stored value read back as markup: $value"
+			);
+		}
+	}
+
+	/**
+	 * `sanitize_text_field()` on its own does not hold, which is the reason this helper exists.
+	 *
+	 * Pinning that here means the suite notices if a future refactor drops the helper from a handler
+	 * and goes back to the sanitiser alone.
+	 *
+	 * @covers ::wcorg_sanitize_plain_text
+	 */
+	public function test_sanitize_text_field_alone_is_not_enough() {
+		$this->assertStringContainsString( '<code>', wp_filter_kses( sanitize_text_field( self::SPACED_TAG ) ) );
+		$this->assertStringNotContainsString( '<code>', wp_filter_kses( wcorg_sanitize_plain_text( self::SPACED_TAG ) ) );
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wcpt/tests/bootstrap.php
@@ -10,6 +10,7 @@ if ( 'cli' !== php_sapi_name() ) {
  * Load the plugins that we'll need to be active for the tests
  */
 function manually_load_plugins() {
+	require_once SUT_WPMU_PLUGIN_DIR . '/3-helpers-misc.php';
 	require_once dirname( dirname( dirname( __DIR__ ) ) ) . '/sunrise.php';
 	require_once dirname( __DIR__ ) . '/wcpt-wordcamp/wordcamp-new-site.php';
 

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-application.php
@@ -37,10 +37,11 @@ class Test_WordCamp_Application extends WP_UnitTestCase {
 
 		$title = get_post( $post_id )->post_title;
 
-		$this->assertStringNotContainsString( '<code>', $title );
 		$this->assertFalse(
 			( new \WP_HTML_Tag_Processor( $title ) )->next_tag(),
 			"Stored title read back as markup: $title"
 		);
+		// In full, so that a value which lost text on the way through fails too.
+		$this->assertSame( 'WordCamp Portland&lt; code &gt;" data-x="&lt; /code &gt;Oregon', $title );
 	}
 }

--- a/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/tests/wcpt-wordcamp/test-wordcamp-application.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WordCamp\WCPT\Tests;
+use WP_UnitTestCase;
+use WordPress_Community\Applications\WordCamp_Application;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group wcpt
+ * @group wcpt-application
+ */
+class Test_WordCamp_Application extends WP_UnitTestCase {
+	/**
+	 * The submitted location has to reach `post_title` as text, not as markup.
+	 *
+	 * `sanitize_text_field()` does not manage that on its own: it is built on `strip_tags()`, which
+	 * only treats `<` as a tag opener when a letter, `/`, `!` or `?` follows it, while the
+	 * `wp_filter_kses()` that core puts on `title_save_pre` also accepts whitespace there and
+	 * rebuilds the element. See `wcorg_sanitize_plain_text()`.
+	 *
+	 * @covers WordPress_Community\Applications\WordCamp_Application::create_post
+	 */
+	public function test_create_post_does_not_store_markup_in_the_title() {
+		// A user without `unfiltered_html`, so `title_save_pre` filters through kses.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$application = new WordCamp_Application();
+		$data        = $application->get_default_application_values();
+
+		$data['q_1079103_wordcamp_location'] = 'Portland< code >" data-x="< /code >Oregon';
+		$data['q_4236565_wporg_username']    = 'nobody-with-this-name';
+
+		$post_id = $application->create_post( $data );
+
+		$this->assertNotWPError( $post_id );
+
+		$title = get_post( $post_id )->post_title;
+
+		$this->assertStringNotContainsString( '<code>', $title );
+		$this->assertFalse(
+			( new \WP_HTML_Tag_Processor( $title ) )->next_tag(),
+			"Stored title read back as markup: $title"
+		);
+	}
+}

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/class-wordcamp-application.php
@@ -196,7 +196,8 @@ class WordCamp_Application extends Event_Application {
 
 		$post = array(
 			'post_type'   => $this->get_event_type(),
-			'post_title'  => 'WordCamp ' . $data['q_1079103_wordcamp_location'],
+			// `sanitize_text_field()` is not enough on its own here. See `wcorg_sanitize_plain_text()`.
+			'post_title'  => 'WordCamp ' . wcorg_sanitize_plain_text( $data['q_1079103_wordcamp_location'] ),
 			'post_status' => WCPT_DEFAULT_STATUS,
 			'post_author' => is_a( $user, 'WP_User' ) ? $user->ID : 7694169, // Set `wordcamp` as author if supplied username is not valid.
 		);

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1052,6 +1052,11 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 			$is_event     = is_event_url( $wordcamp_url );
 			$title        = sprintf( 'New %s scheduled!!!', $is_event ? 'Next Generation Event' : 'WordCamp' );
 
+			/*
+			 * `post_title` can hold `&lt;` for a `<` the applicant typed, see
+			 * `wcorg_sanitize_plain_text()`. Slack decodes that back to `<` in mrkdwn, so it reads
+			 * correctly here -- worth knowing before this string is reused somewhere that does not.
+			 */
 			$message = sprintf(
 				"<%s|%s> has been scheduled for a start date of %s. :tada: :community: :WordPress:\n\n%s",
 				$wordcamp_url,

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/bootstrap.php
@@ -13,6 +13,7 @@ if ( 'cli' !== php_sapi_name() ) {
  * so Jetpack has to be loaded before the plugin under test.
  */
 function manually_load_plugins() {
+	require_once SUT_WPMU_PLUGIN_DIR . '/3-helpers-misc.php';
 	require_once dirname( dirname( __DIR__ ) ) . '/jetpack/jetpack.php';
 	require_once dirname( __DIR__ ) . '/wordcamp-forms-to-drafts.php';
 }

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
@@ -43,6 +43,16 @@ class Test_Draft_Content extends WP_UnitTestCase {
 	const MARKUP_INPUT = 'Test< code >" data-x="< /code >Co';
 
 	/**
+	 * What MARKUP_INPUT must look like once it has been stored as a title.
+	 *
+	 * Asserted in full rather than by "contains no tag", so that a value which lost text on the way
+	 * through -- rather than only one that kept its markup -- fails too.
+	 *
+	 * @var string
+	 */
+	const MARKUP_TITLE = 'Test&lt; code &gt;" data-x="&lt; /code &gt;Co';
+
+	/**
 	 * Set up the plugin instance.
 	 */
 	public function set_up() {
@@ -95,8 +105,8 @@ class Test_Draft_Content extends WP_UnitTestCase {
 			( new \WP_HTML_Tag_Processor( $title ) )->next_tag(),
 			"Stored title read back as markup: $title"
 		);
-		// The submission text itself is still there.
-		$this->assertStringContainsString( 'Test', $title, 'The submission text was not preserved.' );
+		// The whole submission is still there, character for character.
+		$this->assertSame( self::MARKUP_TITLE, $title );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
@@ -53,6 +53,17 @@ class Test_Draft_Content extends WP_UnitTestCase {
 	const MARKUP_TITLE = 'Test&lt; code &gt;" data-x="&lt; /code &gt;Co';
 
 	/**
+	 * The shape these handlers actually receive.
+	 *
+	 * Jetpack runs `wp_kses_post()` over the values before the handler sees them, which rebuilds a
+	 * spaced `< strong >` into a real element -- so on this path markup arrives already formed, and
+	 * MARKUP_INPUT's spaced form never occurs in production. Both are covered.
+	 *
+	 * @var string
+	 */
+	const KSESED_INPUT = '<strong>Test</strong> Co';
+
+	/**
 	 * Set up the plugin instance.
 	 */
 	public function set_up() {
@@ -100,13 +111,13 @@ class Test_Draft_Content extends WP_UnitTestCase {
 	 *
 	 * @param string $title The stored draft title.
 	 */
-	protected function assertTitleIsText( $title ) {
+	protected function assertTitleIsText( $title, $expected = self::MARKUP_TITLE ) {
 		$this->assertFalse(
 			( new \WP_HTML_Tag_Processor( $title ) )->next_tag(),
 			"Stored title read back as markup: $title"
 		);
 		// The whole submission is still there, character for character.
-		$this->assertSame( self::MARKUP_TITLE, $title );
+		$this->assertSame( $expected, $title );
 	}
 
 	/**
@@ -300,5 +311,31 @@ class Test_Draft_Content extends WP_UnitTestCase {
 		$this->assertNotEmpty( $speaker );
 		$this->assertStringContainsString( '<strong>bold</strong>', $speaker[0]->post_content );
 		$this->assertStringContainsString( 'My%20Notes.pdf', $speaker[0]->post_content );
+	}
+
+	/**
+	 * Markup that reached the handler already formed is stored as text too.
+	 *
+	 * This is the production-shaped case: Jetpack's `wp_kses_post()` pass means a submitter's
+	 * `<strong>` arrives as a real element rather than in the spaced form the other cases use.
+	 */
+	public function test_title_from_already_formed_markup_is_stored_as_text() {
+		$this->plugin->call_for_sponsors(
+			$this->make_submission( 'call-for-sponsors' ),
+			array(
+				'Company Name'        => self::KSESED_INPUT,
+				'Company Description' => 'A description.',
+				'Website'             => 'https://example.org',
+			),
+			array()
+		);
+
+		$sponsor = get_posts( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $sponsor );
+		$this->assertTitleIsText( $sponsor[0]->post_title, 'Test Co' );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
@@ -33,6 +33,16 @@ class Test_Draft_Content extends WP_UnitTestCase {
 	const SHORTCODE_INPUT = "[camptix_private logged_out_message='hello']world[/camptix_private]";
 
 	/**
+	 * A submitted value that Jetpack's `wp_kses_post()` pass leaves as real markup.
+	 *
+	 * Titles are rendered as text -- in headings, in `title` attributes and in the tracker's JSON --
+	 * so markup reaching `post_title` is stored where only text was meant to be.
+	 *
+	 * @var string
+	 */
+	const MARKUP_INPUT = 'Test< code >" data-x="< /code >Co';
+
+	/**
 	 * Set up the plugin instance.
 	 */
 	public function set_up() {
@@ -73,6 +83,20 @@ class Test_Draft_Content extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '[', $content, 'A shortcode delimiter was stored.' );
 		// The submission text itself is still there, just inert.
 		$this->assertStringContainsString( 'camptix_private', $content, 'The submission text was not preserved.' );
+	}
+
+	/**
+	 * Assert a draft title holds the submission as text rather than as markup.
+	 *
+	 * @param string $title The stored draft title.
+	 */
+	protected function assertTitleIsText( $title ) {
+		$this->assertFalse(
+			( new \WP_HTML_Tag_Processor( $title ) )->next_tag(),
+			"Stored title read back as markup: $title"
+		);
+		// The submission text itself is still there.
+		$this->assertStringContainsString( 'Test', $title, 'The submission text was not preserved.' );
 	}
 
 	/**
@@ -154,5 +178,117 @@ class Test_Draft_Content extends WP_UnitTestCase {
 		) );
 		$this->assertNotEmpty( $sponsor );
 		$this->assertShortcodeNeutralized( $sponsor[0]->post_content );
+	}
+
+	/**
+	 * A submitted Company Name is stored as text in the generated draft Sponsor.
+	 */
+	public function test_sponsor_title_is_stored_as_text() {
+		$this->plugin->call_for_sponsors(
+			$this->make_submission( 'call-for-sponsors' ),
+			array(
+				'Company Name'        => self::MARKUP_INPUT,
+				'Company Description' => 'A description.',
+				'Website'             => 'https://example.org',
+			),
+			array()
+		);
+
+		$sponsor = get_posts( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $sponsor );
+		$this->assertTitleIsText( $sponsor[0]->post_title );
+	}
+
+	/**
+	 * A submitted volunteer Name is stored as text in the generated draft Volunteer.
+	 */
+	public function test_volunteer_title_is_stored_as_text() {
+		$this->plugin->call_for_volunteers(
+			$this->make_submission( 'call-for-volunteers' ),
+			array(
+				'Name'                   => self::MARKUP_INPUT,
+				'Email'                  => 'volunteer@example.org',
+				'WordPress.org Username' => 'nonexistent-user-for-tests',
+			),
+			array()
+		);
+
+		$volunteer = get_posts( array(
+			'post_type'   => 'wcb_volunteer',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $volunteer );
+		$this->assertTitleIsText( $volunteer[0]->post_title );
+	}
+
+	/**
+	 * A submitted speaker Name and Topic Title are stored as text in the generated drafts.
+	 */
+	public function test_speaker_and_session_titles_are_stored_as_text() {
+		$this->plugin->call_for_speakers(
+			$this->make_submission( 'call-for-speakers' ),
+			array(
+				'Name'                   => self::MARKUP_INPUT,
+				'Email Address'          => 'speaker@example.org',
+				'WordPress.org Username' => 'nonexistent-user-for-tests',
+				'Your Bio'               => 'A bio.',
+				'Topic Title'            => self::MARKUP_INPUT,
+				'Topic Description'      => 'A description.',
+			),
+			array()
+		);
+
+		$speaker = get_posts( array(
+			'post_type'   => 'wcb_speaker',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $speaker );
+		$this->assertTitleIsText( $speaker[0]->post_title );
+
+		$session = get_posts( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $session );
+		$this->assertTitleIsText( $session[0]->post_title );
+	}
+
+	/**
+	 * Formatting and percent-encoded URLs a submitter typed still reach the draft body.
+	 *
+	 * Jetpack runs `wp_kses_post()` over these values before the handler sees them, so the
+	 * allow-listed markup is deliberate and is left alone here.
+	 */
+	public function test_body_keeps_formatting_and_percent_encoding() {
+		$body = 'Bio with <strong>bold</strong>. See https://example.org/My%20Notes.pdf';
+
+		$this->plugin->call_for_speakers(
+			$this->make_submission( 'call-for-speakers' ),
+			array(
+				'Name'                   => 'Test Speaker',
+				'Email Address'          => 'speaker@example.org',
+				'WordPress.org Username' => 'nonexistent-user-for-tests',
+				'Your Bio'               => $body,
+				'Topic Title'            => 'A talk',
+				'Topic Description'      => 'A description.',
+			),
+			array()
+		);
+
+		$speaker = get_posts( array(
+			'post_type'   => 'wcb_speaker',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $speaker );
+		$this->assertStringContainsString( '<strong>bold</strong>', $speaker[0]->post_content );
+		$this->assertStringContainsString( 'My%20Notes.pdf', $speaker[0]->post_content );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -417,8 +417,8 @@ class WordCamp_Forms_To_Drafts {
 		// Create the post.
 		$draft_id = wp_insert_post( array(
 			'post_type'    => 'wcb_sponsor',
-			'post_title'   => $all_values['Company Name'] ?? '',
-			'post_content' => $this->escape_shortcodes( $all_values['Company Description'] ?? '' ),
+			'post_title'   => wcorg_sanitize_plain_text( $all_values['Company Name'] ?? '' ),
+			'post_content' => $this->escape_shortcodes( wcorg_sanitize_plain_text( $all_values['Company Description'] ?? '', true ) ),
 			'post_status'  => 'draft',
 			'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
 		) );
@@ -512,7 +512,7 @@ class WordCamp_Forms_To_Drafts {
 
 		$draft_id = wp_insert_post( array(
 			'post_type'    => 'wcb_volunteer',
-			'post_title'   => sanitize_text_field( $all_values['Name'] ?? '' ),
+			'post_title'   => wcorg_sanitize_plain_text( $all_values['Name'] ?? '' ),
 			'post_status'  => 'draft',
 			'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
 		) );
@@ -652,6 +652,8 @@ class WordCamp_Forms_To_Drafts {
 	 * keeps that text as literal characters instead of letting it run as shortcodes,
 	 * so a submission is shown as written rather than executed.
 	 *
+	 * Callers pair this with `wcorg_sanitize_plain_text()`, which does the same job for `<`.
+	 *
 	 * @param string $content Submitted content.
 	 *
 	 * @return string Content with shortcode delimiters encoded.
@@ -668,7 +670,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_speaker( $speaker ) {
-		$content = $this->escape_shortcodes( $speaker['Your Bio'] ?? '' );
+		$content = $this->escape_shortcodes( wcorg_sanitize_plain_text( $speaker['Your Bio'] ?? '', true ) );
 
 		if ( $content ) {
 			$content = wpautop( $content );
@@ -683,7 +685,7 @@ class WordCamp_Forms_To_Drafts {
 		$speaker_id = wp_insert_post(
 			array(
 				'post_type'    => 'wcb_speaker',
-				'post_title'   => $speaker['Name'] ?? 'Untitled',
+				'post_title'   => wcorg_sanitize_plain_text( $speaker['Name'] ?? 'Untitled' ),
 				'post_content' => $content,
 				'post_status'  => 'draft',
 				'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
@@ -717,7 +719,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_session( $session, $speaker ) {
-		$content = $this->escape_shortcodes( $session['Topic Description'] ?? '' );
+		$content = $this->escape_shortcodes( wcorg_sanitize_plain_text( $session['Topic Description'] ?? '', true ) );
 
 		if ( $content ) {
 			$content = wpautop( $content );
@@ -731,7 +733,7 @@ class WordCamp_Forms_To_Drafts {
 		$session_id = wp_insert_post(
 			array(
 				'post_type'    => 'wcb_session',
-				'post_title'   => $session['Topic Title'] ?? '',
+				'post_title'   => wcorg_sanitize_plain_text( $session['Topic Title'] ?? '' ),
 				'post_content' => $content,
 				'post_status'  => 'draft',
 				'post_author'  => $this->get_user_id_from_username( $session['WordPress.org Username'] ?? '' ),

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -418,7 +418,7 @@ class WordCamp_Forms_To_Drafts {
 		$draft_id = wp_insert_post( array(
 			'post_type'    => 'wcb_sponsor',
 			'post_title'   => wcorg_sanitize_plain_text( $all_values['Company Name'] ?? '' ),
-			'post_content' => $this->escape_shortcodes( wcorg_sanitize_plain_text( $all_values['Company Description'] ?? '', true ) ),
+			'post_content' => $this->escape_shortcodes( $all_values['Company Description'] ?? '' ),
 			'post_status'  => 'draft',
 			'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
 		) );
@@ -652,7 +652,8 @@ class WordCamp_Forms_To_Drafts {
 	 * keeps that text as literal characters instead of letting it run as shortcodes,
 	 * so a submission is shown as written rather than executed.
 	 *
-	 * Callers pair this with `wcorg_sanitize_plain_text()`, which does the same job for `<`.
+	 * Tags are not a concern here: Jetpack has already run these values through `wp_kses_post()`,
+	 * and `content_save_pre` runs them through it again on the way into the database.
 	 *
 	 * @param string $content Submitted content.
 	 *
@@ -670,7 +671,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_speaker( $speaker ) {
-		$content = $this->escape_shortcodes( wcorg_sanitize_plain_text( $speaker['Your Bio'] ?? '', true ) );
+		$content = $this->escape_shortcodes( $speaker['Your Bio'] ?? '' );
 
 		if ( $content ) {
 			$content = wpautop( $content );
@@ -719,7 +720,7 @@ class WordCamp_Forms_To_Drafts {
 	 * @return int | WP_Error
 	 */
 	protected function create_draft_session( $session, $speaker ) {
-		$content = $this->escape_shortcodes( wcorg_sanitize_plain_text( $session['Topic Description'] ?? '', true ) );
+		$content = $this->escape_shortcodes( $session['Topic Description'] ?? '' );
 
 		if ( $content ) {
 			$content = wpautop( $content );


### PR DESCRIPTION
## Summary

The handlers that turn a form submission into a `post_title` treat `sanitize_text_field()` as enough to
reduce a submitted value to text. It isn't, because that sanitiser and `wp_kses()` disagree about what
opens a tag:

- `strip_tags()`, which `wp_strip_all_tags()` and therefore `sanitize_text_field()` are built on, only
  treats `<` as a tag opener when a letter, `/`, `!` or `?` follows it. `strip_tags( 'a < b > c' )`
  returns the string unchanged.
- `wp_kses()`'s tag grammar also accepts whitespace there (`'%^<\s*(/\s*)?([a-zA-Z0-9-]+)([^>]*)>?$%'`).

So a value like `< code >` passes the sanitiser untouched, and the `wp_filter_kses()` that core registers
on `title_save_pre` for users without `unfiltered_html` then rebuilds it into a real element. The handler
meant to store text and stored markup instead.

The Forms to Drafts titles get there by a shorter route: Jetpack hands those values over already through
`wp_kses_post()` (`Contact_Form_Plugin::strip_tags()`, applied at `class-contact-form.php:3055`), so
plain `<strong>` reaches `post_title` today without needing the spaced-tag form at all.

Either way the fix is the same — ask for text explicitly — so this adds one shared helper and applies it
wherever a submitted value becomes a title.

## Changes

- **New** `wcorg_sanitize_plain_text( $value )` in `mu-plugins/3-helpers-misc.php`. It runs
  `wp_check_invalid_utf8()` and `wp_strip_all_tags()`, then encodes any `<` that survived, so nothing is
  left for kses to read back as a tag. Idempotent, and `esc_html()` / `esc_attr()` won't double-encode the
  result (`_wp_specialchars()` is called with `$double_encode = false`).
- Applied to the titles built by the WordCamp application (`class-wordcamp-application.php`), the Campus
  Connect bridge (`events/jetpack-form-to-wcpt-application.php`), and the four Forms to Drafts handlers
  (sponsor, volunteer, speaker, session).
- `class-meetup-application.php` and `class-events-application.php` already `esc_html()` their titles and
  are left alone.

Two things the helper deliberately does **not** do:

- It does not call `sanitize_text_field()`, which would also delete every `%[a-f0-9]{2}` sequence and so
  quietly turn `https://example.org/My%20Notes.pdf` into `https://example.org/MyNotes.pdf`.
- It does not use `wp_kses( $value, array() )`, which deletes whole `<...>` spans rather than neutralising
  them, so `Hall < 100 > seats` comes back as `Hall  seats`, and rewrites every `&`.

### Post bodies are intentionally untouched

An earlier revision of this PR also ran the three Forms to Drafts bodies (`Company Description`,
`Your Bio`, `Topic Description`) through the helper. That is reverted, because it cost something and
bought nothing.

Jetpack has already run those values through `wp_kses_post()` before the handler sees them, and
`content_save_pre` runs them through it again on the way into the database. Measured on the installed
Jetpack:

| submitted | after `Contact_Form_Plugin::strip_tags()` |
|---|---|
| `< code >" data-x="< /code >` | `<code>" data-x="</code>` — already normalised |
| `< script >alert(1)< /script >` | `alert(1)` — dangerous tag already gone |
| `<strong>bold</strong>` | `<strong>bold</strong>` — formatting kept, deliberately |

So there is no sanitiser disagreement left to settle on the body path: the spaced form has already been
rebuilt into ordinary markup, constrained to the `wp_kses_post()` allow-list. Running the helper over it
only stripped formatting that submitters can use today and broke percent-encoded URLs. A test now pins
both behaviours.

### It also recovers text that is lost today

Worth stating, because it argues for the change on its own: a title containing a `<...>` span currently
loses that span and everything in it, because kses deletes it on save. Measured through both call-site
paths -- `sanitize_text_field()` then `title_save_pre` for the application handlers, Jetpack's
`wp_kses_post()` then `title_save_pre` for Forms to Drafts:

| submitted | stored today | stored on this branch |
|---|---|---|
| `Hall < 100 > seats` | `Hall  seats` | `Hall &lt; 100 &gt; seats` |
| `Wine < Beer` | `Wine &lt; Beer` | `Wine &lt; Beer` |
| `Rated <A best` | `Rated &lt;A best` | `Rated &lt;A best` |

Only the first row changes. The other two are already preserved today by `wp_pre_kses_less_than()`, which
encodes a `<` run that contains no `>` -- and the helper runs it for the same reason, so it does not
regress them.

### Note on stored values

Encoding `<` means an affected title is stored as `&lt;`, which renders correctly everywhere it goes
through `the_title` or `esc_*`. Two places consume these titles without decoding, so a title containing a
literal `<` would show `&lt;` there: the Application Tracker's JSON payload (`wcpt-event/tracker.php:88`)
and the new-site `blogname` (`wordcamp-new-site.php:479`). A third goes out as text: the organizer
reminder mails substitute `post_title` into `[wordcamp_name]` (`wcor-mailer.php:395`), and that plugin
never sets a `text/html` content type, so `wp_mail()` sends them plain. Both already show raw entities for any title
containing `&`, since kses stores that as `&amp;`, so this isn't a new class of problem — flagging it
because it's the one visible side effect. A `<` in a camp or venue name is rare enough that I'd rather not
add decoding on those paths speculatively.

This only changes values on the way in. Any existing rows are untouched.

## Testing

- `mu-plugins/tests/test-3-helpers-misc.php` — the helper, including entity-encoded input, NUL bytes,
  percent-encoded URLs, arrays, non-scalars and idempotence.
- `wcpt/tests/wcpt-wordcamp/test-wordcamp-application.php` — the WordCamp application handler end to end.
- `wordcamp-forms-to-drafts/tests/test-draft-content.php` — the four Forms to Drafts titles, plus a case
  asserting bodies keep their formatting and percent-encoding.

The handler tests each fail if the helper is removed from the call site they cover, so the suite notices a
future refactor that drops one. `mu-plugins/tests/bootstrap.php` now requires `3-helpers-misc.php`
directly, rather than relying on an unrelated plugin's bootstrap to have loaded it.

```
docker compose -f docker-compose.phpunit.yml run --rm phpunit_wp \
  phpunit --testsuite "WordCamp MU Plugins","WordCamp Post Type","WordCamp Forms to Drafts"
```

- [x] Full suite: 0 failures (6 pre-existing skips — missing `intl`, one GatherPress data provider)
- [x] `phpcs` reports no new violations; the new files are clean

### Manual test steps

Restart the container first so opcache can't serve the old bytecode:

```
git checkout add/plain-text-form-values
docker restart wordcamptest-wordcamp.test-1
```

Both `wp eval` steps below start with `kses_init_filters()`. WP-CLI removes the kses filters that a normal
web request has, and those filters are the second half of what this PR is about, so without that call the
snippets don't exercise the path a real form submission takes. Both clean up after themselves.

1. **A location containing angle brackets is stored as text.** This runs the real application handler:

   ```
   docker exec wordcamptest-wordcamp.test-1 wp --url=central.wordcamp.test --allow-root eval '
   kses_init_filters();
   require_once WP_PLUGIN_DIR . "/wcpt/wcpt-loader.php";
   $a = new WordPress_Community\Applications\WordCamp_Application();
   $d = $a->get_default_application_values();
   $d["q_1079103_wordcamp_location"] = "Portland< code >\" data-x=\"< /code >Oregon";
   $id = $a->create_post( $d );
   echo "title: " . get_post( $id )->post_title . "\n";
   wp_delete_post( $id, true );
   '
   ```

   Expected on this branch — the submitted text, with the angle brackets encoded:

   ```
   title: WordCamp Portland&lt; code &gt;" data-x="&lt; /code &gt;Oregon
   ```

   On `production` the same command gives `WordCamp Portland<code>" data-x="</code>Oregon` — an element
   where the submitted text should be.

2. **It renders back as what was typed.**

   ```
   docker exec wordcamptest-wordcamp.test-1 wp --url=central.wordcamp.test --allow-root eval '
   kses_init_filters();
   $v = "Portland< code >\" data-x=\"< /code >Oregon";
   $id = wp_insert_post( array( "post_type" => "wordcamp", "post_status" => "wcpt-needs-vetting",
     "post_title" => "WordCamp " . wcorg_sanitize_plain_text( $v ) ) );
   echo "rendered: " . apply_filters( "the_title", get_post( $id )->post_title, $id ) . "\n";
   wp_delete_post( $id, true );
   '
   ```

   Expected on this branch:

   ```
   rendered: WordCamp Portland&lt; code &gt;&#8221; data-x=&#8221;&lt; /code &gt;Oregon
   ```

   The `&lt;` / `&gt;` entities render as `<` and `>`, and `wptexturize()` curls the straight quotes to
   `&#8221;`, so a browser shows:

   ```
   WordCamp Portland< code >” data-x=”< /code >Oregon
   ```

   The curly quotes are the point of comparison here: `wptexturize()` skips the contents of a `code`
   element, so on `production` the same title keeps its straight quotes. Getting them curled means no
   element was formed and the value is being treated as ordinary title text, like any other title.

3. **Ordinary submissions are unaffected.** Submit a WordCamp application at
   `https://central.wordcamp.test/become-an-organizer/` with a normal location (`Portland, Oregon`), and
   confirm the tracker title on `/wp-admin/edit.php?post_type=wordcamp` is `WordCamp Portland, Oregon`,
   exactly as before. A value containing an `&` (`Smith & Sons Hall`) should also be unchanged from
   `production`.

4. **Forms to Drafts still works.** On a camp site, submit the Call for Speakers and Call for Sponsors
   forms and confirm the drafted speaker, session and sponsor posts have the submitted titles and bodies,
   with paragraphs intact in the bodies.

5. **Forms to Drafts, without depending on a form.** Step 4 only reaches the handlers if the form's post
   carries the right `wcfd-key` meta and its fields are labelled `Company Name` / `Company Description` /
   `Website`, which is easy to miss on a local site. This calls the handlers directly instead, so it works
   on any camp site. Substitute your own camp URL, and note this one needs `sh -c` because of the heredoc:

   ```
   docker exec wordcamptest-wordcamp.test-1 sh -c 'cat > /tmp/fd.php <<"PHP"
   <?php
   kses_init_filters();
   $wcfd = $GLOBALS["wordcamp_forms_to_drafts"];
   $text = "Portland< code >\" data-x=\"< /code >Oregon";
   $body = "First paragraph with <strong>bold</strong> and https://example.org/My%20Notes.pdf\n\nSecond paragraph.";

   $form_id = wp_insert_post( array( "post_type" => "post", "post_title" => "tmp form", "post_status" => "draft" ) );
   update_post_meta( $form_id, "wcfd-key", "call-for-sponsors" );
   $sub_id = wp_insert_post( array( "post_type" => "feedback", "post_status" => "publish", "post_parent" => $form_id ) );

   $wcfd->call_for_sponsors( $sub_id, array(
       "1_Company Name"        => $text,
       "2_Company Description" => $body,
       "3_Website"             => "https://example.org",
   ), array() );

   $s = get_posts( array( "post_type" => "wcb_sponsor", "post_status" => "draft", "numberposts" => 1 ) );
   echo "sponsor title:   " . $s[0]->post_title . "\n";
   echo "sponsor content: " . str_replace( "\n", " / ", trim( $s[0]->post_content ) ) . "\n";
   echo "sponsor website: " . get_post_meta( $s[0]->ID, "_wcpt_sponsor_website", true ) . "\n";

   $m = new ReflectionMethod( $wcfd, "create_draft_speaker" );
   $m->setAccessible( true );
   $speaker_id = $m->invoke( $wcfd, array( "Name" => $text, "Your Bio" => $body ) );
   echo "speaker title:   " . get_post( $speaker_id )->post_title . "\n";
   echo "speaker content: " . str_replace( "\n", " / ", trim( get_post( $speaker_id )->post_content ) ) . "\n";

   foreach ( array( $form_id, $sub_id, $s[0]->ID, $speaker_id ) as $id ) {
       wp_delete_post( $id, true );
   }
   PHP
   wp --url=shinynew.wordcamp.test/2023 --allow-root eval-file /tmp/fd.php; rm /tmp/fd.php'
   ```

   Expected on this branch — **titles** have their angle brackets encoded, while the **bodies** keep the
   `<strong>`, the percent-encoded URL and their paragraph split:

   ```
   sponsor title:   Portland&lt; code &gt;" data-x="&lt; /code &gt;Oregon
   sponsor content: First paragraph with <strong>bold</strong> and https://example.org/My%20Notes.pdf /  / Second paragraph.
   sponsor website: https://example.org
   speaker title:   Portland&lt; code &gt;" data-x="&lt; /code &gt;Oregon
   speaker content: <!-- wp:paragraph --> / <p>First paragraph with <strong>bold</strong> and https://example.org/My%20Notes.pdf</p> / <!-- /wp:paragraph --> / <!-- wp:paragraph --> / <p>Second paragraph.</p> / <!-- /wp:paragraph --> / ...
   ```

   The bodies are the point of this step as much as the titles: they should be byte-identical to
   `production`. On `production` the titles instead store `<code>` elements. The script cleans up
   everything it creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113Xx49sx6VqVgEZgymZoM5
