### PR TITLE
Budget: resolve the map_meta_cap subject from the check's arguments

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/bootstrap.php
@@ -28,6 +28,10 @@ function manually_load_plugin() {
 	// budget CPTs.
 	$GLOBALS['wcp_payment_request'] = new \WCP_Payment_Request();
 
+	// The shared `wcb-*` statuses are registered by `WordCamp_Budgets`' constructor, which the plugin only
+	// instantiates in the admin. Register them on their own so posts can be stored at those statuses.
+	add_action( 'init', array( '\WordCamp_Budgets', 'register_post_statuses' ) );
+
 	require_once dirname( __DIR__ )  . '/includes/payment-requests-dashboard.php';
 	require_once dirname( __DIR__ )  . '/includes/wordcamp-budgets-dashboard.php';
 }

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-map-meta-cap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-map-meta-cap.php
@@ -83,30 +83,34 @@ class Test_Map_Meta_Cap extends WP_UnitTestCase {
 
 		unset( $GLOBALS['post'] );
 
-		remove_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10 );
-		remove_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10 );
-		remove_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10 );
-
-		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status', 10 );
-		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10 );
-		remove_filter( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ), 10 );
+		foreach ( $this->save_handlers() as $handler ) {
+			remove_filter( $handler[0], $handler[1], 10 );
+		}
 	}
 
 	/**
-	 * Re-attach the handlers detached in `set_up()`.
+	 * `WP_UnitTestCase` restores `$wp_filter`, so the handlers detached in `set_up()` re-attach themselves.
 	 */
 	public function tear_down() {
-		add_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10, 2 );
-		add_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10, 2 );
-		add_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10, 2 );
-
-		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status', 10, 2 );
-		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10, 2 );
-		add_filter( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ), 10, 2 );
-
 		unset( $GLOBALS['post'] );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * The save handlers that run as a budget CPT is stored, as `array( $hook, $callback )` pairs.
