### PR TITLE
Content: add a WP-CLI command to find references to lapsed domains

### DIFF
--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -401,11 +401,27 @@ function verify_unregistered( $domain ) {
 		)
 	);
 
+	/*
+	 * A registry that couldn't be reached hasn't said the domain is registered -- it hasn't said anything.
+	 * Reporting that as `false` would read an unreachable network as evidence of registration, and quietly
+	 * downgrade every genuine finding on a host with no outbound HTTPS.
+	 */
 	if ( is_wp_error( $response ) ) {
+		return null;
+	}
+
+	$code = wp_remote_retrieve_response_code( $response );
+
+	if ( 404 === $code ) {
+		return true;
+	}
+
+	if ( 200 === $code ) {
 		return false;
 	}
 
-	return 404 === wp_remote_retrieve_response_code( $response );
+	// Rate limiting, a 5xx, an unexpected redirect. The registry didn't answer the question either way.
+	return null;
 }
 
 /**
@@ -586,13 +602,21 @@ function scan_network( array $args = array() ) {
 
 			$domain = $result['domain'];
 
-			if ( ! isset( $verified[ $domain ] ) ) {
+			// `array_key_exists`, not `isset`, so a cached `null` isn't looked up again on every host.
+			if ( ! array_key_exists( $domain, $verified ) ) {
 				$verified[ $domain ] = verify_unregistered( $domain );
 			}
 
-			if ( ! $verified[ $domain ] ) {
+			/*
+			 * Only a registry that answered can overturn what DNS found. When it couldn't be asked, the DNS
+			 * evidence is all there is, so the finding stands -- flagged as unconfirmed rather than dropped,
+			 * which is what `verified` carries to the caller.
+			 */
+			if ( false === $verified[ $domain ] ) {
 				$checked[ $host ]['status'] = 'unresolved';
 			}
+
+			$checked[ $host ]['verified'] = $verified[ $domain ];
 		}
 	}
 
@@ -605,8 +629,9 @@ function scan_network( array $args = array() ) {
 			continue;
 		}
 
-		$reference['status'] = $result['status'];
-		$reference['domain'] = $result['domain'];
+		$reference['status']   = $result['status'];
+		$reference['domain']   = $result['domain'];
+		$reference['verified'] = $result['verified'] ?? null;
 
 		$results[] = $reference;
 	}

--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -3,11 +3,7 @@
  * Find external references in published content whose domains no longer exist.
  *
  * Old WordCamp content links to and embeds a lot of third-party sites, and some of those domains eventually
- * lapse. A lapsed domain can be re-registered by anyone, at which point our content is pointing at whatever the
- * new owner puts there. That matters more for some references than others: a stale `<a href>` is a broken link,
- * but a WordPress oEmbed is a live consumer. Core's `wp-embed.min.js` un-hides the `wp-embedded-content` iframe
- * as soon as the framed document answers the embed handshake, so whatever the domain serves ends up rendered in
- * our page without the visitor doing anything.
+ * lapse. Our content goes on referencing them, and nothing currently notices.
  *
  * These functions only report. Deciding what to do about a reference -- update it, unlink it, point it at an
  * archived copy -- needs a human looking at the post.
@@ -54,11 +50,11 @@ const MULTI_LABEL_PUBLIC_SUFFIXES = array(
 );
 
 /**
- * Reference kinds, ordered by how much a re-registered domain would get to do with one.
+ * Reference kinds, ordered by how much the referenced host contributes to the rendered page.
  *
- * `script` is first because a script source runs in our origin. `embed` is a Core oEmbed iframe, which is
- * sandboxed but gets revealed automatically. `url` is a bare URL on its own line, which `WP_Embed::autoembed()`
- * turns into an `embed` when the post is rendered -- so it carries the same weight as one, just later.
+ * A `script` or an `embed` is loaded and used as part of the page, where a `link` is only followed if somebody
+ * clicks it, so the first two are worth reviewing first. `url` is a bare URL on its own line, which
+ * `WP_Embed::autoembed()` turns into an `embed` when the post is rendered, so it belongs with them.
  */
 const REFERENCE_KINDS = array( 'script', 'embed', 'iframe', 'img', 'link', 'url' );
 
