### PR TITLE
Groups: give the post editor canvas a side gutter (#1967)

### DIFF
--- a/public_html/wp-content/themes/groups-site/functions.php
+++ b/public_html/wp-content/themes/groups-site/functions.php
@@ -54,17 +54,14 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_assets' );
 /**
  * Give the post editor canvas a side gutter. See #1967.
  *
- * The front end gets its gutter from the `edge-space` group wrapping
- * `post-content` in the templates, which the post editor never renders. Not
- * done as `styles.spacing.padding` in `theme.json`, because root padding also
- * lands on `.wp-site-blocks` and would stack with the templates' own.
- *
- * Only the post editor. The site editor draws the template and its gutter.
+ * Not `styles.spacing.padding` in `theme.json`: root padding also hits
+ * `.wp-site-blocks`, stacking with the gutter the templates already set.
  *
  * @param array                    $settings Block editor settings.
  * @param \WP_Block_Editor_Context $context  Editor context.
  */
 function add_post_editor_canvas_gutter( $settings, $context ) {
+	// Post editor only. The site editor draws the template's own gutter.
 	if ( empty( $context->post ) ) {
 		return $settings;
 	}

--- a/public_html/wp-content/themes/groups-site/functions.php
+++ b/public_html/wp-content/themes/groups-site/functions.php
@@ -52,6 +52,50 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
+ * Give the post editor canvas the same side gutter the front end has.
+ *
+ * On the front end every template wraps `post-content` in a group padded by
+ * `spacing|edge-space` (see `templates/page.html`), so the 1160px content
+ * column never touches the viewport edge. The post editor renders
+ * `post-content` on its own — no template, no wrapper — and the theme sets no
+ * root padding in `theme.json`, so the canvas gets none of that. The
+ * content-width cap doesn't save it either: the canvas is usually *narrower*
+ * than the theme's 1160px `contentSize` (a 1440px window minus the 280px
+ * settings sidebar leaves exactly 1160), so the cap never binds and the text
+ * runs flush to the left edge of the frame.
+ *
+ * Padding the root container rather than adding `styles.spacing.padding` to
+ * `theme.json`: root padding also lands on `.wp-site-blocks` on the front
+ * end, where it would stack on top of the padding the templates already
+ * apply.
+ *
+ * Scoped to the post editor via `$context->post`. The site editor renders the
+ * template, gutter and all, and would come out double-padded.
+ *
+ * @param array                    $settings Block editor settings.
+ * @param \WP_Block_Editor_Context $context  Editor context.
+ */
+function add_post_editor_canvas_gutter( $settings, $context ) {
+	if ( empty( $context->post ) ) {
+		return $settings;
+	}
+
+	// The title sits in its own wrapper, a sibling of the block canvas
+	// rather than a block inside it, so it needs the gutter of its own —
+	// without it the heading hangs off the left of the body below it.
+	$settings['styles'][] = array(
+		'css' => '.is-root-container,
+			.editor-visual-editor__post-title-wrapper {
+				padding-left: var(--wp--preset--spacing--edge-space);
+				padding-right: var(--wp--preset--spacing--edge-space);
+			}',
+	);
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\add_post_editor_canvas_gutter', 10, 2 );
+
+/**
  * Adjust the featured image inside event card grids.
  *
  * Two changes, both scoped so the single-event hero is left alone. The guard

--- a/public_html/wp-content/themes/groups-site/functions.php
+++ b/public_html/wp-content/themes/groups-site/functions.php
@@ -52,25 +52,14 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_assets' );
 
 /**
- * Give the post editor canvas the same side gutter the front end has.
+ * Give the post editor canvas a side gutter. See #1967.
  *
- * On the front end every template wraps `post-content` in a group padded by
- * `spacing|edge-space` (see `templates/page.html`), so the 1160px content
- * column never touches the viewport edge. The post editor renders
- * `post-content` on its own — no template, no wrapper — and the theme sets no
- * root padding in `theme.json`, so the canvas gets none of that. The
- * content-width cap doesn't save it either: the canvas is usually *narrower*
- * than the theme's 1160px `contentSize` (a 1440px window minus the 280px
- * settings sidebar leaves exactly 1160), so the cap never binds and the text
- * runs flush to the left edge of the frame.
+ * The front end gets its gutter from the `edge-space` group wrapping
+ * `post-content` in the templates, which the post editor never renders. Not
+ * done as `styles.spacing.padding` in `theme.json`, because root padding also
+ * lands on `.wp-site-blocks` and would stack with the templates' own.
  *
- * Padding the root container rather than adding `styles.spacing.padding` to
- * `theme.json`: root padding also lands on `.wp-site-blocks` on the front
- * end, where it would stack on top of the padding the templates already
- * apply.
- *
- * Scoped to the post editor via `$context->post`. The site editor renders the
- * template, gutter and all, and would come out double-padded.
+ * Only the post editor. The site editor draws the template and its gutter.
  *
  * @param array                    $settings Block editor settings.
  * @param \WP_Block_Editor_Context $context  Editor context.
@@ -80,9 +69,8 @@ function add_post_editor_canvas_gutter( $settings, $context ) {
 		return $settings;
 	}
 
-	// The title sits in its own wrapper, a sibling of the block canvas
-	// rather than a block inside it, so it needs the gutter of its own —
-	// without it the heading hangs off the left of the body below it.
+	// The title is a sibling of the block canvas, not a block in it, so it
+	// needs its own padding or it hangs off the left of the body text.
 	$settings['styles'][] = array(
 		'css' => '.is-root-container,
 			.editor-visual-editor__post-title-wrapper {


### PR DESCRIPTION
Fixes #1967.

Page content in the group site post editor sits flush against the left edge of the frame.

The theme sets `contentSize: 1160px` and no root padding, and the canvas is 1160px wide at a 1440px window, so the content-width cap never binds. On the front end the gutter comes from the `edge-space` group wrapping `post-content` in the templates, which the post editor does not render.

Fix pads the canvas root container and the title wrapper, scoped to the post editor. The site editor renders the template and already has its gutter.

## Test plan

- [x] phpcs clean
- [x] Manual pass at 1440px: title and first paragraph both start at x=70 instead of x=0
- [x] Site editor unchanged, no double gutter
- [ ] CSS only, no phpunit change

### Screenshots

| Description | Screenshot |
| --- | --- |
| Before | <kbd><img width="987" height="751" alt="Screenshot 2026-08-28 at 16 35 49" src="https://github.com/user-attachments/assets/40bf8c67-494e-450d-a4c0-e304c71d7ac8" /></kbd> |
| After | <kbd><img width="977" height="807" alt="image" src="https://github.com/user-attachments/assets/e48c6b4b-abc7-40ba-950a-ec3e11a4cd47" /></kbd> |