+	 *
+	 * @return array
+	 */
+	protected function save_handlers() {
+		return array(
+			array( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request' ),
+			array( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice' ),
+			array( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ) ),
+			array( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status' ),
+			array( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status' ),
+			array( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ) ),
+		);
 	}
 
 	/**
@@ -323,6 +327,25 @@ class Test_Map_Meta_Cap extends WP_UnitTestCase {
 		$this->assertFalse( current_user_can( 'edit_post', 'not-a-post-id' ) );
 		$this->assertFalse( current_user_can( 'delete_post', 'not-a-post-id' ) );
 		$this->assertFalse( current_user_can( 'edit_post', PHP_INT_MAX ) );
+	}
+
+	/**
+	 * An ID carrying trailing characters names no post, matching what `get_post()` resolves it to.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_id_with_trailing_characters_names_no_post( $post_type ) {
+		$request = $this->create_non_draft( $post_type );
+
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertNull( get_post( $request . 'abc' ) );
+		$this->assertNull( WordCamp_Budgets::get_map_meta_cap_post( array( $request . 'abc' ) ) );
+
+		$this->assertFalse( current_user_can( 'edit_post', $request . 'abc' ) );
+		$this->assertFalse( current_user_can( 'delete_post', $request . 'abc' ) );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-map-meta-cap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-map-meta-cap.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace WordCamp\Budgets_Dashboard\Tests;
+
+use WP_UnitTestCase;
+use WordCamp_Budgets;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Who may edit and delete a budget CPT record once it's left draft.
+ *
+ * Each of the three budget CPTs adds `manage_network` to the capabilities required for `edit_post` and
+ * `delete_post` once a record is past draft, so that requests queued for payout are only changed by network
+ * admins. All three resolve the record they're deciding about through
+ * `WordCamp_Budgets::get_map_meta_cap_post()`, so these assert the outcome for every form a post can arrive
+ * in -- an int ID, a numeric string ID (what Core's `wp_ajax_upload_attachment()` passes), and a `WP_Post`
+ * -- and regardless of what the global `$post` is set to at the time.
+ *
+ * @group budgets-dashboard
+ */
+class Test_Map_Meta_Cap extends WP_UnitTestCase {
+	/**
+	 * The organizer who filed the request. Not a network admin.
+	 *
+	 * @var int
+	 */
+	protected static $requester_id;
+
+	/**
+	 * Another organizer on the same site, holding `edit_others_posts` and `delete_others_posts` but not
+	 * `manage_network`.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * A network administrator: may edit and delete requests at any status.
+	 *
+	 * @var int
+	 */
+	protected static $network_admin_id;
+
+	/**
+	 * The budget CPTs, and a post status for each that's past draft.
+	 *
+	 * @var array
+	 */
+	const NON_DRAFT_STATUSES = array(
+		'wcb_reimbursement'   => 'wcb-approved',
+		'wcp_payment_request' => 'wcb-approved',
+		'wcb_sponsor_invoice' => 'wcbsi_submitted',
+	);
+
+	/**
+	 * Create the shared users.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$requester_id     = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$editor_id        = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$network_admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		grant_super_admin( self::$network_admin_id );
+	}
+
+	/**
+	 * Put the request into the shape the `map_meta_cap` callbacks read it in.
+	 *
+	 * They treat any `action` other than `edit` as saving rather than as opening the edit screen, so
+	 * `editpost` is what makes them evaluate the `edit_post` rule at all. The `save_post` and
+	 * `wp_insert_post_data` handlers are detached so the fixtures below can be stored at an arbitrary status
+	 * without running the nonce checks and status rules that other tests cover, and restored in
+	 * `tear_down()` so other suites are unaffected.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$_POST    = array();
+		$_REQUEST = array( 'action' => 'editpost' );
+
+		unset( $GLOBALS['post'] );
+
+		remove_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10 );
+		remove_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10 );
+		remove_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10 );
+
+		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status', 10 );
+		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10 );
+		remove_filter( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ), 10 );
+	}
+
+	/**
+	 * Re-attach the handlers detached in `set_up()`.
+	 */
+	public function tear_down() {
+		add_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10, 2 );
+		add_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10, 2 );
+		add_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10, 2 );
+
+		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status', 10, 2 );
+		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10, 2 );
+		add_filter( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ), 10, 2 );
+
+		unset( $GLOBALS['post'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a stored request of the given CPT, authored by the requester, at a status past draft.
+	 *
+	 * @param string $post_type
+	 *
+	 * @return int
+	 */
+	protected function create_non_draft( $post_type ) {
+		return self::factory()->post->create( array(
+			'post_type'   => $post_type,
+			'post_status' => self::NON_DRAFT_STATUSES[ $post_type ],
+			'post_author' => self::$requester_id,
+		) );
+	}
+
+	/**
+	 * The forms a post can reach a `map_meta_cap` callback in.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return array Label => value.
+	 */
+	protected function argument_forms( $post_id ) {
+		return array(
+			'int ID'    => $post_id,
+			'string ID' => (string) $post_id,
+			'WP_Post'   => get_post( $post_id ),
+		);
+	}
+
+	/**
+	 * Set the global `$post`, which several of these assert isn't consulted.
+	 *
+	 * @param int $post_id
+	 */
+	protected function set_global_post( $post_id ) {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- this is the state under test.
+		$GLOBALS['post'] = get_post( $post_id );
+	}
+
+	/**
+	 * Each budget CPT, as a data provider.
+	 *
+	 * @return array
+	 */
+	public function data_budget_post_types() {
+		return array(
+			'reimbursement request' => array( 'wcb_reimbursement' ),
+			'vendor payment'        => array( 'wcp_payment_request' ),
+			'sponsor invoice'       => array( 'wcb_sponsor_invoice' ),
+		);
+	}
+
+	/**
+	 * An editor can't edit another organizer's request once it's past draft, however the post reaches the
+	 * capability check.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_editor_cannot_edit_non_draft_request( $post_type ) {
+		$request = $this->create_non_draft( $post_type );
+
+		wp_set_current_user( self::$editor_id );
+
+		foreach ( $this->argument_forms( $request ) as $label => $argument ) {
+			$this->assertFalse(
+				current_user_can( 'edit_post', $argument ),
+				"An editor was allowed to edit a non-draft $post_type passed as a $label."
+			);
+		}
+	}
+
+	/**
+	 * The same, for deleting.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_editor_cannot_delete_non_draft_request( $post_type ) {
+		$request = $this->create_non_draft( $post_type );
+
+		wp_set_current_user( self::$editor_id );
+
+		foreach ( $this->argument_forms( $request ) as $label => $argument ) {
+			$this->assertFalse(
+				current_user_can( 'delete_post', $argument ),
+				"An editor was allowed to delete a non-draft $post_type passed as a $label."
+			);
+		}
+	}
+
+	/**
+	 * The outcome is decided from the post the check names, not from whatever the global `$post` is.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_unrelated_global_post_is_not_consulted( $post_type ) {
+		$request = $this->create_non_draft( $post_type );
+
+		$this->set_global_post( self::factory()->post->create( array(
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_author' => self::$editor_id,
+		) ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		foreach ( $this->argument_forms( $request ) as $label => $argument ) {
+			$this->assertFalse(
+				current_user_can( 'edit_post', $argument ),
+				"An unrelated global \$post let an editor edit a non-draft $post_type passed as a $label."
+			);
+
+			$this->assertFalse(
+				current_user_can( 'delete_post', $argument ),
+				"An unrelated global \$post let an editor delete a non-draft $post_type passed as a $label."
+			);
+		}
+	}
+
+	/**
+	 * Conversely, a budget record in the global `$post` doesn't affect checks about a different post.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_global_budget_post_does_not_affect_an_unrelated_post( $post_type ) {
+		$this->set_global_post( $this->create_non_draft( $post_type ) );
+
+		$blog_post = self::factory()->post->create( array(
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_author' => self::$editor_id,
+		) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertTrue( current_user_can( 'edit_post', $blog_post ) );
+		$this->assertTrue( current_user_can( 'edit_post', (string) $blog_post ) );
+	}
+
+	/**
+	 * A network admin can still edit and delete a request past draft -- `manage_network` is what's required,
+	 * not a blanket denial.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_network_admin_can_edit_and_delete_non_draft_request( $post_type ) {
+		$request = $this->create_non_draft( $post_type );
+
+		wp_set_current_user( self::$network_admin_id );
+
+		foreach ( $this->argument_forms( $request ) as $label => $argument ) {
+			$this->assertTrue(
+				current_user_can( 'edit_post', $argument ),
+				"A network admin was refused editing a non-draft $post_type passed as a $label."
+			);
+
+			$this->assertTrue(
+				current_user_can( 'delete_post', $argument ),
+				"A network admin was refused deleting a non-draft $post_type passed as a $label."
+			);
+		}
+	}
+
+	/**
+	 * A request that's still a draft isn't restricted, so organizers can keep working on their own.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_draft_request_is_not_restricted( $post_type ) {
+		$draft = self::factory()->post->create( array(
+			'post_type'   => $post_type,
+			'post_status' => 'draft',
+			'post_author' => self::$requester_id,
+		) );
+
+		wp_set_current_user( self::$requester_id );
+
+		foreach ( $this->argument_forms( $draft ) as $label => $argument ) {
+			$this->assertTrue(
+				current_user_can( 'edit_post', $argument ),
+				"An organizer was refused editing their own draft $post_type passed as a $label."
+			);
+		}
+	}
+
+	/**
+	 * An argument that doesn't name a post is refused.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_unresolvable_post_is_refused( $post_type ) {
+		// A restricted record in the global $post, to confirm it isn't consulted for an argument that names
+		// some other post.
+		$this->set_global_post( $this->create_non_draft( $post_type ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertFalse( current_user_can( 'edit_post', 'not-a-post-id' ) );
+		$this->assertFalse( current_user_can( 'delete_post', 'not-a-post-id' ) );
+		$this->assertFalse( current_user_can( 'edit_post', PHP_INT_MAX ) );
+	}
+
+	/**
+	 * The helper resolves every form of the argument, and prefers it over the global `$post`.
+	 */
+	public function test_get_map_meta_cap_post_resolves_every_argument_form() {
+		$request    = $this->create_non_draft( 'wcp_payment_request' );
+		$other_post = self::factory()->post->create( array( 'post_type' => 'post' ) );
+
+		$this->set_global_post( $other_post );
+
+		$this->assertSame( $request, WordCamp_Budgets::get_map_meta_cap_post( array( $request ) )->ID );
+		$this->assertSame( $request, WordCamp_Budgets::get_map_meta_cap_post( array( (string) $request ) )->ID );
+		$this->assertSame( $request, WordCamp_Budgets::get_map_meta_cap_post( array( get_post( $request ) ) )->ID );
+
+		// No argument, so the global is the only thing left to go on.
+		$this->assertSame( $other_post, WordCamp_Budgets::get_map_meta_cap_post( array() )->ID );
+
+		// An argument that names nothing resolvable doesn't fall back to the global.
+		$this->assertNull( WordCamp_Budgets::get_map_meta_cap_post( array( 'not-a-post-id' ) ) );
+		$this->assertNull( WordCamp_Budgets::get_map_meta_cap_post( array( PHP_INT_MAX ) ) );
+	}
+
+	/**
+	 * The helper doesn't create a global `$post` when there isn't one, since that would leak into whatever
+	 * ran the capability check.
+	 */
+	public function test_get_map_meta_cap_post_does_not_create_a_global_post() {
+		$request = $this->create_non_draft( 'wcp_payment_request' );
+
+		WordCamp_Budgets::get_map_meta_cap_post( array( $request ) );
+		$this->assertArrayNotHasKey( 'post', $GLOBALS );
+
+		WordCamp_Budgets::get_map_meta_cap_post( array() );
+		$this->assertArrayNotHasKey( 'post', $GLOBALS );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -980,6 +980,12 @@ Thanks for helping us with these details!",
 	 */
 	public function modify_capabilities( $required_capabilities, $requested_capability, $user_id, $args ) {
 		// todo maybe centralize this, since almost identical to counterparts in other modules
+
+		// `map_meta_cap` runs for every capability check, so skip the post lookup for the ones this ignores.
+		if ( ! in_array( $requested_capability, array( 'edit_post', 'delete_post' ), true ) ) {
+			return $required_capabilities;
+		}
+
 		$post = \WordCamp_Budgets::get_map_meta_cap_post( $args );
 
 		if ( is_a( $post, 'WP_Post' ) && self::POST_TYPE == $post->post_type ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -915,6 +915,11 @@ function notify_organizer_request_updated( $new_status, $old_status, $request ) 
  * @param array  $args                  Adds the context to the cap. Typically the object ID.
  */
 function modify_capabilities( $required_capabilities, $requested_capability, $user_id, $args ) {
+	// `map_meta_cap` runs for every capability check, so skip the post lookup for the ones this ignores.
+	if ( ! in_array( $requested_capability, array( 'edit_post', 'draft_post', 'delete_post' ), true ) ) {
+		return $required_capabilities;
+	}
+
 	$post = \WordCamp_Budgets::get_map_meta_cap_post( $args );
 
 	if ( ! is_a( $post, 'WP_Post' ) || POST_TYPE !== $post->post_type ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -682,6 +682,12 @@ function action_success_message() {
  */
 function modify_capabilities( $required_capabilities, $requested_capability, $user_id, $args ) {
 	// todo maybe centralize this, since almost identical to counterpart in payment-requests.php.
+
+	// `map_meta_cap` runs for every capability check, so skip the post lookup for the ones this ignores.
+	if ( ! in_array( $requested_capability, array( 'edit_post', 'delete_post' ), true ) ) {
+		return $required_capabilities;
+	}
+
 	$post = \WordCamp_Budgets::get_map_meta_cap_post( $args );
 
 	if ( is_a( $post, 'WP_Post' ) && POST_TYPE === $post->post_type ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -872,8 +872,9 @@ class WordCamp_Budgets {
 
 			/*
 			 * $args[0] is whatever was passed to `current_user_can()`, so an ID can arrive as an int or as a
-			 * string -- `wp_ajax_upload_attachment()`, for example, passes `$_REQUEST['post_id']` as-is. Cast
-			 * and look it up the way Core's `map_meta_cap()` does, so both resolve the same post.
+			 * string -- `wp_ajax_upload_attachment()`, for example, passes `$_REQUEST['post_id']` as-is. The
+			 * numeric check and the cast mirror `get_post()`'s own contract, so this resolves the post Core's
+			 * `map_meta_cap()` resolves, and resolves nothing where Core resolves nothing.
 			 */
 			return is_numeric( $args[0] ) ? get_post( (int) $args[0] ) : null;
 		}

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -854,16 +854,29 @@ class WordCamp_Budgets {
 	}
 
 	/**
-	 * Get the current post when inside a `map_meta_cap` callback
+	 * Get the post that a `map_meta_cap` callback is being asked about
 	 *
-	 * Normally it's just the global $post, but sometimes you have to dig it out of $args (e.g., a bulk edit)
+	 * That's the object named in $args. The global $post is only a fallback for checks that don't name one,
+	 * because it's often a different post -- e.g., during a bulk edit, or while a list table builds the row
+	 * actions for a post other than the one in the loop.
 	 *
-	 * @param array $args The $args that was passed to the `map_meta_cap` callback
+	 * @param array $args The $args that was passed to the `map_meta_cap` callback.
 	 *
 	 * @return WP_Post|null
 	 */
 	public static function get_map_meta_cap_post( $args ) {
-		$post = null;
+		if ( isset( $args[0] ) ) {
+			if ( $args[0] instanceof WP_Post ) {
+				return $args[0];
+			}
+
+			/*
+			 * $args[0] is whatever was passed to `current_user_can()`, so an ID can arrive as an int or as a
+			 * string -- `wp_ajax_upload_attachment()`, for example, passes `$_REQUEST['post_id']` as-is. Cast
+			 * and look it up the way Core's `map_meta_cap()` does, so both resolve the same post.
+			 */
+			return is_numeric( $args[0] ) ? get_post( (int) $args[0] ) : null;
+		}
 
 		/*
 		 * Use a reference to the global $post if it already exists, but don't create one otherwise
@@ -873,13 +886,7 @@ class WordCamp_Budgets {
 		 * If $GLOBAL['post'] didn't already exist and then we created one, then that could have unintentional
 		 * side-effects outside of this function.
 		 */
-		if ( isset( $GLOBALS['post'] ) ) {
-			$post = $GLOBALS['post'];
-		} elseif ( isset( $args[0] ) && is_int( $args[0] ) ) {
-			$post = get_post( $args[0] );
-		}
-
-		return $post;
+		return isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 	}
 
 	/**


### PR DESCRIPTION
`WordCamp_Budgets::get_map_meta_cap_post()` returns the post that a `map_meta_cap` callback is being asked about. The three budget CPTs use it to decide whether a record past draft needs `manage_network` to edit or delete, so it has to resolve the post the capability check actually names.

It didn't, in two ways:

- It preferred the global `$post` over `$args`, ignoring the argument entirely whenever a global happened to exist. The global is frequently a different post -- during a bulk edit, or while a list table builds the row actions for a post other than the one in the loop -- so the decision could be made about the wrong record, in either direction.
- Its `$args[0]` fallback required `is_int()`. A post ID reaches `current_user_can()` as whatever the caller passed, and Core itself passes strings in places (`wp_ajax_upload_attachment()` forwards `$_REQUEST['post_id']` uncast), so those lookups returned `null` and the callbacks fell through to their early return.

Now the argument comes first and the global is only a fallback for checks that don't name a post, matching how Core's own `map_meta_cap()` resolves its subject. `WP_Post` objects and numeric-string IDs both resolve; anything that names nothing resolvable stays `null`. The "don't create a global `$post` if there isn't one" behaviour is unchanged.

The numeric check mirrors `get_post()`'s own contract rather than being an extra restriction: `get_post()` gates on `is_numeric()` before calling `WP_Post::get_instance()`, and `map_meta_cap()` appends `do_not_allow` when it gets `null` back. So an ID carrying trailing characters names no post here for the same reason it names none in Core.

The second commit keeps that lookup off capability checks the callbacks don't act on. `map_meta_cap` runs for every capability check site-wide, and all three callbacks resolved the post before looking at which capability was requested, so an `$args[0]` that isn't a post ID -- a user or term ID, say -- meant a `get_post()` miss per callback, and `WP_Post::get_instance()` doesn't cache misses. Each callback now returns early unless the requested capability is one of the ones it acts on (`edit_post`/`delete_post`, plus `draft_post` for reimbursements). Behaviour is identical; for the capabilities that still reach the lookup, Core has already primed the cache with its own `get_post( $args[0] )`.

`budget-tool.php`'s `map_meta_cap` filter doesn't use this helper and is unaffected.

### Tests

New `Test_Map_Meta_Cap` in the Budgets Dashboard suite, whose bootstrap already loads the three payment modules. For each budget CPT it asserts the `edit_post`/`delete_post` outcome across all three argument forms -- int ID, numeric-string ID, `WP_Post` -- and with both an unrelated post and a budget record sitting in the global `$post`. Network admins and an author's own draft are covered too, so the mapping is asserted in both directions rather than only as a denial. A further case pins `get_post()`'s contract for an ID with trailing characters, so a change to it upstream surfaces here rather than silently shifting what this helper resolves.

The suite bootstrap now registers the shared `wcb-*` post statuses. `WordCamp_Budgets`' constructor does that at runtime, but the plugin only instantiates it in the admin, so storing a post at `wcb-approved` was emitting `Attempt to read property "label" on null` from `reimbursement-request.php`.

### How to test the changes in this Pull Request:

1. Check out this branch and run the suite:
   ```
   ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist --testsuite "WordCamp Budgets Dashboard"
   ```
   Expect `OK (40 tests, 143 assertions)`, with no `Attempt to read property "label" on null` warnings in the output.

2. Confirm the new tests are load-bearing by restoring the helper to its `production` version, re-running, and putting it back:
   ```
   git checkout production -- public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
   ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist --filter Test_Map_Meta_Cap
   git checkout HEAD -- public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
   ```
   Expect 13 failures across `Test_Map_Meta_Cap` on the middle command, and a clean `git status` after the third.

3. Run the full suite to confirm nothing else moved:
   ```
   npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend
   ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist
   ```
   Expect 1049 tests. Six skip without the `intl` extension. Without the build step above, the eight `Test_Groups_Blocks` page-content tests fail -- that baseline is identical on `production` at 0296b646 and is unrelated to this branch.

4. In wp-admin on a camp site, as a network admin, go to **Budget > Reimbursement Requests** (and the Vendor Payments and Sponsor Invoices screens). Confirm the list tables render, rows are linked, and the Edit row action appears.

5. As an organizer who is not a network admin, create a reimbursement request, save it as a draft, and confirm the form fields are editable. Submit it for review, reopen it, and confirm the request is still reachable from the list table and its details are still readable.

6. As a network admin, open a request that has been approved and confirm it can still be edited and saved.

7. Visit a few screens that check capabilities against things that aren't posts -- **Users**, **Comments**, and a taxonomy screen such as **Posts > Tags** -- and confirm they render normally and that row actions appear as before.
