### PR TITLE
WordCamp User: Suppress note notifications for system user

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/test-wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/tests/test-wcorg-wordcamp-user.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace WordCamp\WordCampUser\Tests;
+
+use WP_UnitTestCase;
+use function WordCamp\WordCampUser\{
+	get_user_id,
+	protect_user,
+	suppress_note_notifications_for_system_user,
+	USER_LOGIN
+};
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group mu-plugins
+ * @group wordcamp-user
+ */
+class Test_WordCamp_User extends WP_UnitTestCase {
+	protected static $wordcamp_user_id;
+	protected static $admin_user_id;
+	protected static $super_admin_id;
+
+	public static function wpSetUpBeforeClass( $factory ): void {
+		self::$wordcamp_user_id = $factory->user->create(
+			array(
+				'user_login' => USER_LOGIN,
+				'user_email' => 'support@wordcamp.org',
+				'role'       => 'administrator',
+			)
+		);
+
+		self::$admin_user_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		self::$super_admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		grant_super_admin( self::$super_admin_id );
+	}
+
+	/**
+	 * @covers \WordCamp\WordCampUser\protect_user()
+	 */
+	public function test_protect_user_blocks_non_super_admin() {
+		$this->assertSame(
+			array( 'do_not_allow' ),
+			protect_user( array(), 'remove_user', self::$admin_user_id, array( self::$wordcamp_user_id ) )
+		);
+
+		$this->assertSame(
+			array( 'do_not_allow' ),
+			protect_user( array(), 'promote_user', self::$admin_user_id, array( self::$wordcamp_user_id ) )
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\WordCampUser\protect_user()
+	 */
+	public function test_protect_user_allows_super_admin() {
+		$this->assertSame(
+			array( 'remove_users' ),
+			protect_user( array( 'remove_users' ), 'remove_user', self::$super_admin_id, array( self::$wordcamp_user_id ) )
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\WordCampUser\suppress_note_notifications_for_system_user()
+	 */
+	public function test_suppress_note_notifications_for_system_user_post() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$wordcamp_user_id,
+				'post_type'   => 'page',
+			)
+		);
+
+		$note_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'comment_content' => 'Test note on block',
+			)
+		);
+
+		// Notes on posts authored by the system user should have notifications suppressed.
+		$this->assertFalse(
+			suppress_note_notifications_for_system_user( true, $note_id )
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\WordCampUser\suppress_note_notifications_for_system_user()
+	 */
+	public function test_do_not_suppress_note_notifications_for_regular_user_post() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$admin_user_id,
+				'post_type'   => 'page',
+			)
+		);
+
+		$note_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'note',
+				'comment_content' => 'Test note on regular post',
+			)
+		);
+
+		// Notes on posts authored by regular users should not be suppressed.
+		$this->assertTrue(
+			suppress_note_notifications_for_system_user( true, $note_id )
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\WordCampUser\suppress_note_notifications_for_system_user()
+	 */
+	public function test_do_not_suppress_non_note_comments() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$wordcamp_user_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'comment',
+				'comment_content' => 'Regular comment',
+			)
+		);
+
+		// Regular comments should not be modified by this filter.
+		$this->assertTrue(
+			suppress_note_notifications_for_system_user( true, $comment_id )
+		);
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/tests/test-wcorg-wordcamp-user.php
@@ -3,6 +3,7 @@
 namespace WordCamp\WordCampUser\Tests;
 
 use WP_UnitTestCase;
