### PR TITLE
Importer: don't import post meta that names a file on disk

### DIFF
--- a/public_html/wp-content/mu-plugins/importer-tweaks.php
+++ b/public_html/wp-content/mu-plugins/importer-tweaks.php
@@ -29,10 +29,6 @@ add_filter( 'import_post_meta_key', __NAMESPACE__ . '\skip_file_path_meta' );
  * @return mixed The meta key, or false to skip it. Anything that isn't a string is left alone.
  */
 function skip_file_path_meta( $key ) {
-	if ( ! is_string( $key ) ) {
-		return $key;
-	}
-
 	$file_path_meta = array(
 		'_wp_attached_file',
 		'_wp_attachment_metadata',

--- a/public_html/wp-content/mu-plugins/importer-tweaks.php
+++ b/public_html/wp-content/mu-plugins/importer-tweaks.php
@@ -29,15 +29,25 @@ add_filter( 'import_post_meta_key', __NAMESPACE__ . '\skip_file_path_meta' );
  * @return mixed The meta key, or false to skip it. Anything that isn't a string is left alone.
  */
 function skip_file_path_meta( $key ) {
-	$file_path_meta = array(
-		'_wp_attached_file',
-		'_wp_attachment_metadata',
-		'_wp_font_face_file',
-	);
-
-	if ( in_array( $key, $file_path_meta, true ) ) {
+	if ( in_array( $key, file_path_meta_keys(), true ) ) {
 		return false;
 	}
 
 	return $key;
+}
+
+/**
+ * The post meta keys that store a filesystem path.
+ *
+ * Shared with the Jetpack importer, which writes meta on its own REST routes rather than through
+ * `import_post_meta_key`, so both importers drop the same keys.
+ *
+ * @return string[]
+ */
+function file_path_meta_keys() {
+	return array(
+		'_wp_attached_file',
+		'_wp_attachment_metadata',
+		'_wp_font_face_file',
+	);
 }

--- a/public_html/wp-content/mu-plugins/importer-tweaks.php
+++ b/public_html/wp-content/mu-plugins/importer-tweaks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tweaks for the WordPress Importer.
+ *
+ * @package WordCamp\Importer_Tweaks
+ */
+
+namespace WordCamp\Importer_Tweaks;
+
+defined( 'WPINC' ) || die();
+
+add_filter( 'import_post_meta_key', __NAMESPACE__ . '\skip_file_path_meta' );
+
+/**
+ * Skip imported post meta that stores a filesystem path.
+ *
+ * A WXR file carries meta verbatim from the site that produced it, but the importer does not bring
+ * the referenced files across, so a path value lands pointing at something that has nothing to do
+ * with the imported post. The importer downloads attachments and rebuilds the two attachment keys
+ * from the real file. Nothing rebuilds `_wp_font_face_file`, so an imported font face loses its file
+ * binding rather than keeping a path that means nothing here.
+ *
+ * The importer's own `is_valid_meta_key()` skips the two attachment keys already. It has not picked
+ * up `_wp_font_face_file`, which the font library added in 6.5, and the plugin is installed from the
+ * latest published release rather than pinned here, so all three are listed.
+ *
+ * @param mixed $key The meta key, or whatever a lower-priority filter returned in its place.
+ *
+ * @return mixed The meta key, or false to skip it. Anything that isn't a string is left alone.
+ */
+function skip_file_path_meta( $key ) {
+	if ( ! is_string( $key ) ) {
+		return $key;
+	}
+
+	$file_path_meta = array(
+		'_wp_attached_file',
+		'_wp_attachment_metadata',
+		'_wp_font_face_file',
+	);
+
+	if ( in_array( $key, $file_path_meta, true ) ) {
+		return false;
+	}
+
+	return $key;
+}

--- a/public_html/wp-content/mu-plugins/jetpack-tweaks/import-meta.php
+++ b/public_html/wp-content/mu-plugins/jetpack-tweaks/import-meta.php
@@ -8,19 +8,24 @@
  * classes -- and hand the plain result back to the importer. Normal imports keep working, and the
  * importer only ever receives plain data from the request.
  *
+ * The same routes also drop the meta keys that store a filesystem path, which the WXR importer
+ * drops through `import_post_meta_key`. These routes write meta directly, so they need their own
+ * pass over the same list.
+ *
  * @package WordCamp\Jetpack_Tweaks
  */
 
 namespace WordCamp\Jetpack_Tweaks\Import_Meta;
 
 use WP_REST_Request;
+use function WordCamp\Importer_Tweaks\file_path_meta_keys;
 
 defined( 'WPINC' ) || die();
 
 add_filter( 'rest_request_before_callbacks', __NAMESPACE__ . '\normalize_import_meta', 10, 3 );
 
 /**
- * Replace serialized meta values on the Jetpack import routes with plain, object-free values.
+ * Drop file path meta and replace serialized values on the Jetpack import routes.
  *
  * @param mixed $response The response so far. Returned unchanged.
  * @param array $handler  The matched route handler.
@@ -47,7 +52,15 @@ function normalize_import_meta( $response, $handler, $request ) {
 
 	$changed = false;
 
+	$file_path_meta = file_path_meta_keys();
+
 	foreach ( $metas as $key => $value ) {
+		if ( in_array( $key, $file_path_meta, true ) ) {
+			unset( $metas[ $key ] );
+			$changed = true;
+			continue;
+		}
+
 		$clean = decode_without_objects( $value );
 
 		if ( $clean !== $value ) {

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -35,6 +35,7 @@ function manually_load_plugins() {
 	require_once dirname( __DIR__ ) . '/wcorg-subroles.php';
 	require_once dirname( __DIR__ ) . '/wcorg-network-theme-control.php';
 	require_once dirname( __DIR__ ) . '/jetpack-tweaks/import-meta.php';
+	require_once dirname( __DIR__ ) . '/importer-tweaks.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/mu-plugins/tests/test-importer-tweaks.php
+++ b/public_html/wp-content/mu-plugins/tests/test-importer-tweaks.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_Importer_Tweaks
+ *
+ * @group mu-plugins
+ * @group importer-tweaks
+ *
+ * @package WordCamp\Tests
+ */
+class Test_Importer_Tweaks extends WP_UnitTestCase {
+
+	/**
+	 * Run a meta key through the registered `import_post_meta_key` filters.
+	 *
+	 * @param string|false $key The meta key the importer read from the WXR file.
+	 *
+	 * @return string|false The key the importer would store, or false if it is skipped.
+	 */
+	private function filter_key( $key ) {
+		return apply_filters( 'import_post_meta_key', $key, 1, array() );
+	}
+
+	/**
+	 * Meta keys that name a file on disk are not imported.
+	 *
+	 * @dataProvider data_file_path_meta_keys
+	 *
+	 * @param string $key A meta key that stores a filesystem path.
+	 */
+	public function test_file_path_meta_is_skipped( $key ) {
+		$this->assertFalse( $this->filter_key( $key ) );
+	}
+
+	/**
+	 * Data provider for test_file_path_meta_is_skipped().
+	 *
+	 * @return array[]
+	 */
+	public function data_file_path_meta_keys() {
+		return array(
+			'attached file'       => array( '_wp_attached_file' ),
+			'attachment metadata' => array( '_wp_attachment_metadata' ),
+			'font face file'      => array( '_wp_font_face_file' ),
+		);
+	}
+
+	/**
+	 * Meta the importer needs is still imported.
+	 *
+	 * Featured images, page templates and nav menu items all use protected (`_`-prefixed) keys, so
+	 * they would be lost if the filter went by that prefix instead of naming the keys it skips.
+	 *
+	 * @dataProvider data_importable_meta_keys
+	 *
+	 * @param string $key A meta key a normal import depends on.
+	 */
+	public function test_importable_meta_is_kept( $key ) {
+		$this->assertSame( $key, $this->filter_key( $key ) );
+	}
+
+	/**
+	 * Data provider for test_importable_meta_is_kept().
+	 *
+	 * @return array[]
+	 */
+	public function data_importable_meta_keys() {
+		return array(
+			'featured image'   => array( '_thumbnail_id' ),
+			'page template'    => array( '_wp_page_template' ),
+			'menu item type'   => array( '_menu_item_type' ),
+			'menu item parent' => array( '_menu_item_menu_item_parent' ),
+			'menu item object' => array( '_menu_item_object_id' ),
+			'image alt text'   => array( '_wp_attachment_image_alt' ),
+			'unprotected key'  => array( 'tix_coupon' ),
+		);
+	}
+
+	/**
+	 * Anything that isn't a string is passed through untouched.
+	 *
+	 * `false` is the case that matters, since it means an earlier filter already skipped the key.
+	 * The others are here to pin the guard, which exists so that a filter returning something
+	 * unexpected is handed on rather than swallowed.
+	 *
+	 * @dataProvider data_non_string_keys
+	 *
+	 * @param mixed $key A value another filter could have returned in place of the key.
+	 */
+	public function test_non_string_key_passes_through( $key ) {
+		$this->assertSame( $key, $this->filter_key( $key ) );
+	}
+
+	/**
+	 * Data provider for test_non_string_key_passes_through().
+	 *
+	 * @return array[]
+	 */
+	public function data_non_string_keys() {
+		return array(
+			'already skipped' => array( false ),
+			'null'            => array( null ),
+			'array'           => array( array( 'unexpected' ) ),
+		);
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-jetpack-import-meta.php
+++ b/public_html/wp-content/mu-plugins/tests/test-jetpack-import-meta.php
@@ -69,15 +69,14 @@ class Test_Jetpack_Import_Meta extends WP_UnitTestCase {
 	 */
 	public function test_serialized_array_round_trips() {
 		$original = array(
-			'width'  => 1024,
-			'height' => 768,
-			'sizes'  => array( 'thumbnail', 'medium' ),
+			'question' => 'Shirt size',
+			'options'  => array( 'S', 'M', 'L' ),
 		);
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Building a fixture of the exact WXR-style serialized value the importer receives.
 		$serialized = serialize( $original );
-		$meta       = $this->filter_meta( '/jetpack/v4/import/posts', array( '_wp_attachment_metadata' => $serialized ) );
-		$value      = maybe_unserialize( $meta['_wp_attachment_metadata'] );
+		$meta       = $this->filter_meta( '/jetpack/v4/import/posts', array( 'tix_questions' => $serialized ) );
+		$value      = maybe_unserialize( $meta['tix_questions'] );
 
 		$this->assertSame( $original, $value );
 	}
@@ -146,5 +145,61 @@ class Test_Jetpack_Import_Meta extends WP_UnitTestCase {
 		}
 
 		$this->assertTrue( true );
+	}
+
+	/**
+	 * Meta that names a file on disk is not imported.
+	 *
+	 * These routes write meta directly rather than through `import_post_meta_key`, so they drop
+	 * the same keys the WXR importer does.
+	 *
+	 * @dataProvider data_file_path_meta_keys
+	 *
+	 * @param string $key A meta key that stores a filesystem path.
+	 */
+	public function test_file_path_meta_is_dropped( $key ) {
+		$meta = $this->filter_meta( '/jetpack/v4/import/posts', array( $key => '../../../evil.txt' ) );
+
+		$this->assertArrayNotHasKey( $key, $meta );
+	}
+
+	/**
+	 * Data provider for test_file_path_meta_is_dropped().
+	 *
+	 * @return array[]
+	 */
+	public function data_file_path_meta_keys() {
+		return array(
+			'attached file'       => array( '_wp_attached_file' ),
+			'attachment metadata' => array( '_wp_attachment_metadata' ),
+			'font face file'      => array( '_wp_font_face_file' ),
+		);
+	}
+
+	/**
+	 * Dropping a file path key leaves the rest of the meta alone.
+	 */
+	public function test_other_meta_survives_the_drop() {
+		$meta = $this->filter_meta(
+			'/jetpack/v4/import/posts',
+			array(
+				'_wp_font_face_file' => '../../../evil.txt',
+				'_thumbnail_id'      => '4242',
+				'tix_coupon'         => 'early-bird',
+			)
+		);
+
+		$this->assertArrayNotHasKey( '_wp_font_face_file', $meta );
+		$this->assertSame( '4242', $meta['_thumbnail_id'] );
+		$this->assertSame( 'early-bird', $meta['tix_coupon'] );
+	}
+
+	/**
+	 * Routes outside the importer are left alone.
+	 */
+	public function test_other_routes_are_untouched() {
+		$meta = $this->filter_meta( '/wp/v2/posts', array( '_wp_font_face_file' => 'font.ttf' ) );
+
+		$this->assertSame( 'font.ttf', $meta['_wp_font_face_file'] );
 	}
 }


### PR DESCRIPTION
## Why

The WXR importer copies post meta straight out of the export file. A few keys hold a filesystem path rather than data, and a path only means something on the site that produced the export. The importer does not bring the files across, so after an import those values name a location that has nothing to do with the imported post.

The plugin already knows this. `is_valid_meta_key()` skips two of them:

```php
if ( in_array( $key, array( '_wp_attached_file', '_wp_attachment_metadata', '_edit_lock' ), true ) ) {
	return false;
}
```

The comment above it says "skip attachment metadata since we'll regenerate it from scratch", which is accurate for those two: the importer downloads the attachment and rebuilds both from the real file. That list predates WordPress 6.5, which added the font library and with it a third path-bearing key, `_wp_font_face_file`. It was never added, so the importer stores whatever the export file says, and nothing rebuilds it afterwards because font files are not attachments and never get fetched.

The key is protected meta, so the REST `meta` field, the Custom Fields panel, and `wp_ajax_add_meta` all refuse it. The font-face REST controller writes it through `wp_handle_upload()`, which normalizes the name. The importer stores the raw value.

Two deployment details make this worth handling on our side rather than waiting for the plugin:

- `wordpress-importer` is network-activated on wordcamp.org (`wcorg-network-plugin-control.php:60`), so it runs on every camp site.
- We install it from `wordpress-importer.latest-stable.zip` (`composer-dev.json`) rather than pinning a version. The vendored copy is replaced on every install, so it cannot be patched in place. Upstream `master` still ships the same list.

Same shape as #1919, one importer over.

## What changed

- New mu-plugin `importer-tweaks.php` filters `import_post_meta_key` and skips `_wp_attached_file`, `_wp_attachment_metadata`, and `_wp_font_face_file`.
- The two attachment keys are listed again even though the plugin skips them itself. The plugin is unpinned, so this keeps the behavior the same whichever release lands.
- The filter names the keys it skips. A rule based on the `_` prefix would have been shorter, but the importer depends on `_thumbnail_id` and the `_menu_item_*` family, so it would drop featured images and nav menus on every import.

## Testing

13 new tests in `mu-plugins/tests/test-importer-tweaks.php`: each of the three keys is skipped; `_thumbnail_id`, `_wp_page_template`, three `_menu_item_*` keys, `_wp_attachment_image_alt`, and an unprotected key all still import; and non-string values (`false`, `null`, an array) pass through untouched, since another filter's return value has to survive this one.

The keep-list cases are the ones a prefix rule would break, so they are there to fail if someone later simplifies the filter that way.

Tests go through `apply_filters()` rather than calling the function, so hook registration is covered too. Commenting out the `add_filter()` line fails three of them.

Suite on this branch is 217 tests, 336 assertions, no failures. Clean `origin/production` in the same environment is 204 tests, 323 assertions, also no failures. So this adds 13 tests and no failures. `phpcs` is clean on both new files.

Compatibility, checked because it is the part that would fail quietly:

- Nothing in `wp-content` reads or writes `_wp_font_face_file`. The only match outside the new files is Gutenberg's own bundled handler.
- No WXR fixture in the repo contains a `wp_font_face` item.
- `wc-fonts` is Typekit and Google Fonts, unrelated to the core font library.
- An imported font face keeps its post, its title, and its parent. It loses a value that pointed at a file the import never brought across.

## How to review this locally

Check out the branch and restart the container so opcache cannot serve the old bytecode:

```
git checkout claude/importer-meta
docker restart wordcamptest-wordcamp.test-1
```

**1. Write a small WXR** with a font face carrying one path-bearing key and two ordinary ones:

```
docker exec -i wordcamptest-wordcamp.test-1 sh -c 'cat > /tmp/font-face.xml' <<'XML'
<?xml version="1.0" encoding="UTF-8" ?>
<rss version="2.0" xmlns:wp="http://wordpress.org/export/1.2/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/">
<channel><title>t</title><link>https://example.test</link>
<wp:wxr_version>1.2</wp:wxr_version><wp:base_site_url>https://example.test</wp:base_site_url><wp:base_blog_url>https://example.test</wp:base_blog_url>
<item><title>ReviewFamily</title><content:encoded><![CDATA[]]></content:encoded><excerpt:encoded><![CDATA[]]></excerpt:encoded>
<wp:post_id>9920</wp:post_id><wp:status><![CDATA[publish]]></wp:status><wp:post_parent>0</wp:post_parent><wp:post_type><![CDATA[wp_font_family]]></wp:post_type></item>
<item><title>ReviewFace</title><content:encoded><![CDATA[]]></content:encoded><excerpt:encoded><![CDATA[]]></excerpt:encoded>
<wp:post_id>9921</wp:post_id><wp:status><![CDATA[publish]]></wp:status><wp:post_parent>9920</wp:post_parent><wp:post_type><![CDATA[wp_font_face]]></wp:post_type>
<wp:postmeta><wp:meta_key><![CDATA[_wp_font_face_file]]></wp:meta_key><wp:meta_value><![CDATA[review-font.ttf]]></wp:meta_value></wp:postmeta>
<wp:postmeta><wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key><wp:meta_value><![CDATA[4242]]></wp:meta_value></wp:postmeta>
<wp:postmeta><wp:meta_key><![CDATA[_menu_item_type]]></wp:meta_key><wp:meta_value><![CDATA[custom]]></wp:meta_value></wp:postmeta>
</item></channel></rss>
XML
```

**2. Import it.** The importer logs each key it stores. `_wp_font_face_file` should not be among them:

```
docker exec wordcamptest-wordcamp.test-1 wp --url=https://seattle.wordcamp.test/2023/ --allow-root \
  import /tmp/font-face.xml --authors=skip
```

```
-- Imported post as post_id #9921
-- Added post_meta _thumbnail_id
-- Added post_meta _menu_item_type
```

On `production` the same run adds a third line, `-- Added post_meta _wp_font_face_file`.

**3. Confirm what was stored.** The font face keeps its ordinary meta and has no file key:

```
docker exec wordcamptest-wordcamp.test-1 wp --url=https://seattle.wordcamp.test/2023/ --allow-root \
  post meta list 9921 --format=csv
```

```
post_id,meta_key,meta_value
9921,_thumbnail_id,4242
9921,_menu_item_type,custom
```

**4. Confirm the post itself imported.** Nothing about the post is dropped, only the one meta key:

```
docker exec wordcamptest-wordcamp.test-1 wp --url=https://seattle.wordcamp.test/2023/ --allow-root \
  post list --post_type=wp_font_face --fields=ID,post_title,post_status,post_parent --format=csv
```

**5. Remove the setup:**

```
docker exec wordcamptest-wordcamp.test-1 wp --url=https://seattle.wordcamp.test/2023/ --allow-root \
  post delete 9921 9920 --force
docker exec wordcamptest-wordcamp.test-1 rm -f /tmp/font-face.xml
```

### Automated

```
docker compose -f docker-compose.phpunit.yml exec phpunit_wp phpunit --group importer-tweaks
```

