### PR TITLE
GatherPress Recurring Events: Switch text domain to wordcamporg and register script translations

### DIFF
--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/editor.js
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/assets/editor.js
@@ -75,15 +75,15 @@
 		const set = ( name, value ) => editPost( { meta: { ...data.meta, [ prefix + name ]: value } } );
 		const frequency = get( 'frequency', '' );
 		const weekdays = get( 'weekdays', [] );
-		const dayLabels = { MO: __( 'Mon', 'gpre' ), TU: __( 'Tue', 'gpre' ), WE: __( 'Wed', 'gpre' ), TH: __( 'Thu', 'gpre' ), FR: __( 'Fri', 'gpre' ), SA: __( 'Sat', 'gpre' ), SU: __( 'Sun', 'gpre' ) };
+		const dayLabels = { MO: __( 'Mon', 'wordcamporg' ), TU: __( 'Tue', 'wordcamporg' ), WE: __( 'Wed', 'wordcamporg' ), TH: __( 'Thu', 'wordcamporg' ), FR: __( 'Fri', 'wordcamporg' ), SA: __( 'Sat', 'wordcamporg' ), SU: __( 'Sun', 'wordcamporg' ) };
 		const dayFullLabels = {
-			MO: __( 'Monday', 'gpre' ),
-			TU: __( 'Tuesday', 'gpre' ),
-			WE: __( 'Wednesday', 'gpre' ),
-			TH: __( 'Thursday', 'gpre' ),
-			FR: __( 'Friday', 'gpre' ),
-			SA: __( 'Saturday', 'gpre' ),
-			SU: __( 'Sunday', 'gpre' ),
+			MO: __( 'Monday', 'wordcamporg' ),
+			TU: __( 'Tuesday', 'wordcamporg' ),
+			WE: __( 'Wednesday', 'wordcamporg' ),
+			TH: __( 'Thursday', 'wordcamporg' ),
+			FR: __( 'Friday', 'wordcamporg' ),
+			SA: __( 'Saturday', 'wordcamporg' ),
+			SU: __( 'Sunday', 'wordcamporg' ),
 		};
 		const weekdayCodes = [ 'SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA' ];
 		const startDate = dateTimeStart ? new Date( dateTimeStart.replace( ' ', 'T' ) ) : null;
