### PR TITLE
Blocks: Fix text domain in speaker pattern content files

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-basic.php
@@ -17,7 +17,7 @@
 <!-- wp:column {"verticalAlignment":"center","width":"66.66%"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.66%"><!-- wp:post-title {"textAlign":"left","isLink":true,"fontSize":"x-large"} /-->
 
-<!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamp' ); ?>"} /--></div>
+<!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamporg' ); ?>"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 <!-- /wp:post-template --></div>

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-centered.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-grid-centered.php
@@ -14,7 +14,7 @@
 <!-- wp:post-title {"textAlign":"center","isLink":true,"fontSize":"x-large"} /-->
 
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamp' ); ?>"} /--></div>
+<div class="wp-block-group"><!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamporg' ); ?>"} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-basic.php
+++ b/public_html/wp-content/mu-plugins/blocks/patterns/speaker-list-basic.php
@@ -14,7 +14,7 @@
 <!-- wp:post-title {"textAlign":"center"} /-->
 
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamp' ); ?>"} /--></div>
+<div class="wp-block-group"><!-- wp:read-more {"content":"<?php esc_attr_e( 'Read More', 'wordcamporg' ); ?>"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:spacer {"height":"50px"} -->


### PR DESCRIPTION
Follows up #1962, which replaced the wordcamp text domain with wordcamporg in the pattern registration code. Three pattern content files carry the same wrong domain in their Read More labels. Pattern files execute through ob_start() and are included by patterns.php, so these calls run at registration and the label can never translate: only the wordcamporg domain has a loaded mo file, and no wp.org plugin named wordcamp exists for just in time loading to find.

Same class of change as #1962, three files, three lines.

Fixes the first point of #1964. See #1927 for the original audit; the remaining Groups domains question stays in #1964.