@@ -578,10 +574,10 @@ function scan_network( array $args = array() ) {
 }
 
 /**
- * Sort the worst findings to the top.
+ * Sort the findings most worth reviewing to the top.
  *
- * Status first, then reference kind, since a dangling script source deserves attention before a dangling link
- * on the same domain.
+ * Status first, then reference kind, since a stale script source is more worth looking at than a stale link on
+ * the same domain.
  *
  * @param array $a
  * @param array $b

--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -385,11 +385,19 @@ function dns_records( $host, $type ) {
  * that lapsed. RDAP is authoritative, and only ever runs against the handful of candidates that reached
  * 'dangling', so it costs almost nothing.
  *
+ * Expect no answer for a lapsed `.com` in particular. Verisign's RDAP server, which every `.com` resolves to,
+ * closes the connection without a TLS `close_notify` on its 404s, and OpenSSL 3 treats that as an error, so
+ * `wp_remote_get()` discards a response it did in fact receive. Registered domains answer 200 and are
+ * unaffected, which puts the failure squarely on the domains worth reporting. Those are left standing on their
+ * DNS evidence and flagged unconfirmed, for a human to settle with `whois`. Inferring a lapse from a failed
+ * request would assert the very thing that couldn't be checked.
+ *
  * @param string $domain
  *
- * @return bool True only when the registry positively reports no such registration. Anything ambiguous (a
- *              timeout, a rate limit, an unexpected status) returns false, so an inconclusive answer downgrades
- *              the finding rather than asserting something we haven't confirmed.
+ * @return bool|null True when the registry positively reports no such registration, false when it reports one,
+ *                   and null when it didn't answer the question -- an unreachable host, a rate limit, an
+ *                   unexpected status. Null is not evidence in either direction, and only a real answer is
+ *                   allowed to overturn what DNS found.
  */
 function verify_unregistered( $domain ) {
 	$response = wp_remote_get(

--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -1,0 +1,611 @@
+<?php
+/*
+ * Find external references in published content whose domains no longer exist.
+ *
+ * Old WordCamp content links to and embeds a lot of third-party sites, and some of those domains eventually
+ * lapse. A lapsed domain can be re-registered by anyone, at which point our content is pointing at whatever the
+ * new owner puts there. That matters more for some references than others: a stale `<a href>` is a broken link,
+ * but a WordPress oEmbed is a live consumer. Core's `wp-embed.min.js` un-hides the `wp-embedded-content` iframe
+ * as soon as the framed document answers the embed handshake, so whatever the domain serves ends up rendered in
+ * our page without the visitor doing anything.
+ *
+ * These functions only report. Deciding what to do about a reference -- update it, unlink it, point it at an
+ * archived copy -- needs a human looking at the post.
+ *
+ * This file intentionally registers no hooks, so the logic stays callable (and testable) on its own. The CLI
+ * wrapper lives in `wp-cli-commands/dangling-hosts.php`.
+ */
+
+namespace WordCamp\Dangling_Hosts;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Hosts we control, or that are operated by WordPress.org.
+ *
+ * These can't lapse out from under us, so there's no point spending a DNS lookup on them.
+ */
+const FIRST_PARTY_HOST_SUFFIXES = array(
+	'wordcamp.org',
+	'wordpress.org',
+	'wordpress.com',
+	'wordpress.net',
+	'w.org',
+	'wp.com',
+	'gravatar.com',
+);
+
+/**
+ * Public suffixes that are two labels deep.
+ *
+ * `get_registrable_domain()` needs to know that the registrable part of `foo.example.co.uk` is `example.co.uk`
+ * and not `co.uk`. This is a pragmatic subset rather than the full Public Suffix List -- see that function for
+ * why the shortcut is safe here.
+ */
+const MULTI_LABEL_PUBLIC_SUFFIXES = array(
+	'co.uk', 'org.uk', 'me.uk', 'ac.uk', 'gov.uk',
+	'co.jp', 'ne.jp', 'or.jp', 'ac.jp',
+	'co.in', 'net.in', 'org.in',
+	'com.au', 'net.au', 'org.au', 'edu.au',
+	'com.br', 'net.br', 'org.br',
+	'co.nz', 'net.nz', 'org.nz',
+	'com.mx', 'com.ar', 'com.co', 'com.tr', 'com.cn', 'com.tw', 'com.sg', 'com.my', 'com.ph',
+	'co.za', 'co.il', 'co.kr', 'co.id', 'co.th',
+);
+
+/**
+ * Reference kinds, ordered by how much a re-registered domain would get to do with one.
+ *
+ * `script` is first because a script source runs in our origin. `embed` is a Core oEmbed iframe, which is
+ * sandboxed but gets revealed automatically. `url` is a bare URL on its own line, which `WP_Embed::autoembed()`
+ * turns into an `embed` when the post is rendered -- so it carries the same weight as one, just later.
+ */
+const REFERENCE_KINDS = array( 'script', 'embed', 'iframe', 'img', 'link', 'url' );
+
+/**
+ * Pull every external reference out of a chunk of post content.
+ *
+ * Both raw `post_content` and cached oEmbed markup from postmeta go through here. Raw content usually holds a
+ * bare URL where the rendered page will have an iframe, which is why `url` is one of the kinds -- looking only
+ * for iframes would miss embeds that have never been rendered and cached.
+ *
+ * @param string $content
+ *
+ * @return array List of `array( 'host' => string, 'kind' => string, 'url' => string )`, deduplicated on
+ *               host + kind. Relative URLs and first-party hosts are omitted.
+ */
+function extract_references( $content ) {
+	if ( ! is_string( $content ) || '' === trim( $content ) ) {
+		return array();
+	}
+
+	$references = array();
+
+	// `src` on a tag we care about. The tag name decides the kind, except that a Core oEmbed iframe is
+	// distinguished from any other iframe by its class.
+	if ( preg_match_all( '#<(script|iframe|img)\b[^>]*>#i', $content, $tags ) ) {
+		foreach ( $tags[0] as $index => $tag ) {
+			$url = get_attribute_value( $tag, 'src' );
+
+			if ( ! $url ) {
+				continue;
+			}
+
+			$kind = strtolower( $tags[1][ $index ] );
+
+			if ( 'iframe' === $kind && false !== stripos( $tag, 'wp-embedded-content' ) ) {
+				$kind = 'embed';
+			}
+
+			add_reference( $references, $url, $kind );
+		}
+	}
+
+	// Anchors.
+	if ( preg_match_all( '#<a\b[^>]*>#i', $content, $anchors ) ) {
+		foreach ( $anchors[0] as $anchor ) {
+			$url = get_attribute_value( $anchor, 'href' );
+
+			if ( $url ) {
+				add_reference( $references, $url, 'link' );
+			}
+		}
+	}
+
+	/*
+	 * A URL alone on its own line. That's what Core's autoembed looks for, and it's how most of these
+	 * references are actually stored -- the iframe only exists in the rendered output.
+	 *
+	 * The `wp:embed` block stores its URL as a JSON attribute rather than on its own line, so match that
+	 * shape too.
+	 */
+	if ( preg_match_all( '#^\s*(https?://[^\s<>"\']+)\s*$#im', $content, $bare ) ) {
+		foreach ( $bare[1] as $url ) {
+			add_reference( $references, $url, 'url' );
+		}
+	}
+
+	if ( preg_match_all( '#"url"\s*:\s*"(https?://[^"\\\\]+)"#i', $content, $block_attrs ) ) {
+		foreach ( $block_attrs[1] as $url ) {
+			add_reference( $references, $url, 'url' );
+		}
+	}
+
+	return array_values( $references );
+}
+
+/**
+ * Read one attribute out of an HTML start tag.
+ *
+ * Deliberately not a DOM parse -- this runs over a lot of old, frequently malformed content, and a regex that
+ * simply finds nothing is a better failure mode here than a parser that throws.
+ *
+ * @param string $tag
+ * @param string $attribute
+ *
+ * @return string Empty string when the attribute isn't present.
+ */
+function get_attribute_value( $tag, $attribute ) {
+	$pattern = sprintf( '#\b%s\s*=\s*("([^"]*)"|\'([^\']*)\')#i', preg_quote( $attribute, '#' ) );
+
+	if ( ! preg_match( $pattern, $tag, $matches ) ) {
+		return '';
+	}
+
+	$value = isset( $matches[3] ) && '' !== $matches[3] ? $matches[3] : $matches[2];
+
+	return trim( html_entity_decode( $value, ENT_QUOTES, 'UTF-8' ) );
+}
+
+/**
+ * Normalize a URL to a host and record it, unless it's one we don't care about.
+ *
+ * @param array  $references Accumulator, keyed on host + kind so a host repeated throughout a post is only
+ *                           reported once. Passed by reference.
+ * @param string $url
+ * @param string $kind
+ */
+function add_reference( array &$references, $url, $kind ) {
+	$url = trim( $url );
+
+	// Protocol-relative. Everything downstream wants a scheme.
+	if ( str_starts_with( $url, '//' ) ) {
+		$url = 'https:' . $url;
+	}
+
+	$host = wp_parse_url( $url, PHP_URL_HOST );
+
+	// Relative URLs, `mailto:`, `#anchor`, and anything malformed enough that there's no host to check.
+	if ( ! $host ) {
+		return;
+	}
+
+	$host = strtolower( $host );
+
+	if ( is_first_party_host( $host ) ) {
+		return;
+	}
+
+	$key = $host . '|' . $kind;
+
+	if ( ! isset( $references[ $key ] ) ) {
+		$references[ $key ] = array(
+			'host' => $host,
+			'kind' => $kind,
+			'url'  => $url,
+		);
+	}
+}
+
+/**
+ * Is this a host that WordPress.org or WordCamp.org controls?
+ *
+ * @param string $host
+ *
+ * @return bool
+ */
+function is_first_party_host( $host ) {
+	$host = strtolower( ltrim( $host, '.' ) );
+
+	foreach ( FIRST_PARTY_HOST_SUFFIXES as $suffix ) {
+		if ( $host === $suffix || str_ends_with( $host, '.' . $suffix ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Reduce a host to the domain that somebody would actually register.
+ *
+ * `www.example.com` and `cdn.example.com` are both `example.com`; whether they resolve is a question about
+ * that one registration.
+ *
+ * This uses a short list of known two-label public suffixes rather than the full Public Suffix List. Getting it
+ * wrong means returning a suffix like `co.uk` instead of `example.co.uk`, which makes the NS lookup in
+ * `check_host()` succeed and the host get reported as `unresolved` rather than `dangling` -- the cautious
+ * direction, and one the RDAP step would catch anyway.
+ *
+ * @param string $host
+ *
+ * @return string
+ */
+function get_registrable_domain( $host ) {
+	$host   = strtolower( trim( $host, '. ' ) );
+	$labels = explode( '.', $host );
+	$count  = count( $labels );
+
+	if ( $count <= 2 ) {
+		return $host;
+	}
+
+	$last_two = implode( '.', array_slice( $labels, -2 ) );
+
+	if ( in_array( $last_two, MULTI_LABEL_PUBLIC_SUFFIXES, true ) ) {
+		return implode( '.', array_slice( $labels, -3 ) );
+	}
+
+	return $last_two;
+}
+
+/**
+ * Work out whether a host still exists.
+ *
+ * Two stages, because "doesn't resolve" and "isn't registered" aren't the same thing and only the second one is
+ * worth acting on. A subdomain of a live domain can stop resolving for all sorts of mundane reasons, and nobody
+ * else can claim it. A domain with no nameservers at all is a different situation.
+ *
+ * @param string $host
+ *
+ * @return array The `host` that was checked, its registrable `domain`, and a `status` of 'ok' (resolves),
+ *               'unresolved' (doesn't resolve, but the domain is registered), or 'dangling' (the domain
+ *               itself has no nameservers).
+ */
+function check_host( $host ) {
+	$host   = strtolower( $host );
+	$domain = get_registrable_domain( $host );
+
+	/**
+	 * Short-circuit the DNS lookups for a host.
+	 *
+	 * Exists so tests don't depend on the network. Return an array shaped like `check_host()`'s return value
+	 * to take over, or `null` to let the normal lookups run.
+	 *
+	 * @param array|null $result
+	 * @param string     $host
+	 * @param string     $domain
+	 */
+	$pre = apply_filters( 'wcorg_dangling_hosts_pre_check_host', null, $host, $domain );
+
+	if ( is_array( $pre ) ) {
+		return $pre;
+	}
+
+	if ( host_resolves( $host ) ) {
+		return array(
+			'host'   => $host,
+			'domain' => $domain,
+			'status' => 'ok',
+		);
+	}
+
+	// Nothing at the host, so the question becomes whether the registration behind it still exists.
+	$nameservers = dns_records( $domain, DNS_NS );
+
+	return array(
+		'host'   => $host,
+		'domain' => $domain,
+		'status' => empty( $nameservers ) ? 'dangling' : 'unresolved',
+	);
+}
+
+/**
+ * Does the host have an address (directly or through a CNAME)?
+ *
+ * Each record type is queried separately rather than as one combined bitmask. `dns_get_record()` fails the
+ * whole call when any type in the mask errors out -- asking for `DNS_A | DNS_CNAME` on a host that has an
+ * address but no CNAME returns `false`, not the address -- which would make every host look unresolvable.
+ * Querying one at a time and stopping at the first answer also means the usual case costs a single lookup.
+ *
+ * @param string $host
+ *
+ * @return bool
+ */
+function host_resolves( $host ) {
+	foreach ( array( DNS_A, DNS_AAAA, DNS_CNAME ) as $type ) {
+		if ( ! empty( dns_records( $host, $type ) ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Look up DNS records, without letting a lookup failure become a PHP warning.
+ *
+ * `dns_get_record()` emits a warning for NXDOMAIN and some resolver errors, and PHPUnit is configured to turn
+ * warnings into test failures, so suppression here is deliberate rather than lazy.
+ *
+ * @param string $host
+ * @param int    $type One of the `DNS_*` constants.
+ *
+ * @return array
+ */
+function dns_records( $host, $type ) {
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- A failed lookup is an expected result here, not an error.
+	$records = @dns_get_record( $host, $type );
+
+	return is_array( $records ) ? $records : array();
+}
+
+/**
+ * Confirm with the registry that a domain really has no registration.
+ *
+ * DNS not answering is suggestive but not conclusive -- a resolver hiccup mid-scan looks identical to a domain
+ * that lapsed. RDAP is authoritative, and only ever runs against the handful of candidates that reached
+ * 'dangling', so it costs almost nothing.
+ *
+ * @param string $domain
+ *
+ * @return bool True only when the registry positively reports no such registration. Anything ambiguous (a
+ *              timeout, a rate limit, an unexpected status) returns false, so an inconclusive answer downgrades
+ *              the finding rather than asserting something we haven't confirmed.
+ */
+function verify_unregistered( $domain ) {
+	$response = wp_remote_get(
+		'https://rdap.org/domain/' . rawurlencode( $domain ),
+		array(
+			'timeout'     => 15,
+			'redirection' => 5,
+			'headers'     => array( 'Accept' => 'application/rdap+json' ),
+		)
+	);
+
+	if ( is_wp_error( $response ) ) {
+		return false;
+	}
+
+	return 404 === wp_remote_retrieve_response_code( $response );
+}
+
+/**
+ * Collect the external references in one site's published content.
+ *
+ * Reads `post_content` straight out of the database rather than going through `WP_Query`, because this only
+ * needs two columns and may run across a thousand sites.
+ *
+ * Cached oEmbed markup is scanned as well. Core stores the provider's HTML in `_oembed_{hash}` postmeta, and
+ * that markup is what actually reaches the page -- for a classic-editor embed it's the only place the iframe
+ * exists at all.
+ *
+ * @param int   $blog_id
+ * @param array $args Optional. `post_types` limits which post types are read; defaults to `post` and `page`.
+ *
+ * @return array List of references, each with `host`, `kind`, `url`, `post_id`, and `permalink`.
+ */
+function scan_site( $blog_id, array $args = array() ) {
+	global $wpdb;
+
+	$args = wp_parse_args(
+		$args,
+		array( 'post_types' => array( 'post', 'page' ) )
+	);
+
+	$switched = false;
+
+	if ( get_current_blog_id() !== (int) $blog_id ) {
+		switch_to_blog( $blog_id );
+		$switched = true;
+	}
+
+	$references = array();
+
+	try {
+		$post_types = array_values( array_filter( array_map( 'sanitize_key', (array) $args['post_types'] ) ) );
+
+		if ( empty( $post_types ) ) {
+			return array();
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a generated list of %s, and $wpdb->posts is not user input.
+		$sql = "SELECT ID, post_content FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_type IN ( $placeholders )";
+
+		$posts = $wpdb->get_results( $wpdb->prepare( $sql, $post_types ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above.
+
+		foreach ( $posts as $post ) {
+			collect_references( $references, extract_references( $post->post_content ), (int) $post->ID, $blog_id );
+		}
+
+		// Cached oEmbed markup, which usually isn't present in `post_content`.
+		$oembed_meta = $wpdb->get_results(
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key LIKE '\_oembed\_%'"
+		);
+
+		foreach ( $oembed_meta as $meta ) {
+			if ( ! is_string( $meta->meta_value ) ) {
+				continue;
+			}
+
+			collect_references( $references, extract_references( $meta->meta_value ), (int) $meta->post_id, $blog_id );
+		}
+	} finally {
+		if ( $switched ) {
+			restore_current_blog();
+		}
+	}
+
+	return array_values( $references );
+}
+
+/**
+ * Merge a post's references into a site-level accumulator.
+ *
+ * Keyed on host + kind + post so the same host appearing in both `post_content` and its cached oEmbed markup
+ * only gets reported once.
+ *
+ * @param array $accumulator Passed by reference.
+ * @param array $references
+ * @param int   $post_id
+ * @param int   $blog_id
+ */
+function collect_references( array &$accumulator, array $references, $post_id, $blog_id ) {
+	foreach ( $references as $reference ) {
+		$key = $reference['host'] . '|' . $reference['kind'] . '|' . $post_id;
+
+		if ( isset( $accumulator[ $key ] ) ) {
+			continue;
+		}
+
+		$reference['post_id']   = $post_id;
+		$reference['blog_id']   = (int) $blog_id;
+		$reference['permalink'] = get_permalink( $post_id );
+
+		$accumulator[ $key ] = $reference;
+	}
+}
+
+/**
+ * Scan sites and report which of their external references point at hosts that no longer exist.
+ *
+ * Each distinct host is checked once no matter how many sites reference it, which is what keeps this
+ * proportional to the number of domains rather than the number of posts.
+ *
+ * @param array $args Optional. `blog_ids` limits the scan to specific sites, defaulting to the whole network;
+ *                     `post_types` defaults to `post` and `page`; `kinds` limits which reference kinds are
+ *                     reported, defaulting to all of `REFERENCE_KINDS`; `verify` confirms lapsed domains
+ *                     against RDAP, default true; `include_ok` also reports hosts that resolve, default
+ *                     false; `progress` is called with each blog ID as it's scanned.
+ *
+ * @return array List of references, each with the fields from `scan_site()` plus `status` and `domain`.
+ *               'dangling' entries are listed first, then 'unresolved', then 'ok'.
+ */
+function scan_network( array $args = array() ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'blog_ids'   => array(),
+			'post_types' => array( 'post', 'page' ),
+			'kinds'      => REFERENCE_KINDS,
+			'verify'     => true,
+			'include_ok' => false,
+			'progress'   => null,
+		)
+	);
+
+	$blog_ids = $args['blog_ids'];
+
+	if ( empty( $blog_ids ) ) {
+		$blog_ids = get_sites(
+			array(
+				'number'   => 0,
+				'fields'   => 'ids',
+				'archived' => 0,
+				'deleted'  => 0,
+				'spam'     => 0,
+			)
+		);
+	}
+
+	$references = array();
+
+	foreach ( $blog_ids as $blog_id ) {
+		foreach ( scan_site( (int) $blog_id, array( 'post_types' => $args['post_types'] ) ) as $reference ) {
+			if ( in_array( $reference['kind'], $args['kinds'], true ) ) {
+				$references[] = $reference;
+			}
+		}
+
+		if ( is_callable( $args['progress'] ) ) {
+			call_user_func( $args['progress'], $blog_id );
+		}
+	}
+
+	// One check per distinct host, however many references share it.
+	$checked = array();
+
+	foreach ( $references as $reference ) {
+		if ( ! isset( $checked[ $reference['host'] ] ) ) {
+			$checked[ $reference['host'] ] = check_host( $reference['host'] );
+		}
+	}
+
+	/*
+	 * Ask the registry about the candidates. A domain that DNS couldn't answer for but that RDAP says is
+	 * registered gets downgraded to 'unresolved' -- still worth a look, but not the thing we're hunting.
+	 */
+	if ( $args['verify'] ) {
+		$verified = array();
+
+		foreach ( $checked as $host => $result ) {
+			if ( 'dangling' !== $result['status'] ) {
+				continue;
+			}
+
+			$domain = $result['domain'];
+
+			if ( ! isset( $verified[ $domain ] ) ) {
+				$verified[ $domain ] = verify_unregistered( $domain );
+			}
+
+			if ( ! $verified[ $domain ] ) {
+				$checked[ $host ]['status'] = 'unresolved';
+			}
+		}
+	}
+
+	$results = array();
+
+	foreach ( $references as $reference ) {
+		$result = $checked[ $reference['host'] ];
+
+		if ( 'ok' === $result['status'] && ! $args['include_ok'] ) {
+			continue;
+		}
+
+		$reference['status'] = $result['status'];
+		$reference['domain'] = $result['domain'];
+
+		$results[] = $reference;
+	}
+
+	usort( $results, __NAMESPACE__ . '\compare_references' );
+
+	return $results;
+}
+
+/**
+ * Sort the worst findings to the top.
+ *
+ * Status first, then reference kind, since a dangling script source deserves attention before a dangling link
+ * on the same domain.
+ *
+ * @param array $a
+ * @param array $b
+ *
+ * @return int
+ */
+function compare_references( $a, $b ) {
+	$status_order = array(
+		'dangling'   => 0,
+		'unresolved' => 1,
+		'ok'         => 2,
+	);
+
+	$by_status = $status_order[ $a['status'] ] <=> $status_order[ $b['status'] ];
+
+	if ( 0 !== $by_status ) {
+		return $by_status;
+	}
+
+	$by_kind = array_search( $a['kind'], REFERENCE_KINDS, true ) <=> array_search( $b['kind'], REFERENCE_KINDS, true );
+
+	if ( 0 !== $by_kind ) {
+		return $by_kind;
+	}
+
+	return strcmp( $a['host'], $b['host'] );
+}

--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -178,7 +178,7 @@ function add_reference( array &$references, $url, $kind ) {
 
 	$host = strtolower( $host );
 
-	if ( is_first_party_host( $host ) ) {
+	if ( ! is_scannable_host( $host ) || is_first_party_host( $host ) ) {
 		return;
 	}
 
@@ -191,6 +191,48 @@ function add_reference( array &$references, $url, $kind ) {
 			'url'  => $url,
 		);
 	}
+}
+
+/**
+ * Is this host a name somebody could have registered?
+ *
+ * Two decades of hand-written content contain hrefs that never described a real host: a comma or a closing
+ * parenthesis swept in from the surrounding prose, a stray space, an IP literal typed during a migration.
+ * None of those is a registration, so none of them can lapse. Reporting one as a lapsed domain states
+ * something untrue about it, and buries the references that do need attention.
+ *
+ * Checking the shape here also keeps the malformed ones out of the DNS and RDAP lookups behind the report,
+ * which is where the scan spends nearly all of its time.
+ *
+ * @param string $host
+ *
+ * @return bool
+ */
+function is_scannable_host( $host ) {
+	// The maximum length of a fully qualified name, per RFC 1035.
+	if ( strlen( $host ) > 253 ) {
+		return false;
+	}
+
+	$labels = explode( '.', $host );
+
+	// A single label is `localhost` or an intranet name, not something anybody registers.
+	if ( count( $labels ) < 2 ) {
+		return false;
+	}
+
+	foreach ( $labels as $label ) {
+		if ( ! preg_match( '#^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$#', $label ) ) {
+			return false;
+		}
+	}
+
+	/*
+	 * A last label that isn't alphabetic means an IP literal, which is an address rather than a registration.
+	 * `xn--` is spelled out because a punycode TLD carries digits and hyphens that a plain alphabetic test
+	 * would reject.
+	 */
+	return (bool) preg_match( '#^(?:[a-z]{2,}|xn--[a-z0-9-]+)$#', end( $labels ) );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -458,6 +458,7 @@ function collect_references( array &$accumulator, array $references, $post_id, $
 
 		$reference['post_id']   = $post_id;
 		$reference['blog_id']   = (int) $blog_id;
+		$reference['site']      = home_url();
 		$reference['permalink'] = get_permalink( $post_id );
 
 		$accumulator[ $key ] = $reference;

--- a/public_html/wp-content/mu-plugins/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/dangling-hosts.php
@@ -121,9 +121,16 @@ function extract_references( $content ) {
 		}
 	}
 
-	if ( preg_match_all( '#"url"\s*:\s*"(https?://[^"\\\\]+)"#i', $content, $block_attrs ) ) {
-		foreach ( $block_attrs[1] as $url ) {
-			add_reference( $references, $url, 'url' );
+	/*
+	 * Scoped to the embed block rather than any block carrying a `url` attribute. A `wp:button` has one too,
+	 * and reporting that as a `url` would both duplicate the `link` its anchor already produces and rank it
+	 * above that link, as though a button were a thing the page loads on its own.
+	 */
+	if ( preg_match_all( '#<!--\s+wp:embed\s+(\{.*?\})\s*/?-->#is', $content, $embed_blocks ) ) {
+		foreach ( $embed_blocks[1] as $attributes ) {
+			if ( preg_match( '#"url"\s*:\s*"(https?://[^"\\\\]+)"#i', $attributes, $matched ) ) {
+				add_reference( $references, $matched[1], 'url' );
+			}
 		}
 	}
 
@@ -482,10 +489,22 @@ function scan_site( $blog_id, array $args = array() ) {
 			collect_references( $references, extract_references( $post->post_content ), (int) $post->ID, $blog_id );
 		}
 
-		// Cached oEmbed markup, which usually isn't present in `post_content`.
-		$oembed_meta = $wpdb->get_results(
-			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key LIKE '\_oembed\_%'"
-		);
+		/*
+		 * Cached oEmbed markup, which usually isn't present in `post_content`.
+		 *
+		 * Joined to the posts table rather than read on its own: postmeta carries no status or type, so the
+		 * rows have to be qualified by the post they hang off, or a draft's cached embed gets reported the
+		 * same as a published one.
+		 */
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a generated list of %s, and the table names are not user input.
+		$oembed_sql = "SELECT meta.post_id, meta.meta_value
+			FROM {$wpdb->postmeta} AS meta
+			INNER JOIN {$wpdb->posts} AS post ON post.ID = meta.post_id
+			WHERE meta.meta_key LIKE '\_oembed\_%'
+			AND post.post_status = 'publish'
+			AND post.post_type IN ( $placeholders )";
+
+		$oembed_meta = $wpdb->get_results( $wpdb->prepare( $oembed_sql, $post_types ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above.
 
 		foreach ( $oembed_meta as $meta ) {
 			if ( ! is_string( $meta->meta_value ) ) {

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -32,6 +32,7 @@ function manually_load_plugins() {
 	require_once dirname( __DIR__ ) . '/0-error-handling.php';
 	require_once dirname( __DIR__ ) . '/wordcamp/lets-encrypt-helper.php';
 	require_once dirname( __DIR__ ) . '/latest-site-hints.php';
+	require_once dirname( __DIR__ ) . '/dangling-hosts.php';
 	require_once dirname( __DIR__ ) . '/trusted-deputy-capabilities.php';
 	require_once dirname( __DIR__ ) . '/wcorg-subroles.php';
 	require_once dirname( __DIR__ ) . '/wcorg-network-theme-control.php';

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -359,10 +359,98 @@ class Test_Dangling_Hosts extends Database_TestCase {
 	}
 
 	/**
-	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 * Run a scan of one site with the registry stubbed to a given response.
 	 *
-	 * A reference that only exists in the raw post content should be found.
+	 * @param array|WP_Error $response What `wp_remote_get()` should return for the RDAP request.
+	 *
+	 * @return array The references the scan reported.
 	 */
+	protected function scan_with_registry_response( $response ) {
+		$stub = function () use ( $response ) {
+			return $response;
+		};
+
+		add_filter( 'pre_http_request', $stub );
+
+		try {
+			return scan_network( array( 'blog_ids' => array( get_current_blog_id() ), 'verify' => true ) );
+		} finally {
+			remove_filter( 'pre_http_request', $stub );
+		}
+	}
+
+	/**
+	 * A registry that confirms the domain is gone leaves the finding standing.
+	 *
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 * @covers WordCamp\Dangling_Hosts\verify_unregistered
+	 */
+	public function test_a_confirmed_lapsed_domain_stays_dangling() {
+		$this->stubbed_hosts['gone.example'] = 'dangling';
+		$this->create_published_post( '<a href="https://gone.example/a">Link</a>' );
+
+		$references = $this->scan_with_registry_response( array( 'response' => array( 'code' => 404 ) ) );
+
+		$this->assertCount( 1, $references );
+		$this->assertSame( 'dangling', $references[0]['status'] );
+		$this->assertTrue( $references[0]['verified'] );
+	}
+
+	/**
+	 * A registry that says the domain is registered overturns what DNS found.
+	 *
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 * @covers WordCamp\Dangling_Hosts\verify_unregistered
+	 */
+	public function test_a_registered_domain_is_downgraded() {
+		$this->stubbed_hosts['parked.example'] = 'dangling';
+		$this->create_published_post( '<a href="https://parked.example/a">Link</a>' );
+
+		$references = $this->scan_with_registry_response( array( 'response' => array( 'code' => 200 ) ) );
+
+		$this->assertCount( 1, $references );
+		$this->assertSame( 'unresolved', $references[0]['status'] );
+		$this->assertFalse( $references[0]['verified'] );
+	}
+
+	/**
+	 * A registry that couldn't be reached is not evidence that the domain is registered.
+	 *
+	 * Reading a failed request as `registered` downgrades every genuine finding to `unresolved`, so a host
+	 * with no outbound HTTPS reports a clean run while suppressing exactly what the scan is looking for.
+	 *
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 * @covers WordCamp\Dangling_Hosts\verify_unregistered
+	 */
+	public function test_an_unreachable_registry_does_not_downgrade_a_finding() {
+		$this->stubbed_hosts['gone.example'] = 'dangling';
+		$this->create_published_post( '<a href="https://gone.example/a">Link</a>' );
+
+		$references = $this->scan_with_registry_response(
+			new \WP_Error( 'http_request_failed', 'Could not resolve host.' )
+		);
+
+		$this->assertCount( 1, $references );
+		$this->assertSame( 'dangling', $references[0]['status'] );
+		$this->assertNull( $references[0]['verified'], 'An unreachable registry must not read as confirmation.' );
+	}
+
+	/**
+	 * A registry that answers with neither a 200 nor a 404 hasn't answered the question.
+	 *
+	 * @covers WordCamp\Dangling_Hosts\verify_unregistered
+	 */
+	public function test_an_inconclusive_registry_response_does_not_downgrade_a_finding() {
+		$this->stubbed_hosts['gone.example'] = 'dangling';
+		$this->create_published_post( '<a href="https://gone.example/a">Link</a>' );
+
+		$references = $this->scan_with_registry_response( array( 'response' => array( 'code' => 429 ) ) );
+
+		$this->assertCount( 1, $references );
+		$this->assertSame( 'dangling', $references[0]['status'] );
+		$this->assertNull( $references[0]['verified'] );
+	}
+
 	/**
 	 * The scan reports; it never writes.
 	 *
@@ -410,6 +498,11 @@ class Test_Dangling_Hosts extends Database_TestCase {
 		$this->assertSame( array(), $writes, 'The scan issued a statement that writes.' );
 	}
 
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
+	 * A reference that only exists in the raw post content should be found.
+	 */
 	public function test_scan_site_finds_references_in_post_content() {
 		$post_id = $this->create_published_post(
 			'<a href="https://example.net/article">Read more</a>'

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -166,6 +166,22 @@ class Test_Dangling_Hosts extends Database_TestCase {
 				array( 'blog.example.net|url' ),
 			),
 
+			/*
+			 * Other blocks carry a `url` attribute too. A button's is a link the visitor may follow, not
+			 * something the page loads, so it should be reported once as the link its anchor already is.
+			 */
+			'button block url is only a link' => array(
+				'<!-- wp:button {"url":"https://shop.example.net/buy"} -->' .
+				'<div class="wp-block-button"><a class="wp-block-button__link" href="https://shop.example.net/buy">Buy</a></div>' .
+				'<!-- /wp:button -->',
+				array( 'shop.example.net|link' ),
+			),
+
+			'multiline embed block attribute' => array(
+				"<!-- wp:embed {\n\t\"url\": \"https://blog.example.net/a-post/\",\n\t\"type\": \"rich\"\n} /-->",
+				array( 'blog.example.net|url' ),
+			),
+
 			'protocol relative urls are normalized' => array(
 				'<script src="//cdn.example.net/a.js"></script>',
 				array( 'cdn.example.net|script' ),
@@ -599,6 +615,56 @@ class Test_Dangling_Hosts extends Database_TestCase {
 		$hosts = wp_list_pluck( scan_site( get_current_blog_id() ), 'host' );
 
 		$this->assertNotContains( 'draft-only.example.net', $hosts );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
+	 * The cached oEmbed markup is read from postmeta, which has no status of its own -- it belongs to whatever
+	 * post it hangs off. A draft keeps its `_oembed_` meta, so scanning the meta without consulting the post
+	 * reports content nobody is served, and a scheduled run fails over a page that isn't public.
+	 */
+	public function test_scan_site_ignores_cached_oembed_on_unpublished_posts() {
+		$draft_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			)
+		);
+
+		add_post_meta(
+			$draft_id,
+			'_oembed_1234567890abcdef',
+			'<iframe src="https://draft-embed.example.net/embed/"></iframe>'
+		);
+
+		$hosts = wp_list_pluck( scan_site( get_current_blog_id() ), 'host' );
+
+		$this->assertNotContains( 'draft-embed.example.net', $hosts );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
+	 * Same for a post type the caller didn't ask about.
+	 */
+	public function test_scan_site_ignores_cached_oembed_on_other_post_types() {
+		$other_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'attachment',
+			)
+		);
+
+		add_post_meta(
+			$other_id,
+			'_oembed_abcdef1234567890',
+			'<iframe src="https://other-type.example.net/embed/"></iframe>'
+		);
+
+		$hosts = wp_list_pluck( scan_site( get_current_blog_id() ), 'host' );
+
+		$this->assertNotContains( 'other-type.example.net', $hosts );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -5,7 +5,8 @@ use WP_UnitTest_Factory;
 use WordCamp\Tests\Database_TestCase;
 
 use function WordCamp\Dangling_Hosts\{
-	check_host, extract_references, get_registrable_domain, is_first_party_host, scan_network, scan_site
+	check_host, extract_references, get_registrable_domain, is_first_party_host, is_scannable_host,
+	scan_network, scan_site
 };
 
 defined( 'WPINC' ) || die();
@@ -212,9 +213,71 @@ class Test_Dangling_Hosts extends Database_TestCase {
 				array( 'example.net|link' ),
 			),
 
+			/*
+			 * A URL that picked up the punctuation following it in the prose. The host it yields was never a
+			 * real one, so it shouldn't reach the report as a lapsed domain.
+			 */
+			'href with trailing punctuation' => array(
+				'<a href="https://example.net,/">Link</a>',
+				array(),
+			),
+
+			'href with an ip literal' => array(
+				'<a href="http://192.168.1.1/admin">Link</a>',
+				array(),
+			),
+
 			'empty content' => array( '', array() ),
 
 			'content with no references' => array( '<p>Just some words.</p>', array() ),
+		);
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\is_scannable_host
+	 *
+	 * @dataProvider data_is_scannable_host
+	 *
+	 * @param string $host
+	 * @param bool   $expected
+	 */
+	public function test_is_scannable_host( $host, $expected ) {
+		$this->assertSame( $expected, is_scannable_host( $host ) );
+	}
+
+	/**
+	 * Test cases for `test_is_scannable_host()`.
+	 *
+	 * @return array
+	 */
+	public function data_is_scannable_host() {
+		return array(
+			'ordinary domain'         => array( 'example.net', true ),
+			'subdomain'               => array( 'cdn.example.net', true ),
+			'hyphenated label'        => array( 'my-site.example.net', true ),
+			'digits in label'         => array( 'web2.example.net', true ),
+			'long tld'                => array( 'example.photography', true ),
+			'punycode domain'         => array( 'xn--80ak6aa92e.com', true ),
+			'punycode tld'            => array( 'example.xn--p1ai', true ),
+
+			/*
+			 * The shapes that prompted this check. Each one is a typo in the content rather than a host, so
+			 * calling its domain lapsed would assert something untrue about a name nobody can register.
+			 */
+			'trailing comma'          => array( 'example.net,', false ),
+			'trailing paren'          => array( 'example.net)', false ),
+			'embedded space'          => array( 'example .net', false ),
+			'ipv4 literal'            => array( '192.168.1.1', false ),
+			'bracketed ipv6 literal'  => array( '[::1]', false ),
+
+			'single label'            => array( 'localhost', false ),
+			'empty label'             => array( 'example..net', false ),
+			'leading dot'             => array( '.example.net', false ),
+			'label starting a hyphen' => array( '-example.net', false ),
+			'label ending a hyphen'   => array( 'example-.net', false ),
+			'underscore'              => array( 'my_site.example.net', false ),
+			'single character tld'    => array( 'example.n', false ),
+			'over the length limit'   => array( str_repeat( 'a.', 130 ) . 'net', false ),
 		);
 	}
 

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -373,7 +373,12 @@ class Test_Dangling_Hosts extends Database_TestCase {
 		add_filter( 'pre_http_request', $stub );
 
 		try {
-			return scan_network( array( 'blog_ids' => array( get_current_blog_id() ), 'verify' => true ) );
+			return scan_network(
+				array(
+					'blog_ids' => array( get_current_blog_id() ),
+					'verify'   => true,
+				)
+			);
 		} finally {
 			remove_filter( 'pre_http_request', $stub );
 		}

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -351,6 +351,32 @@ class Test_Dangling_Hosts extends Database_TestCase {
 	/**
 	 * @covers WordCamp\Dangling_Hosts\scan_site
 	 *
+	 * Each finding has to name the site it came from, so a network-wide report can be grouped by site without
+	 * anyone having to parse it back out of the permalink.
+	 */
+	public function test_scan_site_records_the_site_each_reference_came_from() {
+		$this->create_published_post( '<a href="https://example.net/article">Read more</a>' );
+
+		$references = scan_site( get_current_blog_id() );
+		$matched    = false;
+
+		foreach ( $references as $reference ) {
+			if ( 'example.net' !== $reference['host'] ) {
+				continue;
+			}
+
+			$matched = true;
+
+			$this->assertSame( get_current_blog_id(), $reference['blog_id'] );
+			$this->assertSame( home_url(), $reference['site'] );
+		}
+
+		$this->assertTrue( $matched, 'The seeded reference was not found.' );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
 	 * Unpublished content isn't served to anyone, so it shouldn't generate findings.
 	 */
 	public function test_scan_site_ignores_unpublished_posts() {

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -77,9 +77,9 @@ class Test_Dangling_Hosts extends Database_TestCase {
 	 * Create a published post whose content reaches the database verbatim.
 	 *
 	 * The suite defines `DISALLOW_UNFILTERED_HTML`, so `wp_insert_post()` runs the content through kses and
-	 * strips tags like `<script>`. Old imported content can still contain them, and they're the highest-risk
-	 * thing this scanner looks for, so the fixture writes the column directly rather than going through the
-	 * editor's sanitization.
+	 * strips tags like `<script>`. Old imported content can still contain them, and the scanner needs to
+	 * report them, so the fixture writes the column directly rather than going through the editor's
+	 * sanitization.
 	 *
 	 * @param string $content
 	 *
@@ -423,8 +423,8 @@ class Test_Dangling_Hosts extends Database_TestCase {
 	/**
 	 * @covers WordCamp\Dangling_Hosts\scan_network
 	 *
-	 * A subdomain that stopped resolving under a domain that's still registered is a broken reference, but
-	 * nobody else can take it over, so it must not be conflated with a lapsed domain.
+	 * A subdomain that stopped resolving under a domain that's still registered needs different follow-up
+	 * than a lapsed registration, so the two must not be conflated.
 	 */
 	public function test_scan_network_separates_unresolved_from_dangling() {
 		$this->create_published_post(

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -363,6 +363,53 @@ class Test_Dangling_Hosts extends Database_TestCase {
 	 *
 	 * A reference that only exists in the raw post content should be found.
 	 */
+	/**
+	 * The scan reports; it never writes.
+	 *
+	 * That's what makes it safe to point at a production database, and it's a property worth failing a build
+	 * over rather than re-deriving by reading the code. Every `wpdb` query passes through the `query` filter,
+	 * so watching that catches a write wherever somebody later adds one.
+	 *
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 */
+	public function test_the_scan_issues_no_write_statements() {
+		$this->create_published_post(
+			'<a href="https://example.net/article">Read more</a>'
+		);
+
+		$writes = array();
+
+		$watch = function ( $query ) use ( &$writes ) {
+			$normalized = ltrim( $query, "( \t\n\r" );
+			$reads      = array(
+				'SELECT', 'SHOW', 'DESCRIBE', 'DESC', 'EXPLAIN',
+				'SET', 'USE', 'START TRANSACTION', 'BEGIN', 'COMMIT', 'ROLLBACK', 'UNLOCK',
+			);
+
+			foreach ( $reads as $prefix ) {
+				if ( 0 === stripos( $normalized, $prefix ) ) {
+					return $query;
+				}
+			}
+
+			$writes[] = $normalized;
+
+			return $query;
+		};
+
+		add_filter( 'query', $watch );
+
+		try {
+			scan_site( get_current_blog_id() );
+			scan_network( array( 'blog_ids' => array( get_current_blog_id() ) ) );
+		} finally {
+			remove_filter( 'query', $watch );
+		}
+
+		$this->assertSame( array(), $writes, 'The scan issued a statement that writes.' );
+	}
+
 	public function test_scan_site_finds_references_in_post_content() {
 		$post_id = $this->create_published_post(
 			'<a href="https://example.net/article">Read more</a>'

--- a/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/tests/test-dangling-hosts.php
@@ -1,0 +1,514 @@
+<?php
+
+namespace WordCamp\Dangling_Hosts\Tests;
+use WP_UnitTest_Factory;
+use WordCamp\Tests\Database_TestCase;
+
+use function WordCamp\Dangling_Hosts\{
+	check_host, extract_references, get_registrable_domain, is_first_party_host, scan_network, scan_site
+};
+
+defined( 'WPINC' ) || die();
+
+/*
+ * The `WordPress.WP.EnqueuedResources` sniff fires on the `<script src=...>` samples below. They're strings of
+ * content being fed to the parser, not scripts this file outputs, so there's nothing to enqueue.
+ *
+ * phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+ */
+
+/**
+ * @group mu-plugins
+ * @group dangling-hosts
+ */
+class Test_Dangling_Hosts extends Database_TestCase {
+	/**
+	 * DNS answers to hand back instead of making real lookups, keyed by host.
+	 *
+	 * @var array
+	 */
+	protected $stubbed_hosts = array();
+
+	/**
+	 * Replace the DNS lookups for the duration of each test.
+	 *
+	 * Every test in here would otherwise be at the mercy of whatever the resolver says today, and asserting on
+	 * a real domain's registration status would make the suite fail the moment somebody registered it.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->stubbed_hosts = array();
+
+		add_filter( 'wcorg_dangling_hosts_pre_check_host', array( $this, 'stub_check_host' ), 10, 3 );
+	}
+
+	/**
+	 * Remove the DNS stub.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'wcorg_dangling_hosts_pre_check_host', array( $this, 'stub_check_host' ), 10 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Return the canned status for a host, if the test registered one.
+	 *
+	 * @param array|null $result
+	 * @param string     $host
+	 * @param string     $domain
+	 *
+	 * @return array|null
+	 */
+	public function stub_check_host( $result, $host, $domain ) {
+		if ( ! isset( $this->stubbed_hosts[ $host ] ) ) {
+			return $result;
+		}
+
+		return array(
+			'host'   => $host,
+			'domain' => $domain,
+			'status' => $this->stubbed_hosts[ $host ],
+		);
+	}
+
+	/**
+	 * Create a published post whose content reaches the database verbatim.
+	 *
+	 * The suite defines `DISALLOW_UNFILTERED_HTML`, so `wp_insert_post()` runs the content through kses and
+	 * strips tags like `<script>`. Old imported content can still contain them, and they're the highest-risk
+	 * thing this scanner looks for, so the fixture writes the column directly rather than going through the
+	 * editor's sanitization.
+	 *
+	 * @param string $content
+	 *
+	 * @return int Post ID.
+	 */
+	protected function create_published_post( $content ) {
+		global $wpdb;
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$wpdb->update( $wpdb->posts, array( 'post_content' => $content ), array( 'ID' => $post_id ) );
+		clean_post_cache( $post_id );
+
+		return $post_id;
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\extract_references
+	 *
+	 * @dataProvider data_extract_references
+	 *
+	 * @param string $content
+	 * @param array  $expected List of `host|kind` pairs.
+	 */
+	public function test_extract_references( $content, $expected ) {
+		$actual = array_map(
+			function ( $reference ) {
+				return $reference['host'] . '|' . $reference['kind'];
+			},
+			extract_references( $content )
+		);
+
+		sort( $actual );
+		sort( $expected );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Test cases for `test_extract_references()`.
+	 *
+	 * @return array
+	 */
+	public function data_extract_references() {
+		return array(
+			'script source' => array(
+				'<script src="https://cdn.example.net/player.js"></script>',
+				array( 'cdn.example.net|script' ),
+			),
+
+			'core oembed iframe is distinguished from a plain one' => array(
+				'<iframe class="wp-embedded-content" src="https://blog.example.net/post/embed/#?secret=abc"></iframe>',
+				array( 'blog.example.net|embed' ),
+			),
+
+			'plain iframe' => array(
+				'<iframe src="https://video.example.net/watch/123"></iframe>',
+				array( 'video.example.net|iframe' ),
+			),
+
+			'image' => array(
+				'<img src="https://images.example.net/photo.jpg" alt="" />',
+				array( 'images.example.net|img' ),
+			),
+
+			'anchor' => array(
+				'<a href="https://example.net/article">Read more</a>',
+				array( 'example.net|link' ),
+			),
+
+			'bare url on its own line is what autoembed acts on' => array(
+				"Some text\n\nhttps://blog.example.net/a-post/\n\nMore text",
+				array( 'blog.example.net|url' ),
+			),
+
+			'embed block attribute' => array(
+				'<!-- wp:embed {"url":"https://blog.example.net/a-post/","type":"rich"} /-->',
+				array( 'blog.example.net|url' ),
+			),
+
+			'protocol relative urls are normalized' => array(
+				'<script src="//cdn.example.net/a.js"></script>',
+				array( 'cdn.example.net|script' ),
+			),
+
+			'relative urls have no host to check' => array(
+				'<a href="/local/page">Local</a><img src="../uploads/a.png" />',
+				array(),
+			),
+
+			'non http schemes are ignored' => array(
+				'<a href="mailto:someone@example.net">Mail</a><a href="#section">Jump</a>',
+				array(),
+			),
+
+			'first party hosts are skipped' => array(
+				'<a href="https://central.wordcamp.org/">Central</a>
+				 <img src="https://secure.gravatar.com/avatar/abc" />
+				 <script src="https://s0.wp.com/a.js"></script>',
+				array(),
+			),
+
+			'a host repeated in the same kind is only reported once' => array(
+				'<a href="https://example.net/one">One</a><a href="https://example.net/two">Two</a>',
+				array( 'example.net|link' ),
+			),
+
+			'the same host in different kinds is reported per kind' => array(
+				'<a href="https://example.net/a">A</a><img src="https://example.net/b.png" />',
+				array( 'example.net|link', 'example.net|img' ),
+			),
+
+			'single quoted attributes' => array(
+				"<img src='https://images.example.net/photo.jpg' />",
+				array( 'images.example.net|img' ),
+			),
+
+			'entity encoded attribute values' => array(
+				'<a href="https://example.net/a?x=1&amp;y=2">Link</a>',
+				array( 'example.net|link' ),
+			),
+
+			'uppercase host is normalized' => array(
+				'<a href="https://EXAMPLE.NET/a">Link</a>',
+				array( 'example.net|link' ),
+			),
+
+			'empty content' => array( '', array() ),
+
+			'content with no references' => array( '<p>Just some words.</p>', array() ),
+		);
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\is_first_party_host
+	 *
+	 * @dataProvider data_is_first_party_host
+	 *
+	 * @param string $host
+	 * @param bool   $expected
+	 */
+	public function test_is_first_party_host( $host, $expected ) {
+		$this->assertSame( $expected, is_first_party_host( $host ) );
+	}
+
+	/**
+	 * Test cases for `test_is_first_party_host()`.
+	 *
+	 * @return array
+	 */
+	public function data_is_first_party_host() {
+		return array(
+			'apex'                     => array( 'wordcamp.org', true ),
+			'subdomain'                => array( 'seattle.wordcamp.org', true ),
+			'deep subdomain'           => array( '2020.seattle.wordcamp.org', true ),
+			'sibling org'              => array( 'make.wordpress.org', true ),
+			'third party'              => array( 'example.net', false ),
+
+			/*
+			 * The suffix has to match on a label boundary. A domain someone else registered that merely ends
+			 * in our name is not ours.
+			 */
+			'lookalike is not matched' => array( 'notwordcamp.org', false ),
+		);
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\get_registrable_domain
+	 *
+	 * @dataProvider data_get_registrable_domain
+	 *
+	 * @param string $host
+	 * @param string $expected
+	 */
+	public function test_get_registrable_domain( $host, $expected ) {
+		$this->assertSame( $expected, get_registrable_domain( $host ) );
+	}
+
+	/**
+	 * Test cases for `test_get_registrable_domain()`.
+	 *
+	 * @return array
+	 */
+	public function data_get_registrable_domain() {
+		return array(
+			'apex'                    => array( 'example.net', 'example.net' ),
+			'subdomain'               => array( 'www.example.net', 'example.net' ),
+			'deep subdomain'          => array( 'a.b.c.example.net', 'example.net' ),
+			'multi label suffix'      => array( 'www.example.co.uk', 'example.co.uk' ),
+			'multi label suffix apex' => array( 'example.com.au', 'example.com.au' ),
+			'uppercase'               => array( 'WWW.EXAMPLE.NET', 'example.net' ),
+			'trailing dot'            => array( 'www.example.net.', 'example.net' ),
+		);
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\check_host
+	 *
+	 * Verify the stub short-circuits the real lookups, so the rest of the suite can rely on it.
+	 */
+	public function test_check_host_uses_injected_result() {
+		$this->stubbed_hosts = array( 'cdn.example.net' => 'dangling' );
+
+		$actual = check_host( 'cdn.example.net' );
+
+		$this->assertSame( 'dangling', $actual['status'] );
+		$this->assertSame( 'example.net', $actual['domain'] );
+		$this->assertSame( 'cdn.example.net', $actual['host'] );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
+	 * A reference that only exists in the raw post content should be found.
+	 */
+	public function test_scan_site_finds_references_in_post_content() {
+		$post_id = $this->create_published_post(
+			'<a href="https://example.net/article">Read more</a>'
+		);
+
+		$references = scan_site( get_current_blog_id() );
+		$hosts      = wp_list_pluck( $references, 'host' );
+
+		$this->assertContains( 'example.net', $hosts );
+
+		foreach ( $references as $reference ) {
+			if ( 'example.net' === $reference['host'] ) {
+				$this->assertSame( $post_id, $reference['post_id'] );
+				$this->assertSame( 'link', $reference['kind'] );
+			}
+		}
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
+	 * The iframe for a classic-editor embed lives in the oEmbed cache rather than in the post, so scanning
+	 * `post_content` alone would miss the host it points at.
+	 */
+	public function test_scan_site_finds_references_in_cached_oembed_markup() {
+		$post_id = $this->create_published_post(
+			'No links here.'
+		);
+
+		add_post_meta(
+			$post_id,
+			'_oembed_1234567890abcdef',
+			'<blockquote class="wp-embedded-content"><a href="https://blog.example.net/a-post/">A post</a></blockquote>' .
+			'<iframe class="wp-embedded-content" src="https://blog.example.net/a-post/embed/#?secret=abc"></iframe>'
+		);
+
+		$references = scan_site( get_current_blog_id() );
+		$found      = array();
+
+		foreach ( $references as $reference ) {
+			if ( 'blog.example.net' === $reference['host'] ) {
+				$found[] = $reference['kind'];
+			}
+		}
+
+		$this->assertContains( 'embed', $found );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_site
+	 *
+	 * Unpublished content isn't served to anyone, so it shouldn't generate findings.
+	 */
+	public function test_scan_site_ignores_unpublished_posts() {
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'draft',
+				'post_type'    => 'post',
+				'post_content' => '<a href="https://draft-only.example.net/x">Link</a>',
+			)
+		);
+
+		$hosts = wp_list_pluck( scan_site( get_current_blog_id() ), 'host' );
+
+		$this->assertNotContains( 'draft-only.example.net', $hosts );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 *
+	 * Only lapsed and unresolvable hosts are reported by default; a host that resolves is noise.
+	 */
+	public function test_scan_network_reports_only_problem_hosts_by_default() {
+		$this->create_published_post(
+			'<a href="https://gone.example.net/a">Gone</a>' .
+					'<a href="https://live.example.net/b">Live</a>'
+		);
+
+		$this->stubbed_hosts = array(
+			'gone.example.net' => 'dangling',
+			'live.example.net' => 'ok',
+		);
+
+		$hosts = wp_list_pluck(
+			scan_network(
+				array(
+					'blog_ids' => array( get_current_blog_id() ),
+					'verify'   => false,
+				)
+			),
+			'host'
+		);
+
+		$this->assertContains( 'gone.example.net', $hosts );
+		$this->assertNotContains( 'live.example.net', $hosts );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 *
+	 * `--include-ok` is how someone reviews the whole external surface, not just the broken parts.
+	 */
+	public function test_scan_network_can_include_healthy_hosts() {
+		$this->create_published_post(
+			'<a href="https://live.example.net/b">Live</a>'
+		);
+
+		$this->stubbed_hosts = array( 'live.example.net' => 'ok' );
+
+		$references = scan_network(
+			array(
+				'blog_ids'   => array( get_current_blog_id() ),
+				'verify'     => false,
+				'include_ok' => true,
+			)
+		);
+
+		$this->assertContains( 'live.example.net', wp_list_pluck( $references, 'host' ) );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 *
+	 * A subdomain that stopped resolving under a domain that's still registered is a broken reference, but
+	 * nobody else can take it over, so it must not be conflated with a lapsed domain.
+	 */
+	public function test_scan_network_separates_unresolved_from_dangling() {
+		$this->create_published_post(
+			'<a href="https://gone.example.net/a">Lapsed</a>' .
+					'<a href="https://missing.example.org/b">Missing subdomain</a>'
+		);
+
+		$this->stubbed_hosts = array(
+			'gone.example.net'    => 'dangling',
+			'missing.example.org' => 'unresolved',
+		);
+
+		$statuses = array();
+
+		$references = scan_network(
+			array(
+				'blog_ids' => array( get_current_blog_id() ),
+				'verify'   => false,
+			)
+		);
+
+		foreach ( $references as $reference ) {
+			$statuses[ $reference['host'] ] = $reference['status'];
+		}
+
+		$this->assertSame( 'dangling', $statuses['gone.example.net'] );
+		$this->assertSame( 'unresolved', $statuses['missing.example.org'] );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 *
+	 * The riskiest findings have to be at the top, because that's the order somebody triages them in.
+	 */
+	public function test_scan_network_sorts_worst_findings_first() {
+		$this->create_published_post(
+			'<a href="https://gone.example.net/a">Link</a>' .
+					'<script src="https://gone.example.net/a.js"></script>' .
+					'<a href="https://missing.example.org/b">Missing</a>'
+		);
+
+		$this->stubbed_hosts = array(
+			'gone.example.net'    => 'dangling',
+			'missing.example.org' => 'unresolved',
+		);
+
+		$references = scan_network(
+			array(
+				'blog_ids' => array( get_current_blog_id() ),
+				'verify'   => false,
+			)
+		);
+
+		$this->assertSame( 'script', $references[0]['kind'] );
+		$this->assertSame( 'dangling', $references[0]['status'] );
+		$this->assertSame( 'unresolved', end( $references )['status'] );
+	}
+
+	/**
+	 * @covers WordCamp\Dangling_Hosts\scan_network
+	 *
+	 * `--kinds` narrows the report to the reference types worth acting on.
+	 */
+	public function test_scan_network_filters_by_kind() {
+		$this->create_published_post(
+			'<a href="https://gone.example.net/a">Link</a>' .
+					'<script src="https://gone.example.net/a.js"></script>'
+		);
+
+		$this->stubbed_hosts = array( 'gone.example.net' => 'dangling' );
+
+		$kinds = wp_list_pluck(
+			scan_network(
+				array(
+					'blog_ids' => array( get_current_blog_id() ),
+					'kinds'    => array( 'script' ),
+					'verify'   => false,
+				)
+			),
+			'kind'
+		);
+
+		$this->assertSame( array( 'script' ), $kinds );
+	}
+}
+
+// phpcs:enable

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/bootstrap.php
@@ -4,12 +4,14 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 
-require_once( __DIR__ . '/miscellaneous.php' );
-require_once( __DIR__ . '/rest-api.php'      );
-require_once( __DIR__ . '/rewrite-rules.php' );
-require_once( __DIR__ . '/users.php'         );
+require_once __DIR__ . '/dangling-hosts.php';
+require_once __DIR__ . '/miscellaneous.php';
+require_once __DIR__ . '/rest-api.php';
+require_once __DIR__ . '/rewrite-rules.php';
+require_once __DIR__ . '/users.php';
 
-WP_CLI::add_command( 'wc-misc',    'WordCamp_CLI_Miscellaneous' );
-WP_CLI::add_command( 'wc-rewrite', 'WordCamp_CLI_Rewrite_Rules' );
-WP_CLI::add_command( 'wc-rest',    'WordCamp_CLI_REST_API'      );
-WP_CLI::add_command( 'wc-users',   'WordCamp_CLI_Users'         );
+WP_CLI::add_command( 'wc-dangling', 'WordCamp_CLI_Dangling_Hosts' );
+WP_CLI::add_command( 'wc-misc',     'WordCamp_CLI_Miscellaneous'  );
+WP_CLI::add_command( 'wc-rewrite',  'WordCamp_CLI_Rewrite_Rules'  );
+WP_CLI::add_command( 'wc-rest',     'WordCamp_CLI_REST_API'       );
+WP_CLI::add_command( 'wc-users',    'WordCamp_CLI_Users'          );

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
@@ -15,8 +15,7 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	 *
 	 * Walks the published posts and pages on each site, collects every third-party host they link to, embed,
 	 * or load a script from, and checks whether those hosts still resolve. A host that doesn't resolve, and
-	 * whose domain has no nameservers, is a domain somebody else can now register -- at which point our
-	 * content is pointing at whatever they decide to put there.
+	 * whose domain has no nameservers, is pointing at a registration that has lapsed.
 	 *
 	 * This only reports. What to do about a given reference depends on the post, so it needs a human.
 	 *
@@ -62,7 +61,7 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	 *     # Audit one site.
 	 *     wp wc-dangling scan --site=seattle.wordcamp.org/2020
 	 *
-	 *     # Only the kinds that execute or render something, as JSON.
+	 *     # Only the kinds that are loaded as part of the page, as JSON.
 	 *     wp wc-dangling scan --kinds=script,embed,url --format=json
 	 *
 	 *     # Every external host the network references, whether or not it still resolves.

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
@@ -1,6 +1,5 @@
 <?php
 
-use cli\progress\Bar;
 use function WordCamp\Dangling_Hosts\{ scan_network };
 use const WordCamp\Dangling_Hosts\REFERENCE_KINDS;
 
@@ -35,7 +34,8 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	 * Defaults to all of them.
 	 *
 	 * [--fields=<fields>]
-	 * : Comma-separated columns to output: status, kind, host, domain, site, blog_id, post_id, permalink, url.
+	 * : Comma-separated columns to output: status, kind, host, domain, verified, site, blog_id, post_id,
+	 * permalink, url.
 	 * Pass `--fields=site` to get just the affected sites.
 	 *
 	 * [--include-ok]
@@ -88,13 +88,30 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 		// Validated up front -- a bad column name shouldn't surface only after a full network scan.
 		$fields = $this->parse_fields( WP_CLI\Utils\get_flag_value( $assoc_args, 'fields', '' ) );
 
-		// A progress bar would interleave with the report itself in the machine-readable formats.
-		$show_progress = in_array( $format, array( 'table', 'count' ), true );
+		/*
+		 * A progress bar would interleave with the report itself in the machine-readable formats, and it has
+		 * nothing to show anyone when stdout is a pipe or a cron log -- where it would instead land in the
+		 * output the caller is trying to parse.
+		 */
+		$show_progress = in_array( $format, array( 'table', 'count' ), true ) && ! \cli\Shell::isPiped();
 		$notify        = null;
 
 		if ( $show_progress ) {
-			$site_count = $blog_ids ? count( $blog_ids ) : (int) get_sites( array( 'count' => true ) );
-			$notify     = new Bar( 'Scanning sites', $site_count );
+			/*
+			 * Counted the way `scan_network()` selects, so the bar doesn't stop short of its total on a
+			 * network run by including sites that are never scanned.
+			 */
+			$site_count = $blog_ids ? count( $blog_ids ) : (int) get_sites(
+				array(
+					'count'    => true,
+					'archived' => 0,
+					'deleted'  => 0,
+					'spam'     => 0,
+				)
+			);
+
+			// `make_progress_bar()` rather than a bare `Bar`, so it also no-ops in the cases the check above doesn't cover.
+			$notify = WP_CLI\Utils\make_progress_bar( 'Scanning sites', $site_count );
 		}
 
 		$references = scan_network(

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
@@ -1,0 +1,222 @@
+<?php
+
+use cli\progress\Bar;
+use function WordCamp\Dangling_Hosts\{ scan_network };
+use const WordCamp\Dangling_Hosts\REFERENCE_KINDS;
+
+defined( 'WP_CLI' ) || die();
+
+/**
+ * WordCamp.org: Audit published content for references to domains that no longer exist.
+ */
+class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
+	/**
+	 * Report external references in published content whose domains have lapsed.
+	 *
+	 * Walks the published posts and pages on each site, collects every third-party host they link to, embed,
+	 * or load a script from, and checks whether those hosts still resolve. A host that doesn't resolve, and
+	 * whose domain has no nameservers, is a domain somebody else can now register -- at which point our
+	 * content is pointing at whatever they decide to put there.
+	 *
+	 * This only reports. What to do about a given reference depends on the post, so it needs a human.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--site=<site>]
+	 * : Scan a single site, by ID or URL, instead of the whole network.
+	 *
+	 * [--post-types=<post-types>]
+	 * : Comma-separated post types to scan.
+	 * ---
+	 * default: post,page
+	 * ---
+	 *
+	 * [--kinds=<kinds>]
+	 * : Comma-separated reference kinds to report: script, embed, iframe, img, link, url.
+	 * Defaults to all of them.
+	 *
+	 * [--include-ok]
+	 * : Also list references whose hosts resolve normally. Useful for seeing the full external surface.
+	 *
+	 * [--skip-verify]
+	 * : Skip the RDAP confirmation of lapsed domains. Faster, and works without outbound HTTP, but a
+	 * transient DNS failure can then look like a lapsed domain.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Audit the whole network.
+	 *     wp wc-dangling scan
+	 *
+	 *     # Audit one site.
+	 *     wp wc-dangling scan --site=seattle.wordcamp.org/2020
+	 *
+	 *     # Only the kinds that execute or render something, as JSON.
+	 *     wp wc-dangling scan --kinds=script,embed,url --format=json
+	 *
+	 *     # Every external host the network references, whether or not it still resolves.
+	 *     wp wc-dangling scan --include-ok --format=csv
+	 *
+	 * @subcommand scan
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function scan( $args, $assoc_args ) {
+		$format     = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
+		$post_types = $this->parse_list( WP_CLI\Utils\get_flag_value( $assoc_args, 'post-types', 'post,page' ) );
+		$kinds      = $this->parse_kinds( WP_CLI\Utils\get_flag_value( $assoc_args, 'kinds', '' ) );
+		$blog_ids   = $this->parse_site( WP_CLI\Utils\get_flag_value( $assoc_args, 'site', '' ) );
+
+		// A progress bar would interleave with the report itself in the machine-readable formats.
+		$show_progress = in_array( $format, array( 'table', 'count' ), true );
+		$notify        = null;
+
+		if ( $show_progress ) {
+			$site_count = $blog_ids ? count( $blog_ids ) : (int) get_sites( array( 'count' => true ) );
+			$notify     = new Bar( 'Scanning sites', $site_count );
+		}
+
+		$references = scan_network(
+			array(
+				'blog_ids'   => $blog_ids,
+				'post_types' => $post_types,
+				'kinds'      => $kinds,
+				'verify'     => ! WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-verify', false ),
+				'include_ok' => (bool) WP_CLI\Utils\get_flag_value( $assoc_args, 'include-ok', false ),
+				'progress'   => $notify ? function () use ( $notify ) {
+					$notify->tick();
+				} : null,
+			)
+		);
+
+		if ( $notify ) {
+			$notify->finish();
+			WP_CLI::line();
+		}
+
+		if ( empty( $references ) ) {
+			WP_CLI::success( 'No references to lapsed domains found.' );
+
+			return;
+		}
+
+		$fields = array( 'status', 'kind', 'host', 'domain', 'permalink', 'url' );
+
+		WP_CLI\Utils\format_items( $format, $references, $fields );
+
+		$dangling = array_filter(
+			$references,
+			function ( $reference ) {
+				return 'dangling' === $reference['status'];
+			}
+		);
+
+		if ( empty( $dangling ) ) {
+			return;
+		}
+
+		// `count` prints a bare number with no trailing newline, which would run into the message below.
+		if ( 'count' === $format ) {
+			WP_CLI::line();
+		}
+
+		/*
+		 * Non-zero exit, so a scheduled run shows up as a failure instead of quietly succeeding with findings
+		 * buried in its output.
+		 */
+		WP_CLI::error(
+			sprintf(
+				'%d reference(s) point at %d lapsed domain(s).',
+				count( $dangling ),
+				count( array_unique( wp_list_pluck( $dangling, 'domain' ) ) )
+			)
+		);
+	}
+
+	/**
+	 * Split a comma-separated option into a trimmed list.
+	 *
+	 * @param string $value
+	 *
+	 * @return array
+	 */
+	protected function parse_list( $value ) {
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			return array();
+		}
+
+		return array_values( array_filter( array_map( 'trim', explode( ',', $value ) ) ) );
+	}
+
+	/**
+	 * Validate the `--kinds` option.
+	 *
+	 * @param string $value
+	 *
+	 * @return array
+	 */
+	protected function parse_kinds( $value ) {
+		$kinds = $this->parse_list( $value );
+
+		if ( empty( $kinds ) ) {
+			return REFERENCE_KINDS;
+		}
+
+		$unknown = array_diff( $kinds, REFERENCE_KINDS );
+
+		if ( $unknown ) {
+			WP_CLI::error(
+				sprintf(
+					'Unknown reference kind(s): %s. Valid kinds are: %s.',
+					implode( ', ', $unknown ),
+					implode( ', ', REFERENCE_KINDS )
+				)
+			);
+		}
+
+		return $kinds;
+	}
+
+	/**
+	 * Resolve the `--site` option to a list holding a single blog ID.
+	 *
+	 * `--url` is reserved by WP-CLI itself for choosing the site to bootstrap, which isn't what's wanted here
+	 * -- the scan needs to bootstrap on the network and switch into each site -- so this takes its own option.
+	 *
+	 * @param string $value ID or URL.
+	 *
+	 * @return array Empty when no site was specified, meaning "scan the whole network".
+	 */
+	protected function parse_site( $value ) {
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			return array();
+		}
+
+		$value = trim( $value );
+
+		if ( ctype_digit( $value ) ) {
+			$site = get_site( (int) $value );
+		} else {
+			$parsed = wp_parse_url( 0 === strpos( $value, 'http' ) ? $value : 'https://' . $value );
+			$site   = get_site_by_path( $parsed['host'] ?? '', $parsed['path'] ?? '/' );
+		}
+
+		if ( ! $site ) {
+			WP_CLI::error( sprintf( 'Could not find a site matching `%s`.', $value ) );
+		}
+
+		return array( (int) $site->blog_id );
+	}
+}

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
@@ -123,6 +123,10 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 
 		WP_CLI\Utils\format_items( $format, $references, $fields );
 
+		if ( ! WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-verify', false ) ) {
+			$this->warn_about_unconfirmed_findings( $references );
+		}
+
 		$dangling = array_filter(
 			$references,
 			function ( $reference ) {
@@ -153,6 +157,36 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	}
 
 	/**
+	 * Say so when the registry couldn't be reached.
+	 *
+	 * Only for a run that asked for verification -- `--skip-verify` opting out of it is not a surprise worth
+	 * a warning. Without this the run looks like a clean verified pass, when its findings are actually resting
+	 * on DNS alone, which hides a weaker result behind the appearance of a stronger one.
+	 *
+	 * @param array[] $references
+	 */
+	protected function warn_about_unconfirmed_findings( array $references ) {
+		$unconfirmed = array_filter(
+			$references,
+			function ( $reference ) {
+				return 'dangling' === $reference['status'] && true !== ( $reference['verified'] ?? null );
+			}
+		);
+
+		if ( empty( $unconfirmed ) ) {
+			return;
+		}
+
+		WP_CLI::warning(
+			sprintf(
+				'Could not reach the registry for %d domain(s), so they are reported on DNS evidence alone: %s.',
+				count( array_unique( wp_list_pluck( $unconfirmed, 'domain' ) ) ),
+				implode( ', ', array_unique( wp_list_pluck( $unconfirmed, 'domain' ) ) )
+			)
+		);
+	}
+
+	/**
 	 * Split a comma-separated option into a trimmed list.
 	 *
 	 * @param string $value
@@ -175,7 +209,7 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	 * @return array
 	 */
 	protected function parse_fields( $value ) {
-		$available = array( 'status', 'kind', 'host', 'domain', 'site', 'blog_id', 'post_id', 'permalink', 'url' );
+		$available = array( 'status', 'kind', 'host', 'domain', 'verified', 'site', 'blog_id', 'post_id', 'permalink', 'url' );
 		$fields    = $this->parse_list( $value );
 
 		if ( empty( $fields ) ) {

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
@@ -157,7 +157,11 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	}
 
 	/**
-	 * Say so when the registry couldn't be reached.
+	 * Say so when the registry didn't settle a finding.
+	 *
+	 * Covers being unable to reach it at all and its answering with something that decides nothing -- a
+	 * rate limit, a 5xx, a redirect that goes nowhere. The distinction doesn't change what the reader has to
+	 * do about it, and claiming the stronger one would misdescribe a registry that plainly did answer.
 	 *
 	 * Only for a run that asked for verification -- `--skip-verify` opting out of it is not a surprise worth
 	 * a warning. Without this the run looks like a clean verified pass, when its findings are actually resting
@@ -179,7 +183,7 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 
 		WP_CLI::warning(
 			sprintf(
-				'Could not reach the registry for %d domain(s), so they are reported on DNS evidence alone: %s.',
+				'Could not confirm %d domain(s) against the registry, so they are reported on DNS evidence alone: %s.',
 				count( array_unique( wp_list_pluck( $unconfirmed, 'domain' ) ) ),
 				implode( ', ', array_unique( wp_list_pluck( $unconfirmed, 'domain' ) ) )
 			)

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/dangling-hosts.php
@@ -34,6 +34,10 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	 * : Comma-separated reference kinds to report: script, embed, iframe, img, link, url.
 	 * Defaults to all of them.
 	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated columns to output: status, kind, host, domain, site, blog_id, post_id, permalink, url.
+	 * Pass `--fields=site` to get just the affected sites.
+	 *
 	 * [--include-ok]
 	 * : Also list references whose hosts resolve normally. Useful for seeing the full external surface.
 	 *
@@ -67,6 +71,9 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 	 *     # Every external host the network references, whether or not it still resolves.
 	 *     wp wc-dangling scan --include-ok --format=csv
 	 *
+	 *     # Just the affected sites, one per line.
+	 *     wp wc-dangling scan --fields=site --format=csv | tail -n +2 | sort -u
+	 *
 	 * @subcommand scan
 	 *
 	 * @param array $args
@@ -77,6 +84,9 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 		$post_types = $this->parse_list( WP_CLI\Utils\get_flag_value( $assoc_args, 'post-types', 'post,page' ) );
 		$kinds      = $this->parse_kinds( WP_CLI\Utils\get_flag_value( $assoc_args, 'kinds', '' ) );
 		$blog_ids   = $this->parse_site( WP_CLI\Utils\get_flag_value( $assoc_args, 'site', '' ) );
+
+		// Validated up front -- a bad column name shouldn't surface only after a full network scan.
+		$fields = $this->parse_fields( WP_CLI\Utils\get_flag_value( $assoc_args, 'fields', '' ) );
 
 		// A progress bar would interleave with the report itself in the machine-readable formats.
 		$show_progress = in_array( $format, array( 'table', 'count' ), true );
@@ -110,8 +120,6 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 
 			return;
 		}
-
-		$fields = array( 'status', 'kind', 'host', 'domain', 'permalink', 'url' );
 
 		WP_CLI\Utils\format_items( $format, $references, $fields );
 
@@ -157,6 +165,36 @@ class WordCamp_CLI_Dangling_Hosts extends WP_CLI_Command {
 		}
 
 		return array_values( array_filter( array_map( 'trim', explode( ',', $value ) ) ) );
+	}
+
+	/**
+	 * Validate the `--fields` option.
+	 *
+	 * @param string $value
+	 *
+	 * @return array
+	 */
+	protected function parse_fields( $value ) {
+		$available = array( 'status', 'kind', 'host', 'domain', 'site', 'blog_id', 'post_id', 'permalink', 'url' );
+		$fields    = $this->parse_list( $value );
+
+		if ( empty( $fields ) ) {
+			return array( 'status', 'kind', 'host', 'domain', 'site', 'permalink', 'url' );
+		}
+
+		$unknown = array_diff( $fields, $available );
+
+		if ( $unknown ) {
+			WP_CLI::error(
+				sprintf(
+					'Unknown field(s): %s. Valid fields are: %s.',
+					implode( ', ', $unknown ),
+					implode( ', ', $available )
+				)
+			);
+		}
+
+		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Published content across the network references a lot of third-party sites — links, embeds, and script sources. Some of those domains eventually lapse, and our content keeps referencing them. We have no way to notice when that happens.

`wp wc-dangling scan` walks published posts and pages, collects the third-party hosts they reference, and reports the ones whose domains no longer resolve, so stale references can be updated or removed.

- Separates a lapsed domain from a subdomain that merely stopped resolving under a domain that's still registered. They need different follow-up, so the report shouldn't conflate them.
- Confirms candidates against RDAP, so a DNS failure mid-scan doesn't get reported as a lapsed registration. Anything inconclusive downgrades rather than asserting something unverified.
- Scans `_oembed_*` postmeta alongside `post_content` — for a classic-editor embed the markup exists only in the cache, so scanning content alone misses the host entirely.
- Report-only — it has no write path at all, so there's no `--dry-run` to add. It exits non-zero when it finds something, so a scheduled run surfaces as a failure rather than succeeding with findings buried in its output.
- Each finding records the site it came from, and `--fields` selects the output columns, so "which sites are affected?" is `--fields=site --format=csv | tail -n +2 | sort -u`.

Logic lives in `mu-plugins/dangling-hosts.php` (hook-free, so it's testable on its own); `wp-cli-commands/dangling-hosts.php` is a thin wrapper.

Not wired into `cron.php` here — the scan's runtime against the real network hasn't been measured, and the command is schedulable as-is. Worth a follow-up with real timings behind it.

- Only reports hosts that could actually have been registered. A href that swept up the comma after it in the prose parses to `example.net,`, and an IP literal reduces to a "domain" of `1.1`; neither is a registration, so reporting either as lapsed asserts something untrue. Both are common enough in old content to bury the findings that matter, and skipping them keeps the DNS and RDAP lookups off them too.

- Only a real answer from the registry overturns what DNS found. A request that fails, is rate limited, or returns an unexpected status decides nothing, so the finding stands and is reported as unconfirmed rather than quietly downgraded. This matters more than it sounds: one TLD's registry closes the connection uncleanly on exactly the "no such registration" responses, so reading a failed request as "registered" would have suppressed every genuine finding under it while every healthy domain kept verifying normally.

## Test plan

- [x] phpunit — 320/321 passing (`WordCamp MU Plugins`). The one failure, `Test_QuickBooks_OAuth_State::test_authorize_url_carries_the_stored_state`, is pre-existing — verified by stashing this branch and re-running it on `production`.
- [x] phpcs clean on all 5 changed files
- [ ] npm run build — n/a, no JS
- [x] Manual CLI pass against the local stack (below)

63 new tests cover reference extraction per kind, host-shape validation, protocol-relative/relative/non-HTTP URLs, first-party filtering, registrable-domain derivation including multi-label suffixes, the three host statuses, `_oembed_` postmeta scanning, draft exclusion, kind filtering, and result ordering. DNS is stubbed through a filter so the suite never depends on the resolver or on a real domain's registration status.

### Sandbox smoke test

Also run against real content on a sandbox, which is what shook out the two fixes above -- neither was reachable from the stubbed suite:

- Reported known-stale references on a site that has some, at the right status, and correctly separated them from a domain that no longer resolves but is still registered.
- Confirmed the registry step downgrades that still-registered domain rather than reporting it as lapsed, and that the command names any domain it could not confirm.
- Verified the scan issues no writes, which is what makes it safe to point at a production database. There is now a test asserting that, so it holds for future changes rather than being re-derived by reading the code.
- Content walk measured at roughly 20-40s for a single site. That is the number the cron decision needs, and it is why this still isn't scheduled here.

### Manual test steps

No browser pass — this is CLI-only with no UI surface. Verified against the local Docker stack instead:

1. Seeded one published post on `central.wordcamp.test` covering all three outcomes: a live host, a nonexistent subdomain of a live domain, and a nonexistent registrable domain placed **only** in `_oembed_*` postmeta.
2. `wp wc-dangling scan --site=5 --skip-verify` — reported the lapsed domain as `dangling` (found via postmeta, confirming that path) and the missing subdomain as `unresolved` against its still-registered parent. Live hosts correctly absent.
3. `--kinds=embed` / `--kinds=script` — filtering works; the latter reports no findings and exits 0.
4. `--include-ok --format=count` — 18 references vs 2, i.e. the full external surface.
5. Exit code 1 with findings, 0 without.
6. `--fields=site --format=csv` — returns just the affected site URLs.
7. `--kinds=bogus`, `--fields=bogus`, and `--site=nope.example.test` — all rejected with a clear message. `--fields` is validated before the scan starts, so it fails in 0.6s rather than after a full network walk.
8. Fixture posts deleted afterward; confirmed gone via `wp post list`.

**The manual pass caught a bug the stubbed unit tests structurally could not.** `host_resolves()` originally issued one combined `dns_get_record( $host, DNS_A | DNS_AAAA | DNS_CNAME )`. That call returns `false` — not the address — when any type in the mask errors out, which is what happens on a host that has an A record but no CNAME. Every host looked unresolvable and the whole report was false positives. Now each type is queried separately, stopping at the first answer, so the common case is still a single lookup. Scan time on the fixture site dropped from 1:15 to 0:08 as a side effect.

## After merge

Nothing here changes the site on its own -- the command reports, and someone has to run it and act on what it says.

1. Run a scan across the network and triage the findings. Each one is a judgement call about a particular post: update the reference, unlink it, or point it at an archived copy.
2. Prefer a host that can reach the registries. Where it can't, findings arrive flagged unconfirmed and resting on DNS alone; `whois` settles those in seconds, and the command tells you which ones need it.
3. Decide on scheduling once there are real timings for a full run. The per-site cost is known; the network-wide cost isn't, and `scan_network()` collects every reference before it checks any host, so memory is the thing to watch on a first full run rather than the lookups.
