### PR TITLE
Groups: let beta testers switch their own role tier

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/capabilities.php
@@ -111,3 +111,94 @@ function current_user_can_manage_group_settings(): bool {
 		current_user_can( 'edit_others_posts' )
 	);
 }
+
+/**
+ * Group sites where members may change their own role tier, keyed by the
+ * host the group lives on.
+ *
+ * Self-serve role switching is a beta-testing affordance, not a product
+ * feature: promoting yourself to `editor` grants the full "Organizer" tier
+ * (everyone's events, member roles, group info and design, ownership
+ * transfer), so on a real community group it would be a privilege
+ * escalation for any logged-in WordPress.org account that joined. The
+ * allow-list keeps it to the groups that exist to be poked at.
+ *
+ * Keyed by host rather than by slug alone so a real community group that
+ * happens to share a slug with a local fixture can't inherit it. Sites are
+ * added here by code change on purpose — there's no admin toggle, because
+ * nobody should be able to switch this on for a live group from the UI.
+ *
+ * @var array<string, string[]>
+ */
+const SELF_SERVE_ROLE_GROUPS = array(
+	// The beta's public testing group (see the "Call for testing" post).
+	'events.wordpress.org'  => array( 'internal-testing-group' ),
+
+	// Local development and the PHPUnit fixture site.
+	'events.wordpress.test' => array( 'sunshine-coast-qld' ),
+);
+
+/**
+ * The `/group/{slug}/` segment identifying the current group site.
+ *
+ * Returns an empty string off the groups network (or on its `/group/`
+ * root, which is the landing page rather than a group).
+ */
+function get_current_group_slug(): string {
+	$site = get_site();
+
+	if ( ! $site ) {
+		return '';
+	}
+
+	$segments = explode( '/', trim( (string) $site->path, '/' ) );
+	$slug     = (string) end( $segments );
+
+	return 'group' === $slug ? '' : $slug;
+}
+
+/**
+ * Whether this group site offers self-serve role switching.
+ *
+ * See `SELF_SERVE_ROLE_GROUPS` for why this is an allow-list.
+ */
+function self_serve_roles_enabled(): bool {
+	$site    = get_site();
+	$allowed = $site ? ( SELF_SERVE_ROLE_GROUPS[ $site->domain ] ?? array() ) : array();
+	$slug    = get_current_group_slug();
+	$enabled = '' !== $slug && in_array( $slug, $allowed, true );
+
+	/**
+	 * Filters whether members of this group can change their own role tier.
+	 *
+	 * Sandboxes and one-off testing sites can opt in through this filter
+	 * rather than by editing `SELF_SERVE_ROLE_GROUPS`.
+	 *
+	 * @param bool $enabled Whether self-serve role switching is available.
+	 */
+	return (bool) apply_filters( 'wporg_groups_frontend_self_serve_roles_enabled', $enabled );
+}
+
+/**
+ * Whether the current user may change their own role tier on this group.
+ *
+ * The authoritative check behind both the members-page UI and the
+ * `POST /members/me/role` endpoint, so the button and the request that
+ * button makes can't disagree about who's allowed.
+ *
+ * Administrators are excluded for the same reason `update_member_role()`
+ * refuses to touch them: the group's admin account is provisioned in
+ * wp-admin, and letting it demote itself from the front end could strand
+ * the site with no one able to restore it.
+ */
+function current_user_can_switch_own_role(): bool {
+	if ( ! is_user_logged_in() || ! self_serve_roles_enabled() ) {
+		return false;
+	}
+
+	if ( ! is_user_member_of_blog() ) {
+		return false;
+	}
+
+	return ! in_array( 'administrator', wp_get_current_user()->roles, true );
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/class-members-controller.php
@@ -20,6 +20,7 @@ defined( 'WPINC' ) || die();
  * Routes:
  *   GET    /wporg-groups/v1/members       — list group members
  *   GET    /wporg-groups/v1/members/{id}  — single member
+ *   POST   /wporg-groups/v1/members/me/role — change your own role (beta groups only)
  *   POST   /wporg-groups/v1/members/join  — join group
  *   DELETE /wporg-groups/v1/members/leave — leave group
  *   POST   /wporg-groups/v1/members/notification-preference — update event email preference
@@ -135,6 +136,32 @@ class Members_Controller extends \WP_REST_Users_Controller {
 								return is_numeric( $param ) && (int) $param > 0;
 							},
 						),
