### PR TITLE
Reports: add a Sponsor ROI report

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-sponsor-roi.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/classes/report/class-sponsor-roi.php
@@ -1,0 +1,749 @@
+<?php
+/**
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Report;
+defined( 'WPINC' ) || die();
+
+use DateTime;
+use Exception;
+use WordCamp\Reports\Utility\Date_Range;
+use WordCamp\Utilities\Currency_XRT_Client;
+use WordPressdotorg\MU_Plugins\Utilities\Export_CSV;
+use const WordCamp\Reports\CAPABILITY;
+use function WordCamp\Reports\get_views_dir_path;
+use function WordCamp\Reports\Validation\validate_date_range;
+
+/**
+ * Class Sponsor_ROI
+ *
+ * Joins sponsor spend (Sponsor Invoices) with event reach (registered + checked-in attendee
+ * counts), rolled up across each sponsor's portfolio (their Multi-Event Sponsor agreement).
+ * Aggregates only — no new tracking.
+ *
+ * @package WordCamp\Reports\Report
+ */
+class Sponsor_ROI extends Base {
+	/**
+	 * Invoice statuses that count toward spend, default mode: paid only.
+	 *
+	 * @var array
+	 */
+	const COUNTED_STATUSES_PAID = array( 'wcbsi_paid' );
+
+	/**
+	 * Invoice statuses that count toward spend when including sent invoices.
+	 *
+	 * @var array
+	 */
+	const COUNTED_STATUSES_PAID_SENT = array( 'wcbsi_paid', 'wcbsi_approved' );
+
+	/**
+	 * The currency that all spend amounts are normalized to.
+	 *
+	 * @var string
+	 */
+	const BASE_CURRENCY = 'USD';
+
+	/**
+	 * Sponsor country meta key.
+	 *
+	 * @var string
+	 */
+	const COUNTRY_META = '_wcpt_sponsor_country';
+
+	/**
+	 * Report name.
+	 *
+	 * @var string
+	 */
+	public static $name = 'Sponsor ROI';
+
+	/**
+	 * Report slug.
+	 *
+	 * @var string
+	 */
+	public static $slug = 'sponsor-roi';
+
+	/**
+	 * Report description.
+	 *
+	 * @var string
+	 */
+	public static $description = 'Sponsor spend joined with event reach (registered + checked-in), rolled up across each sponsor\'s portfolio.';
+
+	/**
+	 * Report methodology.
+	 *
+	 * @var string
+	 */
+	public static $methodology = "
+		<ol>
+			<li>Retrieve the WordCamps whose start date falls within the specified date range (WordCamp Details report), skipping camps without a website.</li>
+			<li>On each camp site, list published Sponsor posts. For each sponsor, sum their Sponsor Invoice amounts — paid invoices only by default — grouped by currency, and normalize to USD at the event-date exchange rate.</li>
+			<li>Count the camp's reach: published attendee records (registered) and attendees marked as attended via CampTix check-in (checked in). When no check-in data exists at all, the camp is flagged 'attendance not measured' rather than counted as zero.</li>
+			<li>Roll the per-camp rows up into one portfolio per Multi-Event Sponsor agreement (sponsors without an agreement stay as single-camp rows) and compute cost per registered / checked-in attendee.</li>
+		</ol>
+	";
+
+	/**
+	 * Report group.
+	 *
+	 * @var string
+	 */
+	public static $group = 'wordcamp';
+
+	/**
+	 * The date range that defines the scope of the report data.
+	 *
+	 * @var null|Date_Range
+	 */
+	public $range = null;
+
+	/**
+	 * Optional Multi-Event Sponsor agreement filter (0 = all).
+	 *
+	 * @var int
+	 */
+	public $mes_id = 0;
+
+	/**
+	 * Exchange-rate client. Settable for tests.
+	 *
+	 * @var Currency_XRT_Client|object|null
+	 */
+	public $xrt = null;
+
+	/**
+	 * Memoized camp list from the WordCamp Details report.
+	 *
+	 * @var array|null
+	 */
+	protected $wordcamps = null;
+
+	/**
+	 * Data fields that can be visible in a public context.
+	 *
+	 * @var array An associative array of key/default value pairs.
+	 */
+	protected $public_data_fields = array(
+		'rollup_key'          => '',
+		'mes_id'              => 0,
+		'wordcamp_id'         => 0,
+		'wordcamp_name'       => '',
+		'event_date'          => '',
+		'sponsor_name'        => '',
+		'tier'                => '',
+		'website'             => '',
+		'country'             => '',
+		'first_time'          => '',
+		'registered'          => 0,
+		'attended'            => 0,
+		'attendance_measured' => false,
+	);
+
+	/**
+	 * Data fields that should only be visible in a private context.
+	 *
+	 * @var array An associative array of key/default value pairs.
+	 */
+	protected $private_data_fields = array(
+		'site_id'     => 0,
+		'sponsor_id'  => 0,
+		'spend_usd'   => 0.0,
+		'has_invoice' => false,
+	);
+
+	/**
+	 * Sponsor_ROI constructor.
+	 *
+	 * @param string $start_date The start of the date range for the report.
+	 * @param string $end_date   The end of the date range for the report.
+	 * @param int    $mes_id     Optional. Filter the report to one MES agreement.
+	 * @param array  $options    Optional. Additional report parameters. See Base::__construct
+	 *                          and the functions in WordCamp\Reports\Validation for the full set.
+	 */
+	public function __construct( $start_date, $end_date, $mes_id = 0, array $options = array() ) {
+		parent::__construct( $options );
+
+		$this->mes_id = absint( $mes_id );
+
+		try {
+			$this->range = validate_date_range( $start_date, $end_date, $options );
+		} catch ( Exception $e ) {
+			$this->error->add(
+				self::$slug . '-date-error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Generate a cache key.
+	 *
+	 * The base key only varies by report slug and public/private context; without
+	 * the range and filters in the key, a 2024 run would serve cached 2025 data.
+	 *
+	 * @return string
+	 */
+	protected function get_cache_key() {
+		$cache_key_segments = array(
+			parent::get_cache_key(),
+			$this->range->generate_cache_key_segment(),
+		);
+
+		if ( $this->mes_id ) {
+			$cache_key_segments[] = 'mes-' . $this->mes_id;
+		}
+
+		if ( ! empty( $this->options['include_sent_invoices'] ) ) {
+			$cache_key_segments[] = '+sent';
+		}
+
+		return implode( '_', $cache_key_segments );
+	}
+
+	/**
+	 * Generate a cache expiration interval.
+	 *
+	 * @return int A time interval in seconds.
+	 */
+	protected function get_cache_expiration() {
+		return $this->range->generate_cache_duration( parent::get_cache_expiration() );
+	}
+
+	/**
+	 * Query and parse the data for the report.
+	 *
+	 * Emits one raw row per sponsor per camp. Reach counts are whole-event
+	 * numbers repeated on every sponsor row for that camp — the audience the
+	 * sponsor's placement reached, not a per-sponsor figure.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		// Bail if there are errors.
+		if ( ! empty( $this->error->get_error_messages() ) ) {
+			return array();
+		}
+
+		// Maybe use cached data.
+		$cached = $this->maybe_get_cached_data();
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$camp_rows = array();
+		$wordcamps = $this->get_wordcamps();
+
+		foreach ( $wordcamps as $wordcamp_id => $info ) {
+			$valid = $this->resolve_wordcamp( $wordcamp_id );
+
+			if ( ! $valid ) {
+				continue; // Skip camps without a usable subsite.
+			}
+
+			$event_date = $info['Start Date (YYYY-mm-dd)']
+				? gmdate( 'Y-m-d', (int) $info['Start Date (YYYY-mm-dd)'] )
+				: '';
+
+			$camp_rows[] = $this->get_camp_sponsors( $valid->site_id, $valid->post_id, $info['Name'], $event_date );
+		}
+
+		$data = $camp_rows ? array_merge( ...$camp_rows ) : array();
+
+		$data = $this->filter_data_fields( $data );
+		$this->maybe_cache_data( $data );
+
+		return $data;
+	}
+
+	/**
+	 * Get the list of WordCamps in the date range from the WordCamp Details report.
+	 *
+	 * @return array Camp post ID => array with ID, Name, URL, Start Date, Status.
+	 */
+	protected function get_wordcamps() {
+		if ( is_array( $this->wordcamps ) ) {
+			return $this->wordcamps;
+		}
+
+		$details_report = new WordCamp_Details( $this->range, array(), false, array( 'public' => false ) );
+
+		if ( ! empty( $details_report->error->get_error_messages() ) ) {
+			$this->error = $this->merge_errors( $this->error, $details_report->error );
+
+			return array();
+		}
+
+		$wordcamps = array_filter(
+			$details_report->get_data(),
+			function ( $wordcamp ) {
+				return ! empty( $wordcamp['URL'] );
+			}
+		);
+
+		$this->wordcamps = array_reduce(
+			$wordcamps,
+			function ( $carry, $item ) {
+				$keep = array(
+					'ID'                      => '',
+					'Name'                    => '',
+					'URL'                     => '',
+					'Start Date (YYYY-mm-dd)' => '',
+					'Status'                  => '',
+				);
+
+				$carry[ $item['ID'] ] = array_intersect_key( $item, $keep );
+
+				return $carry;
+			},
+			array()
+		);
+
+		return $this->wordcamps;
+	}
+
+	/**
+	 * Resolve a WordCamp post ID to its site/post ID pair, or null when unusable.
+	 *
+	 * @param int $wordcamp_id WordCamp post ID on the central site.
+	 *
+	 * @return object|null Object with site_id and post_id properties, or null.
+	 */
+	protected function resolve_wordcamp( $wordcamp_id ) {
+		try {
+			return \WordCamp\Reports\Validation\validate_wordcamp_id( $wordcamp_id );
+		} catch ( Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Gather one raw row per sponsor on a single camp subsite.
+	 *
+	 * @param int    $site_id       The camp's subsite blog ID.
+	 * @param int    $wordcamp_id   The WordCamp post ID on the central site.
+	 * @param string $wordcamp_name The camp's name.
+	 * @param string $event_date    The camp's start date, 'Y-m-d'.
+	 *
+	 * @return array
+	 */
+	protected function get_camp_sponsors( $site_id, $wordcamp_id, $wordcamp_name, $event_date ) {
+		$rows           = array();
+		$count_statuses = $this->get_counted_statuses();
+
+		switch_to_blog( $site_id );
+
+		$sponsor_query = array(
+			'post_type'      => 'wcb_sponsor',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+		);
+
+		if ( $this->mes_id ) {
+			$sponsor_query['meta_key']   = '_mes_id';
+			$sponsor_query['meta_value'] = $this->mes_id;
+		}
+
+		$sponsors = get_posts( $sponsor_query );
+
+		if ( empty( $sponsors ) ) {
+			restore_current_blog();
+
+			return $rows;
+		}
+
+		$reach = $this->get_camp_reach();
+
+		foreach ( $sponsors as $sponsor ) {
+			$mes_id = absint( get_post_meta( $sponsor->ID, '_mes_id', true ) );
+			$totals = $this->get_sponsor_invoice_totals( $sponsor->ID, $count_statuses );
+
+			$spend_usd = 0.0;
+			foreach ( $totals as $currency => $amount ) {
+				$spend_usd += $this->to_base_currency( $amount, $currency, $event_date );
+			}
+
+			$levels       = wp_get_post_terms( $sponsor->ID, 'wcb_sponsor_level', array( 'fields' => 'names' ) );
+			$company_name = (string) get_post_meta( $sponsor->ID, '_wcpt_sponsor_company_name', true );
+
+			$rows[] = array(
+				'rollup_key'          => $mes_id ? (string) $mes_id : "local-{$site_id}-{$sponsor->ID}",
+				'mes_id'              => $mes_id,
+				'wordcamp_id'         => (int) $wordcamp_id,
+				'site_id'             => (int) $site_id,
+				'wordcamp_name'       => (string) $wordcamp_name,
+				'event_date'          => (string) $event_date,
+				'sponsor_id'          => (int) $sponsor->ID,
+				'sponsor_name'        => '' !== $company_name ? $company_name : $sponsor->post_title,
+				'tier'                => ! empty( $levels ) && ! is_wp_error( $levels ) ? (string) $levels[0] : '',
+				'website'             => (string) get_post_meta( $sponsor->ID, '_wcpt_sponsor_website', true ),
+				'country'             => (string) get_post_meta( $sponsor->ID, self::COUNTRY_META, true ),
+				'first_time'          => (string) get_post_meta( $sponsor->ID, '_wcb_sponsor_first_time', true ),
+				'spend_usd'           => $spend_usd,
+				'has_invoice'         => ! empty( $totals ),
+				'registered'          => $reach['registered'],
+				'attended'            => $reach['attended'],
+				'attendance_measured' => $reach['measured'],
+			);
+		}
+
+		restore_current_blog();
+
+		return $rows;
+	}
+
+	/**
+	 * Counted invoice statuses, honoring the include-sent option.
+	 *
+	 * @return array
+	 */
+	protected function get_counted_statuses() {
+		return ! empty( $this->options['include_sent_invoices'] )
+			? self::COUNTED_STATUSES_PAID_SENT
+			: self::COUNTED_STATUSES_PAID;
+	}
+
+	/**
+	 * Compile the raw rows into per-portfolio totals and ratios.
+	 *
+	 * Camps where attendance wasn't measured contribute to `registered` but not
+	 * to `attended` — unknown is not zero — and are counted in `unmeasured_camps`
+	 * so the display layer can caveat the cost-per-attended ratio.
+	 *
+	 * @param array $data The data to compile.
+	 *
+	 * @return array
+	 */
+	public function compile_report_data( array $data ) {
+		$portfolios = array();
+
+		foreach ( $data as $row ) {
+			$key = $row['rollup_key'];
+
+			if ( ! isset( $portfolios[ $key ] ) ) {
+				$portfolios[ $key ] = array(
+					'sponsor_name' => $row['sponsor_name'],
+					'mes_id'       => $row['mes_id'],
+					'camps'        => array(),
+					'tiers'        => array(),
+					'totals'       => array(
+						'spend_usd'        => 0.0,
+						'registered'       => 0,
+						'attended'         => 0,
+						'camp_count'       => 0,
+						'unmeasured_camps' => 0,
+					),
+					'ratios'       => array(
+						'cost_per_registered' => null,
+						'cost_per_attended'   => null,
+					),
+				);
+			}
+
+			$portfolios[ $key ]['camps'][]                      = $row;
+			$portfolios[ $key ]['tiers'][ $row['wordcamp_id'] ] = $row['tier'];
+			$portfolios[ $key ]['totals']['spend_usd']         += $row['spend_usd'] ?? 0.0; // Private field, absent in a public context.
+			$portfolios[ $key ]['totals']['registered']        += $row['registered'];
+			++$portfolios[ $key ]['totals']['camp_count'];
+
+			if ( ! empty( $row['attendance_measured'] ) ) {
+				$portfolios[ $key ]['totals']['attended'] += $row['attended'];
+			} else {
+				++$portfolios[ $key ]['totals']['unmeasured_camps'];
+			}
+		}
+
+		foreach ( $portfolios as &$portfolio ) {
+			$spend      = $portfolio['totals']['spend_usd'];
+			$registered = $portfolio['totals']['registered'];
+			$attended   = $portfolio['totals']['attended'];
+
+			$portfolio['ratios']['cost_per_registered'] = $registered > 0 ? $spend / $registered : null;
+			$portfolio['ratios']['cost_per_attended']   = $attended > 0 ? $spend / $attended : null;
+		}
+		unset( $portfolio );
+
+		return $portfolios;
+	}
+
+	/**
+	 * Sum a sponsor's invoice amounts, grouped by currency, filtered by status.
+	 *
+	 * Must be called within switch_to_blog() of the sponsor's subsite.
+	 *
+	 * @param int   $sponsor_id     Local wcb_sponsor post ID.
+	 * @param array $count_statuses Invoice post statuses that count toward spend.
+	 *
+	 * @return array Map of currency code => summed amount (float).
+	 */
+	protected function get_sponsor_invoice_totals( $sponsor_id, array $count_statuses ) {
+		$totals = array();
+
+		$invoices = get_posts( array(
+			'post_type'      => 'wcb_sponsor_invoice',
+			'post_status'    => $count_statuses,
+			'posts_per_page' => -1,
+			'meta_key'       => '_wcbsi_sponsor_id',
+			'meta_value'     => absint( $sponsor_id ),
+		) );
+
+		foreach ( $invoices as $invoice ) {
+			// WP_Query silently drops statuses that aren't registered in the current
+			// context, which makes the query fail OPEN (returns every status). Re-check
+			// in PHP so an unregistered status can never inflate spend.
+			if ( ! in_array( $invoice->post_status, $count_statuses, true ) ) {
+				continue;
+			}
+
+			$currency = (string) get_post_meta( $invoice->ID, '_wcbsi_currency', true );
+			$amount   = floatval( get_post_meta( $invoice->ID, '_wcbsi_amount', true ) );
+
+			if ( '' === $currency ) {
+				continue;
+			}
+
+			$totals[ $currency ] = ( $totals[ $currency ] ?? 0.0 ) + $amount;
+		}
+
+		return $totals;
+	}
+
+	/**
+	 * Convert an amount to the base currency (USD).
+	 *
+	 * @param float  $amount   Amount in $currency.
+	 * @param string $currency ISO currency code.
+	 * @param string $date     'Y-m-d' rate date (the event date).
+	 *
+	 * @return float Amount in base currency; 0.0 if the currency is unknown.
+	 */
+	protected function to_base_currency( $amount, $currency, $date ) {
+		if ( self::BASE_CURRENCY === $currency ) {
+			return (float) $amount; // convert() has no special case for the base currency.
+		}
+
+		if ( null === $this->xrt ) {
+			$this->xrt = new Currency_XRT_Client( self::BASE_CURRENCY );
+		}
+
+		$conversion = $this->xrt->convert( $amount, $currency, $date );
+
+		if ( is_wp_error( $conversion ) ) {
+			if ( 'unknown_currency' !== $conversion->get_error_code() ) {
+				$this->merge_errors( $this->error, $conversion );
+			}
+
+			return 0.0;
+		}
+
+		$base = self::BASE_CURRENCY;
+
+		return (float) $conversion->$base;
+	}
+
+	/**
+	 * Count registered and checked-in attendees for the current (switched) site.
+	 *
+	 * `measured` distinguishes "check-in wasn't used at this event" from a real zero,
+	 * so events checked in with external tools aren't reported as 100% no-show.
+	 *
+	 * @return array { 'registered' => int, 'attended' => int, 'measured' => bool }
+	 */
+	protected function get_camp_reach() {
+		$registered = new \WP_Query( array(
+			'post_type'      => 'tix_attendee',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'no_found_rows'  => false,
+		) );
+
+		$attended = new \WP_Query( array(
+			'post_type'      => 'tix_attendee',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_key'       => 'tix_attended',
+			'meta_value'     => '1', // A boolean true lands in the database as the string '1'.
+		) );
+
+		$measured = new \WP_Query( array(
+			'post_type'      => 'tix_attendee',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_query'     => array(
+				array(
+					'key'     => 'tix_attended',
+					'compare' => 'EXISTS',
+				),
+			),
+		) );
+
+		return array(
+			'registered' => (int) $registered->found_posts,
+			'attended'   => (int) $attended->found_posts,
+			'measured'   => $measured->found_posts > 0,
+		);
+	}
+
+	/**
+	 * Flat CSV headers (one row per sponsor-per-camp; internal export).
+	 *
+	 * @return array Map of row key => column label.
+	 */
+	public function get_data_headers() {
+		return array(
+			'rollup_key'          => 'Portfolio Key',
+			'mes_id'              => 'MES ID',
+			'sponsor_name'        => 'Sponsor',
+			'wordcamp_name'       => 'WordCamp',
+			'event_date'          => 'Event Date',
+			'tier'                => 'Tier',
+			'spend_usd'           => 'Spend (USD)',
+			'has_invoice'         => 'Has Invoice',
+			'registered'          => 'Registered',
+			'attended'            => 'Checked In',
+			'attendance_measured' => 'Attendance Measured',
+			'website'             => 'Sponsor Website',
+			'country'             => 'Country',
+		);
+	}
+
+	/**
+	 * Render an HTML version of the report output.
+	 *
+	 * @return void
+	 */
+	public function render_html() {
+		$data = $this->get_data();
+
+		if ( ! empty( $this->error->get_error_messages() ) ) {
+			$this->render_error_html();
+
+			return;
+		}
+
+		$compiled = $this->compile_report_data( $data );
+
+		include get_views_dir_path() . 'html/sponsor-roi.php';
+	}
+
+	/**
+	 * Render the page for this report in the WP Admin.
+	 *
+	 * @return void
+	 */
+	public static function render_admin_page() {
+		if ( ! current_user_can( CAPABILITY ) ) {
+			return;
+		}
+
+		$start_date = wp_unslash( $_POST['start-date'] ?? '' );
+		$end_date   = wp_unslash( $_POST['end-date'] ?? '' );
+		$mes_id     = absint( $_POST['mes-id'] ?? 0 );
+		$refresh    = filter_input( INPUT_POST, 'refresh', FILTER_VALIDATE_BOOLEAN );
+		$action     = wp_unslash( $_POST['action'] ?? '' );
+		$nonce      = wp_unslash( $_POST[ self::$slug . '-nonce' ] ?? '' );
+
+		$report = null;
+
+		if ( 'Show results' === $action
+			&& wp_verify_nonce( $nonce, 'run-report' )
+			&& current_user_can( CAPABILITY )
+		) {
+			$options = array(
+				'earliest_start' => new DateTime( '2015-01-01' ), // No indexed payment data before 2015.
+				'public'         => false,
+			);
+
+			if ( $refresh ) {
+				$options['flush_cache'] = true;
+			}
+
+			$report = new self( $start_date, $end_date, $mes_id, $options );
+		}
+
+		include get_views_dir_path() . 'report/sponsor-roi.php';
+	}
+
+	/**
+	 * Export the report data to a file.
+	 *
+	 * @return void
+	 */
+	public static function export_to_file() {
+		$start_date = wp_unslash( $_POST['start-date'] ?? '' );
+		$end_date   = wp_unslash( $_POST['end-date'] ?? '' );
+		$mes_id     = absint( $_POST['mes-id'] ?? 0 );
+		$action     = wp_unslash( $_POST['action'] ?? '' );
+		$report     = wp_unslash( $_GET['report'] ?? '' );
+		$nonce      = wp_unslash( $_POST[ self::$slug . '-nonce' ] ?? '' );
+
+		if ( $report !== self::$slug ) {
+			return;
+		}
+		if ( 'Export CSV' !== $action ) {
+			return;
+		}
+		if ( ! wp_verify_nonce( $nonce, 'run-report' ) || ! current_user_can( CAPABILITY ) ) {
+			return;
+		}
+
+		$report = new self( $start_date,
+			$end_date,
+			$mes_id,
+			array(
+				'earliest_start' => new DateTime( '2015-01-01' ),
+				'public'         => false,
+			)
+		);
+
+		$filename = array( $report::$name, wp_date( 'Y-m-d' ) );
+
+		$exporter = new Export_CSV( array(
+			'filename' => $filename,
+			'headers'  => array_values( $report->get_data_headers() ),
+			'data'     => self::flatten_for_csv( $report->get_data(), array_keys( $report->get_data_headers() ) ),
+		) );
+
+		if ( ! empty( $report->error->get_error_messages() ) ) {
+			$exporter->error = $report->merge_errors( $report->error, $exporter->error );
+		}
+
+		$exporter->emit_file();
+	}
+
+	/**
+	 * Reduce raw rows to ordered scalar columns for CSV.
+	 *
+	 * @param array $rows    Raw data rows.
+	 * @param array $columns Ordered list of row keys to keep.
+	 *
+	 * @return array
+	 */
+	protected static function flatten_for_csv( array $rows, array $columns ) {
+		return array_map(
+			function ( $row ) use ( $columns ) {
+				$out = array();
+
+				foreach ( $columns as $col ) {
+					$value = $row[ $col ] ?? '';
+
+					if ( is_bool( $value ) ) {
+						$value = $value ? 'Yes' : 'No';
+					}
+
+					$out[ $col ] = $value;
+				}
+
+				return $out;
+			},
+			$rows
+		);
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-reports/includes/validation.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/includes/validation.php
@@ -105,7 +105,7 @@ function validate_date_range( $start_date, $end_date, array $config = [] ) {
 
 	// If the end date doesn't have a specific time, make sure the entire day is included.
 	if ( $config['include_end_date'] && '00:00:00' === $end_date->format( 'H:i:s' ) ) {
-		$end_date->setTime( 23, 59, 59 );
+		$end_date = $end_date->setTime( 23, 59, 59 );
 	}
 
 	return new Date_Range( $start_date, $end_date );

--- a/public_html/wp-content/plugins/wordcamp-reports/index.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/index.php
@@ -143,6 +143,7 @@ function get_report_classes() {
 		__NAMESPACE__ . '\Report\Meetup_Sponsors',
 		__NAMESPACE__ . '\Report\WordCamp_Counts',
 		__NAMESPACE__ . '\Report\Sponsor_Details',
+		__NAMESPACE__ . '\Report\Sponsor_ROI',
 		__NAMESPACE__ . '\Report\WordCamp_Speaker_Feedback',
 		__NAMESPACE__ . '\Report\CampusConnect_Details',
 	);

--- a/public_html/wp-content/plugins/wordcamp-reports/tests/test-sponsor-roi-integration.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/tests/test-sponsor-roi-integration.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Tests;
+
+use WP_UnitTestCase;
+use WordCamp\Reports\Report\Sponsor_ROI;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/camptix/tests/trait-wordcamp-root-blog.php';
+
+/**
+ * A Sponsor_ROI subclass with camp enumeration stubbed to a single test subsite.
+ *
+ * Camp enumeration (WordCamp_Details) and site resolution (validate_wordcamp_id)
+ * depend on the wcpt plugin, which isn't loaded in the isolated suite. Everything
+ * downstream — the per-camp gatherer, spend join, currency, reach — runs for real
+ * against a factory-created subsite.
+ */
+class Stubbed_Sponsor_ROI extends Sponsor_ROI {
+	/**
+	 * The single camp this stub reports, as [ wordcamp_id, site_id, name, start_timestamp ].
+	 *
+	 * @var array
+	 */
+	public $test_camp = array();
+
+	/**
+	 * Return the single fixture camp instead of querying WordCamp_Details.
+	 *
+	 * @return array
+	 */
+	protected function get_wordcamps() {
+		return array(
+			$this->test_camp[0] => array(
+				'ID'                      => $this->test_camp[0],
+				'Name'                    => $this->test_camp[2],
+				'URL'                     => 'https://test.wordcamp.test',
+				'Start Date (YYYY-mm-dd)' => $this->test_camp[3],
+				'Status'                  => 'wcpt-closed',
+			),
+		);
+	}
+
+	/**
+	 * Resolve the fixture camp without wcpt, which the isolated harness lacks.
+	 *
+	 * @param int $wordcamp_id
+	 *
+	 * @return array|null
+	 */
+	protected function resolve_wordcamp( $wordcamp_id ) {
+		$valid          = new \stdClass();
+		$valid->post_id = $this->test_camp[0];
+		$valid->site_id = $this->test_camp[1];
+
+		return $valid;
+	}
+}
+
+/**
+ * Cross-site integration tests for the Sponsor ROI report.
+ *
+ * @group wordcamp-reports
+ * @group sponsor-roi
+ */
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound -- the stub above is only meaningful to this test case.
+class Test_Sponsor_ROI_Integration extends WP_UnitTestCase {
+	use \CampTix_Root_Blog_Fixture;
+
+	/**
+	 * Provision central — see the same fixture in Test_Sponsor_ROI for why.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::create_wordcamp_root_blog( $factory );
+	}
+
+	/**
+	 * Remove the root blog this class created.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_wordcamp_root_blog();
+	}
+
+	/**
+	 * Register the invoice statuses and sponsor-level taxonomy the join needs.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		foreach ( array( 'wcbsi_paid', 'wcbsi_approved', 'wcbsi_submitted' ) as $status ) {
+			register_post_status( $status );
+		}
+
+		register_taxonomy( 'wcb_sponsor_level', 'wcb_sponsor' );
+	}
+
+	/**
+	 * Build a stubbed report pointed at a fresh subsite.
+	 *
+	 * @return Stubbed_Sponsor_ROI
+	 */
+	protected function stubbed_report() {
+		$site_id = self::factory()->blog->create();
+
+		$report            = new Stubbed_Sponsor_ROI( '2024-01-01',
+			'2024-12-31',
+			0,
+			array(
+				'cache_data' => false,
+				'public'     => false,
+			)
+		);
+		$report->test_camp = array( 987, $site_id, 'WordCamp Test', strtotime( '2024-06-01' ) );
+
+		return $report;
+	}
+
+	/**
+	 * `get_data` emits one row per sponsor per camp.
+	 */
+	public function test_get_data_emits_one_row_per_sponsor_per_camp() {
+		$report  = $this->stubbed_report();
+		$site_id = $report->test_camp[1];
+
+		switch_to_blog( $site_id );
+
+		$sponsor_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+			'post_title'  => 'PayPal',
+		) );
+		update_post_meta( $sponsor_id, '_mes_id', 4242 );
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_website', 'https://paypal.com' );
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_company_name', 'PayPal' );
+
+		wp_set_object_terms( $sponsor_id, 'Gold', 'wcb_sponsor_level' );
+
+		// Suspend wordcamp-payments' invoice status workflow for the fixture insert —
+		// see make_invoice() in Test_Sponsor_ROI.
+		$intercepted = remove_filter( 'wp_insert_post_data', 'WordCamp\\Budgets\\Sponsor_Invoices\\set_invoice_status', 10 );
+
+		$invoice_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor_invoice',
+			'post_status' => 'wcbsi_paid',
+		) );
+
+		if ( $intercepted ) {
+			add_filter( 'wp_insert_post_data', 'WordCamp\\Budgets\\Sponsor_Invoices\\set_invoice_status', 10, 2 );
+		}
+		update_post_meta( $invoice_id, '_wcbsi_sponsor_id', $sponsor_id );
+		update_post_meta( $invoice_id, '_wcbsi_amount', 5000 );
+		update_post_meta( $invoice_id, '_wcbsi_currency', 'USD' );
+
+		$attendee_id = self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+		update_post_meta( $attendee_id, 'tix_attended', true );
+
+		restore_current_blog();
+
+		$rows = $report->get_data();
+
+		$this->assertCount( 1, $rows );
+
+		$row = $rows[0];
+
+		$this->assertSame( '4242', $row['rollup_key'] );
+		$this->assertSame( 4242, $row['mes_id'] );
+		$this->assertSame( 987, $row['wordcamp_id'] );
+		$this->assertSame( $site_id, $row['site_id'] );
+		$this->assertSame( 'WordCamp Test', $row['wordcamp_name'] );
+		$this->assertSame( '2024-06-01', $row['event_date'] );
+		$this->assertSame( 'PayPal', $row['sponsor_name'] );
+		$this->assertSame( 'Gold', $row['tier'] );
+		$this->assertSame( 'https://paypal.com', $row['website'] );
+		$this->assertSame( 5000.0, $row['spend_usd'] );
+		$this->assertTrue( $row['has_invoice'] );
+		$this->assertSame( 1, $row['registered'] );
+		$this->assertSame( 1, $row['attended'] );
+		$this->assertTrue( $row['attendance_measured'] );
+	}
+
+	/**
+	 * `get_data` flags missing invoice and unmeasured attendance.
+	 */
+	public function test_get_data_flags_missing_invoice_and_unmeasured_attendance() {
+		$report  = $this->stubbed_report();
+		$site_id = $report->test_camp[1];
+
+		switch_to_blog( $site_id );
+
+		// A sponsor with no invoice at all, on a camp that never used check-in.
+		self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+			'post_title'  => 'Local Hosting Co',
+		) );
+
+		self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+
+		restore_current_blog();
+
+		$rows = $report->get_data();
+
+		$this->assertCount( 1, $rows );
+
+		$row = $rows[0];
+
+		$this->assertSame( "local-{$site_id}-{$row['sponsor_id']}", $row['rollup_key'] );
+		$this->assertSame( 0, $row['mes_id'] );
+		$this->assertSame( 0.0, $row['spend_usd'] );
+		$this->assertFalse( $row['has_invoice'] );
+		$this->assertSame( 1, $row['registered'] );
+		$this->assertSame( 0, $row['attended'] );
+		$this->assertFalse( $row['attendance_measured'] );
+	}
+
+	/**
+	 * `get_data` filters by `mes_id`.
+	 */
+	public function test_get_data_filters_by_mes_id() {
+		$report  = $this->stubbed_report();
+		$site_id = $report->test_camp[1];
+
+		$filtered            = new Stubbed_Sponsor_ROI(
+			'2024-01-01',
+			'2024-12-31',
+			4242,
+			array(
+				'cache_data' => false,
+				'public'     => false,
+			)
+		);
+		$filtered->test_camp = $report->test_camp;
+
+		switch_to_blog( $site_id );
+
+		$match = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+			'post_title'  => 'Matching Global Sponsor',
+		) );
+		update_post_meta( $match, '_mes_id', 4242 );
+
+		$other = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+			'post_title'  => 'Other Sponsor',
+		) );
+		update_post_meta( $other, '_mes_id', 1111 );
+
+		restore_current_blog();
+
+		$rows = $filtered->get_data();
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'Matching Global Sponsor', $rows[0]['sponsor_name'] );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-reports/tests/test-sponsor-roi.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/tests/test-sponsor-roi.php
@@ -1,0 +1,517 @@
+<?php
+/**
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Tests;
+
+use WP_UnitTestCase;
+use WordCamp\Reports\Report\Sponsor_ROI;
+use function WordCamp\Reports\get_report_classes;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__, 2 ) . '/camptix/tests/trait-wordcamp-root-blog.php';
+
+/**
+ * Unit tests for the Sponsor ROI report.
+ *
+ * @group wordcamp-reports
+ * @group sponsor-roi
+ */
+class Test_Sponsor_ROI extends WP_UnitTestCase {
+	use \CampTix_Root_Blog_Fixture;
+
+	/**
+	 * Provision central, so attendee saves don't query a blog that doesn't exist.
+	 *
+	 * Saving a `tix_attendee` runs CampTix's `is_wordcamp_closed()`, which does
+	 * `switch_to_blog( WORDCAMP_ROOT_BLOG_ID )` without checking that the blog
+	 * exists.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::create_wordcamp_root_blog( $factory );
+	}
+
+	/**
+	 * Remove the root blog this class created.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_wordcamp_root_blog();
+	}
+
+	/**
+	 * Register the custom invoice statuses the spend join filters by.
+	 *
+	 * In production these are registered by wordcamp-payments
+	 * (includes/sponsor-invoice.php); WP_Query silently ignores
+	 * unregistered statuses, so the isolated suite must register them.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		foreach ( array( 'wcbsi_paid', 'wcbsi_approved', 'wcbsi_submitted', 'wcbsi_uncollectible', 'wcbsi_refunded' ) as $status ) {
+			register_post_status( $status );
+		}
+	}
+
+	/**
+	 * Invoke a protected/private method for testing.
+	 *
+	 * @param object $instance The object to invoke the method on.
+	 * @param string $method   The method name.
+	 * @param array  $args     Arguments to pass to the method.
+	 *
+	 * @return mixed
+	 */
+	protected function invoke( $instance, $method, array $args = array() ) {
+		$ref = new \ReflectionMethod( $instance, $method );
+
+		return $ref->invokeArgs( $instance, $args );
+	}
+
+	/**
+	 * Build a raw data row with sensible defaults, overridden by $overrides.
+	 *
+	 * @param array $overrides Values to override the defaults.
+	 *
+	 * @return array
+	 */
+	protected function row( array $overrides = array() ) {
+		return array_merge(
+			array(
+				'rollup_key'          => '',
+				'mes_id'              => 0,
+				'wordcamp_id'         => 0,
+				'site_id'             => 0,
+				'wordcamp_name'       => '',
+				'event_date'          => '',
+				'sponsor_id'          => 0,
+				'sponsor_name'        => '',
+				'tier'                => '',
+				'website'             => '',
+				'country'             => '',
+				'first_time'          => '',
+				'spend_usd'           => 0.0,
+				'has_invoice'         => false,
+				'registered'          => 0,
+				'attended'            => 0,
+				'attendance_measured' => false,
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Build a report instance with a valid date range.
+	 *
+	 * @param array $options Optional report options.
+	 *
+	 * @return Sponsor_ROI
+	 */
+	protected function report( array $options = array() ) {
+		$options = array_merge( array( 'cache_data' => false ), $options );
+
+		return new Sponsor_ROI( '2024-01-01', '2024-12-31', 0, $options );
+	}
+
+	/**
+	 * Report is registered.
+	 */
+	public function test_report_is_registered() {
+		$this->assertContains(
+			'WordCamp\Reports\Report\Sponsor_ROI',
+			get_report_classes()
+		);
+	}
+
+	/**
+	 * Slug and group.
+	 */
+	public function test_slug_and_group() {
+		$this->assertSame( 'sponsor-roi', Sponsor_ROI::$slug );
+		$this->assertSame( 'wordcamp', Sponsor_ROI::$group );
+	}
+
+	/**
+	 * Invalid date range yields error and empty data.
+	 */
+	public function test_invalid_date_range_yields_error_and_empty_data() {
+		$report = new Sponsor_ROI( 'not-a-date', 'also-not-a-date' );
+
+		$this->assertNotEmpty( $report->error->get_error_messages() );
+		$this->assertSame( array(), $report->get_data() );
+	}
+
+	/**
+	 * Create a sponsor invoice post with the meta the spend join relies on.
+	 *
+	 * @param int    $sponsor_id Local wcb_sponsor post ID.
+	 * @param float  $amount     Invoice amount.
+	 * @param string $currency   ISO currency code.
+	 * @param string $status     Invoice post status.
+	 *
+	 * @return int The invoice post ID.
+	 */
+	protected function make_invoice( $sponsor_id, $amount, $currency, $status ) {
+		// When the integrated suite loads wordcamp-payments, its `set_invoice_status()`
+		// forces invoices with incomplete request data back to `draft` on insert. The
+		// plugin itself removes this filter before programmatic status writes; do the same.
+		$intercepted = remove_filter( 'wp_insert_post_data', 'WordCamp\\Budgets\\Sponsor_Invoices\\set_invoice_status', 10 );
+
+		$id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor_invoice',
+			'post_status' => $status,
+		) );
+
+		if ( $intercepted ) {
+			add_filter( 'wp_insert_post_data', 'WordCamp\\Budgets\\Sponsor_Invoices\\set_invoice_status', 10, 2 );
+		}
+
+		update_post_meta( $id, '_wcbsi_sponsor_id', $sponsor_id );
+		update_post_meta( $id, '_wcbsi_amount', $amount );
+		update_post_meta( $id, '_wcbsi_currency', $currency );
+
+		return $id;
+	}
+
+	/**
+	 * `get_sponsor_invoice_totals` sums and filters by status.
+	 */
+	public function test_get_sponsor_invoice_totals_sums_and_filters_by_status() {
+		$sponsor_id = self::factory()->post->create( array( 'post_type' => 'wcb_sponsor' ) );
+		$other_id   = self::factory()->post->create( array( 'post_type' => 'wcb_sponsor' ) );
+
+		$this->make_invoice( $sponsor_id, 3000, 'USD', 'wcbsi_paid' );
+		$this->make_invoice( $sponsor_id, 2000, 'USD', 'wcbsi_paid' );
+		$this->make_invoice( $sponsor_id, 1500, 'EUR', 'wcbsi_paid' );
+		$this->make_invoice( $sponsor_id, 9999, 'USD', 'wcbsi_submitted' ); // Excluded by status.
+		$this->make_invoice( $other_id, 8888, 'USD', 'wcbsi_paid' );        // Excluded by sponsor.
+
+		$report = $this->report();
+		$totals = $this->invoke( $report, 'get_sponsor_invoice_totals', array( $sponsor_id, Sponsor_ROI::COUNTED_STATUSES_PAID ) );
+
+		$this->assertEqualSets( array( 'USD', 'EUR' ), array_keys( $totals ) );
+		$this->assertSame( 5000.0, $totals['USD'] );
+		$this->assertSame( 1500.0, $totals['EUR'] );
+	}
+
+	/**
+	 * `get_sponsor_invoice_totals` filters even when statuses unregistered.
+	 */
+	public function test_get_sponsor_invoice_totals_filters_even_when_statuses_unregistered() {
+		// WP_Query silently drops unregistered statuses from post_status, failing
+		// open. Simulate a context where the wcbsi_* statuses were never registered
+		// (found live: a submitted invoice inflated spend in the pilot run).
+		$sponsor_id = self::factory()->post->create( array( 'post_type' => 'wcb_sponsor' ) );
+
+		$this->make_invoice( $sponsor_id, 5000, 'USD', 'wcbsi_paid' );
+		$this->make_invoice( $sponsor_id, 99999, 'USD', 'wcbsi_submitted' );
+
+		foreach ( array( 'wcbsi_paid', 'wcbsi_approved', 'wcbsi_submitted', 'wcbsi_uncollectible', 'wcbsi_refunded' ) as $status ) {
+			unset( $GLOBALS['wp_post_statuses'][ $status ] );
+		}
+
+		$totals = $this->invoke( $this->report(), 'get_sponsor_invoice_totals', array( $sponsor_id, Sponsor_ROI::COUNTED_STATUSES_PAID ) );
+
+		$this->assertSame( 5000.0, $totals['USD'] );
+	}
+
+	/**
+	 * `get_sponsor_invoice_totals` includes sent when configured.
+	 */
+	public function test_get_sponsor_invoice_totals_includes_sent_when_configured() {
+		$sponsor_id = self::factory()->post->create( array( 'post_type' => 'wcb_sponsor' ) );
+
+		$this->make_invoice( $sponsor_id, 1000, 'USD', 'wcbsi_paid' );
+		$this->make_invoice( $sponsor_id, 500, 'USD', 'wcbsi_approved' );
+
+		$report = $this->report();
+
+		$paid_only = $this->invoke( $report, 'get_sponsor_invoice_totals', array( $sponsor_id, Sponsor_ROI::COUNTED_STATUSES_PAID ) );
+		$paid_sent = $this->invoke( $report, 'get_sponsor_invoice_totals', array( $sponsor_id, Sponsor_ROI::COUNTED_STATUSES_PAID_SENT ) );
+
+		$this->assertSame( 1000.0, $paid_only['USD'] );
+		$this->assertSame( 1500.0, $paid_sent['USD'] );
+	}
+
+	/**
+	 * `to_base_currency` short circuits usd.
+	 */
+	public function test_to_base_currency_short_circuits_usd() {
+		$report = $this->report();
+
+		$this->assertSame( 1234.5, $this->invoke( $report, 'to_base_currency', array( 1234.5, 'USD', '2024-06-01' ) ) );
+	}
+
+	/**
+	 * `to_base_currency` reads converted value.
+	 */
+	public function test_to_base_currency_reads_converted_value() {
+		$report = $this->report();
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- currency codes are the XRT API's own property names.
+		// Stub the XRT client: convert() returns an object with a ->USD prop.
+		$report->xrt = new class() {
+			/**
+			 * Stubbed conversion: a fixed USD rate, no network call.
+			 *
+			 * @param float  $amount
+			 * @param string $currency
+			 * @param string $date
+			 *
+			 * @return object
+			 */
+			public function convert( $amount, $currency, $date = '' ) {
+				$o = new \stdClass();
+
+				$o->{$currency} = $amount;
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- currency codes are the XRT API's own property names.
+				$o->USD = $amount * 1.1; // Pretend EUR->USD = 1.1.
+
+				return $o;
+			}
+		};
+
+		$this->assertEqualsWithDelta( 110.0, $this->invoke( $report, 'to_base_currency', array( 100.0, 'EUR', '2024-06-01' ) ), 0.001 );
+	}
+
+	/**
+	 * `to_base_currency` tolerates unknown currency.
+	 */
+	public function test_to_base_currency_tolerates_unknown_currency() {
+		$report = $this->report();
+
+		$report->xrt = new class() {
+			/**
+			 * Stubbed conversion that reports an unknown currency.
+			 *
+			 * @param float  $amount
+			 * @param string $currency
+			 * @param string $date
+			 *
+			 * @return \WP_Error
+			 */
+			public function convert( $amount, $currency, $date = '' ) {
+				return new \WP_Error( 'unknown_currency', 'nope' );
+			}
+		};
+
+		$this->assertSame( 0.0, $this->invoke( $report, 'to_base_currency', array( 50.0, 'XYZ', '2024-06-01' ) ) );
+		$this->assertEmpty( $report->error->get_error_messages() ); // Tolerated, not surfaced.
+	}
+
+	/**
+	 * `get_camp_reach` counts registered and attended.
+	 */
+	public function test_get_camp_reach_counts_registered_and_attended() {
+		// 3 published attendees, 2 of them checked in; 1 draft (ignored).
+		$a1 = self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+		$a2 = self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+		self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+		self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'draft',
+		) );
+
+		update_post_meta( $a1, 'tix_attended', true );
+		update_post_meta( $a2, 'tix_attended', true );
+
+		$reach = $this->invoke( $this->report(), 'get_camp_reach' );
+
+		$this->assertSame( 3, $reach['registered'] );
+		$this->assertSame( 2, $reach['attended'] );
+		$this->assertTrue( $reach['measured'] );
+	}
+
+	/**
+	 * `get_camp_reach` flags unmeasured attendance.
+	 */
+	public function test_get_camp_reach_flags_unmeasured_attendance() {
+		// Attendees exist but none were ever checked in: attendance was not measured.
+		self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+		self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+
+		$reach = $this->invoke( $this->report(), 'get_camp_reach' );
+
+		$this->assertSame( 2, $reach['registered'] );
+		$this->assertSame( 0, $reach['attended'] );
+		$this->assertFalse( $reach['measured'] );
+	}
+
+	/**
+	 * `to_base_currency` surfaces other errors.
+	 */
+	public function test_to_base_currency_surfaces_other_errors() {
+		$report = $this->report();
+
+		$report->xrt = new class() {
+			/**
+			 * Stubbed conversion that fails with an unexpected error code.
+			 *
+			 * @param float  $amount
+			 * @param string $currency
+			 * @param string $date
+			 *
+			 * @return \WP_Error
+			 */
+			public function convert( $amount, $currency, $date = '' ) {
+				return new \WP_Error( 'request_error', 'API down' );
+			}
+		};
+
+		$this->assertSame( 0.0, $this->invoke( $report, 'to_base_currency', array( 50.0, 'EUR', '2024-06-01' ) ) );
+		$this->assertNotEmpty( $report->error->get_error_messages() );
+	}
+
+	/**
+	 * `compile_report_data` rolls up by rollup key.
+	 */
+	public function test_compile_report_data_rolls_up_by_rollup_key() {
+		$rows = array(
+			// PayPal at two camps under the same agreement (mes_id 42).
+			$this->row( array(
+				'rollup_key' => '42', 'mes_id' => 42, 'sponsor_name' => 'PayPal', 'wordcamp_id' => 1, 'tier' => 'Gold', 'spend_usd' => 5000.0, 'registered' => 2000, 'attended' => 1800, 'attendance_measured' => true,
+			) ),
+			$this->row( array(
+				'rollup_key' => '42', 'mes_id' => 42, 'sponsor_name' => 'PayPal', 'wordcamp_id' => 2, 'tier' => 'Silver', 'spend_usd' => 3000.0, 'registered' => 1000, 'attended' => 900, 'attendance_measured' => true,
+			) ),
+			// A local-only sponsor (no agreement).
+			$this->row( array(
+				'rollup_key' => 'local-9-7', 'mes_id' => 0, 'sponsor_name' => 'Local Co', 'wordcamp_id' => 2, 'tier' => 'Bronze', 'spend_usd' => 500.0, 'registered' => 1000, 'attended' => 900, 'attendance_measured' => true,
+			) ),
+		);
+
+		$compiled = $this->report()->compile_report_data( $rows );
+
+		$this->assertArrayHasKey( '42', $compiled );
+
+		$paypal = $compiled['42'];
+
+		$this->assertSame( 'PayPal', $paypal['sponsor_name'] );
+		$this->assertSame( 8000.0, $paypal['totals']['spend_usd'] );
+		$this->assertSame( 3000, $paypal['totals']['registered'] );
+		$this->assertSame( 2700, $paypal['totals']['attended'] );
+		$this->assertSame( 2, $paypal['totals']['camp_count'] );
+		$this->assertSame( 0, $paypal['totals']['unmeasured_camps'] );
+		$expected_tiers = array(
+			1 => 'Gold',
+			2 => 'Silver',
+		);
+
+		$this->assertSame( $expected_tiers, $paypal['tiers'] );
+		$this->assertCount( 2, $paypal['camps'] );
+
+		// cost_per_attended = 8000 / 2700.
+		$this->assertEqualsWithDelta( 2.963, $paypal['ratios']['cost_per_attended'], 0.001 );
+		$this->assertEqualsWithDelta( 2.667, $paypal['ratios']['cost_per_registered'], 0.001 );
+
+		$this->assertArrayHasKey( 'local-9-7', $compiled );
+	}
+
+	/**
+	 * `compile_report_data` null ratio when no attendance.
+	 */
+	public function test_compile_report_data_null_ratio_when_no_attendance() {
+		$rows = array(
+			$this->row( array(
+				'rollup_key' => '7', 'mes_id' => 7, 'spend_usd' => 100.0, 'registered' => 0, 'attended' => 0, 'attendance_measured' => true,
+			) ),
+		);
+
+		$compiled = $this->report()->compile_report_data( $rows );
+
+		$this->assertNull( $compiled['7']['ratios']['cost_per_attended'] );
+		$this->assertNull( $compiled['7']['ratios']['cost_per_registered'] );
+	}
+
+	/**
+	 * Cache key varies with range and filters.
+	 */
+	public function test_cache_key_varies_with_range_and_filters() {
+		$a = new Sponsor_ROI( '2024-01-01', '2024-12-31' );
+		$b = new Sponsor_ROI( '2025-01-01', '2025-12-31' );
+		$c = new Sponsor_ROI( '2024-01-01', '2024-12-31', 4242 );
+		$d = new Sponsor_ROI( '2024-01-01', '2024-12-31', 0, array( 'include_sent_invoices' => true ) );
+		$e = new Sponsor_ROI( '2024-01-01', '2024-12-31' );
+
+		$keys = array(
+			'a' => $this->invoke( $a, 'get_cache_key' ),
+			'b' => $this->invoke( $b, 'get_cache_key' ),
+			'c' => $this->invoke( $c, 'get_cache_key' ),
+			'd' => $this->invoke( $d, 'get_cache_key' ),
+		);
+
+		// A different range, MES filter, or status policy must never share a cache entry.
+		$this->assertSame( count( $keys ), count( array_unique( $keys ) ) );
+
+		// Identical parameters must share one.
+		$this->assertSame( $keys['a'], $this->invoke( $e, 'get_cache_key' ) );
+	}
+
+	/**
+	 * Private fields excluded from public safelist.
+	 */
+	public function test_private_fields_excluded_from_public_safelist() {
+		$public  = new Sponsor_ROI( '2024-01-01', '2024-12-31', 0, array( 'public' => true ) );
+		$private = new Sponsor_ROI( '2024-01-01', '2024-12-31', 0, array( 'public' => false ) );
+
+		$public_keys  = array_keys( $public->get_data_fields_safelist() );
+		$private_keys = array_keys( $private->get_data_fields_safelist() );
+
+		// Spend is internal-only.
+		$this->assertNotContains( 'spend_usd', $public_keys );
+		$this->assertNotContains( 'has_invoice', $public_keys );
+		$this->assertContains( 'spend_usd', $private_keys );
+
+		// Reach aggregates are public-safe.
+		$this->assertContains( 'registered', $public_keys );
+		$this->assertContains( 'attended', $public_keys );
+		$this->assertContains( 'attendance_measured', $public_keys );
+	}
+
+	/**
+	 * Export to file does nothing without capability.
+	 */
+	public function test_export_to_file_does_nothing_without_capability() {
+		// No nonce, no cap, wrong action: must not emit and must not fatal.
+		$_POST = array();
+
+		$this->assertNull( Sponsor_ROI::export_to_file() );
+	}
+
+	/**
+	 * `compile_report_data` excludes unmeasured camps from attended.
+	 */
+	public function test_compile_report_data_excludes_unmeasured_camps_from_attended() {
+		$rows = array(
+			$this->row( array(
+				'rollup_key' => '42', 'wordcamp_id' => 1, 'spend_usd' => 1000.0, 'registered' => 500, 'attended' => 450, 'attendance_measured' => true,
+			) ),
+			// Check-in never used here: registered counts, attended must not count as zero.
+			$this->row( array(
+				'rollup_key' => '42', 'wordcamp_id' => 2, 'spend_usd' => 1000.0, 'registered' => 300, 'attended' => 0, 'attendance_measured' => false,
+			) ),
+		);
+
+		$compiled = $this->report()->compile_report_data( $rows );
+
+		$totals = $compiled['42']['totals'];
+
+		$this->assertSame( 800, $totals['registered'] );
+		$this->assertSame( 450, $totals['attended'] );
+		$this->assertSame( 2, $totals['camp_count'] );
+		$this->assertSame( 1, $totals['unmeasured_camps'] );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/sponsor-roi.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/sponsor-roi.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Views\HTML\Sponsor_ROI;
+defined( 'WPINC' ) || die();
+
+/** @var array $compiled The portfolio map from compile_report_data(). */
+?>
+
+<?php if ( empty( $compiled ) ) : ?>
+	<p>No sponsors found for the given parameters.</p>
+<?php else : ?>
+	<?php foreach ( $compiled as $key => $portfolio ) : ?>
+		<h3>
+			<?php echo esc_html( $portfolio['sponsor_name'] ); ?>
+			<?php if ( $portfolio['mes_id'] ) : ?>
+				<small>(MES agreement #<?php echo absint( $portfolio['mes_id'] ); ?>)</small>
+			<?php else : ?>
+				<small>(local sponsorship)</small>
+			<?php endif; ?>
+		</h3>
+
+		<table class="widefat striped" style="max-width: 700px;">
+			<tbody>
+			<tr>
+				<td>Events sponsored</td>
+				<td><?php echo esc_html( number_format_i18n( $portfolio['totals']['camp_count'] ) ); ?></td>
+			</tr>
+			<tr>
+				<td>Total spend (USD, paid invoices)</td>
+				<td><?php echo esc_html( number_format_i18n( $portfolio['totals']['spend_usd'], 2 ) ); ?></td>
+			</tr>
+			<tr>
+				<td>Registered attendees reached</td>
+				<td><?php echo esc_html( number_format_i18n( $portfolio['totals']['registered'] ) ); ?></td>
+			</tr>
+			<tr>
+				<td>Checked-in attendees reached</td>
+				<td>
+					<?php echo esc_html( number_format_i18n( $portfolio['totals']['attended'] ) ); ?>
+					<?php if ( $portfolio['totals']['unmeasured_camps'] > 0 ) : ?>
+						<em>
+							— attendance not measured at
+							<?php echo absint( $portfolio['totals']['unmeasured_camps'] ); ?>
+							of
+							<?php echo absint( $portfolio['totals']['camp_count'] ); ?>
+							events
+						</em>
+					<?php endif; ?>
+				</td>
+			</tr>
+			<tr>
+				<td>Cost per registered attendee</td>
+				<td>
+					<?php echo null !== $portfolio['ratios']['cost_per_registered'] ? esc_html( number_format_i18n( $portfolio['ratios']['cost_per_registered'], 2 ) ) : '—'; ?>
+				</td>
+			</tr>
+			<tr>
+				<td>Cost per checked-in attendee</td>
+				<td>
+					<?php echo null !== $portfolio['ratios']['cost_per_attended'] ? esc_html( number_format_i18n( $portfolio['ratios']['cost_per_attended'], 2 ) ) : '—'; ?>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+
+		<table class="widefat striped" style="max-width: 900px; margin-top: 8px;">
+			<thead>
+			<tr>
+				<th>WordCamp</th>
+				<th>Event Date</th>
+				<th>Tier</th>
+				<th>Spend (USD)</th>
+				<th>Registered</th>
+				<th>Checked In</th>
+			</tr>
+			</thead>
+			<tbody>
+			<?php foreach ( $portfolio['camps'] as $camp ) : ?>
+				<tr>
+					<td><?php echo esc_html( $camp['wordcamp_name'] ); ?></td>
+					<td><?php echo esc_html( $camp['event_date'] ); ?></td>
+					<td><?php echo esc_html( $camp['tier'] ); ?></td>
+					<td>
+						<?php echo esc_html( number_format_i18n( $camp['spend_usd'] ?? 0, 2 ) ); ?>
+						<?php if ( empty( $camp['has_invoice'] ) ) : ?>
+							<em>(no invoice)</em>
+						<?php endif; ?>
+					</td>
+					<td><?php echo esc_html( number_format_i18n( $camp['registered'] ) ); ?></td>
+					<td>
+						<?php if ( ! empty( $camp['attendance_measured'] ) ) : ?>
+							<?php echo esc_html( number_format_i18n( $camp['attended'] ) ); ?>
+						<?php else : ?>
+							not measured
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endforeach; ?>
+
+	<p class="description" style="margin-top: 16px;">
+		Spend counts paid invoices only (optionally paid + sent), normalized to USD at the event-date exchange rate.
+		Registered = published attendee records; Checked In = attendees marked as attended via CampTix check-in.
+		"Not measured" means in-platform check-in wasn't used at that event — the attendance there is unknown, not zero.
+		Reach numbers are whole-event audiences reached by the sponsor's placement, not per-sponsor interactions.
+	</p>
+<?php endif; ?>

--- a/public_html/wp-content/plugins/wordcamp-reports/views/report/sponsor-roi.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/report/sponsor-roi.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @package WordCamp\Reports
+ */
+
+namespace WordCamp\Reports\Views\Report\Sponsor_ROI;
+
+use WordCamp\Reports;
+use WordCamp\Reports\Report;
+
+defined( 'WPINC' ) || die();
+
+/** @var string $start_date */
+/** @var string $end_date */
+/** @var int $mes_id */
+/** @var Report\Sponsor_ROI|null $report */
+?>
+
+<div class="wrap">
+	<h1>
+		<a href="<?php echo esc_url( Reports\get_page_url() ); ?>">WordCamp Reports</a>
+		&raquo;
+		<?php echo esc_html( Report\Sponsor_ROI::$name ); ?>
+	</h1>
+
+	<?php echo wp_kses_post( wpautop( Report\Sponsor_ROI::$description ) ); ?>
+
+	<h4>Methodology</h4>
+
+	<?php echo wp_kses_post( wpautop( Report\Sponsor_ROI::$methodology ) ); ?>
+
+	<form method="post" action="">
+		<?php wp_nonce_field( 'run-report', Report\Sponsor_ROI::$slug . '-nonce' ); ?>
+
+		<table class="form-table">
+			<tbody>
+			<tr>
+				<th scope="row"><label for="start-date">Start Date</label></th>
+				<td><input type="date" id="start-date" name="start-date" value="<?php echo esc_attr( $start_date ); ?>" /></td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="end-date">End Date</label></th>
+				<td><input type="date" id="end-date" name="end-date" value="<?php echo esc_attr( $end_date ); ?>" /></td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="mes-id">MES Agreement ID (optional)</label></th>
+				<td>
+					<input type="number" id="mes-id" name="mes-id" min="0" value="<?php echo esc_attr( $mes_id ?: '' ); ?>" />
+					<p class="description">Filter to a single Multi-Event Sponsor agreement. Leave empty for all sponsors.</p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="refresh">Refresh results</label></th>
+				<td><input type="checkbox" id="refresh" name="refresh" value="1" /></td>
+			</tr>
+			</tbody>
+		</table>
+
+		<?php submit_button( 'Show results', 'primary', 'action', false ); ?>
+		<?php submit_button( 'Export CSV', 'secondary', 'action', false ); ?>
+	</form>
+
+	<?php if ( $report instanceof Report\Sponsor_ROI ) : ?>
+		<div class="report-results">
+			<?php $report->render_html(); ?>
+		</div>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
Part of #1946 (Sponsor ROI tracking issue — Phase 1).

## What this adds

A new **Sponsor ROI** report in `wordcamp-reports`: spend × reach per sponsor, rolled up across camps by Multi-Event Sponsorship agreement.

For each camp in the date range, the report finds every sponsor carrying an `_mes_id`, joins:

- **Spend** — sum of `_wcbsi_amount` on that sponsor's `wcb_sponsor_invoice` posts. **Paid invoices only** (`wcbsi_paid`) by default; an `include_sent_invoices` option also counts `wcbsi_approved`, for forecasting. Multi-currency amounts are normalized to USD with `Currency_XRT_Client` at the event-date rate (base currency short-circuited, `unknown_currency` tolerated as 0).
- **Reach** — registered = published `tix_attendee` count; checked in = attendees with `tix_attended` meta.
- **Tier** — `wcb_sponsor_level` term.

…then rolls rows up by `_mes_id` into per-agreement portfolios with totals and cost-per-registered / cost-per-attended.

## Semantics worth reviewing

- **"Attendance not measured" is a first-class state.** A camp with zero `tix_attended` flags counts toward registered but never toward attended, increments `totals.unmeasured_camps`, and renders as "not measured" (not `0`). The ratio carries an explicit caveat. This matters because check-in coverage is patchy network-wide, and pretending otherwise produces confidently wrong numbers.
- **Spend is private-context only.** `spend_usd`, `has_invoice`, `site_id`, `sponsor_id` sit in `$private_data_fields`, so they're absent from any public-context run. Aggregates only — no per-attendee data anywhere, including the CSV.

## Implementation notes

- **`WP_Query` fails open on unregistered statuses** — statuses missing from `$wp_post_statuses` are silently dropped from `post_status`, so the invoice query can return *every* status (caught live: $104,999 reported for a $5,000 sponsor). The query result is re-checked in PHP against the counted-status list; a regression test unsets the registered statuses and proves the filter holds.
- **Cache keys include the report parameters.** The base class keys the cache on the report slug alone, which would serve one date-range/MES-filter's cached data to a different query for a week. `get_cache_key()` / `get_cache_expiration()` are overridden accordingly.
- **Exporter follows the current authorization convention** (as in `class-meetup-status.php`): `export_to_file()` early-returns unless `$_GET['report']` matches its own slug (all exporters share `admin_init` and the `run-report` nonce), then requires nonce + capability; `render_admin_page()` fails closed on the capability. The existing `test-report-export-authorization.php` dataProvider picks the new class up automatically.

## Tests

21 tests (unit + subsite integration) in the existing `WordCamp Reports` suite — spend join and status filtering, currency normalization, reach and the unmeasured-camp semantics, `_mes_id` rollup, field privacy, cache keys, export authorization. Two harness notes:

- Attendee-creating tests use camptix's `CampTix_Root_Blog_Fixture`, per #1879.
- Invoice fixtures suspend wordcamp-payments' `set_invoice_status` (`wp_insert_post_data`) around the insert — the same idiom sponsor-invoice.php itself uses for programmatic status writes — since that hook otherwise forces incomplete test invoices back to `draft`.

Suite result: 40 tests / 97 assertions green (the 21 new plus the existing reports tests, which now also exercise this class), no new warnings, no DB-error noise.

## Verified / not verified

- Verified locally (docker sandbox): registration, the full data path against seeded multisite data (portfolio rollup, paid-only filtering with an approved-invoice decoy excluded, unmeasured-camp rendering), and the fail-closed admin page.
- **The Export CSV button is not verifiable locally** — `WordPressdotorg\MU_Plugins\Utilities\Export_CSV` only exists in production. Its authorization path is covered by the guard tests; the button itself gets its first real click in production.

## Post-merge follow-ups (not in this PR)

- Add the report to the central `/reports/` landing page (content edit).
- Pilot run for one agreement's portfolio (Automattic) and reconciliation against the manually-built WCEU exports.
