### PR TITLE
Blocks: refresh the Latest Posts list without ServerSideRender

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -122,40 +122,6 @@ function safelist_block_renderer( $response, $handler, $request ) {
 add_filter( 'rest_request_after_callbacks', __NAMESPACE__ . '\safelist_block_renderer', 10, 3 );
 
 /**
- * Whether the markup is one `<ul>` container spanning the whole string.
- *
- * The tag swap below renames the first `<ul` and the last `</ul>`, so both have to
- * belong to the same element. A sibling list would otherwise leave
- * `<div>…</ul><ul>…</div>`.
- *
- * The nesting count reads the raw string. That is safe because `esc_attr()` escapes
- * `<`, so `<ul` and `</ul` cannot appear inside an attribute value. If that stops
- * being true the count goes wrong and the rewrite silently stops attaching.
- *
- * @param string $markup Rendered block markup.
- * @return bool
- */
-function is_swappable_container( $markup ) {
-	if ( ! preg_match( '#\A\s*<ul\b#', $markup ) || ! preg_match( '#</ul>\s*\z#', $markup ) ) {
-		return false;
-	}
-
-	preg_match_all( '#<(/?)ul\b#', $markup, $matches );
-	$depth = 0;
-
-	foreach ( $matches[1] as $index => $slash ) {
-		$depth += '' === $slash ? 1 : -1;
-
-		// The container closed, so it has to be the last `</ul>` in the markup.
-		if ( 0 === $depth ) {
-			return count( $matches[1] ) - 1 === $index;
-		}
-	}
-
-	return false;
-}
-
-/**
  * Drop the attributes the renderer route will not accept.
  *
  * The route validates `attributes` against the registered schema and rejects anything
@@ -177,7 +143,16 @@ function pollable_attributes( $attrs ) {
 		return $attrs;
 	}
 
-	return array_intersect_key( $attrs, $block_type->attributes );
+	$registered = array_intersect_key( $attrs, $block_type->attributes );
+
+	// A null serialises into the query string as an empty value, which the route
+	// refuses for anything the schema does not type as a string.
+	return array_filter(
+		$registered,
+		static function ( $value ) {
+			return null !== $value;
+		}
+	);
 }
 
 /**
@@ -199,7 +174,7 @@ function render( $block_content, $block ) {
 	$enabled = isset( $block['attrs']['liveUpdateEnabled'] ) && $block['attrs']['liveUpdateEnabled'];
 	// Order by date, desc is the default, so these properties are not set.
 	$order_date_desc = ! isset( $block['attrs']['orderBy'] ) && ! isset( $block['attrs']['order'] );
-	if ( $enabled && $order_date_desc && is_swappable_container( $block_content ) ) {
+	if ( $enabled && $order_date_desc ) {
 		/*
 		 * Rewrite the container through the HTML API, not by string content:
 		 * `str_replace()` also matched its needle inside attribute values (the
@@ -215,15 +190,6 @@ function render( $block_content, $block ) {
 			$processor->set_attribute( 'data-attributes', rawurlencode( wp_json_encode( pollable_attributes( $block['attrs'] ) ) ) );
 
 			$block_content = $processor->get_updated_html();
-
-			/*
-			 * `render-frontend.js` renders the polled markup into this element, and that
-			 * markup has been through this filter too, so it arrives as a `<div>`. A
-			 * `<ul>` cannot hold it. Anchored to the ends of the string, where an
-			 * attribute value cannot match.
-			 */
-			$block_content = preg_replace( '#\A(\s*)<ul\b#', '$1<div', $block_content, 1 );
-			$block_content = preg_replace( '#</ul>(\s*)\z#', '</div>$1', $block_content, 1 );
 		}
 	}
 

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -3,6 +3,8 @@ namespace WordCamp\Blocks\Hooks\Latest_Posts;
 
 defined( 'WPINC' ) || die();
 
+const POLL_CACHE_SECONDS = 60;
+
 /**
  * Check editor versions.
  *
@@ -117,7 +119,18 @@ function safelist_block_renderer( $response, $handler, $request ) {
 		return $response;
 	}
 
-	return call_user_func( $handler['callback'], $request );
+	$response = call_user_func( $handler['callback'], $request );
+
+	/*
+	 * Everyone on a page polls the same URL, so let a cache answer most of them. A
+	 * minute is short against the five the block waits between polls, and core only
+	 * sends no-cache headers for a logged-in request, which this never is.
+	 */
+	if ( $response instanceof \WP_REST_Response ) {
+		$response->header( 'Cache-Control', 'max-age=' . POLL_CACHE_SECONDS );
+	}
+
+	return $response;
 }
 add_filter( 'rest_request_after_callbacks', __NAMESPACE__ . '\safelist_block_renderer', 10, 3 );
 

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -57,8 +57,6 @@ function init() {
 		'before'
 	);
 