+						'role' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => array( $this, 'validate_assignable_role' ),
+						),
+					),
+				),
+			)
+		);
+
+		// Self-serve role change: POST /members/me/role.
+		//
+		// Distinct from `/members/{id}/role` rather than a relaxation of it:
+		// that endpoint is the organizer-facing member manager and explicitly
+		// refuses self-changes, and it should keep doing so. `me` can't
+		// collide with it because the `{id}` route only matches digits.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/me/role',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'update_own_role' ),
+					'permission_callback' => array( $this, 'update_own_role_permissions_check' ),
+					'args'                => array(
 						'role' => array(
 							'type'              => 'string',
 							'required'          => true,
@@ -483,6 +510,95 @@ class Members_Controller extends \WP_REST_Users_Controller {
 		$user = get_userdata( $user_id );
 
 		return rest_ensure_response( $this->prepare_member( $user ) );
+	}
+
+	/**
+	 * Check permissions for changing the current user's own role.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error
+	 */
+	public function update_own_role_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new \WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in.', 'wporg-groups-frontend' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! \WordCamp\Groups\Frontend\Capabilities\self_serve_roles_enabled() ) {
+			return new \WP_Error(
+				'rest_self_serve_roles_disabled',
+				__( 'Changing your own role is not available on this group.', 'wporg-groups-frontend' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( ! is_user_member_of_blog() ) {
+			return new \WP_Error(
+				'not_a_member',
+				__( 'You are not a member of this group.', 'wporg-groups-frontend' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( in_array( 'administrator', wp_get_current_user()->roles, true ) ) {
+			return new \WP_Error(
+				'cannot_manage_administrator',
+				__( 'Site administrators must be managed in wp-admin.', 'wporg-groups-frontend' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Catch-all, so the endpoint can never be more permissive than the
+		// check that decides whether to render the button in the first place.
+		if ( ! \WordCamp\Groups\Frontend\Capabilities\current_user_can_switch_own_role() ) {
+			return new \WP_Error(
+				'rest_cannot_change_own_role',
+				__( 'Sorry, you are not allowed to change your role on this group.', 'wporg-groups-frontend' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Change the current user's own role within this group.
+	 *
+	 * Only reachable on the beta groups listed in `SELF_SERVE_ROLE_GROUPS`;
+	 * see that constant for why this isn't a general capability.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_own_role( $request ) {
+		$role = (string) $request->get_param( 'role' );
+		$user = wp_get_current_user();
+
+		if ( ! $this->validate_assignable_role( $role ) ) {
+			return new \WP_Error(
+				'invalid_role',
+				__( 'Invalid role.', 'wporg-groups-frontend' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// The same floor `update_member_role()` enforces: the last organizer
+		// can't step down and leave the group unmanageable, whether another
+		// organizer demotes them or they demote themselves.
+		if ( ! $this->can_demote_organizer( $user, $role ) ) {
+			return new \WP_Error(
+				'cannot_remove_last_organizer',
+				__( 'A group must have at least one organizer. Promote someone else first.', 'wporg-groups-frontend' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$user->set_role( $role );
+
+		return rest_ensure_response( $this->prepare_member( get_userdata( $user->ID ) ) );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/block.json
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/block.json
@@ -9,9 +9,11 @@
 	"description": "Displays a grid of group members with roles and profile links.",
 	"supports": {
 		"html": false,
+		"interactivity": true,
 		"inserter": false
 	},
 	"render": "file:./render.php",
+	"viewScriptModule": "file:./view.js",
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/render.php
@@ -6,6 +6,7 @@
  */
 
 use WordCamp\Groups\Frontend\Members\Members_Controller;
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_switch_own_role;
 
 $role_labels = Members_Controller::ROLE_LABELS;
 
@@ -50,6 +51,47 @@ usort(
 	}
 );
 
+/*
+ * Self-serve role switching is a beta-testing affordance, limited to the
+ * groups in `Capabilities\SELF_SERVE_ROLE_GROUPS` — see that constant for
+ * why it isn't offered on real community groups.
+ */
+$renders_role_switcher = current_user_can_switch_own_role();
+$current_user_role     = '';
+
+if ( $renders_role_switcher ) {
+	$switcher_user     = wp_get_current_user();
+	$current_user_role = reset( $switcher_user->roles ) ?: 'subscriber';
+
+	// A role outside the three switchable tiers (a stray `contributor`, say)
+	// has no button to mark as current; the switcher still lets them move
+	// into one of the three.
+	$switcher_roles = array(
+		'subscriber' => array(
+			'label'       => __( 'Member', 'wporg-groups-frontend' ),
+			'description' => __( 'Join and leave, RSVP, set email preferences.', 'wporg-groups-frontend' ),
+		),
+		'author'     => array(
+			'label'       => __( 'Event Organizer', 'wporg-groups-frontend' ),
+			'description' => __( 'Everything a Member can do, plus create and manage your own events and venues.', 'wporg-groups-frontend' ),
+		),
+		'editor'     => array(
+			'label'       => __( 'Organizer', 'wporg-groups-frontend' ),
+			'description' => __( "Everything an Event Organizer can do, plus manage everyone's events, member roles, group info and design.", 'wporg-groups-frontend' ),
+		),
+	);
+
+	$switcher_context = array(
+		'currentRole' => $current_user_role,
+		'saving'      => false,
+		'message'     => '',
+		'isError'     => false,
+		'roleApi'     => rest_url( 'wporg-groups/v1/members/me/role' ),
+		'restNonce'   => wp_create_nonce( 'wp_rest' ),
+		'errorLabel'  => __( 'Your role could not be changed. Please try again.', 'wporg-groups-frontend' ),
+	);
+}
+
 $total_count = count( $users );
 
 $wrapper_attributes = get_block_wrapper_attributes(
@@ -67,6 +109,52 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		);
 		?>
 	</h2>
+
+	<?php if ( $renders_role_switcher ) : ?>
+		<div
+			class="wporg-group-members__role-switcher"
+			data-wp-interactive="wporg/group-members"
+			data-wp-context="<?php echo esc_attr( wp_json_encode( $switcher_context ) ); ?>"
+		>
+			<h3 class="wporg-group-members__role-switcher-heading" id="wporg-role-switcher-heading">
+				<?php esc_html_e( 'Your role in this group', 'wporg-groups-frontend' ); ?>
+			</h3>
+			<p class="wporg-group-members__role-switcher-help">
+				<?php esc_html_e( 'This is a testing group, so you can switch your own role to try out the organizer tools. Pick a role below, then switch back whenever you like.', 'wporg-groups-frontend' ); ?>
+			</p>
+
+			<div class="wporg-group-members__role-options" role="group" aria-labelledby="wporg-role-switcher-heading">
+				<?php foreach ( $switcher_roles as $role_slug => $switcher_role ) :
+					$is_current = $role_slug === $current_user_role;
+					?>
+					<button
+						type="button"
+						class="wporg-group-members__role-option<?php echo $is_current ? ' is-current' : ''; ?>"
+						data-role="<?php echo esc_attr( $role_slug ); ?>"
+						aria-pressed="<?php echo $is_current ? 'true' : 'false'; ?>"
+						data-wp-on--click="actions.switchRole"
+						data-wp-bind--disabled="context.saving"
+						data-wp-bind--aria-busy="context.saving"
+					>
+						<span class="wporg-group-members__role-option-label">
+							<?php echo esc_html( $switcher_role['label'] ); ?>
+						</span>
+						<span class="wporg-group-members__role-option-description">
+							<?php echo esc_html( $switcher_role['description'] ); ?>
+						</span>
+					</button>
+				<?php endforeach; ?>
+			</div>
+
+			<p
+				class="wporg-group-members__role-switcher-status"
+				role="status"
+				aria-live="polite"
+				data-wp-text="context.message"
+				data-wp-class--is-error="context.isError"
+			></p>
+		</div>
+	<?php endif; ?>
 
 	<div class="wporg-group-members__grid">
 		<?php foreach ( $users as $user ) :

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/style.css
@@ -85,3 +85,134 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 }
+
+/*
+ * Self-serve role switcher — beta groups only (see
+ * `Capabilities\SELF_SERVE_ROLE_GROUPS`). Framed as a bordered panel above
+ * the member grid rather than an inline control, because it changes what
+ * the whole site lets you do, not just what this page shows.
+ */
+
+.wporg-group-members__role-switcher {
+	margin-bottom: var(--wp--preset--spacing--40);
+	padding: var(--wp--preset--spacing--30);
+	border: 1px solid var(--wp--preset--color--light-grey-1);
+	border-radius: 4px;
+	background: var(--wp--preset--color--white);
+}
+
+/* `!important` for the same reason `.wporg-section-heading` needs it: the
+   parent theme's `.wp-site-blocks h3:not([class*="-font-size"], ...)` rule
+   outranks any plain class selector and would open a spacing-40 gap between
+   the panel's own padding and its heading. */
+.wporg-group-members__role-switcher-heading {
+	margin: 0 !important;
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: 600;
+	color: var(--wp--preset--color--charcoal-0);
+}
+
+.wporg-group-members__role-switcher-help {
+	margin: 4px 0 var(--wp--preset--spacing--20);
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
+	color: var(--wp--preset--color--charcoal-4);
+}
+
+.wporg-group-members__role-options {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: var(--wp--preset--spacing--20);
+}
+
+/* Each option is a card, not a segmented-control segment: the descriptions
+   are the point — a tester picking "Organizer" should be able to read what
+   that grants before clicking. */
+.wporg-group-members__role-option {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	-webkit-appearance: none;
+	appearance: none;
+	padding: var(--wp--preset--spacing--20);
+	border: 1px solid var(--wp--preset--color--light-grey-1);
+	border-radius: 4px;
+	background: var(--wp--preset--color--white);
+	font-family: var(--wp--preset--font-family--inter);
+	text-align: left;
+	cursor: pointer;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* The current role reads as selected rather than as a call to action, so it
+   keeps the accent border but loses the pointer and the hover lift. */
+.wporg-group-members__role-option.is-current {
+	border-color: var(--wp--preset--color--blueberry-1);
+	background: var(--wp--preset--color--blueberry-4);
+	cursor: default;
+}
+
+.wporg-group-members__role-option:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+.wporg-group-members__role-option:focus-visible {
+	border-color: var(--wp--preset--color--blueberry-1);
+	box-shadow: 0 2px 8px rgba(56, 88, 233, 0.1);
+}
+
+/* Ordered after the two rules above to satisfy `no-descending-specificity`;
+   the `:not()`s mean it never actually competes with either. */
+.wporg-group-members__role-option:hover:not(.is-current):not(:disabled) {
+	border-color: var(--wp--preset--color--blueberry-1);
+	box-shadow: 0 2px 8px rgba(56, 88, 233, 0.1);
+}
+
+.wporg-group-members__role-option-label {
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: 600;
+	color: var(--wp--preset--color--charcoal-0);
+}
+
+/* A checkmark on the selected card, so the state isn't carried by colour
+   alone for the border and background above. */
+.wporg-group-members__role-option.is-current .wporg-group-members__role-option-label::after {
+	content: " \2713";
+	color: var(--wp--preset--color--blueberry-1);
+}
+
+.wporg-group-members__role-option-description {
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
+	color: var(--wp--preset--color--charcoal-4);
+}
+
+.wporg-group-members__role-switcher-status:empty {
+	display: none;
+}
+
+/* Matches the notice treatment in `group-membership`'s preference status. */
+.wporg-group-members__role-switcher-status:not(:empty) {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--wp--preset--spacing--10);
+	margin: var(--wp--preset--spacing--20) 0 0;
+	padding: 10px 20px;
+	border: 1px solid;
+	border-radius: 2px;
+	font-size: var(--wp--preset--font-size--small);
+	line-height: 1.55;
+}
+
+.wporg-group-members__role-switcher-status.is-error {
+	border-color: #b32d0f;
+	background: var(--wp--preset--color--pomegranate-3);
+	color: var(--wp--preset--color--charcoal-0);
+}
+
+.wporg-group-members__role-switcher-status.is-error::before {
+	content: "!";
+	font-weight: 600;
+	line-height: 1.55;
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/group-members/view.js
@@ -1,0 +1,67 @@
+/**
+ * Group Members block — Interactivity API store.
+ *
+ * Backs the self-serve role switcher, which only renders on the beta
+ * testing groups listed in `Capabilities\SELF_SERVE_ROLE_GROUPS`.
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+import { store, getContext } from '@wordpress/interactivity';
+
+store( 'wporg/group-members', {
+	actions: {
+		async switchRole( event ) {
+			const ctx = getContext();
+
+			// Read the target role before the first `await` — `currentTarget`
+			// is only set while the event is being dispatched, and the label
+			// and description spans mean `target` may be a child element.
+			const role = event.currentTarget?.dataset?.role;
+
+			if ( ! role || role === ctx.currentRole || ctx.saving ) {
+				return;
+			}
+
+			ctx.saving = true;
+			ctx.message = '';
+			ctx.isError = false;
+
+			try {
+				const resp = await fetch( ctx.roleApi, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': ctx.restNonce,
+					},
+					body: JSON.stringify( { role } ),
+				} );
+
+				const data = await resp.json();
+
+				if ( ! resp.ok ) {
+					throw new Error( data?.message || ctx.errorLabel );
+				}
+
+				ctx.currentRole = data.role;
+
+				/*
+				 * A role change reaches far more of the page than this block —
+				 * the event management buttons, the group settings tab, the
+				 * membership badge in the sidebar — and all of it is rendered
+				 * server side. Reload rather than patch, the same call
+				 * `group-membership` makes for join and leave.
+				 *
+				 * `saving` deliberately stays true: the buttons should remain
+				 * disabled for the moment between here and the new document.
+				 */
+				window.location.reload();
+			} catch ( error ) {
+				ctx.message = error.message || ctx.errorLabel;
+				ctx.isError = true;
+				ctx.saving = false;
+			}
+		},
+	},
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-members.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/group-members.test.js
@@ -1,0 +1,131 @@
+/* eslint-disable id-length -- Fetch Response fixtures use the native `ok` property. */
+
+let mockContext;
+let mockStoreConfig;
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: jest.fn( ( namespace, config ) => {
+			mockStoreConfig = config;
+			return config;
+		} ),
+		getContext: jest.fn( () => mockContext ),
+	} ),
+	{ virtual: true }
+);
+
+function loadStore() {
+	jest.resetModules();
+	require( '../src/blocks/group-members/view' );
+	return mockStoreConfig;
+}
+
+function createContext() {
+	return {
+		currentRole: 'subscriber',
+		errorLabel: 'Your role could not be changed. Please try again.',
+		isError: false,
+		message: '',
+		restNonce: 'rest-nonce',
+		roleApi: '/wp-json/wporg-groups/v1/members/me/role',
+		saving: false,
+	};
+}
+
+function clickOn( role ) {
+	return { currentTarget: { dataset: { role } } };
+}
+
+describe( 'group members self-serve role switcher', () => {
+	beforeEach( () => {
+		mockContext = createContext();
+		mockStoreConfig = null;
+		global.fetch = jest.fn();
+
+		delete window.location;
+		window.location = { reload: jest.fn() };
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'posts the chosen role and reloads on success', async () => {
+		global.fetch.mockResolvedValue( {
+			ok: true,
+			json: async () => ( { role: 'editor', roleLabel: 'Organizer' } ),
+		} );
+		const { actions } = loadStore();
+
+		await actions.switchRole( clickOn( 'editor' ) );
+
+		expect( global.fetch ).toHaveBeenCalledWith( mockContext.roleApi, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': 'rest-nonce',
+			},
+			body: JSON.stringify( { role: 'editor' } ),
+		} );
+		expect( mockContext.currentRole ).toBe( 'editor' );
+		expect( window.location.reload ).toHaveBeenCalled();
+	} );
+
+	test( 'ignores a click on the role the member already has', async () => {
+		const { actions } = loadStore();
+
+		await actions.switchRole( clickOn( 'subscriber' ) );
+
+		expect( global.fetch ).not.toHaveBeenCalled();
+		expect( window.location.reload ).not.toHaveBeenCalled();
+	} );
+
+	test( 'ignores a second click while a change is in flight', async () => {
+		mockContext.saving = true;
+		const { actions } = loadStore();
+
+		await actions.switchRole( clickOn( 'editor' ) );
+
+		expect( global.fetch ).not.toHaveBeenCalled();
+	} );
+
+	/*
+	 * The server-side guard members are most likely to hit: the last
+	 * organizer trying to demote themselves. Its message has to survive to
+	 * the status line, or the click just looks like it did nothing.
+	 */
+	test( 'surfaces the server error message and re-enables the buttons', async () => {
+		global.fetch.mockResolvedValue( {
+			ok: false,
+			json: async () => ( {
+				code: 'cannot_remove_last_organizer',
+				message: 'A group must have at least one organizer. Promote someone else first.',
+			} ),
+		} );
+		const { actions } = loadStore();
+
+		mockContext.currentRole = 'editor';
+		await actions.switchRole( clickOn( 'subscriber' ) );
+
+		expect( mockContext.message ).toBe(
+			'A group must have at least one organizer. Promote someone else first.'
+		);
+		expect( mockContext.isError ).toBe( true );
+		expect( mockContext.saving ).toBe( false );
+		expect( mockContext.currentRole ).toBe( 'editor' );
+		expect( window.location.reload ).not.toHaveBeenCalled();
+	} );
+
+	test( 'falls back to the generic label when the request fails outright', async () => {
+		global.fetch.mockRejectedValue( new Error() );
+		const { actions } = loadStore();
+
+		await actions.switchRole( clickOn( 'author' ) );
+
+		expect( mockContext.message ).toBe( mockContext.errorLabel );
+		expect( mockContext.isError ).toBe( true );
+		expect( mockContext.saving ).toBe( false );
+	} );
+} );

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-capabilities.php
@@ -4,6 +4,9 @@ namespace WordCamp\Groups\Tests;
 
 use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_events;
 use function WordCamp\Groups\Frontend\Capabilities\current_user_can_manage_group_settings;
+use function WordCamp\Groups\Frontend\Capabilities\current_user_can_switch_own_role;
+use function WordCamp\Groups\Frontend\Capabilities\get_current_group_slug;
+use function WordCamp\Groups\Frontend\Capabilities\self_serve_roles_enabled;
 
 defined( 'WPINC' ) || die();
 
@@ -114,5 +117,135 @@ class Test_Groups_Capabilities extends Groups_TestCase {
 		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 
 		$this->assertFalse( user_can( $user_id, 'promote_users' ) );
+	}
+
+	/**
+	 * The fixture site is `events.wordpress.test/group/sunshine-coast-qld/`,
+	 * which is on the `SELF_SERVE_ROLE_GROUPS` allow-list as the local
+	 * development / test group.
+	 */
+	public function test_get_current_group_slug_reads_the_site_path() {
+		$this->assertSame( 'sunshine-coast-qld', get_current_group_slug() );
+	}
+
+	/**
+	 * Self-serve role switching is on for the allow-listed fixture group.
+	 */
+	public function test_self_serve_roles_enabled_on_allow_listed_group() {
+		$this->assertTrue( self_serve_roles_enabled() );
+	}
+
+	/**
+	 * ...and off for every group that isn't on the list. This is the check
+	 * that keeps a real community group from handing out the Organizer tier
+	 * to anyone who joins, so it's worth asserting directly rather than
+	 * inferring it from the allow-list constant.
+	 */
+	public function test_self_serve_roles_disabled_on_other_group() {
+		$other_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/not-a-beta-group/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		switch_to_blog( $other_site_id );
+
+		try {
+			$this->assertSame( 'not-a-beta-group', get_current_group_slug() );
+			$this->assertFalse( self_serve_roles_enabled() );
+		} finally {
+			restore_current_blog();
+			wp_delete_site( $other_site_id );
+		}
+	}
+
+	/**
+	 * Sandboxes opt in through the filter rather than by editing the
+	 * allow-list constant.
+	 */
+	public function test_self_serve_roles_filter_can_enable_a_group() {
+		$other_site_id = self::factory()->blog->create(
+			array(
+				'domain'     => 'events.wordpress.test',
+				'path'       => '/group/filtered-beta-group/',
+				'network_id' => GROUPS_NETWORK_ID,
+			)
+		);
+
+		switch_to_blog( $other_site_id );
+		add_filter( 'wporg_groups_frontend_self_serve_roles_enabled', '__return_true' );
+
+		try {
+			$this->assertTrue( self_serve_roles_enabled() );
+		} finally {
+			remove_filter( 'wporg_groups_frontend_self_serve_roles_enabled', '__return_true' );
+			restore_current_blog();
+			wp_delete_site( $other_site_id );
+		}
+	}
+
+	/**
+	 * Data provider for test_current_user_can_switch_own_role_by_role().
+	 */
+	public function data_switch_own_role_roles(): array {
+		return array(
+			'subscriber switches'    => array( 'subscriber', true ),
+			'author switches'        => array( 'author', true ),
+			'editor switches'        => array( 'editor', true ),
+			'administrator does not' => array( 'administrator', false ),
+		);
+	}
+
+	/**
+	 * Every tier but administrator can move itself between the three
+	 * switchable roles; see `current_user_can_switch_own_role()` for why
+	 * administrators are held back.
+	 *
+	 * @dataProvider data_switch_own_role_roles
+	 */
+	public function test_current_user_can_switch_own_role_by_role( string $role, bool $expected ) {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertSame( $expected, current_user_can_switch_own_role() );
+	}
+
+	/**
+	 * Logged-out visitors have no role to switch.
+	 */
+	public function test_current_user_cannot_switch_own_role_when_logged_out() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( current_user_can_switch_own_role() );
+	}
+
+	/**
+	 * Someone who hasn't joined the group can't promote themselves into it.
+	 */
+	public function test_current_user_cannot_switch_own_role_when_not_a_member() {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		remove_user_from_blog( $user_id, get_current_blog_id() );
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( current_user_can_switch_own_role() );
+	}
+
+	/**
+	 * The allow-list gates the capability, not just the markup — a member of
+	 * a non-beta group gets no self-serve switch at all.
+	 */
+	public function test_current_user_cannot_switch_own_role_on_disabled_group() {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		add_filter( 'wporg_groups_frontend_self_serve_roles_enabled', '__return_false' );
+
+		try {
+			$this->assertFalse( current_user_can_switch_own_role() );
+		} finally {
+			remove_filter( 'wporg_groups_frontend_self_serve_roles_enabled', '__return_false' );
+		}
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-class-members-controller.php
@@ -201,4 +201,177 @@ class Test_Groups_Members_Controller extends Groups_TestCase {
 		$this->assertFalse( self::$controller->validate_per_page( Members_Controller::MAX_PER_PAGE + 1 ) );
 		$this->assertTrue( self::$controller->validate_per_page( Members_Controller::MAX_PER_PAGE ) );
 	}
+
+	/**
+	 * Clears every organizer the fixture/site creation left behind, so
+	 * "is this the last organizer?" assertions are deterministic.
+	 */
+	private function remove_existing_organizers(): void {
+		$existing_organizers = get_users(
+			array(
+				'blog_id'  => self::$groups_root_site_id,
+				'role__in' => array( 'administrator', 'editor' ),
+				'fields'   => 'ids',
+			)
+		);
+
+		foreach ( $existing_organizers as $uid ) {
+			remove_user_from_blog( $uid, self::$groups_root_site_id );
+		}
+	}
+
+	/**
+	 * The point of the beta affordance: a plain Member can hand themselves
+	 * the Organizer tier to try the organizer tools out.
+	 */
+	public function test_member_promotes_self_to_organizer() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'editor' );
+
+		$this->assertTrue( self::$controller->update_own_role_permissions_check( $request ) );
+
+		$response = self::$controller->update_own_role( $request );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( 'editor', $response->get_data()['role'] );
+		$this->assertSame( 'Organizer', $response->get_data()['roleLabel'] );
+		$this->assertContains( 'editor', get_userdata( $member_id )->roles );
+	}
+
+	/**
+	 * ...and switch back down again once they're done testing.
+	 */
+	public function test_organizer_demotes_self_when_another_organizer_remains() {
+		$this->remove_existing_organizers();
+
+		// The organizer left holding the group after the demotion below.
+		self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'subscriber' );
+
+		$response = self::$controller->update_own_role( $request );
+
+		$this->assertNotWPError( $response );
+		$this->assertContains( 'subscriber', get_userdata( $editor_id )->roles );
+	}
+
+	/**
+	 * The last organizer can't step down and strand the group, whether
+	 * someone else demotes them or they demote themselves.
+	 */
+	public function test_cannot_remove_last_organizer_by_self_demotion() {
+		$this->remove_existing_organizers();
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'subscriber' );
+
+		$result = self::$controller->update_own_role( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'cannot_remove_last_organizer', $result->get_error_code() );
+		$this->assertContains( 'editor', get_userdata( $editor_id )->roles );
+	}
+
+	/**
+	 * `administrator` is outside ASSIGNABLE_ROLES here too — self-serve must
+	 * not become a back door to the role the organizer-facing endpoint
+	 * already refuses to grant.
+	 */
+	public function test_update_own_role_rejects_administrator_role() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'administrator' );
+
+		$result = self::$controller->update_own_role( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_role', $result->get_error_code() );
+		$this->assertNotContains( 'administrator', get_userdata( $member_id )->roles );
+	}
+
+	/**
+	 * The group's own administrator account is managed in wp-admin; it can't
+	 * demote itself from the front end and lock the site out.
+	 */
+	public function test_update_own_role_rejects_administrator_user() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'subscriber' );
+
+		$result = self::$controller->update_own_role_permissions_check( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'cannot_manage_administrator', $result->get_error_code() );
+	}
+
+	/**
+	 * On a group that isn't on the `SELF_SERVE_ROLE_GROUPS` allow-list the
+	 * endpoint is closed, even though the route itself is registered
+	 * network-wide. Without this the beta affordance would be a privilege
+	 * escalation on every real community group.
+	 */
+	public function test_update_own_role_blocked_when_self_serve_disabled() {
+		$member_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $member_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'editor' );
+
+		add_filter( 'wporg_groups_frontend_self_serve_roles_enabled', '__return_false' );
+
+		try {
+			$result = self::$controller->update_own_role_permissions_check( $request );
+		} finally {
+			remove_filter( 'wporg_groups_frontend_self_serve_roles_enabled', '__return_false' );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_self_serve_roles_disabled', $result->get_error_code() );
+	}
+
+	/**
+	 * You have to join the group before you can pick a role in it.
+	 */
+	public function test_update_own_role_rejects_non_member() {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		remove_user_from_blog( $user_id, self::$groups_root_site_id );
+		wp_set_current_user( $user_id );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'editor' );
+
+		$result = self::$controller->update_own_role_permissions_check( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'not_a_member', $result->get_error_code() );
+	}
+
+	/**
+	 * Logged-out requests are rejected before anything else is checked.
+	 */
+	public function test_update_own_role_rejects_logged_out() {
+		wp_set_current_user( 0 );
+
+		$request = $this->request( 'POST', '/members/me/role' );
+		$request->set_param( 'role', 'editor' );
+
+		$result = self::$controller->update_own_role_permissions_check( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_not_logged_in', $result->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Summary

The "Call for testing: WordPress community groups on events.WordPress.org" post tells people who want to try the organizer side to comment on the post or ping `#gatherpress-migration` so we can promote them by hand. This makes that self-serve on the testing groups.

- **"Your role in this group" panel** above the member grid on `/members/`, with a card per tier and a one-line description of what each one grants.
- **`POST /wporg-groups/v1/members/me/role`** — new endpoint, deliberately separate from `/members/{id}/role` (the organizer-facing member manager, which keeps refusing self-changes).
- **Allow-listed to testing groups** via `Capabilities\SELF_SERVE_ROLE_GROUPS`, keyed by host so a community group can't inherit it by sharing a slug with a fixture. Currently `events.wordpress.org/group/internal-testing-group/` plus the local/PHPUnit fixture group. A `wporg_groups_frontend_self_serve_roles_enabled` filter is there for sandboxes.

## How to review this PR

Suggested order: `inc/capabilities.php` → `inc/class-members-controller.php` → `src/blocks/group-members/render.php` → `view.js` → `style.css`.

- **Why an allow-list rather than a general feature.** The Organizer tier grants management of everyone's events, member roles, group info and design, and ownership transfer. Self-serve promotion into it only makes sense on a group that exists to be poked at, so the gate is a code constant with no admin toggle — nobody should be able to switch this on for a live group from the UI.
- **Why a separate route.** Relaxing `update_member_role()`'s `cannot_change_own_role` guard would have changed behaviour for organizers managing other members. The new route reuses that controller's `can_demote_organizer()` floor instead, so the last organizer still can't step down and strand the group.
- **Administrators are excluded**, matching `update_member_role()`'s existing refusal to touch them — the group's admin account is provisioned in wp-admin, and a front-end self-demotion could leave nobody able to restore it.
- **`current_user_can_switch_own_role()` is the single authority.** The block calls it to decide whether to render, and the permission callback ends with it as a catch-all, so the button and the request it makes can't drift apart.
- The click reloads the page rather than patching in place, matching what `group-membership` does for join/leave — a role change also affects the sidebar badge, the event-manage controls, and the settings tab, all server-rendered.

## Test plan

- [x] PHPUnit `--group groups` — 375/375 passing, including 18 new
- [x] phpcs — 0 errors across the plugin
- [x] stylelint (`npm run lint:css`) — clean
- [x] Jest — 33/33 passing, including 5 new
- [x] `npm run build`
- [x] Manual browser pass (see below)

New automated coverage: allow-list on and off, filter override in both directions, per-role capability matrix, self-promotion and self-demotion happy paths, last-organizer self-demotion blocked, `administrator` rejected both as an actor and as a target role value, non-member rejected, logged-out rejected, and the JS fetch/reload/error-surfacing paths.

### Manual test steps

Verified on the local stack (`events.wordpress.test/group/sunshine-coast-qld/`, which is on the allow-list):

1. **Logged out, members page** — no panel rendered.
2. **Server-rendered markup per role** — rendered the block as each of `member1` (subscriber), `eventorganiser1` (author), `organiser` (editor), `organiser1` (administrator). The first three get the panel with the correct card marked `aria-pressed="true"` and `is-current`; the administrator gets no panel.
3. **REST round trip against the dev database**, as `member1`: Member → Organizer → Event Organizer → Member, each returning the new role and label, each confirmed against `wp user list`. Then `administrator` as a role value → `invalid_role`, and `organiser1` (site admin) attempting a self-demotion → `cannot_manage_administrator`. Fixture data restored to its starting state afterwards.
4. **Unauthenticated endpoint** — `POST` with no session returns `rest_not_logged_in` (401).
5. **Layout** — panel checked at 360 / 560 / 800px container widths; the card grid reflows 1 → 2 → 3 columns with no horizontal overflow. No console errors on page load.

6. **Logged-in click-through**, as `member1` on the members page: clicked through Member → Organizer → Event Organizer → Member, confirming each transition landed in the database with `wp user get 13 --fields=roles` between clicks. Left back at `subscriber`.

The screenshot below is the real server-rendered markup and real block CSS, injected into a logged-out page for the layout check — the authenticated behaviour it illustrates is covered by step 6.

#### Screenshots

<img width="1356" height="564" alt="Screenshot 2026-08-28 at 13 48 34" src="https://github.com/user-attachments/assets/9ff4283b-e233-4527-9dd2-d6096750554d" />