@@ -103,28 +103,28 @@
 		};
 
 		const endSeries = ( occurrence ) => {
-			if ( window.confirm( __( 'End the series after this occurrence? Later projected occurrences will be cancelled.', 'gpre' ) ) ) {
+			if ( window.confirm( __( 'End the series after this occurrence? Later projected occurrences will be cancelled.', 'wordcamporg' ) ) ) {
 				wp.apiFetch( { path: '/gpre/v1/series/' + postId + '/' + occurrence.recurrence_id + '/end', method: 'POST' } ).then( () => {
 					setOccurrences( occurrences.map( ( item ) => item.start > occurrence.start ? { ...item, status: 'cancelled' } : item ) );
 				} );
 			}
 		};
 
-		return el( PluginDocumentSettingPanel, { name: 'gpre', title: __( 'Repeating event', 'gpre' ) },
+		return el( PluginDocumentSettingPanel, { name: 'gpre', title: __( 'Repeating event', 'wordcamporg' ) },
 			el( 'div', { style: controlStackStyle },
-			locked && el( Notice, { status: 'info', isDismissible: false }, __( 'The recurrence schedule is locked after publication. Shared event content can still be edited.', 'gpre' ) ),
+			locked && el( Notice, { status: 'info', isDismissible: false }, __( 'The recurrence schedule is locked after publication. Shared event content can still be edited.', 'wordcamporg' ) ),
 			el( SelectControl, {
-				label: __( 'Repeats', 'gpre' ), value: frequency, disabled: locked,
+				label: __( 'Repeats', 'wordcamporg' ), value: frequency, disabled: locked,
 				options: [
-					{ label: __( 'Does not repeat', 'gpre' ), value: '' },
-					{ label: __( 'Weekly', 'gpre' ), value: 'weekly' },
-					{ label: __( 'Monthly', 'gpre' ), value: 'monthly' },
-					{ label: __( 'Yearly', 'gpre' ), value: 'yearly' },
+					{ label: __( 'Does not repeat', 'wordcamporg' ), value: '' },
+					{ label: __( 'Weekly', 'wordcamporg' ), value: 'weekly' },
+					{ label: __( 'Monthly', 'wordcamporg' ), value: 'monthly' },
+					{ label: __( 'Yearly', 'wordcamporg' ), value: 'yearly' },
 				], onChange: ( value ) => set( 'frequency', value ),
 			} ),
-			frequency && el( TextControl, { label: __( 'Repeat every', 'gpre' ), type: 'number', min: 1, value: get( 'interval', 1 ), disabled: locked, onChange: ( value ) => set( 'interval', Math.max( 1, Number( value ) ) ) } ),
-			frequency === 'weekly' && el( 'div', { style: weekdaysStyle, role: 'group', 'aria-label': __( 'Repeat on', 'gpre' ) },
-				el( 'span', { style: sectionLabelStyle }, __( 'Repeat on', 'gpre' ) ),
+			frequency && el( TextControl, { label: __( 'Repeat every', 'wordcamporg' ), type: 'number', min: 1, value: get( 'interval', 1 ), disabled: locked, onChange: ( value ) => set( 'interval', Math.max( 1, Number( value ) ) ) } ),
+			frequency === 'weekly' && el( 'div', { style: weekdaysStyle, role: 'group', 'aria-label': __( 'Repeat on', 'wordcamporg' ) },
+				el( 'span', { style: sectionLabelStyle }, __( 'Repeat on', 'wordcamporg' ) ),
 				// Buttons render the three-letter dayLabels rather than a single-letter
 				// form. Single letters collide under gettext dedup (e.g. "T" for both
 				// Tue and Thu, "S" for Sat and Sun), which blocks translation in
@@ -148,23 +148,23 @@
 				)
 			),
 			startWeekdayMismatch && ! locked && el( Notice, { status: 'warning', isDismissible: false },
-				__( 'The event start date doesn’t fall on a selected repeat day. Publishing will add an extra occurrence on the start date, one day before the weekly pattern begins.', 'gpre' )
+				__( 'The event start date doesn’t fall on a selected repeat day. Publishing will add an extra occurrence on the start date, one day before the weekly pattern begins.', 'wordcamporg' )
 			),
-			frequency === 'monthly' && el( RadioControl, { label: __( 'Monthly pattern', 'gpre' ), selected: get( 'monthly_mode', 'day' ), disabled: locked, options: [ { label: __( 'Day of month', 'gpre' ), value: 'day' }, { label: __( 'Ordinal weekday', 'gpre' ), value: 'weekday' } ], onChange: ( value ) => set( 'monthly_mode', value ) } ),
-			frequency === 'monthly' && get( 'monthly_mode', 'day' ) === 'day' && el( TextControl, { label: __( 'Day', 'gpre' ), type: 'number', min: 1, max: 31, value: get( 'monthly_day', 1 ), disabled: locked, onChange: ( value ) => set( 'monthly_day', Math.min( 31, Math.max( 1, Number( value ) ) ) ) } ),
+			frequency === 'monthly' && el( RadioControl, { label: __( 'Monthly pattern', 'wordcamporg' ), selected: get( 'monthly_mode', 'day' ), disabled: locked, options: [ { label: __( 'Day of month', 'wordcamporg' ), value: 'day' }, { label: __( 'Ordinal weekday', 'wordcamporg' ), value: 'weekday' } ], onChange: ( value ) => set( 'monthly_mode', value ) } ),
+			frequency === 'monthly' && get( 'monthly_mode', 'day' ) === 'day' && el( TextControl, { label: __( 'Day', 'wordcamporg' ), type: 'number', min: 1, max: 31, value: get( 'monthly_day', 1 ), disabled: locked, onChange: ( value ) => set( 'monthly_day', Math.min( 31, Math.max( 1, Number( value ) ) ) ) } ),
 			frequency === 'monthly' && get( 'monthly_mode', 'day' ) === 'weekday' && el( wp.element.Fragment, {},
-				el( SelectControl, { label: __( 'Order', 'gpre' ), value: get( 'monthly_order', 'first' ), disabled: locked, options: [ 'first', 'second', 'third', 'fourth', 'last' ].map( ( value ) => ( { label: value, value } ) ), onChange: ( value ) => set( 'monthly_order', value ) } ),
-				el( SelectControl, { label: __( 'Weekday', 'gpre' ), value: get( 'monthly_weekday', 'MO' ), disabled: locked, options: Object.keys( dayLabels ).map( ( value ) => ( { label: dayLabels[ value ], value } ) ), onChange: ( value ) => set( 'monthly_weekday', value ) } )
+				el( SelectControl, { label: __( 'Order', 'wordcamporg' ), value: get( 'monthly_order', 'first' ), disabled: locked, options: [ 'first', 'second', 'third', 'fourth', 'last' ].map( ( value ) => ( { label: value, value } ) ), onChange: ( value ) => set( 'monthly_order', value ) } ),
+				el( SelectControl, { label: __( 'Weekday', 'wordcamporg' ), value: get( 'monthly_weekday', 'MO' ), disabled: locked, options: Object.keys( dayLabels ).map( ( value ) => ( { label: dayLabels[ value ], value } ) ), onChange: ( value ) => set( 'monthly_weekday', value ) } )
 			),
-			frequency && el( RadioControl, { label: __( 'Ends', 'gpre' ), selected: get( 'end_type', 'never' ), disabled: locked, options: [ { label: __( 'Never', 'gpre' ), value: 'never' }, { label: __( 'On date', 'gpre' ), value: 'until' }, { label: __( 'After occurrences', 'gpre' ), value: 'count' } ], onChange: ( value ) => set( 'end_type', value ) } ),
+			frequency && el( RadioControl, { label: __( 'Ends', 'wordcamporg' ), selected: get( 'end_type', 'never' ), disabled: locked, options: [ { label: __( 'Never', 'wordcamporg' ), value: 'never' }, { label: __( 'On date', 'wordcamporg' ), value: 'until' }, { label: __( 'After occurrences', 'wordcamporg' ), value: 'count' } ], onChange: ( value ) => set( 'end_type', value ) } ),
 			frequency && ! locked && get( 'end_type', 'never' ) === 'until' && el( DatePicker, { currentDate: get( 'until', '' ) || undefined, onChange: ( value ) => set( 'until', value.slice( 0, 10 ) ) } ),
-			frequency && get( 'end_type', 'never' ) === 'count' && el( TextControl, { label: __( 'Occurrences', 'gpre' ), type: 'number', min: 1, value: get( 'count', 12 ), disabled: locked, onChange: ( value ) => set( 'count', Math.max( 1, Number( value ) ) ) } ),
+			frequency && get( 'end_type', 'never' ) === 'count' && el( TextControl, { label: __( 'Occurrences', 'wordcamporg' ), type: 'number', min: 1, value: get( 'count', 12 ), disabled: locked, onChange: ( value ) => set( 'count', Math.max( 1, Number( value ) ) ) } ),
 			locked && frequency && el( 'div', { className: 'gpre-editor-occurrences' },
-				el( 'h3', {}, __( 'Upcoming occurrences', 'gpre' ) ),
+				el( 'h3', {}, __( 'Upcoming occurrences', 'wordcamporg' ) ),
 				occurrences.slice( 0, 12 ).map( ( occurrence ) => el( 'div', { key: occurrence.recurrence_id, style: { marginBottom: '12px' } },
-					el( 'div', {}, new Date( occurrence.start ).toLocaleString(), occurrence.status === 'cancelled' ? ' — ' + __( 'Cancelled', 'gpre' ) : '' ),
-					el( wp.components.Button, { variant: 'secondary', size: 'small', onClick: () => changeStatus( occurrence, occurrence.status === 'cancelled' ? 'scheduled' : 'cancelled' ) }, occurrence.status === 'cancelled' ? __( 'Restore', 'gpre' ) : __( 'Cancel', 'gpre' ) ),
-					occurrence.status !== 'cancelled' && el( wp.components.Button, { variant: 'tertiary', size: 'small', onClick: () => endSeries( occurrence ) }, __( 'End series here', 'gpre' ) )
+					el( 'div', {}, new Date( occurrence.start ).toLocaleString(), occurrence.status === 'cancelled' ? ' — ' + __( 'Cancelled', 'wordcamporg' ) : '' ),
+					el( wp.components.Button, { variant: 'secondary', size: 'small', onClick: () => changeStatus( occurrence, occurrence.status === 'cancelled' ? 'scheduled' : 'cancelled' ) }, occurrence.status === 'cancelled' ? __( 'Restore', 'wordcamporg' ) : __( 'Cancel', 'wordcamporg' ) ),
+					occurrence.status !== 'cancelled' && el( wp.components.Button, { variant: 'tertiary', size: 'small', onClick: () => endSeries( occurrence ) }, __( 'End series here', 'wordcamporg' ) )
 				) )
 			)
 			)

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-admin.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-admin.php
@@ -106,5 +106,6 @@ final class Admin {
 			(string) filemtime( DIR . '/assets/editor.js' ),
 			true
 		);
+		wp_set_script_translations( 'gpre-editor', 'wordcamporg' );
 	}
 }

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-comments.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-comments.php
@@ -109,7 +109,7 @@ final class Comments {
 		if ( $requested ) {
 			$occurrence = Occurrences::get( $post_id, $requested );
 			if ( ! $occurrence ) {
-				wp_die( esc_html__( 'Invalid event occurrence.', 'gpre' ), '', 400 );
+				wp_die( esc_html__( 'Invalid event occurrence.', 'wordcamporg' ), '', 400 );
 			}
 			Context::set( $occurrence );
 		}

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-context.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-context.php
@@ -197,7 +197,7 @@ final class Context {
 			$date     = new DateTimeImmutable( $occurrence->datetime_start, $timezone );
 			$label    = wp_date( 'M j @ g:i A T', $date->getTimestamp(), $timezone );
 			if ( 'cancelled' === $occurrence->status ) {
-				$label .= ' — ' . __( 'Cancelled', 'gpre' );
+				$label .= ' — ' . __( 'Cancelled', 'wordcamporg' );
 			}
 
 			$items .= sprintf(
@@ -211,9 +211,9 @@ final class Context {
 
 		$notice = '';
 		if ( 'cancelled' === self::$occurrence->status ) {
-			$notice = '<p class="gpre-cancelled-notice" role="status">' . esc_html__( 'This occurrence has been cancelled.', 'gpre' ) . '</p>';
+			$notice = '<p class="gpre-cancelled-notice" role="status">' . esc_html__( 'This occurrence has been cancelled.', 'wordcamporg' ) . '</p>';
 		} elseif ( self::$occurrence->datetime_end_gmt < current_time( 'mysql', true ) ) {
-			$notice = '<p class="gpre-series-ended" role="status">' . esc_html__( 'This event series has ended.', 'gpre' ) . '</p>';
+			$notice = '<p class="gpre-series-ended" role="status">' . esc_html__( 'This event series has ended.', 'wordcamporg' ) . '</p>';
 		}
 
 		return sprintf(
@@ -224,10 +224,10 @@ final class Context {
 			'<button class="gpre-occurrence-selector__control is-next" type="button" aria-label="%4$s">' .
 			'<span aria-hidden="true">›</span></button>' .
 			'</nav>%5$s',
-			esc_attr__( 'Event dates', 'gpre' ),
-			esc_attr__( 'Previous event dates', 'gpre' ),
+			esc_attr__( 'Event dates', 'wordcamporg' ),
+			esc_attr__( 'Previous event dates', 'wordcamporg' ),
 			$items,
-			esc_attr__( 'Next event dates', 'gpre' ),
+			esc_attr__( 'Next event dates', 'wordcamporg' ),
 			$notice
 		);
 	}
@@ -244,7 +244,7 @@ final class Context {
 		}
 
 		if ( 'cancelled' === self::$occurrence->status ) {
-			return '<p class="gpre-rsvp-closed">' . esc_html__( 'RSVP is closed for this cancelled occurrence.', 'gpre' ) . '</p>';
+			return '<p class="gpre-rsvp-closed">' . esc_html__( 'RSVP is closed for this cancelled occurrence.', 'wordcamporg' ) . '</p>';
 		}
 
 		$tag = new WP_HTML_Tag_Processor( $content );

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/plugin.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/plugin.php
@@ -5,7 +5,7 @@
  * Version: 0.1.0
  * Requires PHP: 8.1
  * Requires Plugins: gatherpress
- * Text Domain: gpre
+ * Text Domain: wordcamporg
  *
  * @package WordPressdotorg\GatherPress_Recurring_Events
  */


### PR DESCRIPTION
### Summary

Fixes #1898.

The `gatherpress-recurring-events` mu-plugin declared `Text Domain: gpre`, but the network infrastructure uses `wordcamporg` as the single shared text domain for custom plugins/themes (connected to the GlotPress `meta/wordcamp` project).

Additionally, `gpre-editor` was missing `wp_set_script_translations()` registration, preventing localized strings in `editor.js` from loading.

### Changes

- Updated `Text Domain: wordcamporg` in `plugin.php`.
- Updated all gettext calls in PHP (`class-comments.php`, `class-context.php`) and JS (`editor.js`) to use `wordcamporg`.
- Added `wp_set_script_translations( 'gpre-editor', 'wordcamporg' )` in `Admin::enqueue()`.

### Testing Instructions

1. Verify `gatherpress-recurring-events` PHP files have no syntax errors.
2. In the event editor with non-English locale, verify that `gpre-editor` script translations are registered and load under the `wordcamporg` domain.