### PR TITLE
CampTix Attendance: add bulk check-in and CSV attendance import

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -110,6 +110,7 @@ require_once( WP_PLUGIN_DIR . '/wordcamp-remote-css/tests/bootstrap.php' );
 require_once WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-payments-network/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-reports/tests/bootstrap.php';
+require_once WP_PLUGIN_DIR . '/camptix-attendance/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/wporg-groups-frontend/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/gatherpress-recurring-events/tests/bootstrap.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,12 @@
 			</directory>
 		</testsuite>
 
+		<testsuite name="CampTix Attendance">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/camptix-attendance/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="CampTix Indian Payments">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/plugins/campt-indian-payment-gateway/tests/

--- a/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.css
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.css
@@ -362,3 +362,10 @@ li.item .spinner:after {
   100% {
     -webkit-transform: rotate(360deg);
     transform: rotate(360deg); } }
+
+/* Bulk (organizers) section in the filter panel. */
+.attendee-filter-view ul.camptix-attendance-bulk {
+  margin-bottom: 30px; }
+
+.attendee-filter-view ul.camptix-attendance-bulk li[data-attending="false"] {
+  color: #ff6b6b; }

--- a/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.js
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.js
@@ -322,7 +322,8 @@ jQuery(document).ready(function($){
 			'fastClick .close': 'close',
 			'fastClick .filter-sort li': 'toggleSort',
 			'fastClick .filter-attendance li': 'toggleAttendance',
-			'fastClick .filter-tickets li': 'toggleTickets'
+			'fastClick .filter-tickets li': 'toggleTickets',
+			'fastClick .filter-bulk li': 'bulkAction'
 		},
 
 		initialize: function( options ) {
@@ -382,6 +383,88 @@ jQuery(document).ready(function($){
 			this.render();
 
 			this.controller.trigger( 'filter', this.filterSettings );
+		},
+
+		/**
+		 * Start a bulk attendance action on everything matching the current filters.
+		 */
+		bulkAction: function( event ) {
+			var attending = 'true' === String( $( event.target ).data( 'attending' ) );
+
+			this.controller.trigger( 'bulk', attending );
+			this.close();
+		}
+	});
+
+	/**
+	 * Bulk Confirm View
+	 *
+	 * The modal that confirms a bulk attendance change, showing the live count
+	 * of matching attendees before anything is written.
+	 */
+	camptix.views.BulkConfirmView = Backbone.View.extend({
+		className: 'attendee-toggle-wrap',
+
+		template: wp.template( 'attendee-bulk-confirm' ),
+
+		events: {
+			'fastClick .yes': 'yes',
+			'fastClick .no': 'close',
+			'fastClick .close': 'close'
+		},
+
+		initialize: function( options ) {
+			this.controller = options.controller;
+			this.count = options.count;
+			this.attending = options.attending;
+			this.error = options.error || false;
+			this.$overlay = $('.overlay');
+		},
+
+		render: function() {
+			this.$el.html( this.template({
+				count: this.count,
+				attending: this.attending,
+				error: this.error
+			}) );
+			this.$overlay.show();
+			return this;
+		},
+
+		/**
+		 * Confirmed: apply the bulk change, guarded by the previewed count.
+		 */
+		yes: function() {
+			var view = this;
+
+			wp.ajax.send({
+				type: 'POST',
+				data: {
+					action: 'camptix-attendance',
+					camptix_secret: _camptixAttendanceSecret,
+					camptix_action: 'sync-bulk',
+					camptix_bulk_nonce: _camptixAttendanceBulkNonce,
+					camptix_set_attendance: this.attending ? 'true' : 'false',
+					camptix_expected_count: this.count,
+					camptix_filters: this.controller.filterSettings,
+					camptix_search: this.controller.keyword || ''
+				}
+			}).done( function() {
+				view.close();
+				view.controller.refresh();
+			}).fail( function( response ) {
+				view.error = response && response.error ? response.error : 'not_allowed';
+				view.count = response && response.actual ? response.actual : view.count;
+				view.render();
+			});
+
+			return false;
+		},
+
+		close: function() {
+			this.$overlay.hide();
+			this.remove();
+			return false;
 		}
 	});
 
@@ -433,6 +516,7 @@ jQuery(document).ready(function($){
 			this.on( 'flush', this.flush, this );
 			this.on( 'more:toggle', this.moreToggle, this );
 			this.on( 'filter', this.filter, this );
+			this.on( 'bulk', this.bulkMark, this );
 
 			this.setupCollection();
 		},
@@ -594,6 +678,44 @@ jQuery(document).ready(function($){
 			delete this.collection;
 			this.flush();
 			this.setupCollection();
+		},
+
+		/**
+		 * Preview a bulk attendance change (dry run), then open the confirm modal.
+		 */
+		bulkMark: function( attending ) {
+			var controller = this;
+
+			wp.ajax.send({
+				type: 'POST',
+				data: {
+					action: 'camptix-attendance',
+					camptix_secret: _camptixAttendanceSecret,
+					camptix_action: 'sync-bulk',
+					camptix_bulk_nonce: _camptixAttendanceBulkNonce,
+					camptix_dry_run: 1,
+					camptix_set_attendance: attending ? 'true' : 'false',
+					camptix_filters: this.filterSettings,
+					camptix_search: this.keyword || ''
+				}
+			}).done( function( response ) {
+				var confirmView = new camptix.views.BulkConfirmView({
+					controller: controller,
+					count: response.matched,
+					attending: attending
+				});
+
+				$(document.body).append( confirmView.render().el );
+			}).fail( function( response ) {
+				var confirmView = new camptix.views.BulkConfirmView({
+					controller: controller,
+					count: 0,
+					attending: attending,
+					error: response && response.error ? response.error : 'not_allowed'
+				});
+
+				$(document.body).append( confirmView.render().el );
+			});
 		},
 
 		/**

--- a/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.scss
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/assets/attendance-ui.scss
@@ -459,3 +459,11 @@ li.item {
     transform: rotate(360deg);
   }
 }
+/* Bulk (organizers) section in the filter panel. */
+.attendee-filter-view ul.camptix-attendance-bulk {
+	margin-bottom: 30px;
+}
+
+.attendee-filter-view ul.camptix-attendance-bulk li[data-attending="false"] {
+	color: #ff6b6b;
+}

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance-ui.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance-ui.php
@@ -24,6 +24,9 @@ $camptix_options = $camptix->get_options();
 	<script>
 		_camptixAttendanceSecret = '<?php echo esc_js( $_GET['camptix-attendance'] ); ?>';
 		_camptixAttendanceTickets = [ <?php echo esc_js( implode( ', ', array_map( 'absint', wp_list_pluck( $camptix_tickets, 'ID' ) ) ) ); ?> ];
+		// Session-bound CSRF token for bulk actions; only useful when the viewer
+		// is a logged-in organizer (the bulk endpoint requires that anyway).
+		_camptixAttendanceBulkNonce = '<?php echo esc_js( wp_create_nonce( 'camptix-attendance-bulk' ) ); ?>';
 	</script>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
@@ -123,6 +126,37 @@ $camptix_options = $camptix->get_options();
 				<li data-ticket-id="<?php echo absint( $ticket->ID ); ?>" <# if ( _.contains( data.tickets, <?php echo absint( $ticket->ID ); ?> ) ) { #> class="selected" <# } #> ><?php echo esc_html( $ticket->post_title ); ?></li>
 				<?php endforeach; ?>
 			</ul>
+
+			<h1 class="section-title">Bulk (organizers)</h1>
+			<ul class="filter-bulk section-controls">
+				<li data-attending="true">Mark all matching as attended</li>
+				<li data-attending="false">Mark all matching as did not attend</li>
+			</ul>
 		</div>
+	</script>
+
+	<script id="tmpl-attendee-bulk-confirm" type="text/template">
+		<p class="bulk-confirm-message">
+			<# if ( 'count_mismatch' == data.error ) { #>
+				The list changed while you were confirming (now {{ data.count }} matching). Please try again.
+			<# } else if ( 'not_allowed' == data.error ) { #>
+				Bulk actions require an organizer login on this device.
+			<# } else if ( 'bad_nonce' == data.error ) { #>
+				Your session expired. Please reload this page and try again.
+			<# } else if ( data.attending ) { #>
+				Mark <strong>{{ data.count }}</strong> matching attendee<# if ( 1 != data.count ) { #>s<# } #> as <strong>attended</strong>?
+			<# } else { #>
+				Mark <strong>{{ data.count }}</strong> matching attendee<# if ( 1 != data.count ) { #>s<# } #> as <strong>did not attend</strong>?
+			<# } #>
+		</p>
+
+		<div class="yes-no-container">
+			<# if ( ! data.error ) { #>
+				<a href="#" class="yes">Yes</a>
+			<# } #>
+			<a href="#" class="no">Cancel</a>
+		</div>
+
+		<a href="#" class="close dashicons dashicons-no"></a>
 	</script>
 </body>

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance-ui.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance-ui.php
@@ -127,10 +127,10 @@ $camptix_options = $camptix->get_options();
 				<?php endforeach; ?>
 			</ul>
 
-			<h1 class="section-title">Bulk (organizers)</h1>
-			<ul class="filter-bulk section-controls">
-				<li data-attending="true">Mark all matching as attended</li>
-				<li data-attending="false">Mark all matching as did not attend</li>
+			<h1 class="section-title"><?php esc_html_e( 'Bulk (organizers)', 'wordcamporg' ); ?></h1>
+			<ul class="filter-bulk section-controls camptix-attendance-bulk">
+				<li data-attending="true"><?php esc_html_e( 'Mark all matching as attended', 'wordcamporg' ); ?></li>
+				<li data-attending="false"><?php esc_html_e( 'Mark all matching as did not attend', 'wordcamporg' ); ?></li>
 			</ul>
 		</div>
 	</script>
@@ -138,23 +138,23 @@ $camptix_options = $camptix->get_options();
 	<script id="tmpl-attendee-bulk-confirm" type="text/template">
 		<p class="bulk-confirm-message">
 			<# if ( 'count_mismatch' == data.error ) { #>
-				The list changed while you were confirming (now {{ data.count }} matching). Please try again.
+				<?php echo esc_html( sprintf( __( 'The list changed while you were confirming (now %s matching). Please try again.', 'wordcamporg' ), '{{ data.count }}' ) ); ?>
 			<# } else if ( 'not_allowed' == data.error ) { #>
-				Bulk actions require an organizer login on this device.
+				<?php esc_html_e( 'Bulk actions require an organizer login on this device.', 'wordcamporg' ); ?>
 			<# } else if ( 'bad_nonce' == data.error ) { #>
-				Your session expired. Please reload this page and try again.
+				<?php esc_html_e( 'Your session expired. Please reload this page and try again.', 'wordcamporg' ); ?>
 			<# } else if ( data.attending ) { #>
-				Mark <strong>{{ data.count }}</strong> matching attendee<# if ( 1 != data.count ) { #>s<# } #> as <strong>attended</strong>?
+				<?php echo wp_kses( sprintf( __( 'Mark <strong>%s</strong> matching attendee(s) as <strong>attended</strong>?', 'wordcamporg' ), '{{ data.count }}' ), array( 'strong' => array() ) ); ?>
 			<# } else { #>
-				Mark <strong>{{ data.count }}</strong> matching attendee<# if ( 1 != data.count ) { #>s<# } #> as <strong>did not attend</strong>?
+				<?php echo wp_kses( sprintf( __( 'Mark <strong>%s</strong> matching attendee(s) as <strong>did not attend</strong>?', 'wordcamporg' ), '{{ data.count }}' ), array( 'strong' => array() ) ); ?>
 			<# } #>
 		</p>
 
 		<div class="yes-no-container">
 			<# if ( ! data.error ) { #>
-				<a href="#" class="yes">Yes</a>
+				<a href="#" class="yes"><?php esc_html_e( 'Yes', 'wordcamporg' ); ?></a>
 			<# } #>
-			<a href="#" class="no">Cancel</a>
+			<a href="#" class="no"><?php esc_html_e( 'Cancel', 'wordcamporg' ); ?></a>
 		</div>
 
 		<a href="#" class="close dashicons dashicons-no"></a>

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -132,34 +132,38 @@ class CampTix_Attendance extends CampTix_Addon {
 		// Two-phase guard: the count the user confirmed must still match the live
 		// set, so a filter change or new registrations between the preview and the
 		// confirmation can't silently widen the write.
-		if ( ! $dry_run && isset( $_REQUEST['camptix_expected_count'] ) ) {
-			$actual = count( $this->query_attendee_ids( $filters, $search ) );
+		$ids = $this->query_attendee_ids( $filters, $search );
 
-			if ( absint( $_REQUEST['camptix_expected_count'] ) !== $actual ) {
-				return wp_send_json_error( array(
-					'error'  => 'count_mismatch',
-					'actual' => $actual,
-				) );
-			}
+		if ( ! $dry_run && isset( $_REQUEST['camptix_expected_count'] )
+			&& absint( $_REQUEST['camptix_expected_count'] ) !== count( $ids )
+		) {
+			return wp_send_json_error( array(
+				'error'  => 'count_mismatch',
+				'actual' => count( $ids ),
+			) );
 		}
 
-		return wp_send_json_success( $this->bulk_set_attendance( $filters, $search, $attending, $dry_run ) );
+		return wp_send_json_success( $this->bulk_set_attendance( $filters, $search, $attending, $dry_run, $ids ) );
 	}
 
 	/**
 	 * Set or unset attendance for every attendee matching the filters.
 	 *
-	 * @param array  $filters   Filter settings (attendance, tickets), as sent by the UI.
-	 * @param string $search    Search keyword.
-	 * @param bool   $attending True to mark attended, false to unmark.
-	 * @param bool   $dry_run   If true, only count the matching set.
+	 * @param array      $filters   Filter settings (attendance, tickets), as sent by the UI.
+	 * @param string     $search    Search keyword.
+	 * @param bool       $attending True to mark attended, false to unmark.
+	 * @param bool       $dry_run   If true, only count the matching set.
+	 * @param int[]|null $ids       Precomputed attendee IDs to act on; null queries
+	 *                              the filters. Pass the IDs the count guard checked
+	 *                              so the confirmed write can't act on a wider set.
 	 *
 	 * @return array { matched, changed, attending, dry_run }
 	 */
-	public function bulk_set_attendance( $filters, $search, $attending, $dry_run = false ) {
-		global $camptix;
+	public function bulk_set_attendance( $filters, $search, $attending, $dry_run = false, $ids = null ) {
+		if ( null === $ids ) {
+			$ids = $this->query_attendee_ids( $filters, $search );
+		}
 
-		$ids     = $this->query_attendee_ids( $filters, $search );
 		$summary = array(
 			'matched'   => count( $ids ),
 			'changed'   => 0,

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -22,6 +22,14 @@ class CampTix_Attendance extends CampTix_Addon {
 			add_filter( 'camptix_validate_options', array( $this, 'validate_options' ), 10, 2 );
 		}
 
+		// Attendance file import under Tickets → Tools. Available regardless of
+		// whether the front-end Attendance UI / secret link is enabled — importing
+		// after the event mustn't require turning the live UI on.
+		if ( current_user_can( $camptix->caps['manage_attendees'] ) ) {
+			add_filter( 'camptix_menu_tools_tabs', array( $this, 'add_import_tools_tab' ) );
+			add_action( 'camptix_menu_tools_attendance-import', array( $this, 'render_import_tools_tab' ) );
+		}
+
 		$camptix_options = $camptix->get_options();
 		if ( empty( $camptix_options['attendance-secret'] ) )
 			return;
@@ -88,7 +96,506 @@ class CampTix_Attendance extends CampTix_Addon {
 			return $this->_ajax_sync_model();
 		} elseif ( 'sync-list' == $action ) {
 			return $this->_ajax_sync_list();
+		} elseif ( 'sync-bulk' == $action ) {
+			return $this->_ajax_sync_bulk();
 		}
+	}
+
+	/**
+	 * Bulk-set attendance for every attendee matching the current filters.
+	 *
+	 * Unlike the per-tap flow, bulk writes are gated to logged-in users with the
+	 * manage_attendees capability by default (the secret link alone shouldn't be
+	 * able to rewrite the whole event). Disable via the filter at your own risk.
+	 */
+	public function _ajax_sync_bulk() {
+		global $camptix;
+
+		if ( apply_filters( 'camptix_attendance_bulk_require_cap', true )
+			&& ! current_user_can( $camptix->caps['manage_attendees'] )
+		) {
+			return wp_send_json_error( array( 'error' => 'not_allowed' ) );
+		}
+
+		// CSRF guard: the capability alone isn't enough — auth cookies ride along
+		// on cross-site top-level GETs (SameSite=Lax), so a logged-in organizer
+		// clicking a crafted link could otherwise trigger a mass write.
+		if ( ! wp_verify_nonce( $_REQUEST['camptix_bulk_nonce'] ?? '', 'camptix-attendance-bulk' ) ) {
+			return wp_send_json_error( array( 'error' => 'bad_nonce' ) );
+		}
+
+		$filters   = isset( $_REQUEST['camptix_filters'] ) ? (array) $_REQUEST['camptix_filters'] : array();
+		$search    = isset( $_REQUEST['camptix_search'] ) ? trim( $_REQUEST['camptix_search'] ) : '';
+		$attending = ! empty( $_REQUEST['camptix_set_attendance'] ) && 'true' == $_REQUEST['camptix_set_attendance'];
+		$dry_run   = ! empty( $_REQUEST['camptix_dry_run'] );
+
+		// Two-phase guard: the count the user confirmed must still match the live
+		// set, so a filter change or new registrations between the preview and the
+		// confirmation can't silently widen the write.
+		if ( ! $dry_run && isset( $_REQUEST['camptix_expected_count'] ) ) {
+			$actual = count( $this->query_attendee_ids( $filters, $search ) );
+
+			if ( absint( $_REQUEST['camptix_expected_count'] ) !== $actual ) {
+				return wp_send_json_error( array(
+					'error'  => 'count_mismatch',
+					'actual' => $actual,
+				) );
+			}
+		}
+
+		return wp_send_json_success( $this->bulk_set_attendance( $filters, $search, $attending, $dry_run ) );
+	}
+
+	/**
+	 * Set or unset attendance for every attendee matching the filters.
+	 *
+	 * @param array  $filters   Filter settings (attendance, tickets), as sent by the UI.
+	 * @param string $search    Search keyword.
+	 * @param bool   $attending True to mark attended, false to unmark.
+	 * @param bool   $dry_run   If true, only count the matching set.
+	 *
+	 * @return array { matched, changed, attending, dry_run }
+	 */
+	public function bulk_set_attendance( $filters, $search, $attending, $dry_run = false ) {
+		global $camptix;
+
+		$ids     = $this->query_attendee_ids( $filters, $search );
+		$summary = array(
+			'matched'   => count( $ids ),
+			'changed'   => 0,
+			'attending' => (bool) $attending,
+			'dry_run'   => (bool) $dry_run,
+		);
+
+		if ( $dry_run ) {
+			return $summary;
+		}
+
+		$summary['changed'] = $this->set_attendance_for_ids( $ids, $attending, 'bulk' );
+
+		return $summary;
+	}
+
+	/**
+	 * The shared write core: set or unset attendance for a list of attendee IDs.
+	 *
+	 * Only writes when the state actually changes, keeps the running stat in
+	 * sync, and logs each change for the audit trail.
+	 *
+	 * @param int[]  $ids       Attendee post IDs.
+	 * @param bool   $attending True to mark attended, false to unmark.
+	 * @param string $source    Short label for the log entries ('bulk', 'import').
+	 *
+	 * @return int Number of attendees actually changed.
+	 */
+	public function set_attendance_for_ids( array $ids, $attending, $source = 'bulk' ) {
+		global $camptix;
+
+		$changed = 0;
+		$source  = sanitize_key( $source );
+
+		// Mass actions are organizer actions with a real session — record the
+		// actor so a wrong-direction bulk/import is attributable in the log.
+		$actor   = wp_get_current_user();
+		$context = $actor->exists() ? "$source by {$actor->user_login}" : $source;
+
+		foreach ( $ids as $attendee_id ) {
+			$attendee_id  = absint( $attendee_id );
+			$is_attending = (bool) get_post_meta( $attendee_id, 'tix_attended', true );
+
+			if ( $is_attending === (bool) $attending ) {
+				continue;
+			}
+
+			if ( $attending ) {
+				update_post_meta( $attendee_id, 'tix_attended', true );
+				$camptix->increment_stats( 'attended', 1 );
+				$this->log( "Marked attendee as attended ($context).", $attendee_id );
+			} else {
+				delete_post_meta( $attendee_id, 'tix_attended' );
+				$camptix->increment_stats( 'attended', -1 );
+				$this->log( "Marked attendee as did not attend ($context).", $attendee_id );
+			}
+
+			$changed++;
+		}
+
+		return $changed;
+	}
+
+	/**
+	 * Add the Attendance Import tab to Tickets → Tools.
+	 *
+	 * @param array $sections
+	 *
+	 * @return array
+	 */
+	public function add_import_tools_tab( $sections ) {
+		$sections['attendance-import'] = __( 'Attendance Import', 'wordcamporg' );
+
+		return $sections;
+	}
+
+	/**
+	 * Render (and handle) the Attendance Import tools tab.
+	 *
+	 * Three states: the upload form; the preview of a parsed file (stored in a
+	 * short-lived user-keyed transient, so the file itself is read once and
+	 * discarded); and the result summary after applying.
+	 */
+	public function render_import_tools_tab() {
+		global $camptix;
+
+		if ( ! current_user_can( $camptix->caps['manage_attendees'] ) ) {
+			return;
+		}
+
+		$transient_key = 'tix_attendance_import_' . get_current_user_id();
+
+		// Step 3: apply a previously previewed plan.
+		if ( isset( $_POST['tix_attendance_import_apply'] )
+			&& wp_verify_nonce( $_POST['tix_attendance_import_nonce'] ?? '', 'tix-attendance-import-apply' )
+		) {
+			$plan = get_transient( $transient_key );
+			delete_transient( $transient_key );
+
+			if ( ! is_array( $plan ) ) {
+				echo '<div class="notice notice-error"><p>' . esc_html__( 'The preview expired. Please upload the file again.', 'wordcamporg' ) . '</p></div>';
+			} elseif ( ! hash_equals( $plan['token'], (string) ( $_POST['tix_attendance_import_token'] ?? '' ) ) ) {
+				// A newer upload replaced this preview (e.g. another tab) — don't
+				// apply a plan the user isn't looking at.
+				echo '<div class="notice notice-error"><p>' . esc_html__( 'This preview was replaced by a newer upload. Please review the latest preview and apply again.', 'wordcamporg' ) . '</p></div>';
+			} else {
+				$marked   = $this->set_attendance_for_ids( $plan['set'], true, 'import' );
+				$unmarked = $this->set_attendance_for_ids( $plan['unset'], false, 'import' );
+
+				printf(
+					'<div class="notice notice-success"><p>%s</p></div>',
+					esc_html( sprintf(
+						__( 'Import applied: %1$d marked attended, %2$d marked did-not-attend, %3$d already correct.', 'wordcamporg' ),
+						$marked,
+						$unmarked,
+						count( $plan['set'] ) + count( $plan['unset'] ) - $marked - $unmarked
+					) )
+				);
+			}
+
+			$this->render_import_form();
+
+			return;
+		}
+
+		// Step 2: parse an uploaded file and preview the plan.
+		if ( isset( $_FILES['tix_attendance_import_file'] )
+			&& wp_verify_nonce( $_POST['tix_attendance_import_nonce'] ?? '', 'tix-attendance-import-upload' )
+		) {
+			$file = $_FILES['tix_attendance_import_file'];
+
+			if ( ! empty( $file['error'] ) || empty( $file['tmp_name'] ) || ! is_uploaded_file( $file['tmp_name'] ) ) {
+				echo '<div class="notice notice-error"><p>' . esc_html__( 'The upload failed. Please try again.', 'wordcamporg' ) . '</p></div>';
+				$this->render_import_form();
+
+				return;
+			}
+
+			$rows = $this->parse_attendance_csv( $file['tmp_name'] );
+
+			if ( is_wp_error( $rows ) ) {
+				echo '<div class="notice notice-error"><p>' . esc_html( $rows->get_error_message() ) . '</p></div>';
+				$this->render_import_form();
+
+				return;
+			}
+
+			$plan = $this->resolve_attendance_rows( $rows );
+
+			set_transient( $transient_key, $plan, 15 * MINUTE_IN_SECONDS );
+
+			$this->render_import_preview( $plan );
+
+			return;
+		}
+
+		// Step 1: the upload form.
+		$this->render_import_form();
+	}
+
+	/**
+	 * The upload form for the import tab.
+	 */
+	protected function render_import_form() {
+		?>
+		<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( add_query_arg( 'tix_section', 'attendance-import' ) ); ?>">
+			<?php wp_nonce_field( 'tix-attendance-import-upload', 'tix_attendance_import_nonce' ); ?>
+
+			<p><?php esc_html_e( 'Upload a CSV of attendees to set their attendance in bulk — e.g. a badge-scanner export, a sign-in sheet, or an edited copy of the attendee Export.', 'wordcamporg' ); ?></p>
+
+			<ul style="list-style: disc; margin-left: 2em;">
+				<li><?php esc_html_e( 'The file needs a header row with an "id" or "email" column (or both — id wins).', 'wordcamporg' ); ?></li>
+				<li><?php esc_html_e( 'An optional "attended" column (yes/no) sets the direction per row; without it, every row is marked attended.', 'wordcamporg' ); ?></li>
+				<li><?php esc_html_e( 'Nothing is written until you confirm a preview of the changes.', 'wordcamporg' ); ?></li>
+			</ul>
+
+			<p>
+				<input type="file" name="tix_attendance_import_file" accept=".csv,text/csv" required />
+			</p>
+
+			<?php submit_button( __( 'Preview Import', 'wordcamporg' ), 'primary', 'tix_attendance_import_preview' ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 * The preview screen: what the uploaded file will change.
+	 *
+	 * @param array $plan The resolved plan from resolve_attendance_rows().
+	 */
+	protected function render_import_preview( $plan ) {
+		?>
+		<h3><?php esc_html_e( 'Import Preview', 'wordcamporg' ); ?></h3>
+
+		<table class="widefat striped" style="max-width: 500px;">
+			<tbody>
+			<tr>
+				<td><?php esc_html_e( 'Rows in file', 'wordcamporg' ); ?></td>
+				<td><?php echo absint( $plan['total_rows'] ); ?></td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Will be marked attended', 'wordcamporg' ); ?></td>
+				<td><?php echo absint( count( $plan['set'] ) ); ?></td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Will be marked did-not-attend', 'wordcamporg' ); ?></td>
+				<td><?php echo absint( count( $plan['unset'] ) ); ?></td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Unmatched rows (will be skipped)', 'wordcamporg' ); ?></td>
+				<td><?php echo absint( count( $plan['unmatched'] ) ); ?></td>
+			</tr>
+			</tbody>
+		</table>
+
+		<?php if ( ! empty( $plan['unmatched'] ) ) : ?>
+			<p><strong><?php esc_html_e( 'Unmatched rows:', 'wordcamporg' ); ?></strong></p>
+			<ul style="list-style: disc; margin-left: 2em;">
+				<?php foreach ( array_slice( $plan['unmatched'], 0, 20 ) as $unmatched ) : ?>
+					<li><code><?php echo esc_html( $unmatched ); ?></code></li>
+				<?php endforeach; ?>
+				<?php if ( count( $plan['unmatched'] ) > 20 ) : ?>
+					<li><?php echo esc_html( sprintf( __( '… and %d more.', 'wordcamporg' ), count( $plan['unmatched'] ) - 20 ) ); ?></li>
+				<?php endif; ?>
+			</ul>
+		<?php endif; ?>
+
+		<form method="post" action="<?php echo esc_url( add_query_arg( 'tix_section', 'attendance-import' ) ); ?>">
+			<?php wp_nonce_field( 'tix-attendance-import-apply', 'tix_attendance_import_nonce' ); ?>
+			<input type="hidden" name="tix_attendance_import_token" value="<?php echo esc_attr( $plan['token'] ); ?>" />
+			<?php submit_button( __( 'Apply Import', 'wordcamporg' ), 'primary', 'tix_attendance_import_apply', false ); ?>
+			<a class="button" href="<?php echo esc_url( add_query_arg( 'tix_section', 'attendance-import' ) ); ?>"><?php esc_html_e( 'Cancel', 'wordcamporg' ); ?></a>
+		</form>
+		<?php
+	}
+
+	/**
+	 * Parse an attendance CSV into normalized rows.
+	 *
+	 * Strict column allowlist: only id, email, and attended are ever read.
+	 *
+	 * @param string $file_path Path to the uploaded CSV.
+	 *
+	 * @return array|WP_Error List of rows: { id: int|0, email: string, attended: bool }.
+	 */
+	public function parse_attendance_csv( $file_path ) {
+		$handle = fopen( $file_path, 'r' );
+
+		if ( ! $handle ) {
+			return new WP_Error( 'unreadable', __( 'Could not read the uploaded file.', 'wordcamporg' ) );
+		}
+
+		// Explicit $escape: '' is the future PHP default and the correct CSV behavior.
+		$header = fgetcsv( $handle, null, ',', '"', '' );
+
+		if ( ! is_array( $header ) ) {
+			fclose( $handle );
+
+			return new WP_Error( 'empty', __( 'The file appears to be empty.', 'wordcamporg' ) );
+		}
+
+		// Normalize headers; strip a possible UTF-8 BOM off the first cell.
+		$header    = array_map( function ( $cell ) {
+			return strtolower( trim( str_replace( "\xEF\xBB\xBF", '', (string) $cell ) ) );
+		}, $header );
+		$id_col    = array_search( 'id', $header, true );
+		if ( false === $id_col ) {
+			$id_col = array_search( 'attendee id', $header, true );
+		}
+		$email_col = array_search( 'email', $header, true );
+		$att_col   = array_search( 'attended', $header, true );
+
+		if ( false === $id_col && false === $email_col ) {
+			fclose( $handle );
+
+			return new WP_Error( 'no_key_column', __( 'The file needs an "id" or "email" column in its header row.', 'wordcamporg' ) );
+		}
+
+		$rows     = array();
+		$max_rows = apply_filters( 'camptix_attendance_import_max_rows', 5000 );
+
+		while ( false !== ( $line = fgetcsv( $handle, null, ',', '"', '' ) ) ) {
+			if ( array( null ) === $line ) {
+				continue; // Blank line.
+			}
+
+			if ( count( $rows ) >= $max_rows ) {
+				fclose( $handle );
+
+				return new WP_Error(
+					'too_many_rows',
+					sprintf( __( 'The file has more than %d rows. Please split it into smaller files.', 'wordcamporg' ), $max_rows )
+				);
+			}
+
+			$attended = true;
+
+			if ( false !== $att_col ) {
+				$raw      = strtolower( trim( (string) ( $line[ $att_col ] ?? '' ) ) );
+				$attended = in_array( $raw, array( 'yes', 'y', '1', 'true' ), true );
+			}
+
+			$rows[] = array(
+				'id'       => false !== $id_col ? absint( $line[ $id_col ] ?? 0 ) : 0,
+				'email'    => false !== $email_col ? strtolower( trim( (string) ( $line[ $email_col ] ?? '' ) ) ) : '',
+				'attended' => $attended,
+			);
+		}
+
+		fclose( $handle );
+
+		return $rows;
+	}
+
+	/**
+	 * Resolve parsed rows to attendee IDs.
+	 *
+	 * A row's id column wins when it points at a real published attendee;
+	 * otherwise the email is matched against tix_email (all matches count —
+	 * duplicate emails each get the row's attendance). Rows matching nothing
+	 * are reported, never silently dropped.
+	 *
+	 * @param array $rows Rows from parse_attendance_csv().
+	 *
+	 * @return array { set: int[], unset: int[], unmatched: string[], total_rows: int }
+	 */
+	public function resolve_attendance_rows( array $rows ) {
+		$plan = array(
+			'set'        => array(),
+			'unset'      => array(),
+			'unmatched'  => array(),
+			'total_rows' => count( $rows ),
+			// One-time token binding this exact plan to its preview's Apply button.
+			'token'      => wp_generate_password( 20, false, false ),
+		);
+
+		foreach ( $rows as $row ) {
+			$matched = array();
+
+			if ( $row['id'] ) {
+				$post = get_post( $row['id'] );
+
+				if ( $post && 'tix_attendee' === $post->post_type && 'publish' === $post->post_status ) {
+					$matched[] = $post->ID;
+				}
+			}
+
+			if ( ! $matched && '' !== $row['email'] && is_email( $row['email'] ) ) {
+				$matched = get_posts( array(
+					'post_type'      => 'tix_attendee',
+					'post_status'    => 'publish',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'meta_key'       => 'tix_email',
+					'meta_value'     => $row['email'],
+				) );
+			}
+
+			if ( ! $matched ) {
+				$plan['unmatched'][] = $row['id'] ? '#' . $row['id'] : $row['email'];
+
+				continue;
+			}
+
+			foreach ( $matched as $attendee_id ) {
+				if ( $row['attended'] ) {
+					$plan['set'][] = (int) $attendee_id;
+				} else {
+					$plan['unset'][] = (int) $attendee_id;
+				}
+			}
+		}
+
+		$plan['set']   = array_values( array_unique( $plan['set'] ) );
+		$plan['unset'] = array_values( array_unique( array_diff( $plan['unset'], $plan['set'] ) ) );
+
+		return $plan;
+	}
+
+	/**
+	 * Get the IDs of all published attendees matching the filters — the same
+	 * matching semantics as the list the volunteer is looking at (_ajax_sync_list),
+	 * without pagination.
+	 *
+	 * @param array  $filters Filter settings (attendance, tickets).
+	 * @param string $search  Search keyword.
+	 *
+	 * @return int[]
+	 */
+	public function query_attendee_ids( $filters, $search = '' ) {
+		$filters = wp_parse_args( (array) $filters, array(
+			'attendance' => 'none',
+			'tickets'    => array(),
+		) );
+
+		$active_filters = array();
+
+		// Filter by attendance.
+		if ( in_array( $filters['attendance'], array( 'attending', 'not-attending' ) ) ) {
+			$active_filters[] = $this->_filter_query_attendance( $filters['attendance'] );
+		}
+
+		// Filter by ticket type.
+		$ticket_ids         = wp_list_pluck( $this->get_tickets(), 'ID' );
+		$filters['tickets'] = array_intersect( (array) $filters['tickets'], $ticket_ids );
+
+		if ( count( array_diff( $ticket_ids, $filters['tickets'] ) ) > 0 ) {
+			// No tickets selected.
+			if ( empty( $filters['tickets'] ) ) {
+				return array();
+			}
+
+			$active_filters[] = $this->_filter_query_tickets( $filters['tickets'] );
+		}
+
+		// Filter by search query.
+		$search = trim( (string) $search );
+		if ( ! empty( $search ) ) {
+			$active_filters[] = $this->_filter_query_search( $search );
+		}
+
+		$attendee_ids = get_posts( array(
+			'post_type'        => 'tix_attendee',
+			'post_status'      => 'publish',
+			'posts_per_page'   => -1,
+			'fields'           => 'ids',
+			'suppress_filters' => false,
+		) );
+
+		// The legacy list flow leaks its clauses for the rest of the request (one
+		// query per request, harmless); repeated calls here would stack them.
+		foreach ( $active_filters as $callback ) {
+			remove_filter( 'posts_clauses', $callback );
+		}
+
+		return array_map( 'absint', $attendee_ids );
 	}
 
 	/**
@@ -266,7 +773,7 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * query under various meta keys.
 	 */
 	public function _filter_query_search( $search ) {
-		add_filter( 'posts_clauses', function( $clauses ) use ( $search ) {
+		$callback = function( $clauses ) use ( $search ) {
 			global $wpdb;
 
 			$search = $wpdb->esc_like( wp_unslash( $search ) );
@@ -285,27 +792,35 @@ class CampTix_Attendance extends CampTix_Addon {
 			", $search, $search, $search );
 
 			return $clauses;
-		} );
+		};
+
+		add_filter( 'posts_clauses', $callback );
+
+		return $callback;
 	}
 
 	/**
 	 * Filter WP_Query to include only specific tickets.
 	 */
 	public function _filter_query_tickets( $ticket_ids ) {
-		add_filter( 'posts_clauses', function( $clauses ) use ( $ticket_ids ) {
+		$callback = function( $clauses ) use ( $ticket_ids ) {
 			global $wpdb;
 
 			$clauses['join'] .= " INNER JOIN $wpdb->postmeta tix_ticket_id ON ( ID = tix_ticket_id.post_id AND tix_ticket_id.meta_key = 'tix_ticket_id' ) ";
 			$clauses['where'] .= sprintf( " AND ( tix_ticket_id.meta_value IN ( %s ) ) ", implode( ', ', array_map( 'absint', $ticket_ids ) ) );
 			return $clauses;
-		} );
+		};
+
+		add_filter( 'posts_clauses', $callback );
+
+		return $callback;
 	}
 
 	/**
 	 * Filter WP_Query to include only attending or non-attending attendees.
 	 */
 	public function _filter_query_attendance( $attendance ) {
-		add_filter( 'posts_clauses', function( $clauses ) use ( $attendance ) {
+		$callback = function( $clauses ) use ( $attendance ) {
 			global $wpdb;
 
 			$clauses['join'] .= " LEFT JOIN $wpdb->postmeta tix_attended ON ( ID = tix_attended.post_id AND tix_attended.meta_key = 'tix_attended' ) ";
@@ -316,7 +831,11 @@ class CampTix_Attendance extends CampTix_Addon {
 				$clauses['where'] .= " AND ( tix_attended.meta_value IS NULL ) ";
 
 			return $clauses;
-		} );
+		};
+
+		add_filter( 'posts_clauses', $callback );
+
+		return $callback;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -550,35 +550,10 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * @return int[]
 	 */
 	public function query_attendee_ids( $filters, $search = '' ) {
-		$filters = wp_parse_args( (array) $filters, array(
-			'attendance' => 'none',
-			'tickets'    => array(),
-		) );
+		$attached = $this->attach_list_filters( $filters, $search );
 
-		$active_filters = array();
-
-		// Filter by attendance.
-		if ( in_array( $filters['attendance'], array( 'attending', 'not-attending' ) ) ) {
-			$active_filters[] = $this->_filter_query_attendance( $filters['attendance'] );
-		}
-
-		// Filter by ticket type.
-		$ticket_ids         = wp_list_pluck( $this->get_tickets(), 'ID' );
-		$filters['tickets'] = array_intersect( (array) $filters['tickets'], $ticket_ids );
-
-		if ( count( array_diff( $ticket_ids, $filters['tickets'] ) ) > 0 ) {
-			// No tickets selected.
-			if ( empty( $filters['tickets'] ) ) {
-				return array();
-			}
-
-			$active_filters[] = $this->_filter_query_tickets( $filters['tickets'] );
-		}
-
-		// Filter by search query.
-		$search = trim( (string) $search );
-		if ( ! empty( $search ) ) {
-			$active_filters[] = $this->_filter_query_search( $search );
+		if ( false === $attached ) {
+			return array();
 		}
 
 		$attendee_ids = get_posts( array(
@@ -589,13 +564,70 @@ class CampTix_Attendance extends CampTix_Addon {
 			'suppress_filters' => false,
 		) );
 
-		// The legacy list flow leaks its clauses for the rest of the request (one
-		// query per request, harmless); repeated calls here would stack them.
-		foreach ( $active_filters as $callback ) {
-			remove_filter( 'posts_clauses', $callback );
-		}
+		$this->detach_list_filters( $attached );
 
 		return array_map( 'absint', $attendee_ids );
+	}
+
+	/**
+	 * Attach the attendee-list filter clauses for this request.
+	 *
+	 * The single source of the matching semantics shared by the on-screen list
+	 * (_ajax_sync_list) and the bulk actions (query_attendee_ids) — a divergence
+	 * between the two would mean bulk-writing attendees the volunteer can't see.
+	 *
+	 * @param array  $filters Filter settings (attendance, tickets).
+	 * @param string $search  Search keyword.
+	 *
+	 * @return array|false Attached posts_clauses callbacks, or false when the
+	 *                     filters cannot match anything (no tickets selected).
+	 */
+	protected function attach_list_filters( $filters, $search = '' ) {
+		$filters = wp_parse_args( (array) $filters, array(
+			'attendance' => 'none',
+			'tickets'    => array(),
+		) );
+
+		$attached = array();
+
+		if ( in_array( $filters['attendance'], array( 'attending', 'not-attending' ), true ) ) {
+			$attached[] = $this->_filter_query_attendance( $filters['attendance'] );
+		}
+
+		$ticket_ids         = wp_list_pluck( $this->get_tickets(), 'ID' );
+		$filters['tickets'] = array_intersect( (array) $filters['tickets'], $ticket_ids );
+
+		if ( count( array_diff( $ticket_ids, $filters['tickets'] ) ) > 0 ) {
+			if ( empty( $filters['tickets'] ) ) {
+				$this->detach_list_filters( $attached );
+
+				return false;
+			}
+
+			$attached[] = $this->_filter_query_tickets( $filters['tickets'] );
+		}
+
+		$search = trim( (string) $search );
+
+		if ( ! empty( $search ) ) {
+			$attached[] = $this->_filter_query_search( $search );
+		}
+
+		return $attached;
+	}
+
+	/**
+	 * Detach filter clauses attached by attach_list_filters().
+	 *
+	 * The legacy _filter_query_* methods leak their closures for the rest of the
+	 * request; anything running a second query must detach or get silently narrowed.
+	 *
+	 * @param array $attached Callbacks returned by attach_list_filters().
+	 */
+	protected function detach_list_filters( array $attached ) {
+		foreach ( $attached as $callback ) {
+			remove_filter( 'posts_clauses', $callback );
+		}
 	}
 
 	/**
@@ -636,13 +668,9 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * returns a batch back to Backbone.sync.
 	 */
 	public function _ajax_sync_list() {
-		global $wpdb;
-
 		$paged = 1;
 		if ( ! empty( $_REQUEST['camptix_paged'] ) )
 			$paged = absint( $_REQUEST['camptix_paged'] );
-
-		$ticket_ids = wp_list_pluck( $this->get_tickets(), 'ID' );
 
 		$query_args = array(
 			'post_type'      => 'tix_attendee',
@@ -687,27 +715,17 @@ class CampTix_Attendance extends CampTix_Addon {
 
 		$filters['search'] = ! empty( $_REQUEST['camptix_search'] ) ? trim( $_REQUEST['camptix_search'] ) : '';
 
-		// Filter by attendance.
-		if ( in_array( $filters['attendance'], array( 'attending', 'not-attending' ) ) )
-			$this->_filter_query_attendance( $filters['attendance'] );
+		$attached = $this->attach_list_filters( $filters, $filters['search'] );
 
-		// Filter by ticket type.
-		$filters['tickets'] = array_intersect( $filters['tickets'], $ticket_ids );
-		if ( count( array_diff( $ticket_ids, $filters['tickets'] ) ) > 0 ) {
-
-			// No tickets selected.
-			if ( empty( $filters['tickets'] ) )
-				return wp_send_json_success( array() );
-
-			$this->_filter_query_tickets( $filters['tickets'] );
+		if ( false === $attached ) {
+			// No tickets selected — same "match nothing" rule the bulk query uses.
+			return wp_send_json_success( array() );
 		}
 
-		// Filter by search query.
-		if ( ! empty( $filters['search'] ) )
-			$this->_filter_query_search( $filters['search'] );
-
 		$query_args['suppress_filters'] = false;
-		$attendees = get_posts( $query_args );
+		$attendees                      = get_posts( $query_args );
+
+		$this->detach_list_filters( $attached );
 
 		$output = array();
 		foreach ( $attendees as $attendee ) {

--- a/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/addons/attendance.php
@@ -426,9 +426,10 @@ class CampTix_Attendance extends CampTix_Addon {
 		}
 
 		// Normalize headers; strip a possible UTF-8 BOM off the first cell.
-		$header    = array_map( function ( $cell ) {
+		$normalize = function ( $cell ) {
 			return strtolower( trim( str_replace( "\xEF\xBB\xBF", '', (string) $cell ) ) );
-		}, $header );
+		};
+		$header    = array_map( $normalize, $header );
 		$id_col    = array_search( 'id', $header, true );
 		if ( false === $id_col ) {
 			$id_col = array_search( 'attendee id', $header, true );
@@ -587,10 +588,13 @@ class CampTix_Attendance extends CampTix_Addon {
 	 *                     filters cannot match anything (no tickets selected).
 	 */
 	protected function attach_list_filters( $filters, $search = '' ) {
-		$filters = wp_parse_args( (array) $filters, array(
-			'attendance' => 'none',
-			'tickets'    => array(),
-		) );
+		$filters = wp_parse_args(
+			(array) $filters,
+			array(
+				'attendance' => 'none',
+				'tickets'    => array(),
+			)
+		);
 
 		$attached = array();
 
@@ -795,7 +799,7 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * query under various meta keys.
 	 */
 	public function _filter_query_search( $search ) {
-		$callback = function( $clauses ) use ( $search ) {
+		$callback = function ( $clauses ) use ( $search ) {
 			global $wpdb;
 
 			$search = $wpdb->esc_like( wp_unslash( $search ) );
@@ -825,7 +829,7 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * Filter WP_Query to include only specific tickets.
 	 */
 	public function _filter_query_tickets( $ticket_ids ) {
-		$callback = function( $clauses ) use ( $ticket_ids ) {
+		$callback = function ( $clauses ) use ( $ticket_ids ) {
 			global $wpdb;
 
 			$clauses['join'] .= " INNER JOIN $wpdb->postmeta tix_ticket_id ON ( ID = tix_ticket_id.post_id AND tix_ticket_id.meta_key = 'tix_ticket_id' ) ";
@@ -842,7 +846,7 @@ class CampTix_Attendance extends CampTix_Addon {
 	 * Filter WP_Query to include only attending or non-attending attendees.
 	 */
 	public function _filter_query_attendance( $attendance ) {
-		$callback = function( $clauses ) use ( $attendance ) {
+		$callback = function ( $clauses ) use ( $attendance ) {
 			global $wpdb;
 
 			$clauses['join'] .= " LEFT JOIN $wpdb->postmeta tix_attended ON ( ID = tix_attended.post_id AND tix_attended.meta_key = 'tix_attended' ) ";

--- a/public_html/wp-content/plugins/camptix-attendance/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * PHPUnit bootstrap for the CampTix Attendance suite, in the repo-wide harness.
+ *
+ * Only registers the addon with CampTix's loader. CampTix itself is loaded by its
+ * own bootstrap — which has to stay last in phpunit-bootstrap.php because it
+ * includes Core's — and wcpt provides the real get_wordcamp_post() that the
+ * standalone bootstrap has to shim.
+ */
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load the plugin that we'll need to be active for the tests.
+ */
+function camptix_attendance_manually_load_plugin() {
+	require_once WP_PLUGIN_DIR . '/camptix/tests/trait-wordcamp-root-blog.php';
+	require_once WP_PLUGIN_DIR . '/camptix-attendance/camptix-attendance.php';
+}
+tests_add_filter( 'muplugins_loaded', 'camptix_attendance_manually_load_plugin' );

--- a/public_html/wp-content/plugins/camptix-attendance/tests/test-attendance-import.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/test-attendance-import.php
@@ -1,0 +1,403 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the Attendance Import (Tools tab) PoC: CSV parsing, row resolution,
+ * and the shared apply core.
+ *
+ * @group camptix-attendance
+ * @group bulk-attendance
+ */
+class Test_Attendance_Import extends WP_UnitTestCase {
+	use CampTix_Root_Blog_Fixture;
+
+	/**
+	 * Provision central when the harness points at a blog the test install lacks.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		if ( ! get_site( WORDCAMP_ROOT_BLOG_ID ) ) {
+			self::create_wordcamp_root_blog( $factory );
+		}
+	}
+
+	/**
+	 * Remove the root blog this class provisioned.
+	 */
+	public static function wpTearDownAfterClass() {
+		if ( self::$wordcamp_root_blog_id ) {
+			self::delete_wordcamp_root_blog();
+
+			self::$wordcamp_root_blog_id = null;
+		}
+	}
+
+	/**
+	 * Write CSV content to a temp file and return its path.
+	 *
+	 * @param string $content
+	 *
+	 * @return string
+	 */
+	protected function csv( $content ) {
+		$path = wp_tempnam( 'attendance-import-test' );
+
+		file_put_contents( $path, $content );
+
+		return $path;
+	}
+
+	/**
+	 * Create a published attendee with an email.
+	 *
+	 * @param string $email
+	 * @param bool   $attended
+	 * @param string $status
+	 *
+	 * @return int
+	 */
+	protected function make_attendee( $email, $attended = false, $status = 'publish' ) {
+		$id = self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => $status,
+		) );
+
+		update_post_meta( $id, 'tix_email', $email );
+
+		if ( $attended ) {
+			update_post_meta( $id, 'tix_attended', true );
+		}
+
+		return $id;
+	}
+
+	/**
+	 * Parser reads id email and attended columns.
+	 */
+	public function test_parser_reads_id_email_and_attended_columns() {
+		$addon = new CampTix_Attendance();
+
+		$rows = $addon->parse_attendance_csv( $this->csv(
+			"id,first_name,email,attended\n" .
+			"12,Ada,ada@example.org,yes\n" .
+			"0,Grace,grace@example.org,no\n" .
+			",Alan,alan@example.org,1\n"
+		) );
+
+		$this->assertCount( 3, $rows );
+
+		$expected_first_row = array(
+			'id'       => 12,
+			'email'    => 'ada@example.org',
+			'attended' => true,
+		);
+
+		$this->assertSame( $expected_first_row, $rows[0] );
+		$this->assertFalse( $rows[1]['attended'] );
+		$this->assertTrue( $rows[2]['attended'] );
+	}
+
+	/**
+	 * Parser defaults to attended without column and handles bom.
+	 */
+	public function test_parser_defaults_to_attended_without_column_and_handles_bom() {
+		$addon = new CampTix_Attendance();
+
+		// A scanner export: just emails, UTF-8 BOM in front of the header.
+		$rows = $addon->parse_attendance_csv( $this->csv(
+			"\xEF\xBB\xBFEmail\n" .
+			"ada@example.org\n"
+		) );
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'ada@example.org', $rows[0]['email'] );
+		$this->assertTrue( $rows[0]['attended'] );
+	}
+
+	/**
+	 * Parser rejects files without key columns.
+	 */
+	public function test_parser_rejects_files_without_key_columns() {
+		$addon = new CampTix_Attendance();
+
+		$error = $addon->parse_attendance_csv( $this->csv( "first_name,last_name\nAda,Lovelace\n" ) );
+
+		$this->assertWPError( $error );
+		$this->assertSame( 'no_key_column', $error->get_error_code() );
+	}
+
+	/**
+	 * Resolver matches by id then email and reports unmatched.
+	 */
+	public function test_resolver_matches_by_id_then_email_and_reports_unmatched() {
+		$addon = new CampTix_Attendance();
+
+		$by_id    = $this->make_attendee( 'ida@example.org' );
+		$by_email = $this->make_attendee( 'emma@example.org' );
+		$draft    = $this->make_attendee( 'draft@example.org', false, 'draft' );
+
+		$plan = $addon->resolve_attendance_rows( array(
+			array(
+				'id' => $by_id, 'email' => '', 'attended' => true,
+			),
+			array(
+				'id' => 0, 'email' => 'emma@example.org', 'attended' => true,
+			),
+			array(
+				'id' => 0, 'email' => 'draft@example.org', 'attended' => true,
+			),   // Draft: must not match.
+			array(
+				'id' => 0, 'email' => 'nobody@example.org', 'attended' => true,
+			),  // Unknown.
+			array(
+				'id' => 999999, 'email' => '', 'attended' => true,
+			),               // Bogus ID.
+		) );
+
+		$this->assertEqualSets( array( $by_id, $by_email ), $plan['set'] );
+		$this->assertSame( array(), $plan['unset'] );
+		$this->assertEqualSets( array( 'draft@example.org', 'nobody@example.org', '#999999' ), $plan['unmatched'] );
+		$this->assertSame( 5, $plan['total_rows'] );
+	}
+
+	/**
+	 * Resolver splits directions and dedupes.
+	 */
+	public function test_resolver_splits_directions_and_dedupes() {
+		$addon = new CampTix_Attendance();
+
+		$going    = $this->make_attendee( 'going@example.org' );
+		$notgoing = $this->make_attendee( 'notgoing@example.org', true );
+
+		$plan = $addon->resolve_attendance_rows( array(
+			array(
+				'id' => $going, 'email' => '', 'attended' => true,
+			),
+			array(
+				'id' => $going, 'email' => '', 'attended' => true,
+			),      // Duplicate row.
+			array(
+				'id' => $notgoing, 'email' => '', 'attended' => false,
+			),
+		) );
+
+		$this->assertSame( array( $going ), $plan['set'] );
+		$this->assertSame( array( $notgoing ), $plan['unset'] );
+	}
+
+	/**
+	 * Resolver email matches all duplicates.
+	 */
+	public function test_resolver_email_matches_all_duplicates() {
+		$addon = new CampTix_Attendance();
+
+		$twin_a = $this->make_attendee( 'shared@example.org' );
+		$twin_b = $this->make_attendee( 'shared@example.org' );
+
+		$plan = $addon->resolve_attendance_rows( array(
+			array(
+				'id' => 0, 'email' => 'shared@example.org', 'attended' => true,
+			),
+		) );
+
+		$this->assertEqualSets( array( $twin_a, $twin_b ), $plan['set'] );
+	}
+
+	/**
+	 * Apply core handles both directions from a plan.
+	 */
+	public function test_apply_core_handles_both_directions_from_a_plan() {
+		$addon = new CampTix_Attendance();
+
+		$a = $this->make_attendee( 'a@example.org' );          // To mark.
+		$b = $this->make_attendee( 'b@example.org', true );    // Already marked: no-op.
+		$c = $this->make_attendee( 'c@example.org', true );    // To unmark.
+
+		$marked   = $addon->set_attendance_for_ids( array( $a, $b ), true, 'import' );
+		$unmarked = $addon->set_attendance_for_ids( array( $c ), false, 'import' );
+
+		$this->assertSame( 1, $marked );
+		$this->assertSame( 1, $unmarked );
+		$this->assertSame( '1', get_post_meta( $a, 'tix_attended', true ) );
+		$this->assertSame( '1', get_post_meta( $b, 'tix_attended', true ) );
+		$this->assertSame( '', get_post_meta( $c, 'tix_attended', true ) );
+	}
+
+	/**
+	 * Full snapshot of an attendee: every post field + every meta row.
+	 *
+	 * The tix_log meta is excluded: it's CampTix's append-only audit trail, which
+	 * vanilla CampTix stores as postmeta (each write ADDS a log entry — that's the
+	 * point). On WordCamp.org production, postmeta logging is disabled and
+	 * camptix-network-tools routes entries to the network log table instead, so
+	 * even this key is untouched there.
+	 *
+	 * @param int $id
+	 *
+	 * @return array
+	 */
+	protected function snapshot( $id ) {
+		clean_post_cache( $id );
+
+		$meta = get_post_meta( $id );
+		unset( $meta['tix_log'] );
+
+		return array(
+			'post' => get_post( $id, ARRAY_A ),
+			'meta' => $meta,
+		);
+	}
+
+	/**
+	 * Import touches only `tix_attended` and nothing else.
+	 */
+	public function test_import_touches_only_tix_attended_and_nothing_else() {
+		$addon = new CampTix_Attendance();
+
+		$id = $this->make_attendee( 'only@example.org' );
+		update_post_meta( $id, 'tix_first_name', 'Only' );
+		update_post_meta( $id, 'tix_ticket_id', 42 );
+		update_post_meta( $id, 'tix_access_token', 'tok123' );
+
+		$before = $this->snapshot( $id );
+
+		$addon->set_attendance_for_ids( array( $id ), true, 'import' );
+
+		$after = $this->snapshot( $id );
+
+		// The post row itself is byte-identical — not even post_modified moves.
+		$this->assertSame( $before['post'], $after['post'] );
+
+		// The meta diff is exactly one key: tix_attended.
+		$added   = array_diff_key( $after['meta'], $before['meta'] );
+		$removed = array_diff_key( $before['meta'], $after['meta'] );
+		$changed = array();
+		foreach ( array_intersect_key( $before['meta'], $after['meta'] ) as $key => $value ) {
+			if ( $value !== $after['meta'][ $key ] ) {
+				$changed[] = $key;
+			}
+		}
+
+		$this->assertSame( array( 'tix_attended' ), array_keys( $added ) );
+		$this->assertSame( array(), array_keys( $removed ) );
+		$this->assertSame( array(), $changed );
+	}
+
+	/**
+	 * Yes then no restores the never attended exactly.
+	 */
+	public function test_yes_then_no_restores_the_never_attended_exactly() {
+		$addon = new CampTix_Attendance();
+
+		$id     = $this->make_attendee( 'fresh@example.org' );
+		$before = $this->snapshot( $id );
+
+		// Upload "yes", then upload "no" (same rows).
+		$addon->set_attendance_for_ids( array( $id ), true, 'import' );
+		$addon->set_attendance_for_ids( array( $id ), false, 'import' );
+
+		// Byte-identical to the original: post row AND all meta (the delete removes
+		// the row entirely, so there's no leftover empty value).
+		$this->assertSame( $before, $this->snapshot( $id ) );
+	}
+
+	/**
+	 * Yes then no is a direction not a rollback.
+	 */
+	public function test_yes_then_no_is_a_direction_not_a_rollback() {
+		$addon = new CampTix_Attendance();
+
+		// This attendee was ALREADY attended before any import (e.g. marked at the
+		// door). The "yes" file is a no-op for them — but a subsequent "no" file
+		// UNMARKS them, which is NOT their pre-import state. Documented asymmetry:
+		// a reverse file sets a direction; it does not roll back the first import.
+		$id = $this->make_attendee( 'door@example.org', true );
+
+		$changed_by_yes = $addon->set_attendance_for_ids( array( $id ), true, 'import' );
+		$this->assertSame( 0, $changed_by_yes );
+
+		$changed_by_no = $addon->set_attendance_for_ids( array( $id ), false, 'import' );
+		$this->assertSame( 1, $changed_by_no );
+		$this->assertSame( '', get_post_meta( $id, 'tix_attended', true ) );
+	}
+
+	/**
+	 * Audit log records the acting user.
+	 */
+	public function test_audit_log_records_the_acting_user() {
+		$addon = new CampTix_Attendance();
+
+		$user_id = self::factory()->user->create( array(
+			'role' => 'administrator', 'user_login' => 'importer_admin',
+		) );
+		wp_set_current_user( $user_id );
+
+		$id = $this->make_attendee( 'audit@example.org' );
+
+		$addon->set_attendance_for_ids( array( $id ), true, 'import' );
+
+		wp_set_current_user( 0 );
+
+		// Vanilla CampTix stores the log as tix_log postmeta in this environment.
+		$log      = get_post_meta( $id, 'tix_log', true );
+		$messages = wp_list_pluck( (array) $log, 'message' );
+
+		$this->assertContains( 'Marked attendee as attended (import by importer_admin).', $messages );
+	}
+
+	/**
+	 * Parser enforces the row cap.
+	 */
+	public function test_parser_enforces_the_row_cap() {
+		$addon = new CampTix_Attendance();
+
+		$cap = function () {
+			return 2;
+		};
+		add_filter( 'camptix_attendance_import_max_rows', $cap );
+
+		$error = $addon->parse_attendance_csv( $this->csv(
+			"email\none@example.org\ntwo@example.org\nthree@example.org\n"
+		) );
+
+		remove_filter( 'camptix_attendance_import_max_rows', $cap );
+
+		$this->assertWPError( $error );
+		$this->assertSame( 'too_many_rows', $error->get_error_code() );
+	}
+
+	/**
+	 * Each plan gets a unique apply token.
+	 */
+	public function test_each_plan_gets_a_unique_apply_token() {
+		$addon = new CampTix_Attendance();
+
+		$plan_a = $addon->resolve_attendance_rows( array() );
+		$plan_b = $addon->resolve_attendance_rows( array() );
+
+		$this->assertNotEmpty( $plan_a['token'] );
+		$this->assertNotSame( $plan_a['token'], $plan_b['token'] );
+	}
+
+	/**
+	 * Tools tab is registered for organizers only.
+	 */
+	public function test_tools_tab_is_registered_for_organizers_only() {
+		// The bootstrap ran camptix_init anonymously, so the tab is absent...
+		$sections = apply_filters( 'camptix_menu_tools_tabs', array( 'summarize' => 'Summarize' ) );
+		$this->assertArrayNotHasKey( 'attendance-import', $sections );
+
+		// ...and registers once an organizer-capable user initializes the addon.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$addon = new CampTix_Attendance();
+		$addon->camptix_init();
+
+		$sections = apply_filters( 'camptix_menu_tools_tabs', array( 'summarize' => 'Summarize' ) );
+		$this->assertArrayHasKey( 'attendance-import', $sections );
+
+		remove_filter( 'camptix_menu_tools_tabs', array( $addon, 'add_import_tools_tab' ) );
+		wp_set_current_user( 0 );
+	}
+}

--- a/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-ajax.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-ajax.php
@@ -195,12 +195,13 @@ class Test_Bulk_Ajax extends WP_Ajax_UnitTestCase {
 			'tickets'    => array( $ticket ),
 		);
 
-		$_POST = $_REQUEST = array(
+		$_REQUEST = array(
 			'action'          => 'camptix-attendance',
 			'camptix_secret'  => self::SECRET,
 			'camptix_action'  => 'sync-list',
 			'camptix_filters' => $filters,
 		);
+		$_POST    = $_REQUEST;
 
 		$response = $this->dispatch();
 

--- a/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-ajax.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-ajax.php
@@ -168,4 +168,51 @@ class Test_Bulk_Ajax extends WP_Ajax_UnitTestCase {
 		$this->assertFalse( $response['success'] );
 		$this->assertSame( 'not_allowed', $response['data']['error'] );
 	}
+
+	/**
+	 * The on-screen list and the bulk query must match the same attendees.
+	 */
+	public function test_sync_list_and_query_attendee_ids_match() {
+		$this->_setRole( 'administrator' );
+
+		$ticket = self::factory()->post->create( array(
+			'post_type'   => 'tix_ticket',
+			'post_status' => 'publish',
+		) );
+
+		foreach ( array( 'Ada Lovelace', 'Grace Hopper', 'Alan Turing' ) as $name ) {
+			$attendee = self::factory()->post->create( array(
+				'post_type'   => 'tix_attendee',
+				'post_status' => 'publish',
+				'post_title'  => $name,
+			) );
+
+			update_post_meta( $attendee, 'tix_ticket_id', $ticket );
+		}
+
+		$filters = array(
+			'attendance' => 'none',
+			'tickets'    => array( $ticket ),
+		);
+
+		$_POST = $_REQUEST = array(
+			'action'          => 'camptix-attendance',
+			'camptix_secret'  => self::SECRET,
+			'camptix_action'  => 'sync-list',
+			'camptix_filters' => $filters,
+		);
+
+		$response = $this->dispatch();
+
+		$this->assertTrue( $response['success'] );
+
+		// _make_object() returns the attendee post ID under 'id'.
+		$listed = array_map( 'absint', wp_list_pluck( $response['data'], 'id' ) );
+		$bulk   = $this->addon->query_attendee_ids( $filters );
+
+		sort( $listed );
+		sort( $bulk );
+
+		$this->assertSame( $bulk, $listed, 'sync-list and query_attendee_ids disagree' );
+	}
 }

--- a/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-ajax.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-ajax.php
@@ -1,0 +1,171 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+/**
+ * AJAX-layer tests for the sync-bulk endpoint: the CSRF nonce and capability
+ * gates, exercised through the real wp_ajax dispatch.
+ *
+ * @group camptix-attendance
+ * @group bulk-attendance
+ * @group ajax
+ */
+class Test_Bulk_Ajax extends WP_Ajax_UnitTestCase {
+	use CampTix_Root_Blog_Fixture;
+
+	const SECRET = 'test-secret-1234567890abcdef1234';
+
+	/**
+	 * Provision central when the harness points at a blog the test install lacks.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		if ( ! get_site( WORDCAMP_ROOT_BLOG_ID ) ) {
+			self::create_wordcamp_root_blog( $factory );
+		}
+	}
+
+	/**
+	 * Remove the root blog this class provisioned.
+	 */
+	public static function wpTearDownAfterClass() {
+		if ( self::$wordcamp_root_blog_id ) {
+			self::delete_wordcamp_root_blog();
+
+			self::$wordcamp_root_blog_id = null;
+		}
+	}
+
+	/**
+	 * The addon instance under test.
+	 *
+	 * @var CampTix_Attendance
+	 */
+	protected $addon;
+
+	/**
+	 * Register the AJAX handler on a fresh addon instance with a known secret.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Register the AJAX handler directly: CampTix caches its options object,
+		// so flipping the attendance options here wouldn't reach camptix_init().
+		$this->addon         = new CampTix_Attendance();
+		$this->addon->secret = self::SECRET;
+
+		add_filter( 'wp_ajax_camptix-attendance', array( $this->addon, 'ajax_callback' ) );
+		add_filter( 'wp_ajax_nopriv_camptix-attendance', array( $this->addon, 'ajax_callback' ) );
+	}
+
+	/**
+	 * Detach the AJAX handlers registered in set_up().
+	 */
+	public function tear_down() {
+		remove_filter( 'wp_ajax_camptix-attendance', array( $this->addon, 'ajax_callback' ) );
+		remove_filter( 'wp_ajax_nopriv_camptix-attendance', array( $this->addon, 'ajax_callback' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Dispatch the AJAX action and return the decoded JSON response.
+	 *
+	 * @return array
+	 */
+	protected function dispatch() {
+		try {
+			$this->_handleAjax( 'camptix-attendance' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// wp_send_json() dies with '' — expected.
+			unset( $e );
+		} catch ( WPAjaxDieStopException $e ) {
+			// A hard die (e.g. secret mismatch returns nothing) — also fine.
+			unset( $e );
+		}
+
+		return json_decode( $this->_last_response, true ) ?: array();
+	}
+
+	/**
+	 * Bulk requires nonce even for admins.
+	 */
+	public function test_bulk_requires_nonce_even_for_admins() {
+		$this->_setRole( 'administrator' );
+
+		$_REQUEST = array(
+			'action'                 => 'camptix-attendance',
+			'camptix_secret'         => self::SECRET,
+			'camptix_action'         => 'sync-bulk',
+			'camptix_dry_run'        => 1,
+			'camptix_set_attendance' => 'true',
+		);
+
+		$_POST = $_REQUEST;
+
+		$response = $this->dispatch();
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'bad_nonce', $response['data']['error'] );
+	}
+
+	/**
+	 * Bulk succeeds with nonce and capability.
+	 */
+	public function test_bulk_succeeds_with_nonce_and_capability() {
+		$this->_setRole( 'administrator' );
+
+		$ticket = self::factory()->post->create( array(
+			'post_type' => 'tix_ticket', 'post_status' => 'publish',
+		) );
+
+		$attendee = self::factory()->post->create( array(
+			'post_type' => 'tix_attendee', 'post_status' => 'publish',
+		) );
+		update_post_meta( $attendee, 'tix_ticket_id', $ticket );
+
+		$_REQUEST = array(
+			'action'                 => 'camptix-attendance',
+			'camptix_secret'         => self::SECRET,
+			'camptix_action'         => 'sync-bulk',
+			'camptix_bulk_nonce'     => wp_create_nonce( 'camptix-attendance-bulk' ),
+			'camptix_set_attendance' => 'true',
+			'camptix_filters'        => array(
+				'attendance' => 'none', 'tickets' => array( $ticket ),
+			),
+		);
+
+		$_POST = $_REQUEST;
+
+		$response = $this->dispatch();
+
+		$this->assertTrue( $response['success'] );
+		$this->assertSame( 1, $response['data']['matched'] );
+		$this->assertSame( 1, $response['data']['changed'] );
+		$this->assertSame( '1', get_post_meta( $attendee, 'tix_attended', true ) );
+	}
+
+	/**
+	 * Bulk refuses anonymous even with nonce.
+	 */
+	public function test_bulk_refuses_anonymous_even_with_nonce() {
+		$this->logout();
+
+		$_REQUEST = array(
+			'action'                 => 'camptix-attendance',
+			'camptix_secret'         => self::SECRET,
+			'camptix_action'         => 'sync-bulk',
+			'camptix_bulk_nonce'     => wp_create_nonce( 'camptix-attendance-bulk' ),
+			'camptix_dry_run'        => 1,
+			'camptix_set_attendance' => 'true',
+		);
+
+		$_POST = $_REQUEST;
+
+		$response = $this->dispatch();
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'not_allowed', $response['data']['error'] );
+	}
+}

--- a/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-attendance.php
@@ -1,0 +1,247 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the bulk "mark all matching" PoC: the shared attendee-ID query and
+ * the bulk write core.
+ *
+ * @group camptix-attendance
+ * @group bulk-attendance
+ */
+class Test_Bulk_Attendance extends WP_UnitTestCase {
+	use CampTix_Root_Blog_Fixture;
+
+	/**
+	 * Provision central when the harness points at a blog the test install lacks.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		if ( ! get_site( WORDCAMP_ROOT_BLOG_ID ) ) {
+			self::create_wordcamp_root_blog( $factory );
+		}
+	}
+
+	/**
+	 * Remove the root blog this class provisioned.
+	 */
+	public static function wpTearDownAfterClass() {
+		if ( self::$wordcamp_root_blog_id ) {
+			self::delete_wordcamp_root_blog();
+
+			self::$wordcamp_root_blog_id = null;
+		}
+	}
+
+	/**
+	 * Ticket A/B post IDs and attendee fixtures shared by most tests.
+	 *
+	 * @var array
+	 */
+	protected $fx;
+
+	/**
+	 * Build the standard fixture: two tickets, four published attendees
+	 * (a1 + a2 on ticket A — a1 already attended — a3 on ticket B), plus one
+	 * draft attendee that must never match anything.
+	 */
+	protected function make_fixture() {
+		$ticket_a = self::factory()->post->create( array(
+			'post_type' => 'tix_ticket', 'post_status' => 'publish', 'post_title' => 'General',
+		) );
+		$ticket_b = self::factory()->post->create( array(
+			'post_type' => 'tix_ticket', 'post_status' => 'publish', 'post_title' => 'Contributor Day',
+		) );
+
+		$make_attendee = function ( $ticket_id, $first, $last, $attended = false, $status = 'publish' ) {
+			$id = self::factory()->post->create( array(
+				'post_type'   => 'tix_attendee',
+				'post_status' => $status,
+				'post_title'  => "$first $last",
+			) );
+
+			update_post_meta( $id, 'tix_ticket_id', $ticket_id );
+			update_post_meta( $id, 'tix_first_name', $first );
+			update_post_meta( $id, 'tix_last_name', $last );
+
+			if ( $attended ) {
+				update_post_meta( $id, 'tix_attended', true );
+			}
+
+			return $id;
+		};
+
+		$this->fx = array(
+			'ticket_a' => $ticket_a,
+			'ticket_b' => $ticket_b,
+			'a1'       => $make_attendee( $ticket_a, 'Ada', 'Lovelace', true ),
+			'a2'       => $make_attendee( $ticket_a, 'Grace', 'Hopper' ),
+			'a3'       => $make_attendee( $ticket_b, 'Alan', 'Turing' ),
+			'draft'    => $make_attendee( $ticket_a, 'Drafty', 'McDraft', false, 'draft' ),
+		);
+
+		// Fresh instance AFTER tickets exist (get_tickets() memoizes per instance).
+		return new CampTix_Attendance();
+	}
+
+	/**
+	 * All-tickets filter set (the UI default: every ticket selected).
+	 *
+	 * @param array $overrides
+	 *
+	 * @return array
+	 */
+	protected function filters( array $overrides = array() ) {
+		$defaults = array(
+			'attendance' => 'none',
+			'tickets'    => array( $this->fx['ticket_a'], $this->fx['ticket_b'] ),
+		);
+
+		return array_merge( $defaults, $overrides );
+	}
+
+	/**
+	 * Query matches published attendees only.
+	 */
+	public function test_query_matches_published_attendees_only() {
+		$addon = $this->make_fixture();
+
+		$ids = $addon->query_attendee_ids( $this->filters() );
+
+		$this->assertEqualSets( array( $this->fx['a1'], $this->fx['a2'], $this->fx['a3'] ), $ids );
+		$this->assertNotContains( $this->fx['draft'], $ids );
+	}
+
+	/**
+	 * Query filters by attendance both ways.
+	 */
+	public function test_query_filters_by_attendance_both_ways() {
+		$addon = $this->make_fixture();
+
+		$attending     = $addon->query_attendee_ids( $this->filters( array( 'attendance' => 'attending' ) ) );
+		$not_attending = $addon->query_attendee_ids( $this->filters( array( 'attendance' => 'not-attending' ) ) );
+
+		$this->assertEqualSets( array( $this->fx['a1'] ), $attending );
+		$this->assertEqualSets( array( $this->fx['a2'], $this->fx['a3'] ), $not_attending );
+	}
+
+	/**
+	 * Query filters by ticket and search.
+	 */
+	public function test_query_filters_by_ticket_and_search() {
+		$addon = $this->make_fixture();
+
+		$ticket_b_only = $addon->query_attendee_ids( $this->filters( array( 'tickets' => array( $this->fx['ticket_b'] ) ) ) );
+		$this->assertEqualSets( array( $this->fx['a3'] ), $ticket_b_only );
+
+		$search = $addon->query_attendee_ids( $this->filters(), 'Grace Hopper' );
+		$this->assertEqualSets( array( $this->fx['a2'] ), $search );
+	}
+
+	/**
+	 * Query returns empty when no tickets selected.
+	 */
+	public function test_query_returns_empty_when_no_tickets_selected() {
+		$addon = $this->make_fixture();
+
+		$this->assertSame( array(), $addon->query_attendee_ids( $this->filters( array( 'tickets' => array() ) ) ) );
+	}
+
+	/**
+	 * Query filters do not stack across calls.
+	 */
+	public function test_query_filters_do_not_stack_across_calls() {
+		$addon = $this->make_fixture();
+
+		// A narrow query first; if its posts_clauses closures leaked, the broad
+		// query after it would be wrongly narrowed too.
+		$narrow = $this->filters( array(
+			'attendance' => 'attending',
+			'tickets'    => array( $this->fx['ticket_b'] ),
+		) );
+
+		$addon->query_attendee_ids( $narrow, 'Ada' );
+
+		$broad = $addon->query_attendee_ids( $this->filters() );
+
+		$this->assertCount( 3, $broad );
+	}
+
+	/**
+	 * Bulk dry run counts without writing.
+	 */
+	public function test_bulk_dry_run_counts_without_writing() {
+		$addon = $this->make_fixture();
+
+		$summary = $addon->bulk_set_attendance( $this->filters(), '', true, true );
+
+		$this->assertSame( 3, $summary['matched'] );
+		$this->assertSame( 0, $summary['changed'] );
+		$this->assertSame( '', get_post_meta( $this->fx['a2'], 'tix_attended', true ) );
+	}
+
+	/**
+	 * Bulk marks only the unmarked.
+	 */
+	public function test_bulk_marks_only_the_unmarked() {
+		$addon = $this->make_fixture();
+
+		$summary = $addon->bulk_set_attendance( $this->filters(), '', true );
+
+		// a1 was already attended: matched 3, changed only 2.
+		$this->assertSame( 3, $summary['matched'] );
+		$this->assertSame( 2, $summary['changed'] );
+
+		foreach ( array( 'a1', 'a2', 'a3' ) as $key ) {
+			$this->assertSame( '1', get_post_meta( $this->fx[ $key ], 'tix_attended', true ) );
+		}
+
+		$this->assertSame( '', get_post_meta( $this->fx['draft'], 'tix_attended', true ) );
+	}
+
+	/**
+	 * Bulk is idempotent.
+	 */
+	public function test_bulk_is_idempotent() {
+		$addon = $this->make_fixture();
+
+		$addon->bulk_set_attendance( $this->filters(), '', true );
+		$again = $addon->bulk_set_attendance( $this->filters(), '', true );
+
+		$this->assertSame( 0, $again['changed'] );
+	}
+
+	/**
+	 * Bulk unmarks with same filter semantics.
+	 */
+	public function test_bulk_unmarks_with_same_filter_semantics() {
+		$addon = $this->make_fixture();
+
+		// The undo story: bulk-unmark everyone currently attending on ticket A.
+		$summary = $addon->bulk_set_attendance(
+			$this->filters( array(
+				'attendance' => 'attending', 'tickets' => array( $this->fx['ticket_a'] ),
+			) ),
+			'',
+			false
+		);
+
+		$this->assertSame( 1, $summary['matched'] );
+		$this->assertSame( 1, $summary['changed'] );
+		$this->assertSame( '', get_post_meta( $this->fx['a1'], 'tix_attended', true ) );
+	}
+
+	/**
+	 * Bulk respects search scope.
+	 */
+	public function test_bulk_respects_search_scope() {
+		$addon = $this->make_fixture();
+
+		$summary = $addon->bulk_set_attendance( $this->filters(), 'Turing', true );
+
+		$this->assertSame( 1, $summary['matched'] );
+		$this->assertSame( '1', get_post_meta( $this->fx['a3'], 'tix_attended', true ) );
+		$this->assertSame( '', get_post_meta( $this->fx['a2'], 'tix_attended', true ) );
+	}
+}

--- a/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-attendance.php
+++ b/public_html/wp-content/plugins/camptix-attendance/tests/test-bulk-attendance.php
@@ -244,4 +244,24 @@ class Test_Bulk_Attendance extends WP_UnitTestCase {
 		$this->assertSame( '1', get_post_meta( $this->fx['a3'], 'tix_attended', true ) );
 		$this->assertSame( '', get_post_meta( $this->fx['a2'], 'tix_attended', true ) );
 	}
+
+	/**
+	 * The confirmed write must act on the IDs the count guard already checked.
+	 */
+	public function test_bulk_set_attendance_accepts_precomputed_ids() {
+		$addon = $this->make_fixture();
+
+		$summary = $addon->bulk_set_attendance(
+			$this->filters(),
+			'',
+			true,
+			false,
+			array( $this->fx['a2'] )
+		);
+
+		$this->assertSame( 1, $summary['matched'] );
+		$this->assertSame( 1, $summary['changed'] );
+		$this->assertSame( '1', get_post_meta( $this->fx['a2'], 'tix_attended', true ) );
+		$this->assertSame( '', get_post_meta( $this->fx['a3'], 'tix_attended', true ) );
+	}
 }


### PR DESCRIPTION
Fixes #1950 (bulk check-in and CSV attendance import).

One PR rather than two: the CSV import applies its plan through the same write core the bulk actions use (`set_attendance_for_ids()`), so the import genuinely depends on the bulk work — splitting them would ship a dependency PR that does nothing user-visible on its own.

## What this adds

**1. Bulk mark/unmark in the Attendance UI.** A "Bulk (organizers)" section in the existing filter panel: mark (or unmark) *all attendees matching the current filters*. Dry-run count → confirm modal → write. The volunteer per-tap flow is completely untouched.

**2. "Attendance Import" tab on Tickets → Tools.** Upload a CSV → preview exactly what will change → apply. Round-trips CampTix's own attendee export (`id` + `email` columns; `id` wins), and accepts a one-column scanner email list. An optional `attended` (yes/no) column sets the direction per row; without it, every row marks attended. No CampTix core changes — the Tools screen already dispatches unknown sections via `do_action( 'camptix_menu_tools_' . $section )`.

## Semantics worth reviewing

- **Only `tix_attended` is ever written.** The parser reads the key columns and the attended column; every other CSV column is ignored at parse level. A snapshot test asserts the attendee's post row stays byte-identical (not even `post_modified` moves) and no other meta changes.
- **A "no" row is a direction, not a rollback** — it unmarks pre-marked people too. That's what makes a corrected re-import converge, and it's covered by its own test.
- **Unmatched rows are reported, never silently dropped**; duplicate emails match *all* matching attendees, by design (one person can hold several tickets).
- **Scope flag:** this closes the gap for events that use CampTix but check in elsewhere. Events that don't use CampTix at all have no attendee records to mark and stay "attendance not measured" (see #1946) by design.

## Security posture

| Gate | Why |
|---|---|
| Bulk requires a logged-in user with `manage_attendees` (maps to `manage_options`, i.e. an admin); filterable via `camptix_attendance_bulk_require_cap` | The per-tap UI is deliberately no-login; a *mass* write is a different risk class and gets a real identity |
| `camptix-attendance-bulk` nonce on every bulk POST, dry-run included | Capability alone is insufficient — SameSite=Lax cookies ride along on cross-site top-level GETs |
| Two-phase count guard: the confirmed write carries the count the organizer saw and acts on the same ID list the guard checked (one query per request) | New registrations or a filter change between preview and confirm can't silently widen the write |
| One-time preview token (`hash_equals`) binding each import preview to its Apply; a newer upload invalidates older previews | A stale tab can't apply a plan computed against different data |
| Import row cap: 5,000 (`camptix_attendance_import_max_rows`) | Bounds worst-case write volume per request |
| Audit trail: every change logs per-attendee with the acting user — "… (bulk/import by {login})" | Mass actions must be reconstructable |

**Pre-existing risks, documented and deliberately NOT touched here:** a leaked secret still allows scripted per-tap writes via the nopriv `sync-model` endpoint and attendee-name/Gravatar-hash enumeration via `sync-list`, and the secret travels in query strings. These predate this PR; fixing them means changing the volunteer no-login model — an upstream product decision. The new paths don't widen them (both require login + capability; the import is wp-admin only).

## Implementation notes

- **The on-screen list and the bulk query share one filter helper** (`attach_list_filters()` / `detach_list_filters()`), so the bulk action can only write to the set the organizer is looking at. A characterization test pins list/bulk parity.
- **Closure-leak trap, fixed:** the legacy `_filter_query_*` methods attached `posts_clauses` closures that never detached — any second query in the same request got silently narrowed. They now return their closures and every caller detaches after querying; regression-tested. Anyone extending this addon would have hit this.
- `bulk_set_attendance()` gained a back-compatible fifth `$ids` parameter so the confirmed write acts on the IDs the count guard checked instead of re-querying.
- PHP 8.4's `fgetcsv()` `$escape` deprecation is handled (explicit `''`).

## i18n

New strings are localized (`wordcamporg` domain, matching the file's existing usage). The rest of the Attendance UI templates were already unlocalized; localizing the whole file is offered as a follow-up rather than mixed into this diff.

## Tests

29 tests / 90 assertions in a new `CampTix Attendance` suite wired into the repo harness (bootstrap follows the existing per-plugin pattern; attendee-creating tests use camptix's `CampTix_Root_Blog_Fixture`, per #1879). Coverage: filter parity, both write directions, the count-mismatch guard, dry-run, CSV parsing (BOM, missing key columns, row cap), resolver matching (id-wins, duplicate emails, unmatched reporting), the only-`tix_attended` snapshot, direction-not-rollback, preview-token staleness, nonce/capability rejections, and the audit log actor. Zero new PHPUnit warnings, zero DB-error noise.

## Verified / not verified

- **Verified locally (docker sandbox):** the suite above — `OK (29 tests, 90 assertions)` on PHP 8.4, zero warnings, zero DB-error noise. WPCS clean against the repo ruleset via this repo's own `phpcs-branch.php` gate: 0 errors on the new files and 0 on the changed lines of `attendance.php` / `attendance-ui.php`.
- **Manual desktop + phone pass: not done yet.** I'll follow up on this PR with the click-through notes and screenshots — the bulk flow at 375px and a wp-admin import round-trip on a seeded camp.

