### PR TITLE
QuickBooks: verify the OAuth `state` on the token exchange

### DIFF
--- a/public_html/wp-content/mu-plugins/quickbooks/includes/client.php
+++ b/public_html/wp-content/mu-plugins/quickbooks/includes/client.php
@@ -215,6 +215,66 @@ class Client {
 	}
 
 	/**
+	 * The user meta key for storing the OAuth `state` value.
+	 *
+	 * User meta is used rather than an option or a transient because it's shared across every site and network
+	 * in the install, while the redirect URI always points at the WordCamp network. That way an authorization
+	 * that starts on the Events network can still be matched up when QBO sends the user back here.
+	 *
+	 * @return string
+	 */
+	protected static function generate_oauth_state_key() {
+		return PLUGIN_PREFIX . '_oauth_state';
+	}
+
+	/**
+	 * Generate a `state` value for an authorization request, and remember it for the callback.
+	 *
+	 * @return string
+	 */
+	protected static function create_oauth_state() {
+		$state = wp_generate_password( 32, false );
+
+		update_user_meta(
+			get_current_user_id(),
+			self::generate_oauth_state_key(),
+			array(
+				'state'   => $state,
+				'expires' => time() + ( 15 * MINUTE_IN_SECONDS ),
+			)
+		);
+
+		return $state;
+	}
+
+	/**
+	 * Check that a callback's `state` matches the authorization request that this user started.
+	 *
+	 * The stored value is good for one callback only, so it's discarded either way.
+	 *
+	 * @param string $state
+	 *
+	 * @return bool
+	 */
+	protected static function verify_oauth_state( $state ) {
+		$user_id = get_current_user_id();
+		$key     = self::generate_oauth_state_key();
+		$stored  = get_user_meta( $user_id, $key, true );
+
+		delete_user_meta( $user_id, $key );
+
+		if ( ! is_string( $state ) || ! $state || ! is_array( $stored ) ) {
+			return false;
+		}
+
+		if ( empty( $stored['state'] ) || empty( $stored['expires'] ) || time() > $stored['expires'] ) {
+			return false;
+		}
+
+		return hash_equals( $stored['state'], $state );
+	}
+
+	/**
 	 * Shortcut for importing an Exception into the client's WP_Error instance.
 	 *
 	 * @param Exception $exception
@@ -311,37 +371,54 @@ class Client {
 	 */
 	public function get_authorize_url() {
 		try {
-			return $this->data_service()->getOAuth2LoginHelper()->getAuthorizationCodeURL();
+			$url = $this->data_service()->getOAuth2LoginHelper()->getAuthorizationCodeURL();
 		} catch ( Exception $exception ) {
 			$this->add_error_from_exception( $exception );
 
 			return '';
 		}
+
+		// The SDK generates a `state` of its own, but never stores it, so there'd be nothing to compare against
+		// when QBO sends it back. Replace it with one tied to the user who started the process.
+		return add_query_arg( 'state', self::create_oauth_state(), $url );
 	}
 
 	/**
 	 * Send authorization data over to QBO and get back an OAuth token.
 	 *
 	 * Once a user has authorized a connection on the Intuit site, they are redirected back to our page, along with
-	 * an authorization code and realm ID. These are then sent back to the OAuth server to exchange for the actual
-	 * access token.
+	 * an authorization code, a realm ID, and the `state` that was sent along with the authorization request. The
+	 * `state` has to match the one this user started with before the code is worth exchanging, since this leg of
+	 * the process arrives from Intuit and so can't carry a nonce of its own.
 	 *
 	 * @return void
 	 */
 	public function maybe_exchange_code_for_token() {
 		$authorization_code = wp_unslash( $_GET['code'] ?? '' );
 		$realm_id           = wp_unslash( $_GET['realmId'] ?? '' );
+		$state              = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
 
-		if ( ! $this->has_valid_token() && $authorization_code && $realm_id ) {
-			try {
-				$token = $this->data_service()->getOAuth2LoginHelper()->exchangeAuthorizationCodeForToken( $authorization_code, $realm_id );
+		if ( $this->has_valid_token() || ! $authorization_code || ! $realm_id ) {
+			return;
+		}
 
-				$this->data_service()->updateOAuth2Token( $token );
+		if ( ! self::verify_oauth_state( $state ) ) {
+			$this->error->add(
+				'invalid_state',
+				'Your request could not be validated. Please start the connection process again.'
+			);
 
-				self::save_oauth_token_data( $token );
-			} catch ( Exception | SdkException | ServiceException $exception ) {
-				$this->add_error_from_exception( $exception );
-			}
+			return;
+		}
+
+		try {
+			$token = $this->data_service()->getOAuth2LoginHelper()->exchangeAuthorizationCodeForToken( $authorization_code, $realm_id );
+
+			$this->data_service()->updateOAuth2Token( $token );
+
+			self::save_oauth_token_data( $token );
+		} catch ( Exception | SdkException | ServiceException $exception ) {
+			$this->add_error_from_exception( $exception );
 		}
 	}
 

--- a/public_html/wp-content/mu-plugins/quickbooks/includes/client.php
+++ b/public_html/wp-content/mu-plugins/quickbooks/includes/client.php
@@ -250,28 +250,40 @@ class Client {
 	/**
 	 * Check that a callback's `state` matches the authorization request that this user started.
 	 *
-	 * The stored value is good for one callback only, so it's discarded either way.
+	 * This only reads the stored value; discarding it is left to `maybe_exchange_code_for_token()`. That way a
+	 * stray request to the callback endpoint -- a reloaded tab, an old one out of history -- can't throw away an
+	 * authorization that's still in flight, and a callback that dies on an upstream error can still be retried.
 	 *
 	 * @param string $state
 	 *
 	 * @return bool
 	 */
 	protected static function verify_oauth_state( $state ) {
-		$user_id = get_current_user_id();
-		$key     = self::generate_oauth_state_key();
-		$stored  = get_user_meta( $user_id, $key, true );
-
-		delete_user_meta( $user_id, $key );
+		$stored = get_user_meta( get_current_user_id(), self::generate_oauth_state_key(), true );
 
 		if ( ! is_string( $state ) || ! $state || ! is_array( $stored ) ) {
 			return false;
 		}
 
-		if ( empty( $stored['state'] ) || empty( $stored['expires'] ) || time() > $stored['expires'] ) {
+		// `hash_equals()` throws a TypeError on anything but strings, so check the stored side too.
+		if ( empty( $stored['state'] ) || ! is_string( $stored['state'] ) ) {
+			return false;
+		}
+
+		if ( empty( $stored['expires'] ) || time() > $stored['expires'] ) {
 			return false;
 		}
 
 		return hash_equals( $stored['state'], $state );
+	}
+
+	/**
+	 * Discard the `state` stored for the current user, once it can't be of any more use.
+	 *
+	 * @return bool
+	 */
+	protected static function delete_oauth_state() {
+		return delete_user_meta( get_current_user_id(), self::generate_oauth_state_key() );
 	}
 
 	/**
@@ -371,16 +383,26 @@ class Client {
 	 */
 	public function get_authorize_url() {
 		try {
-			$url = $this->data_service()->getOAuth2LoginHelper()->getAuthorizationCodeURL();
+			// Bail through the usual insulation if the SDK or the credentials are unavailable.
+			$this->data_service();
+
+			/*
+			 * The SDK generates a `state` of its own, but never stores it, so there'd be nothing to compare
+			 * against when QBO sends it back. It accepts one from the caller, though, so hand it a value that's
+			 * tied to the user who started the process.
+			 *
+			 * That value is minted here rather than in `get_client_config()`, so that only an actual
+			 * authorization request writes to user meta.
+			 */
+			$config          = $this->get_client_config();
+			$config['state'] = self::create_oauth_state();
+
+			return DataService::Configure( $config )->getOAuth2LoginHelper()->getAuthorizationCodeURL();
 		} catch ( Exception $exception ) {
 			$this->add_error_from_exception( $exception );
 
 			return '';
 		}
-
-		// The SDK generates a `state` of its own, but never stores it, so there'd be nothing to compare against
-		// when QBO sends it back. Replace it with one tied to the user who started the process.
-		return add_query_arg( 'state', self::create_oauth_state(), $url );
 	}
 
 	/**
@@ -391,14 +413,24 @@ class Client {
 	 * `state` has to match the one this user started with before the code is worth exchanging, since this leg of
 	 * the process arrives from Intuit and so can't carry a nonce of its own.
 	 *
+	 * The stored value is only discarded once it's served its purpose, so that a callback which fails somewhere
+	 * upstream can be retried until it expires.
+	 *
 	 * @return void
 	 */
 	public function maybe_exchange_code_for_token() {
-		$authorization_code = wp_unslash( $_GET['code'] ?? '' );
-		$realm_id           = wp_unslash( $_GET['realmId'] ?? '' );
+		$authorization_code = sanitize_text_field( wp_unslash( $_GET['code'] ?? '' ) );
+		$realm_id           = sanitize_text_field( wp_unslash( $_GET['realmId'] ?? '' ) );
 		$state              = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
 
-		if ( $this->has_valid_token() || ! $authorization_code || ! $realm_id ) {
+		if ( ! $authorization_code || ! $realm_id ) {
+			return;
+		}
+
+		if ( $this->has_valid_token() ) {
+			// There's a working connection already, so whatever this user had in flight is moot.
+			self::delete_oauth_state();
+
 			return;
 		}
 
@@ -417,6 +449,9 @@ class Client {
 			$this->data_service()->updateOAuth2Token( $token );
 
 			self::save_oauth_token_data( $token );
+
+			// The code has been spent, so the value that vouched for it is done too.
+			self::delete_oauth_state();
 		} catch ( Exception | SdkException | ServiceException $exception ) {
 			$this->add_error_from_exception( $exception );
 		}

--- a/public_html/wp-content/mu-plugins/tests/test-quickbooks-oauth-state.php
+++ b/public_html/wp-content/mu-plugins/tests/test-quickbooks-oauth-state.php
@@ -52,6 +52,15 @@ class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Clear out the callback parameters that the exchange tests set.
+	 */
+	public function tear_down() {
+		$_GET = array();
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Call one of the client's OAuth `state` helpers.
 	 *
 	 * They're protected because nothing outside the OAuth process should be creating or consuming a `state`.
@@ -92,6 +101,61 @@ class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @return string
+	 */
+	protected function token_key() {
+		return $this->call_client_method( 'generate_oauth_option_key' );
+	}
+
+	/**
+	 * Whatever token data is stored for the network, or `not set` if there isn't any.
+	 *
+	 * @return array|string
+	 */
+	protected function stored_token_data() {
+		return get_network_option( WORDCAMP_NETWORK_ID, $this->token_key(), 'not set' );
+	}
+
+	/**
+	 * Give the client enough configuration to build an authorization URL.
+	 *
+	 * The values are fake, but nothing in these tests sends a request to Intuit, so they only need to be
+	 * non-empty. `Production` avoids the SDK's log directory, which the `Development` value sets up.
+	 *
+	 * @return void
+	 */
+	protected function add_fake_credentials() {
+		add_filter(
+			'wordcamp_qbo_client_config',
+			static function ( array $config ) {
+				$config['ClientID']     = 'fake-client-id';
+				$config['ClientSecret'] = 'fake-client-secret';
+				$config['baseUrl']      = 'Production';
+
+				return $config;
+			}
+		);
+	}
+
+	/**
+	 * Play back a callback from Intuit.
+	 *
+	 * @param array  $query  The query parameters Intuit redirected with.
+	 * @param Client $client Optional. The client to run it through. Default a new one.
+	 *
+	 * @return Client
+	 */
+	protected function handle_callback( array $query, $client = null ) {
+		$_GET = $query;
+
+		$client = $client ?? new Client();
+
+		$client->maybe_exchange_code_for_token();
+
+		return $client;
+	}
+
+	/**
 	 * The value sent to QBO is remembered for the user who started the process.
 	 *
 	 * @covers \WordCamp\QuickBooks\Client::create_oauth_state
@@ -117,17 +181,16 @@ class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The value is good for a single callback, so a replay of the same one is turned away.
+	 * A callback that can't be matched leaves a pending authorization alone, so the genuine one that follows
+	 * can still complete.
 	 *
 	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
 	 */
-	public function test_state_can_only_be_used_once() {
+	public function test_unmatched_callback_leaves_a_pending_state_alone() {
 		$state = $this->create_state();
 
-		$this->verify_state( $state );
-
-		$this->assertFalse( $this->verify_state( $state ) );
-		$this->assertSame( '', get_user_meta( self::$admin_id, $this->state_key(), true ) );
+		$this->assertFalse( $this->verify_state( 'AJd83ndKSl92mfkeAJd83ndKSl92mfke' ) );
+		$this->assertTrue( $this->verify_state( $state ) );
 	}
 
 	/**
@@ -179,6 +242,25 @@ class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A stored value that isn't a string is turned away rather than handed to `hash_equals()`, which would
+	 * throw a TypeError.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 */
+	public function test_non_string_stored_state_is_not_verified() {
+		update_user_meta(
+			self::$admin_id,
+			$this->state_key(),
+			array(
+				'state'   => array( 'nope' ),
+				'expires' => time() + MINUTE_IN_SECONDS,
+			)
+		);
+
+		$this->assertFalse( $this->verify_state( 'AJd83ndKSl92mfkeAJd83ndKSl92mfke' ) );
+	}
+
+	/**
 	 * The value only counts for the user it was created for.
 	 *
 	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
@@ -207,5 +289,121 @@ class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$this->assertFalse( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * The URL the user is sent to carries the value we stored for them, so the callback has something to match.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::get_authorize_url
+	 */
+	public function test_authorize_url_carries_the_stored_state() {
+		$this->add_fake_credentials();
+
+		$url = ( new Client() )->get_authorize_url();
+
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query );
+
+		$stored = get_user_meta( self::$admin_id, $this->state_key(), true );
+
+		$this->assertNotEmpty( $query['state'] );
+		$this->assertSame( $stored['state'], $query['state'] );
+	}
+
+	/**
+	 * A callback that doesn't match the authorization this user started never reaches Intuit, and never
+	 * results in a stored token.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::maybe_exchange_code_for_token
+	 */
+	public function test_exchange_is_refused_without_a_matching_state() {
+		$state  = $this->create_state();
+		$client = $this->handle_callback(
+			array(
+				'code'    => 'ANYTHING',
+				'realmId' => '9999999999',
+				'state'   => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			)
+		);
+
+		$this->assertNotEmpty( $client->error->get_error_messages( 'invalid_state' ) );
+		$this->assertSame( 'not set', $this->stored_token_data() );
+
+		// The authorization that's actually in flight is untouched, so its callback can still complete.
+		$this->assertTrue( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * A callback carrying an array instead of a code is turned away before anything is handed to the SDK.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::maybe_exchange_code_for_token
+	 */
+	public function test_exchange_is_refused_without_a_usable_code() {
+		$state  = $this->create_state();
+		$client = $this->handle_callback(
+			array(
+				'code'    => array( 'ANYTHING' ),
+				'realmId' => '9999999999',
+				'state'   => $state,
+			)
+		);
+
+		$this->assertEmpty( $client->error->get_error_messages( 'invalid_state' ) );
+		$this->assertSame( 'not set', $this->stored_token_data() );
+		$this->assertTrue( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * A callback that gets past the check but fails further along can be retried, because the value that
+	 * vouched for it is only discarded once a token comes back.
+	 *
+	 * The client here has no credentials, so the exchange fails without sending anything to Intuit.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::maybe_exchange_code_for_token
+	 */
+	public function test_exchange_keeps_the_state_when_the_token_request_fails() {
+		$state  = $this->create_state();
+		$client = $this->handle_callback(
+			array(
+				'code'    => 'ANYTHING',
+				'realmId' => '9999999999',
+				'state'   => $state,
+			)
+		);
+
+		$this->assertEmpty( $client->error->get_error_messages( 'invalid_state' ) );
+		$this->assertSame( 'not set', $this->stored_token_data() );
+		$this->assertTrue( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * A callback that arrives once the connection is already made discards whatever this user had pending,
+	 * rather than leaving it behind.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::maybe_exchange_code_for_token
+	 */
+	public function test_exchange_discards_the_state_when_a_token_already_exists() {
+		$connected = new class() extends Client {
+			/**
+			 * Stand in for a connection that's already working.
+			 *
+			 * @return bool
+			 */
+			public function has_valid_token() {
+				return true;
+			}
+		};
+
+		$state = $this->create_state();
+
+		$this->handle_callback(
+			array(
+				'code'    => 'ANYTHING',
+				'realmId' => '9999999999',
+				'state'   => $state,
+			),
+			$connected
+		);
+
+		$this->assertSame( '', get_user_meta( self::$admin_id, $this->state_key(), true ) );
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-quickbooks-oauth-state.php
+++ b/public_html/wp-content/mu-plugins/tests/test-quickbooks-oauth-state.php
@@ -62,8 +62,8 @@ class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
 	 * @return mixed
 	 */
 	protected function call_client_method( $name, array $args = array() ) {
+		// No `setAccessible()` call -- it's been a no-op since PHP 8.1, and deprecated since 8.5.
 		$method = new ReflectionMethod( Client::class, $name );
-		$method->setAccessible( true );
 
 		return $method->invokeArgs( null, $args );
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-quickbooks-oauth-state.php
+++ b/public_html/wp-content/mu-plugins/tests/test-quickbooks-oauth-state.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use ReflectionMethod;
+use WP_UnitTestCase;
+use WordCamp\QuickBooks\Client;
+
+defined( 'WPINC' ) || die();
+
+if ( ! defined( 'WordCamp\QuickBooks\PLUGIN_PREFIX' ) ) {
+	define( 'WordCamp\QuickBooks\PLUGIN_PREFIX', 'wordcamp-qbo' );
+}
+
+require_once dirname( __DIR__ ) . '/quickbooks/includes/client.php';
+
+/**
+ * Tests for the `state` value that ties a QuickBooks OAuth callback to the authorization request that
+ * started it.
+ *
+ * @group mu-plugins
+ * @group quickbooks
+ *
+ * @package WordCamp\Tests
+ */
+class Test_QuickBooks_OAuth_State extends WP_UnitTestCase {
+	/**
+	 * A network admin, who is the only kind of user that can run the OAuth process.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Create the shared fixtures.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Start each test as the network admin who initiates the process.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Call one of the client's OAuth `state` helpers.
+	 *
+	 * They're protected because nothing outside the OAuth process should be creating or consuming a `state`.
+	 *
+	 * @param string $name
+	 * @param array  $args
+	 *
+	 * @return mixed
+	 */
+	protected function call_client_method( $name, array $args = array() ) {
+		$method = new ReflectionMethod( Client::class, $name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( null, $args );
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function create_state() {
+		return $this->call_client_method( 'create_oauth_state' );
+	}
+
+	/**
+	 * @param mixed $state
+	 *
+	 * @return bool
+	 */
+	protected function verify_state( $state ) {
+		return $this->call_client_method( 'verify_oauth_state', array( $state ) );
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function state_key() {
+		return $this->call_client_method( 'generate_oauth_state_key' );
+	}
+
+	/**
+	 * The value sent to QBO is remembered for the user who started the process.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::create_oauth_state
+	 */
+	public function test_created_state_is_stored_for_the_current_user() {
+		$state = $this->create_state();
+		$meta  = get_user_meta( self::$admin_id, $this->state_key(), true );
+
+		$this->assertSame( 32, strlen( $state ) );
+		$this->assertSame( $state, $meta['state'] );
+		$this->assertGreaterThan( time(), $meta['expires'] );
+	}
+
+	/**
+	 * A callback carrying the value we sent is accepted.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 */
+	public function test_matching_state_is_verified() {
+		$state = $this->create_state();
+
+		$this->assertTrue( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * The value is good for a single callback, so a replay of the same one is turned away.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 */
+	public function test_state_can_only_be_used_once() {
+		$state = $this->create_state();
+
+		$this->verify_state( $state );
+
+		$this->assertFalse( $this->verify_state( $state ) );
+		$this->assertSame( '', get_user_meta( self::$admin_id, $this->state_key(), true ) );
+	}
+
+	/**
+	 * A callback that doesn't carry the value we sent is turned away.
+	 *
+	 * @dataProvider data_unverified_states
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 *
+	 * @param mixed $state
+	 */
+	public function test_other_states_are_not_verified( $state ) {
+		$this->create_state();
+
+		$this->assertFalse( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * Data provider for `test_other_states_are_not_verified`.
+	 *
+	 * @return array
+	 */
+	public function data_unverified_states() {
+		return array(
+			'empty'      => array( '' ),
+			'mismatched' => array( 'AJd83ndKSl92mfkeAJd83ndKSl92mfke' ),
+			'not a string' => array( array( 'nope' ) ),
+		);
+	}
+
+	/**
+	 * A callback that arrives long after the process started is turned away.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 */
+	public function test_expired_state_is_not_verified() {
+		$state = $this->create_state();
+		$key   = $this->state_key();
+
+		update_user_meta(
+			self::$admin_id,
+			$key,
+			array(
+				'state'   => $state,
+				'expires' => time() - 1,
+			)
+		);
+
+		$this->assertFalse( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * The value only counts for the user it was created for.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 */
+	public function test_state_is_not_verified_for_another_user() {
+		$state = $this->create_state();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertFalse( $this->verify_state( $state ) );
+
+		// The original user's value is untouched, so their own callback can still complete.
+		wp_set_current_user( self::$admin_id );
+
+		$this->assertTrue( $this->verify_state( $state ) );
+	}
+
+	/**
+	 * A callback from a logged-out request is turned away.
+	 *
+	 * @covers \WordCamp\QuickBooks\Client::verify_oauth_state
+	 */
+	public function test_state_is_not_verified_without_a_user() {
+		$state = $this->create_state();
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->verify_state( $state ) );
+	}
+}


### PR DESCRIPTION
## Summary

The QuickBooks OAuth `exchange` leg had nothing tying a callback to the authorize request that started it. The SDK emits a `state`, but never stores one, so there was nothing to compare against when Intuit sends the user back.

- `Client::get_authorize_url()` now generates a random 32-character `state`, stores it for the user who started the process, and hands it to the SDK to build the URL sent to Intuit.
- `Client::maybe_exchange_code_for_token()` requires a `hash_equals()` match before it will exchange the code, and surfaces an error through the existing error view otherwise.
- The stored value expires after 15 minutes, and is discarded once it's served its purpose: a token came back, or a connection already exists. Verification itself doesn't touch it, so a stray hit on the callback endpoint can't throw away an authorization that's still in flight, and a callback that fails upstream can be retried.

## How to review this PR

Read `includes/client.php` top to bottom; the new helpers sit next to the existing token-storage helpers and follow the same `generate_*_key()` naming.

Two decisions worth calling out:

- **User meta, not a transient.** The redirect URI is hardcoded to the WordCamp network, but the token option is deliberately shared with Events (`get_network_option( WORDCAMP_NETWORK_ID, ... )`). A process that starts on Events finishes on WordCamp, and transients are per-site — user meta is global across the install, so it survives the round trip.
- **`state`, not a nonce.** The `authorize` and `revoke` legs verify nonces because they're our own form posts. `exchange` arrives from Intuit at a redirect URI registered with them, so it can't carry a nonce of its own — `state` is the equivalent for that leg.
- The existing `current_user_can( OAUTH_CAP )` gate in `admin.php` and the "refuse if a valid token already exists" check are unchanged; this only adds the missing link between the two legs.

**Deploy note:** any authorize started before this ships won't have a stored value, so that one callback will be turned away. Clicking Connect again resolves it.

## Test plan

- [x] phpunit — full suite 867/867 passing (6 pre-existing skips: `intl` extension, GatherPress data provider)
- [x] phpunit — new `quickbooks` group, 15/15 passing
- [x] phpcs clean on both changed files
- [x] Manual browser pass as a network admin (steps below)

New coverage in `tests/test-quickbooks-oauth-state.php`: storage, match, mismatched/empty/non-string input on both sides, expiry, wrong user, logged out. Plus the seam itself, all without leaving the local stack — the authorize URL carries the stored value, and the exchange refuses a bad `state`, ignores an unusable `code`, writes no token in either case, and keeps a pending value for a retry.

### Manual test steps

All as a network admin on the local stack, at `/wp-admin/network/settings.php?page=quickbooks`.

1. **Page renders.** Load the settings page. It should show "Not connected" with an enabled **Connect** button, no errors.

2. **Callback with no `state` is refused.** Load this directly, substituting your local host:

   ```
   /wp-admin/admin-post.php?action=wordcamp-qbo-oauth&cmd=exchange&code=ANYTHING&realmId=9999999999
   ```

   Expected: *"Your request could not be validated. Please start the connection process again."* On `production` this instead reaches Intuit and comes back with `{"error":"invalid_client"}` — that difference is the point of the change.

3. **Authorize sends a `state`, and we remember it.** Click **Connect**. You'll land on Intuit's sign-in page — read the `state` query param out of that URL, then check it against what got stored:

   ```bash
   wp --url=https://central.wordcamp.test user meta get admin "wordcamp-qbo_oauth_state"
   ```

   Expected: the `state` in the array matches the one in the Intuit URL, with `expires` ~15 minutes out. No need to actually sign in to Intuit.

4. **Wrong `state` is refused.** With that process still pending, load the step-2 URL again but append `&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`. Expected: the same "could not be validated" message.

5. **Matching `state` gets through.** Seed a known value and use it:

   ```bash
   wp --url=https://central.wordcamp.test eval '
     update_user_meta( get_user_by( "login", "admin" )->ID, "wordcamp-qbo_oauth_state",
       array( "state" => "KNOWNGOODSTATEVALUE1234567890abc", "expires" => time() + 900 ) );'
   ```

   Then load the step-2 URL with `&state=KNOWNGOODSTATEVALUE1234567890abc`. Expected: `Exchange Authorization Code for Access Token failed. Body: [{"error":"invalid_client"}]` — an upstream error, meaning the request got past the check and reached Intuit. Reloading gives the same upstream error rather than "could not be validated": the value survives a failed exchange so the callback can be retried, and is only discarded once a token comes back.

6. **Nothing was stored along the way.** After all of the above:

   ```bash
   wp --url=https://central.wordcamp.test eval 'var_dump( get_network_option( 1, "wordcamp-qbo_oauth", "NOT SET" ) );'
   ```

   Expected: `NOT SET` — no token data written by any of the attempts.

A full round trip against a real QBO company wasn't exercised — the local stack has placeholder client credentials, so step 5 stops at Intuit's client check. Worth someone with sandbox credentials completing an actual Connect → authorize → callback cycle before this comes out of draft.

Note the error page in steps 2/4 renders unstyled — `admin-post.php` has no admin chrome. That matches the existing nonce-failure path on the `authorize` and `revoke` legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

