### PR TITLE
Blocks: Fix text domain in block patterns registration

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/patterns.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns.php
@@ -60,7 +60,7 @@ function register_patterns() {
 						esc_html(
 							sprintf(
 								/* translators: %s: file name. */
-								__( 'Could not register file "%s" as a block pattern ("Slug" field missing)', 'wordcamp' ),
+								__( 'Could not register file "%s" as a block pattern ("Slug" field missing)', 'wordcamporg' ),
 								$file
 							)
 						),
@@ -75,7 +75,7 @@ function register_patterns() {
 						esc_html(
 							sprintf(
 								/* translators: %1s: file name; %2s: slug value found. */
-								__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")', 'wordcamp' ),
+								__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")', 'wordcamporg' ),
 								$file,
 								$pattern_data['slug']
 							)
@@ -95,7 +95,7 @@ function register_patterns() {
 						esc_html(
 							sprintf(
 								/* translators: %1s: file name; %2s: slug value found. */
-								__( 'Could not register file "%s" as a block pattern ("Title" field missing)', 'wordcamp' ),
+								__( 'Could not register file "%s" as a block pattern ("Title" field missing)', 'wordcamporg' ),
 								$file
 							)
 						),
@@ -141,10 +141,10 @@ function register_patterns() {
 				}
 
 				//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
-				$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', 'wordcamp' );
+				$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', 'wordcamporg' );
 				if ( ! empty( $pattern_data['description'] ) ) {
 					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
-					$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'wordcamp' );
+					$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'wordcamporg' );
 				}
 
 				// The actual pattern content is the output of the file.


### PR DESCRIPTION
### Summary

Fixes #1927.

In `mu-plugins/blocks/patterns.php`, strings were registered under the text domain `wordcamp` instead of the canonical `wordcamporg` text domain loaded across the network and used by the meta/wordcamp GlotPress project.

### Changes

- Replaced `wordcamp` with `wordcamporg` in gettext and `translate_with_gettext_context()` calls in `mu-plugins/blocks/patterns.php`.

### Testing Instructions

1. Ensure `patterns.php` passes syntax checks.
2. Verify block patterns in WordCamp sites load and translate titles/descriptions under the `wordcamporg` domain.