+use WP_UnitTest_Factory;
 use function WordCamp\WordCampUser\{
 	get_user_id,
 	protect_user,
@@ -21,7 +22,14 @@ class Test_WordCamp_User extends WP_UnitTestCase {
 	protected static $admin_user_id;
 	protected static $super_admin_id;
 
-	public static function wpSetUpBeforeClass( $factory ): void {
+	/**
+	 * Setup shared fixtures before any tests are run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Unit test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		parent::wpSetUpBeforeClass( $factory );
+
 		self::$wordcamp_user_id = $factory->user->create(
 			array(
 				'user_login' => USER_LOGIN,
@@ -41,32 +49,74 @@ class Test_WordCamp_User extends WP_UnitTestCase {
 				'role' => 'administrator',
 			)
 		);
-		grant_super_admin( self::$super_admin_id );
+
+		get_user_id( true );
+	}
+
+	/**
+	 * Clean up persistent fixtures after all tests run.
+	 */
+	public static function wpTearDownAfterClass(): void {
+		wp_delete_user( self::$wordcamp_user_id );
+		wp_delete_user( self::$admin_user_id );
+		wp_delete_user( self::$super_admin_id );
+		get_user_id( true );
+
+		parent::wpTearDownAfterClass();
+	}
+
+	/**
+	 * @covers \WordCamp\WordCampUser\get_user_id()
+	 */
+	public function test_get_user_id() {
+		$this->assertSame( self::$wordcamp_user_id, get_user_id() );
 	}
 
 	/**
 	 * @covers \WordCamp\WordCampUser\protect_user()
 	 */
 	public function test_protect_user_blocks_non_super_admin() {
-		$this->assertSame(
-			array( 'do_not_allow' ),
-			protect_user( array(), 'remove_user', self::$admin_user_id, array( self::$wordcamp_user_id ) )
-		);
+		$original_super_admins   = $GLOBALS['super_admins'] ?? null;
+		$GLOBALS['super_admins'] = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$this->assertSame(
-			array( 'do_not_allow' ),
-			protect_user( array(), 'promote_user', self::$admin_user_id, array( self::$wordcamp_user_id ) )
-		);
+		try {
+			$this->assertSame(
+				array( 'do_not_allow' ),
+				protect_user( array(), 'remove_user', self::$admin_user_id, array( self::$wordcamp_user_id ) )
+			);
+
+			$this->assertSame(
+				array( 'do_not_allow' ),
+				protect_user( array(), 'promote_user', self::$admin_user_id, array( self::$wordcamp_user_id ) )
+			);
+		} finally {
+			if ( null === $original_super_admins ) {
+				unset( $GLOBALS['super_admins'] );
+			} else {
+				$GLOBALS['super_admins'] = $original_super_admins; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+		}
 	}
 
 	/**
 	 * @covers \WordCamp\WordCampUser\protect_user()
 	 */
 	public function test_protect_user_allows_super_admin() {
-		$this->assertSame(
-			array( 'remove_users' ),
-			protect_user( array( 'remove_users' ), 'remove_user', self::$super_admin_id, array( self::$wordcamp_user_id ) )
-		);
+		$original_super_admins   = $GLOBALS['super_admins'] ?? null;
+		$GLOBALS['super_admins'] = array( get_userdata( self::$super_admin_id )->user_login ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		try {
+			$this->assertSame(
+				array( 'remove_users' ),
+				protect_user( array( 'remove_users' ), 'remove_user', self::$super_admin_id, array( self::$wordcamp_user_id ) )
+			);
+		} finally {
+			if ( null === $original_super_admins ) {
+				unset( $GLOBALS['super_admins'] );
+			} else {
+				$GLOBALS['super_admins'] = $original_super_admins; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+		}
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
@@ -7,6 +7,8 @@
  * - Prevents non-super-admins from removing the `wordcamp` user from a site or
  *   changing its role there, so changes to it don't cause unintended side
  *   effects across the network.
+ * - Suppresses "Notes" email notifications for posts/pages authored by the system
+ *   user to prevent noise in the shared support inbox.
  *
  * @package WordCamp\WordCampUser
  */
@@ -19,6 +21,7 @@ const USER_LOGIN = 'wordcamp';
 
 add_action( 'wp_initialize_site', __NAMESPACE__ . '\add_to_new_site', 100, 1 );
 add_filter( 'map_meta_cap', __NAMESPACE__ . '\protect_user', 10, 4 );
+add_filter( 'notify_post_author', __NAMESPACE__ . '\suppress_note_notifications_for_system_user', 10, 2 );
 
 
 /**
@@ -88,4 +91,44 @@ function protect_user( $required_caps, $cap, $acting_user, $args ) {
 	}
 
 	return array( 'do_not_allow' );
+}
+
+/**
+ * Suppress "Notes" email notifications for posts/pages authored by the system user.
+ *
+ * When a note is left on a block, WordPress notifies the post author by email. For
+ * auto-generated content authored by the system account (support@wordcamp.org), these
+ * emails land in the shared support inbox without being actionable.
+ *
+ * @param bool $notify     Whether to notify the post author.
+ * @param int  $comment_id The ID of the note/comment.
+ *
+ * @return bool
+ */
+function suppress_note_notifications_for_system_user( $notify, $comment_id ): bool {
+	if ( ! $notify ) {
+		return false;
+	}
+
+	$comment = get_comment( $comment_id );
+	if ( ! $comment || 'note' !== $comment->comment_type ) {
+		return (bool) $notify;
+	}
+
+	$post = get_post( $comment->comment_post_ID );
+	if ( ! $post ) {
+		return (bool) $notify;
+	}
+
+	$system_user_id = get_user_id();
+	if ( $system_user_id && (int) $post->post_author === $system_user_id ) {
+		return false;
+	}
+
+	$author = get_user_by( 'id', (int) $post->post_author );
+	if ( $author && ( USER_LOGIN === $author->user_login || 'support@wordcamp.org' === $author->user_email ) ) {
+		return false;
+	}
+
+	return (bool) $notify;
 }

--- a/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
+++ b/public_html/wp-content/mu-plugins/wcorg-wordcamp-user.php
@@ -29,11 +29,14 @@ add_filter( 'notify_post_author', __NAMESPACE__ . '\suppress_note_notifications_
  *
  * Returns 0 if the user doesn't exist (e.g. on a network where it hasn't been created),
  * so callers can short-circuit without breaking site creation or cap checks.
+ *
+ * @param bool $force Optional. Whether to force-refresh the cached ID. Default false.
+ * @return int User ID, or 0 if user does not exist.
  */
-function get_user_id(): int {
+function get_user_id( bool $force = false ): int {
 	static $user_id = null;
 
-	if ( null === $user_id ) {
+	if ( null === $user_id || 0 === $user_id || $force ) {
 		$user    = get_user_by( 'login', USER_LOGIN );
 		$user_id = $user ? (int) $user->ID : 0;
 	}
@@ -105,9 +108,9 @@ function protect_user( $required_caps, $cap, $acting_user, $args ) {
  *
  * @return bool
  */
-function suppress_note_notifications_for_system_user( $notify, $comment_id ): bool {
-	if ( ! $notify ) {
-		return false;
+function suppress_note_notifications_for_system_user( $notify, $comment_id = 0 ): bool {
+	if ( ! $notify || empty( $comment_id ) ) {
+		return (bool) $notify;
 	}
 
 	$comment = get_comment( $comment_id );


### PR DESCRIPTION
### Summary

Fixes #1759.

When a note is added on a block, WordPress sends an email notification to the post author by default. For auto-generated content authored by the WordCamp.org system user (`support@wordcamp.org`), these notifications land in the shared support inbox without being actionable.

This PR hooks into `notify_post_author` in `mu-plugins/wcorg-wordcamp-user.php` to suppress note notifications when the post or page is authored by the system account.

### Testing Instructions

1. Run the test suite: `phpunit --filter Test_WordCamp_User`.
2. Confirm that `suppress_note_notifications_for_system_user` returns `false` for note comments on posts authored by the system user, and `true` for non-note comments or posts authored by regular users.