-	wp_set_script_translations( 'wordcamp-live-posts', 'wordcamporg' );
-
 	$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );
 	if ( $block_type ) {
 		unregister_block_type( $block_type->name );
@@ -158,6 +156,31 @@ function is_swappable_container( $markup ) {
 }
 
 /**
+ * Drop the attributes the renderer route will not accept.
+ *
+ * The route validates `attributes` against the registered schema and rejects anything
+ * outside it, while the render path still honours older keys such as `postLayout`.
+ * Those only feed container classes, and the container on the page keeps its own, so
+ * dropping them here costs nothing and keeps the request valid.
+ *
+ * This filters keys, not values. A registered key with a stale value can still be
+ * refused, `categories` saved as a string being the one that used to be: it survives
+ * because core migrates it on `render_block_data`, before this filter runs.
+ *
+ * @param array $attrs Saved block attributes.
+ * @return array
+ */
+function pollable_attributes( $attrs ) {
+	$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );
+
+	if ( ! $block_type || empty( $block_type->attributes ) ) {
+		return $attrs;
+	}
+
+	return array_intersect_key( $attrs, $block_type->attributes );
+}
+
+/**
  * Filter the content of the latest posts block.
  *
  * @param string $block_content The block content about to be appended.
@@ -189,7 +212,7 @@ function render( $block_content, $block ) {
 		if ( $processor->next_tag() && 'UL' === $processor->get_tag() ) {
 			$processor->add_class( 'has-live-update' );
 			$processor->add_class( 'is-loading' );
-			$processor->set_attribute( 'data-attributes', rawurlencode( wp_json_encode( $block['attrs'] ) ) );
+			$processor->set_attribute( 'data-attributes', rawurlencode( wp_json_encode( pollable_attributes( $block['attrs'] ) ) ) );
 
 			$block_content = $processor->get_updated_html();
 
@@ -208,7 +231,6 @@ function render( $block_content, $block ) {
 }
 add_filter( 'render_block', __NAMESPACE__ . '\render', 10, 2 );
 
-
 /**
  * Add data to be used by the JS scripts in the block editor.
  *
@@ -218,7 +240,10 @@ add_filter( 'render_block', __NAMESPACE__ . '\render', 10, 2 );
  */
 function add_script_data( array $data ) {
 	if ( check_version_support() ) {
-		$data['latest-posts'] = array();
+		$data['latest-posts'] = array(
+			// Root-relative, so the request stays same-origin on a non-canonical host.
+			'renderer' => wp_make_link_relative( rest_url( 'wp/v2/block-renderer/core/latest-posts' ) ),
+		);
 	}
 
 	return $data;

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/controller.php
@@ -122,12 +122,16 @@ function safelist_block_renderer( $response, $handler, $request ) {
 	$response = call_user_func( $handler['callback'], $request );
 
 	/*
-	 * Everyone on a page polls the same URL, so let a cache answer most of them. A
-	 * minute is short against the five the block waits between polls, and core only
-	 * sends no-cache headers for a logged-in request, which this never is.
+	 * Everyone on a page polls the same URL, so let a shared cache answer most of
+	 * them. A minute is short against the five the block waits between polls, and core
+	 * only sends no-cache headers for a logged-in request, which this never is.
+	 *
+	 * `s-maxage` because all of the value is in a shared cache: a browser's own copy
+	 * expires long before that browser polls again. And every guard above has to have
+	 * run first, since this is the one response here that is safe to hold.
 	 */
 	if ( $response instanceof \WP_REST_Response ) {
-		$response->header( 'Cache-Control', 'max-age=' . POLL_CACHE_SECONDS );
+		$response->header( 'Cache-Control', 'public, s-maxage=' . POLL_CACHE_SECONDS );
 	}
 
 	return $response;
@@ -197,7 +201,16 @@ function render( $block_content, $block ) {
 		 */
 		$processor = new \WP_HTML_Tag_Processor( $block_content );
 
-		if ( $processor->next_tag() && 'UL' === $processor->get_tag() ) {
+		// By what it is, not by what comes first: the markup can hold a list belonging
+		// to something else, and a container of ours can sit inside a group.
+		$found = $processor->next_tag(
+			array(
+				'tag_name'   => 'UL',
+				'class_name' => 'wp-block-latest-posts',
+			)
+		);
+
+		if ( $found ) {
 			$processor->add_class( 'has-live-update' );
 			$processor->add_class( 'is-loading' );
 			$processor->set_attribute( 'data-attributes', rawurlencode( wp_json_encode( pollable_attributes( $block['attrs'] ) ) ) );

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
@@ -1,61 +1,159 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import ServerSideRender from '@wordpress/server-side-render';
+import { addQueryArgs } from '@wordpress/url';
+
+const SELECTOR = '.wp-block-latest-posts.has-live-update';
+const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes in milliseconds.
 
 /**
- * Internal dependencies
+ * The endpoint that renders this block, localised by the controller.
+ *
+ * @return {string} The endpoint, or an empty string when the data is missing.
  */
-import renderFrontend from '../../utils/render-frontend';
+function rendererUrl() {
+	const data = window.WordCampBlocks || {};
 
-class LivePosts extends Component {
-	constructor( props ) {
-		super( props );
-		this.renderInterval = setInterval(
-			() => {
-				// `forceUpdate` is a React internal that triggers a render cycle.
-				this.forceUpdate();
-			},
-			5 * 60 * 1000 // 5 minutes in milliseconds.
-		);
+	return ( data[ 'latest-posts' ] || {} ).renderer || '';
+}
+
+/**
+ * Read the block's saved attributes off the container.
+ *
+ * @param {Element} element Container element.
+ * @return {Object|null} The attributes, or null when they cannot be read.
+ */
+function readAttributes( element ) {
+	const encoded = element.dataset.attributes;
+
+	if ( ! encoded ) {
+		return null;
 	}
 
-	componentWillUnmount() {
-		clearInterval( this.renderInterval );
-	}
+	try {
+		const parsed = JSON.parse( decodeURIComponent( encoded ) );
 
-	render() {
-		const { attributes } = this.props;
-		// Remove the helper data-attribute.
-		delete attributes.attributes;
-
-		// Note: the `LoadingResponsePlaceholder` is intentionally an anonymous function to trigger re-render when
-		// `forceUpdate` happens.
-		return (
-			<ServerSideRender
-				block="core/latest-posts"
-				attributes={ attributes }
-				LoadingResponsePlaceholder={ () => (
-					<p>{ __( 'Loading', 'wordcamporg' ) }</p>
-				) }
-			/>
-		);
+		// Anything but a plain object would ask the route for the block's defaults.
+		return parsed && 'object' === typeof parsed && ! Array.isArray( parsed )
+			? parsed
+			: null;
+	} catch {
+		return null;
 	}
 }
 
-const getAttributesFromData = ( element ) => {
-	let parsedAttributes = {};
-	const { attributes } = element.dataset;
-	if ( attributes ) {
-		parsedAttributes = JSON.parse( decodeURIComponent( attributes ) );
-	}
-	return { attributes: parsedAttributes };
-};
+/**
+ * Take the list items out of a rendered response.
+ *
+ * The response has been through the `render_block` filter too, so it arrives wearing a
+ * container of its own. The container already on the page is the one carrying the
+ * block's classes, so only its contents are replaced.
+ *
+ * @param {string} html Rendered block markup.
+ * @return {string} The container's contents, or the markup unchanged if it has none.
+ */
+function unwrapContainer( html ) {
+	const template = document.createElement( 'template' );
+	template.innerHTML = html.trim();
 
-renderFrontend(
-	'.wp-block-latest-posts.has-live-update',
-	LivePosts,
-	getAttributesFromData
-);
+	const container = template.content.querySelector(
+		'.wp-block-latest-posts'
+	);
+
+	return container ? container.innerHTML : html;
+}
+
+/**
+ * Keep one container's list up to date.
+ *
+ * The markup is written straight into the container, so a refreshed list has the same
+ * shape as the one the server rendered and any styling written against that markup
+ * still applies. A failed request leaves the page alone.
+ *
+ * @param {Element} element Container element.
+ */
+function start( element ) {
+	const attributes = readAttributes( element );
+
+	element.classList.remove( 'is-loading' );
+
+	/*
+	 * Without the saved attributes a refresh would ask for the block's default
+	 * settings, replacing a correct list with a wrong one. Leave the page's own.
+	 */
+	if ( ! attributes ) {
+		return;
+	}
+
+	let warned = false;
+	let lastContent = null;
+
+	/**
+	 * Report the first failure, so a list that stops updating can be diagnosed.
+	 *
+	 * @param {string} reason What went wrong.
+	 */
+	function warn( reason ) {
+		if ( ! warned ) {
+			warned = true;
+			// eslint-disable-next-line no-console
+			console.warn( 'Latest Posts live update failed:', reason );
+		}
+	}
+
+	function refresh() {
+		// The container can be taken off the page by something else on the site. Stop
+		// rather than keep polling into a node nobody can see.
+		if ( ! element.isConnected ) {
+			clearInterval( timer );
+			return;
+		}
+
+		const endpoint = rendererUrl();
+
+		if ( ! endpoint ) {
+			warn( 'the renderer endpoint is missing' );
+			return;
+		}
+
+		/*
+		 * Deliberately not `apiFetch`: it attaches an `X-WP-Nonce`, which expires for a
+		 * logged-out visitor, and an expired nonce is refused before the request is
+		 * routed. Sending none leaves the request anonymous, which is what this needs.
+		 */
+		window
+			.fetch( addQueryArgs( endpoint, { context: 'edit', attributes } ) )
+			.then( ( response ) => {
+				if ( ! response.ok ) {
+					throw new Error( `HTTP ${ response.status }` );
+				}
+
+				return response.json();
+			} )
+			.then( ( body ) => {
+				if ( ! body || ! body.rendered ) {
+					return;
+				}
+
+				const content = unwrapContainer( body.rendered );
+
+				/*
+				 * Rewriting the list rebuilds every node in it, which drops focus and
+				 * any selection inside it and restarts the images. Most polls return
+				 * what is already on screen, so only write when something changed.
+				 */
+				if ( content === lastContent ) {
+					return;
+				}
+
+				lastContent = content;
+				element.innerHTML = content;
+			} )
+			.catch( ( error ) => warn( error.message ) );
+	}
+
+	// `refresh` closes over this; it only ever runs once the interval exists.
+	const timer = setInterval( refresh, REFRESH_INTERVAL );
+}
+
+document.querySelectorAll( SELECTOR ).forEach( start );

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
@@ -5,6 +5,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 const SELECTOR = '.wp-block-latest-posts.has-live-update';
 const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes in milliseconds.
+const MAX_FAILURES = 3;
 
 /**
  * The endpoint that renders this block, localised by the controller.
@@ -23,7 +24,7 @@ function rendererUrl() {
  * @param {Element} element Container element.
  * @return {Object|null} The attributes, or null when they cannot be read.
  */
-function readAttributes( element ) {
+export function readAttributes( element ) {
 	const encoded = element.dataset.attributes;
 
 	if ( ! encoded ) {
@@ -52,7 +53,7 @@ function readAttributes( element ) {
  * @param {string} html Rendered block markup.
  * @return {string} The container's contents, or the markup unchanged if it has none.
  */
-function unwrapContainer( html ) {
+export function unwrapContainer( html ) {
 	const template = document.createElement( 'template' );
 	template.innerHTML = html.trim();
 
@@ -86,6 +87,7 @@ function start( element ) {
 	}
 
 	let warned = false;
+	let failures = 0;
 	let lastContent = null;
 
 	/**
@@ -112,7 +114,10 @@ function start( element ) {
 		const endpoint = rendererUrl();
 
 		if ( ! endpoint ) {
+			// A page cached before the deploy carries the old inline data with no
+			// endpoint in it. That will not change while this page is open.
 			warn( 'the renderer endpoint is missing' );
+			clearInterval( timer );
 			return;
 		}
 
@@ -131,6 +136,9 @@ function start( element ) {
 				return response.json();
 			} )
 			.then( ( body ) => {
+				// The route answered, so whatever went wrong before has passed.
+				failures = 0;
+
 				if ( ! body || ! body.rendered ) {
 					return;
 				}
@@ -141,6 +149,9 @@ function start( element ) {
 				 * Rewriting the list rebuilds every node in it, which drops focus and
 				 * any selection inside it and restarts the images. Most polls return
 				 * what is already on screen, so only write when something changed.
+				 * The page's own copy cannot seed this, since the markup it parsed
+				 * from is not byte-identical to the response, so the first poll always
+				 * writes and the saving starts from the second.
 				 */
 				if ( content === lastContent ) {
 					return;
@@ -149,7 +160,20 @@ function start( element ) {
 				lastContent = content;
 				element.innerHTML = content;
 			} )
-			.catch( ( error ) => warn( error.message ) );
+			.catch( ( error ) => {
+				warn( error.message );
+
+				/*
+				 * A refusal usually repeats: a page cached before the deploy sends
+				 * attributes the route no longer accepts, and will until it expires.
+				 * Give the network a couple of chances, then stop asking.
+				 */
+				failures++;
+
+				if ( failures >= MAX_FAILURES ) {
+					clearInterval( timer );
+				}
+			} );
 	}
 
 	// `refresh` closes over this; it only ever runs once the interval exists.

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/front-end.js
@@ -50,8 +50,12 @@ export function readAttributes( element ) {
  * container of its own. The container already on the page is the one carrying the
  * block's classes, so only its contents are replaced.
  *
+ * The container on the page is the `<ul>` core rendered, which can only legally hold
+ * list items, so markup that does not carry a container is not written at all. The
+ * server's list stays where it is instead.
+ *
  * @param {string} html Rendered block markup.
- * @return {string} The container's contents, or the markup unchanged if it has none.
+ * @return {string|null} The container's contents, or null if there is no container.
  */
 export function unwrapContainer( html ) {
 	const template = document.createElement( 'template' );
@@ -61,7 +65,7 @@ export function unwrapContainer( html ) {
 		'.wp-block-latest-posts'
 	);
 
-	return container ? container.innerHTML : html;
+	return container ? container.innerHTML : null;
 }
 
 /**
@@ -130,7 +134,13 @@ function start( element ) {
 			.fetch( addQueryArgs( endpoint, { context: 'edit', attributes } ) )
 			.then( ( response ) => {
 				if ( ! response.ok ) {
-					throw new Error( `HTTP ${ response.status }` );
+					const error = new Error( `HTTP ${ response.status }` );
+
+					// A refusal repeats; a dropped connection does not.
+					error.permanent =
+						response.status >= 400 && response.status < 500;
+
+					throw error;
 				}
 
 				return response.json();
@@ -144,6 +154,10 @@ function start( element ) {
 				}
 
 				const content = unwrapContainer( body.rendered );
+
+				if ( null === content ) {
+					return;
+				}
 
 				/*
 				 * Rewriting the list rebuilds every node in it, which drops focus and
@@ -164,13 +178,26 @@ function start( element ) {
 				warn( error.message );
 
 				/*
-				 * A refusal usually repeats: a page cached before the deploy sends
-				 * attributes the route no longer accepts, and will until it expires.
-				 * Give the network a couple of chances, then stop asking.
+				 * A refusal repeats by construction: a page cached before the deploy
+				 * sends attributes the route no longer accepts, and will until it
+				 * expires. A dropped connection is the opposite, and a screen left
+				 * running unattended has to survive a bad afternoon of them, so only
+				 * a refusal counts against the budget.
 				 */
+				if ( ! error.permanent ) {
+					return;
+				}
+
 				failures++;
 
 				if ( failures >= MAX_FAILURES ) {
+					// `warn()` latched on the first one, so say this separately.
+					// eslint-disable-next-line no-console
+					console.warn(
+						'Latest Posts live update gave up after',
+						failures,
+						'refused requests.'
+					);
 					clearInterval( timer );
 				}
 			} );

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/tests/index.test.js
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import { readAttributes, unwrapContainer } from '../front-end';
+
+describe( 'readAttributes', () => {
+	const container = ( attributes ) => {
+		const element = document.createElement( 'div' );
+
+		if ( undefined !== attributes ) {
+			element.dataset.attributes = attributes;
+		}
+
+		return element;
+	};
+
+	it( 'reads the attributes the container carries', () => {
+		const encoded = encodeURIComponent(
+			JSON.stringify( { postsToShow: 3, liveUpdateEnabled: true } )
+		);
+
+		expect( readAttributes( container( encoded ) ) ).toEqual( {
+			postsToShow: 3,
+			liveUpdateEnabled: true,
+		} );
+	} );
+
+	it( 'returns null when there is nothing to read', () => {
+		expect( readAttributes( container() ) ).toBeNull();
+		expect( readAttributes( container( '' ) ) ).toBeNull();
+	} );
+
+	it( 'returns null for a payload it cannot parse', () => {
+		expect( readAttributes( container( 'not json' ) ) ).toBeNull();
+		expect( readAttributes( container( '%E0%A4%A' ) ) ).toBeNull();
+	} );
+
+	// Anything but a plain object would ask the route for the block's defaults,
+	// which renders a different list over a correct one.
+	it( 'returns null for a payload that is not a plain object', () => {
+		[ '[]', '"nope"', '5', 'null', 'true' ].forEach( ( json ) => {
+			expect(
+				readAttributes( container( encodeURIComponent( json ) ) )
+			).toBeNull();
+		} );
+	} );
+} );
+
+describe( 'unwrapContainer', () => {
+	it( 'returns the contents of the response container, not the container', () => {
+		const html =
+			'<ul class="wp-block-latest-posts__list wp-block-latest-posts"><li>one</li><li>two</li></ul>';
+
+		expect( unwrapContainer( html ) ).toBe( '<li>one</li><li>two</li>' );
+	} );
+
+	it( 'unwraps whichever element the block class lands on', () => {
+		const html =
+			'<div data-attributes="%7B%7D" class="wp-block-latest-posts has-live-update"><li>one</li></div>';
+
+		expect( unwrapContainer( html ) ).toBe( '<li>one</li>' );
+	} );
+
+	it( 'keeps a nested list inside the items', () => {
+		const html =
+			'<ul class="wp-block-latest-posts"><li>one<ul><li>nested</li></ul></li></ul>';
+
+		expect( unwrapContainer( html ) ).toBe(
+			'<li>one<ul><li>nested</li></ul></li>'
+		);
+	} );
+
+	it( 'returns the markup unchanged when there is no container to strip', () => {
+		expect( unwrapContainer( '<li>one</li>' ) ).toBe( '<li>one</li>' );
+		expect( unwrapContainer( '' ) ).toBe( '' );
+	} );
+} );

--- a/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/tests/index.test.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/hooks/latest-posts/tests/index.test.js
@@ -70,8 +70,11 @@ describe( 'unwrapContainer', () => {
 		);
 	} );
 
-	it( 'returns the markup unchanged when there is no container to strip', () => {
-		expect( unwrapContainer( '<li>one</li>' ) ).toBe( '<li>one</li>' );
-		expect( unwrapContainer( '' ) ).toBe( '' );
+	// The container on the page is a `<ul>`, so markup without a container of its own
+	// is not something we can write into it. The caller leaves the list alone.
+	it( 'returns null when there is no container to strip', () => {
+		expect( unwrapContainer( '<li>one</li>' ) ).toBeNull();
+		expect( unwrapContainer( '<p>something else</p>' ) ).toBeNull();
+		expect( unwrapContainer( '' ) ).toBeNull();
 	} );
 } );

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
@@ -31,6 +31,13 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 	protected $draft_id;
 
 	/**
+	 * Whether this test added the attribute the hook registers at `init`.
+	 *
+	 * @var bool
+	 */
+	protected $added_live_update_attribute = false;
+
+	/**
 	 * Boot a REST server so `rest_do_request()` runs the real dispatch.
 	 */
 	public function set_up() {
@@ -41,6 +48,8 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 		do_action( 'rest_api_init', $wp_rest_server );
 
 		wp_set_current_user( 0 );
+
+		$this->register_live_update_attribute();
 
 		$this->draft_id = self::factory()->post->create( array(
 			'post_status'  => 'draft',
@@ -61,7 +70,39 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
+		if ( $this->added_live_update_attribute ) {
+			$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );
+
+			if ( $block_type ) {
+				unset( $block_type->attributes['liveUpdateEnabled'] );
+			}
+
+			$this->added_live_update_attribute = false;
+		}
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Give the block the attribute the hook adds at `init`.
+	 *
+	 * This suite loads `controller.php` directly, long after `init` has fired, so the
+	 * hook's own registration never runs. Without it the block's schema is missing the
+	 * attribute the front end sends, and the renderer route rejects it.
+	 */
+	protected function register_live_update_attribute() {
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );
+
+		if ( ! $block_type || isset( $block_type->attributes['liveUpdateEnabled'] ) ) {
+			return;
+		}
+
+		$block_type->attributes['liveUpdateEnabled'] = array(
+			'type'    => 'boolean',
+			'default' => false,
+		);
+
+		$this->added_live_update_attribute = true;
 	}
 
 	/**
@@ -251,6 +292,59 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 			'data-attributes="' . rawurlencode( wp_json_encode( array( 'liveUpdateEnabled' => true ) ) ) . '"',
 			$output
 		);
+	}
+
+	/**
+	 * Attributes the renderer route would reject stay out of `data-attributes`.
+	 *
+	 * A block saved years ago can carry keys core has since dropped from the schema,
+	 * `postLayout` and `columns` among them. The render path still honours those and
+	 * they only feed container classes, which the container on the page keeps, but the
+	 * route validates against the current schema and refuses the whole request. The
+	 * fixture uses a name core will never register, so the test covers the mechanism
+	 * rather than whichever keys core happens to declare today.
+	 */
+	public function test_unregistered_attributes_are_not_polled() {
+		$output = $this->render_container(
+			'<ul class="wp-block-latest-posts is-grid"><li>a</li></ul>',
+			array(
+				'postsToShow'         => 3,
+				'wcorgRetiredSetting' => 'grid',
+				'liveUpdateEnabled'   => true,
+			)
+		);
+
+		preg_match( '/data-attributes="([^"]*)"/', $output, $matches );
+		$polled = json_decode( rawurldecode( $matches[1] ), true );
+
+		$this->assertArrayNotHasKey( 'wcorgRetiredSetting', $polled );
+		$this->assertSame( 3, $polled['postsToShow'] );
+		$this->assertTrue( $polled['liveUpdateEnabled'] );
+	}
+
+	/**
+	 * The attributes the container carries are ones the renderer route accepts.
+	 *
+	 * This is the loop the rewrite exists for. The front end reads `data-attributes`
+	 * off the container and sends it straight back to the route, so if the route
+	 * refuses them the block renders once and never updates again.
+	 */
+	public function test_polled_attributes_are_accepted_by_the_route() {
+		$markup = $this->render_container(
+			'<ul class="wp-block-latest-posts"><li>a</li></ul>',
+			array(
+				'postsToShow'         => 2,
+				'wcorgRetiredSetting' => 'grid',
+				'liveUpdateEnabled'   => true,
+			)
+		);
+
+		preg_match( '/data-attributes="([^"]*)"/', $markup, $matches );
+		$attributes = json_decode( rawurldecode( $matches[1] ), true );
+
+		$response = $this->render( 'core/latest-posts', array( 'attributes' => $attributes ) );
+
+		$this->assertSame( 200, $response->get_status(), 'the route refused the attributes the container carries.' );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
@@ -410,6 +410,25 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The class match works against the class list core actually emits.
+	 *
+	 * Copied from a rendered page: the block class sits mid-string, next to a class
+	 * that has it as a prefix, so a token match is the only thing that finds it.
+	 */
+	public function test_the_real_container_class_list_is_matched() {
+		$output = $this->render_container(
+			'<ul class="wp-block-latest-posts__list has-dates wp-block-latest-posts is-layout-flow wp-block-latest-posts-is-layout-flow"><li>a</li></ul>'
+		);
+
+		$this->assertSame(
+			1,
+			preg_match( '/<ul[^>]*class="[^"]*\bwp-block-latest-posts\b[^"]*\bhas-live-update\b[^"]*"/', $output ),
+			'the block class was not found in the class list core emits.'
+		);
+		$this->assertStringContainsString( 'data-attributes=', $output );
+	}
+
+	/**
 	 * A list nested inside the container is left where it is.
 	 */
 	public function test_nested_list_is_untouched() {

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
@@ -128,6 +128,27 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertStringContainsString( 'Published title', $response->get_data()['rendered'] );
+
+		// Only this response is safe to hold, and only after every guard has run.
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringContainsString( 's-maxage=', $headers['Cache-Control'] );
+	}
+
+	/**
+	 * An authorised render is not marked cacheable.
+	 *
+	 * The header belongs to the anonymous re-run and nothing else. A logged-in
+	 * editor's response returns before it, and telling a shared cache to hold that
+	 * one would hand it to everyone behind the cache.
+	 */
+	public function test_an_authorised_request_is_not_marked_cacheable() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$response = $this->render( 'core/latest-posts', array( 'attributes' => array( 'postsToShow' => 2 ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayNotHasKey( 'Cache-Control', $response->get_headers() );
 	}
 
 	/**
@@ -216,6 +237,10 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 
 		$this->assertSame( 403, $response->get_status() );
 		$this->assertSame( 'rest_cannot_access', $response->get_data()['code'] );
+
+		// A refusal must never be cached: moving the header above the guards would
+		// tell a shared cache to hold a lockdown for everyone behind it.
+		$this->assertArrayNotHasKey( 'Cache-Control', $response->get_headers() );
 	}
 
 	/**
@@ -368,12 +393,18 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 			'leading'  => '<!-- x --><ul class="wp-block-latest-posts"><li>a</li></ul>',
 			'trailing' => '<ul class="wp-block-latest-posts"><li>a</li></ul><style>.x{}</style>',
 			'siblings' => '<ul class="wp-block-latest-posts"><li>a</li></ul><ul class="other"><li>b</li></ul>',
+			'siblings-reversed' => '<ul class="other"><li>b</li></ul><ul class="wp-block-latest-posts"><li>a</li></ul>',
 		);
 
 		foreach ( $cases as $label => $markup ) {
 			$output = $this->render_container( $markup );
 
-			$this->assertStringContainsString( 'has-live-update', $output, $label . ': container was not marked.' );
+			// The marking has to land on the block's own list, not on a neighbour's.
+			$this->assertSame(
+				1,
+				preg_match( '/<ul[^>]*class="[^"]*\bwp-block-latest-posts\b[^"]*\bhas-live-update\b[^"]*"/', $output ),
+				$label . ': the block\'s own list was not the one marked.'
+			);
 			$this->assertStringContainsString( 'data-attributes=', $output, $label . ': no attributes were written.' );
 		}
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-latest-posts.php
@@ -278,14 +278,14 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 	/**
 	 * The live-update markup the front-end script keys on still gets written.
 	 *
-	 * `render-frontend.js` matches `.wp-block-latest-posts.has-live-update`, reads
-	 * `data-attributes` off it, and renders the polled markup into it.
+	 * `front-end.js` matches `.wp-block-latest-posts.has-live-update` and reads
+	 * `data-attributes` off it. The element itself is left as core rendered it.
 	 */
 	public function test_container_still_gets_live_update_markup() {
 		$output = $this->render_container( $this->markup_with_needles_in_values() );
 
-		$this->assertStringStartsWith( '<div ', $output );
-		$this->assertStringEndsWith( '</div>', $output );
+		$this->assertStringStartsWith( '<ul ', $output );
+		$this->assertStringEndsWith( '</ul>', $output );
 		$this->assertStringContainsString( 'has-live-update', $output );
 		$this->assertStringContainsString( 'is-loading', $output );
 		$this->assertStringContainsString(
@@ -314,7 +314,7 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 			)
 		);
 
-		preg_match( '/data-attributes="([^"]*)"/', $output, $matches );
+		$this->assertSame( 1, preg_match( '/data-attributes="([^"]*)"/', $output, $matches ), 'the container carries no data-attributes.' );
 		$polled = json_decode( rawurldecode( $matches[1] ), true );
 
 		$this->assertArrayNotHasKey( 'wcorgRetiredSetting', $polled );
@@ -339,7 +339,7 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 			)
 		);
 
-		preg_match( '/data-attributes="([^"]*)"/', $markup, $matches );
+		$this->assertSame( 1, preg_match( '/data-attributes="([^"]*)"/', $markup, $matches ), 'the container carries no data-attributes.' );
 		$attributes = json_decode( rawurldecode( $matches[1] ), true );
 
 		$response = $this->render( 'core/latest-posts', array( 'attributes' => $attributes ) );
@@ -357,14 +357,13 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Markup the tag swap cannot handle is left completely alone.
+	 * Markup around the container no longer matters.
 	 *
-	 * The swap renames the first `<ul` and the last `</ul>`, so anything that makes
-	 * those two different elements has to skip the rewrite entirely. Marking a
-	 * container that then keeps its `<ul>` would be just as wrong, because the
-	 * front-end script would render a `<div>` into a list.
+	 * Nothing is renamed any more, so the classes go on the block's own element and
+	 * whatever sits beside it is irrelevant. These shapes used to opt out of live
+	 * update entirely, and silently.
 	 */
-	public function test_unswappable_markup_is_left_alone() {
+	public function test_markup_around_the_container_still_gets_marked() {
 		$cases = array(
 			'leading'  => '<!-- x --><ul class="wp-block-latest-posts"><li>a</li></ul>',
 			'trailing' => '<ul class="wp-block-latest-posts"><li>a</li></ul><style>.x{}</style>',
@@ -372,21 +371,25 @@ class Test_Latest_Posts_Block extends WP_UnitTestCase {
 		);
 
 		foreach ( $cases as $label => $markup ) {
-			$this->assertSame( $markup, $this->render_container( $markup ), $label . ': markup was rewritten.' );
+			$output = $this->render_container( $markup );
+
+			$this->assertStringContainsString( 'has-live-update', $output, $label . ': container was not marked.' );
+			$this->assertStringContainsString( 'data-attributes=', $output, $label . ': no attributes were written.' );
 		}
 	}
 
 	/**
-	 * A list nested inside the container is still one container, so it still swaps.
+	 * A list nested inside the container is left where it is.
 	 */
-	public function test_nested_list_still_swaps() {
+	public function test_nested_list_is_untouched() {
 		$output = $this->render_container(
 			'<ul class="wp-block-latest-posts"><li>a<ul><li>b</li></ul></li></ul>'
 		);
 
-		$this->assertStringStartsWith( '<div ', $output );
-		$this->assertStringEndsWith( '</div>', $output );
-		$this->assertSame( 1, substr_count( $output, '<ul' ), 'the nested list should survive' );
-		$this->assertSame( 1, substr_count( $output, '</ul>' ) );
+		$this->assertStringStartsWith( '<ul ', $output );
+		$this->assertStringEndsWith( '</ul>', $output );
+		$this->assertStringContainsString( 'has-live-update', $output );
+		$this->assertSame( 2, substr_count( $output, '<ul' ), 'the nested list should survive' );
+		$this->assertSame( 2, substr_count( $output, '</ul>' ) );
 	}
 }


### PR DESCRIPTION
## Why

A `core/latest-posts` block with live update on renders its list server-side, then loses it a second later. `render-frontend.js` mounts the component into the container, `ServerSideRender` throws, and the crash boundary replaces the posts with "There was an error trying to render this content". Two live examples:

- [leipzig.wordcamp.org/2025/day-of-event/](https://leipzig.wordcamp.org/2025/day-of-event/) serves 5 items, shows 0
- [events.wordpress.org/campusconnect/2026/kolkata/day-of-event/](https://events.wordpress.org/campusconnect/2026/kolkata/day-of-event/) serves 2, shows 0

34 sites on the network have a page carrying the block. Three separate things are wrong, and the first one hides the other two.

**`ServerSideRender` is an editor component.** The [handbook](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-server-side-render/) describes it as rendering a preview of dynamic blocks in the editor, and calls it a legacy fallback not appropriate for new development. The blocker is in the code rather than the guidance: since 2.0 it calls `__experimentalSanitizeBlockAttributes()`, which looks the block up with `getBlockType()` and throws when it is missing from the client-side registry. Nothing registers core blocks outside the editor, so it throws before it fetches. 1.9.0 (April 2020) has no such call and 2.0.0 (May 2021) does, so this stopped working when core picked that up, around WP 5.8. The npm pin in `package.json` never mattered, since `@wordpress/*` imports are externalised to core's bundled scripts.

**The renderer route rejects attributes the render path still honours.** `postLayout` and `columns` moved to the layout support and are gone from the block's schema, but `render_block_core_latest_posts()` still reads them. The two WordPress copies in this repo bracket the change: the phpunit suite runs 7.0.4, which declares both, and the site runs 7.2-alpha, which declares neither. A block saved with them draws its grid and then fails every poll. `slovenia.wordcamp.org/2026` is one of them:

```
attributes[postLayout]=grid   400  "postLayout is not a valid property of Object."
the same request without it   200
```

**The nonce expires and nothing recovers it.** `apiFetch` attaches `X-WP-Nonce`. For a logged-out visitor that nonce dies after 12 to 24 hours, and `rest_cookie_check_errors()` refuses an invalid one before the request is routed, so the safelist never runs. api-fetch then tries `admin-ajax.php?action=rest-nonce`, which core registers for logged-in users only. Measured against `us.wordcamp.org/2019`:

```
no nonce      200
stale nonce   403  rest_cookie_invalid_nonce
rest-nonce    400
```

A page served from a cache older than a day is born in that state, which is the hallway-screen case the feature exists for.

## What changed

- `front-end.js` drops `ServerSideRender` and requests the renderer route itself, so nothing looks the block up in a registry it was never added to. The block needs a URL and a fetch, not an editor preview component.
- The response is written straight into the container, so a refreshed list has the same shape the server rendered. That is the markup any theme or custom CSS was written against, and it leaves nothing interposed for the layout rules to land on: the block gap and the grid both address direct children.
- Nothing is fetched until the interval fires, so the list on screen is the server's until there is something newer to show. A failed or refused request leaves it alone.
- The request goes out through `window.fetch`, against a root-relative endpoint `add_script_data()` localises from `rest_url()`. No nonce, so there is nothing to expire, and no absolute host, so it cannot turn cross-origin.
- `render()` keeps unregistered attributes out of `data-attributes`. They only feed container classes and the container on the page keeps its own, so a block saved with `postLayout` keeps its grid and starts polling again.
- Attributes that cannot be read, or are not there at all, stop the refresh rather than starting one. Asking with no attributes would render the block's defaults over a correctly configured list.
- A failure is reported once through `console.warn`, so a list that stops updating can be diagnosed instead of going quiet.

- The list is only rewritten when the markup actually changed. Rebuilding it drops focus and any selection inside it and restarts the images, and most polls return what is already on screen.
- Polling stops when the container leaves the page, when the endpoint is missing, and after three refused requests. A refusal repeats by construction, so retrying it forever is pointless; a dropped connection is not, so those keep retrying and a screen left running unattended survives a bad afternoon.
- The safelisted response carries `Cache-Control: public, s-maxage=60`. Everyone on a page polls the same URL, and a minute is short against the five between polls, so a shared cache can absorb most of the traffic without adding much to how stale the list gets. It is the only response on that route marked cacheable: an authorised render, and anything the guards refused, are not.

Dropping the component takes React with it, and with no strings left to translate the script no longer sets translations either. A page carrying the block went from loading `react-jsx-runtime`, `wp-element`, `wp-i18n`, `wp-hooks` and `wp-server-side-render` to loading `wp-url` alone, with the built file at 947 bytes.

## Test plan

- [x] `--group=blocks` 29/29, and a full `phpunit` run clean apart from the pre-existing skips
- [x] `lint:js` clean, `wp-scripts test-unit-js` 23/23
- [x] `phpcs` clean on the changed lines (the one error it reports, in `check_version_support()`, is on `production` too and is not touched here)
- [x] Browser pass on a local multisite camp, steps below

Two new tests, plus a fix to the suite's environment. The suite loads `controller.php` directly, after `init` has fired, so the hook's own registration never ran and the block's schema was missing `liveUpdateEnabled`. `set_up` now adds it and `tear_down` removes it, which is what lets a test send the attribute the front end actually sends.

`test_unregistered_attributes_are_not_polled` uses a name core will never declare rather than `postLayout`, because the phpunit WordPress still registers `postLayout` and the site does not. `test_polled_attributes_are_accepted_by_the_route` closes the loop the change exists for: it takes the `data-attributes` payload the filter wrote and sends it back through `rest_do_request()`, which fails without the filtering.

### Manual test steps

Two pages on a local camp site, one with plain attributes and one carrying the legacy pair.

```bash
docker compose exec -T wordcamp.test wp --url=seattle.wordcamp.test/2023/ eval '
$a = wp_insert_post( array( "post_type"=>"page", "post_status"=>"publish", "post_title"=>"Modern",
 "post_content"=>"<!-- wp:latest-posts {\"displayPostDate\":true,\"liveUpdateEnabled\":true} /-->" ) );
$b = wp_insert_post( array( "post_type"=>"page", "post_status"=>"publish", "post_title"=>"Legacy",
 "post_content"=>"<!-- wp:latest-posts {\"postsToShow\":3,\"postLayout\":\"grid\",\"columns\":3,\"liveUpdateEnabled\":true} /-->" ) );
foreach ( array( "news one", "news two" ) as $t ) {
  wp_insert_post( array( "post_type"=>"post", "post_status"=>"publish", "post_title"=>$t, "post_content"=>"body" ) );
}
echo get_permalink( $a ) . "\n" . get_permalink( $b ) . "\n";'
```

Load each page logged out and watch the list. On `production` the posts are replaced by the error string within a second and the console carries `Block type 'core/latest-posts' is not registered`. Here the list stays, the console is quiet, and one request to the renderer route goes out on load.

Driven with Playwright on both pages:

|  | `production` | this branch |
| --- | --- | --- |
| list items after mount | 0 | 4 and 3 |
| console | `Block type 'core/latest-posts' is not registered.` | none |
| `X-WP-Nonce` sent | yes | none |
| renderer request on load | none | 200 |

The legacy page keeps `is-grid columns-3` on its container while its `data-attributes` payload comes back as `{"postsToShow":3,"liveUpdateEnabled":true}`.

For the interval itself, install a fake clock, publish a post with the page open, and move five minutes on. The new post arrives at the top of the list and both requests return 200.

### Screenshots

#### Before

<img width="674" height="268" alt="image" src="https://github.com/user-attachments/assets/c99d3d92-c7f8-4a4a-9371-3291c2a0de37" />

<img width="745" height="327" alt="image" src="https://github.com/user-attachments/assets/0ed3896a-63cb-4107-9996-e83cd5344b42" />

#### After

<img width="801" height="281" alt="image" src="https://github.com/user-attachments/assets/2b551920-412b-40f1-a694-8eb157c027aa" />

<img width="635" height="378" alt="image" src="https://github.com/user-attachments/assets/7e6fad20-9409-4efd-a1e3-1cd9ad7867b9" />





