### PR TITLE
Budgets: stop the privacy exporters referencing admin-only constants

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -428,7 +428,8 @@ function vendor_payment_exporter( $email_address, $page ) {
 		);
 
 		$vendor_payment_exp_data = array_merge(
-			$vendor_payment_exp_data, get_meta_details( $meta, PAYMENT_REQUEST_POST_TYPE )
+			$vendor_payment_exp_data,
+			get_meta_details( $meta, PAYMENT_REQUEST_POST_TYPE )
 		);
 
 		if ( ! empty( $vendor_payment_exp_data ) ) {
@@ -484,7 +485,8 @@ function reimbursements_exporter( $email_address, $page ) {
 
 		// Meta fields.
 		$reimbursement_data_to_export = array_merge(
-			$reimbursement_data_to_export, get_meta_details( $meta, REIMBURSEMENT_POST_TYPE )
+			$reimbursement_data_to_export,
+			get_meta_details( $meta, REIMBURSEMENT_POST_TYPE )
 		);
 
 		if ( ! empty( $reimbursement_data_to_export ) ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -3,8 +3,6 @@
 namespace WordCamp\Budgets\Privacy;
 
 use WP_Query, WP_Post;
-use WordCamp\Budgets\Reimbursement_Requests;
-use WCP_Payment_Request;
 
 defined( 'WPINC' ) || die();
 
@@ -41,15 +39,23 @@ function is_cli_request() {
 
 
 /**
- * The post types whose attachments carry financial details.
+ * The post types this file acts on.
  *
- * Duplicates the `POST_TYPE` constants rather than referencing them: those files only load in the admin, and
- * this one loads everywhere. `Test_Privacy` asserts the two stay in step.
+ * Duplicates the `POST_TYPE` constants in `reimbursement-request.php` and `payment-request.php` rather than
+ * referencing them: those files only load in the admin, and this one loads everywhere -- referencing them from
+ * here fatals on front-end, REST, and XML-RPC requests. `Test_Privacy` asserts the two stay in step.
+ */
+const REIMBURSEMENT_POST_TYPE   = 'wcb_reimbursement';
+const PAYMENT_REQUEST_POST_TYPE = 'wcp_payment_request';
+
+
+/**
+ * The post types whose attachments carry financial details.
  *
  * @return string[]
  */
 function get_budget_request_post_types() {
-	return array( 'wcb_reimbursement', 'wcp_payment_request' );
+	return array( REIMBURSEMENT_POST_TYPE, PAYMENT_REQUEST_POST_TYPE );
 }
 
 
@@ -400,7 +406,7 @@ function vendor_payment_exporter( $email_address, $page ) {
 		'done' => true,
 	);
 
-	$vendor_payment_requests = get_post_wp_query( WCP_Payment_Request::POST_TYPE, $page, $email_address );
+	$vendor_payment_requests = get_post_wp_query( PAYMENT_REQUEST_POST_TYPE, $page, $email_address );
 
 	if ( empty( $vendor_payment_requests ) ) {
 		return $results;
@@ -422,14 +428,14 @@ function vendor_payment_exporter( $email_address, $page ) {
 		);
 
 		$vendor_payment_exp_data = array_merge(
-			$vendor_payment_exp_data, get_meta_details( $meta, WCP_Payment_Request::POST_TYPE )
+			$vendor_payment_exp_data, get_meta_details( $meta, PAYMENT_REQUEST_POST_TYPE )
 		);
 
 		if ( ! empty( $vendor_payment_exp_data ) ) {
 			$data_to_export[] = array(
-				'group_id'    => WCP_Payment_Request::POST_TYPE,
+				'group_id'    => PAYMENT_REQUEST_POST_TYPE,
 				'group_label' => __( 'WordCamp Vendor Payments', 'wordcamporg' ),
-				'item_id'     => WCP_Payment_Request::POST_TYPE . "-{$post->ID}",
+				'item_id'     => PAYMENT_REQUEST_POST_TYPE . "-{$post->ID}",
 				'data'        => $vendor_payment_exp_data,
 			);
 		}
@@ -455,7 +461,7 @@ function reimbursements_exporter( $email_address, $page ) {
 		'done' => true,
 	);
 
-	$reimbursements = get_post_wp_query( Reimbursement_Requests\POST_TYPE, $page, $email_address );
+	$reimbursements = get_post_wp_query( REIMBURSEMENT_POST_TYPE, $page, $email_address );
 
 	if ( empty( $reimbursements ) ) {
 		return $results;
@@ -478,14 +484,14 @@ function reimbursements_exporter( $email_address, $page ) {
 
 		// Meta fields.
 		$reimbursement_data_to_export = array_merge(
-			$reimbursement_data_to_export, get_meta_details( $meta, Reimbursement_Requests\POST_TYPE )
+			$reimbursement_data_to_export, get_meta_details( $meta, REIMBURSEMENT_POST_TYPE )
 		);
 
 		if ( ! empty( $reimbursement_data_to_export ) ) {
 			$data_to_export[] = array(
-				'group_id'    => Reimbursement_Requests\POST_TYPE,
+				'group_id'    => REIMBURSEMENT_POST_TYPE,
 				'group_label' => __( 'WordCamp Reimbursement Request', 'wordcamporg' ),
-				'item_id'     => Reimbursement_Requests\POST_TYPE . "-{$post->ID}",
+				'item_id'     => REIMBURSEMENT_POST_TYPE . "-{$post->ID}",
 				'data'        => $reimbursement_data_to_export,
 			);
 		}
@@ -519,7 +525,7 @@ function get_post_wp_query( $query_type, $page, $email_address ) {
 	);
 
 	switch ( $query_type ) {
-		case Reimbursement_Requests\POST_TYPE:
+		case REIMBURSEMENT_POST_TYPE:
 			$user = get_user_by( 'email', $email_address );
 
 			if ( empty( $user ) ) {
@@ -529,7 +535,7 @@ function get_post_wp_query( $query_type, $page, $email_address ) {
 			$query_args = array_merge( $query_args, array( 'post_author' => $user->ID ) );
 			break;
 
-		case WCP_Payment_Request::POST_TYPE:
+		case PAYMENT_REQUEST_POST_TYPE:
 			$query_args['meta_query'] = array(
 				'relation' => 'AND',
 			);
@@ -581,7 +587,7 @@ function get_meta_details( $meta, $post_type ) {
 function get_meta_fields_mapping( $post_type ) {
 	$mapping_fields = array();
 
-	if ( Reimbursement_Requests\POST_TYPE === $post_type ) {
+	if ( REIMBURSEMENT_POST_TYPE === $post_type ) {
 		$prefix         = '_wcbrr_';
 		$mapping_fields = array_merge(
 			$mapping_fields,
@@ -634,7 +640,7 @@ function get_meta_fields_mapping( $post_type ) {
 				$prefix . 'beneficiary_country_iso3166' => __( 'Beneficiary’s Country', 'wordcamporg' ),
 			)
 		);
-	} elseif ( WCP_Payment_Request::POST_TYPE === $post_type ) {
+	} elseif ( PAYMENT_REQUEST_POST_TYPE === $post_type ) {
 		$prefix         = '_camppayments_';
 		$mapping_fields = array_merge(
 			$mapping_fields,

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -323,6 +323,33 @@ class Test_Privacy extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The duplicated slugs above are only worth anything if nothing in `privacy.php` reaches for the originals.
+	 *
+	 * `reimbursement-request.php` and `payment-request.php` load in the admin only, so any reference to a symbol
+	 * they define is a fatal on every front-end, REST, and XML-RPC request -- which is how the personal data
+	 * exporters brought down `wp-json/wporg/v1/data-erase-preflight`. The admin loads both files, so a runtime
+	 * test can't see this; read the source instead.
+	 */
+	public function test_privacy_does_not_reference_admin_only_symbols() {
+		$source = file_get_contents( WORDCAMP_PAYMENTS_PATH . 'includes/privacy.php' );
+
+		$admin_only_symbols = array(
+			'Reimbursement_Requests\\POST_TYPE',
+			'WCP_Payment_Request',
+			'WordCamp_Budgets',
+			'Sponsor_Invoices',
+		);
+
+		foreach ( $admin_only_symbols as $symbol ) {
+			$this->assertStringNotContainsString(
+				$symbol,
+				$source,
+				"`privacy.php` loads outside the admin, so it can't reference `$symbol`."
+			);
+		}
+	}
+
+	/**
 	 * The people who are supposed to see the files.
 	 *
 	 * @return array

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -331,7 +331,7 @@ class Test_Privacy extends WP_UnitTestCase {
 	 * test can't see this; read the source instead.
 	 */
 	public function test_privacy_does_not_reference_admin_only_symbols() {
-		$source = file_get_contents( WORDCAMP_PAYMENTS_PATH . 'includes/privacy.php' );
+		$source = file_get_contents( dirname( __DIR__ ) . '/includes/privacy.php' );
 
 		$admin_only_symbols = array(
 			'Reimbursement_Requests\\POST_TYPE',


### PR DESCRIPTION
## Problem

Production is throwing an uncaught fatal on every site the WordPress.org GDPR Data Exporter crawls:

```
E_ERROR Uncaught Error: Undefined constant "WordCamp\Budgets\Reimbursement_Requests\POST_TYPE"
in wp-content/plugins/wordcamp-payments/includes/privacy.php:458
URL https://<site>.wordcamp.org/<year>/wp-json/wporg/v1/data-erase-preflight?email=...
```

Reported from `melbourne.wordcamp.org/2007`, `miami.wordcamp.org/2013`, and `nyc.wordcamp.org/2014`, at 140+ occurrences per site since last report.

## Cause

#1959 moved `privacy.php` out of the admin-only block in `bootstrap.php` so the payment file visibility guards would cover the REST media endpoints and XML-RPC. That change correctly avoided the `POST_TYPE` constants in the new guard code -- `get_budget_request_post_types()` duplicates the slugs and says why -- but the file's pre-existing personal data exporters were left as they were, still referencing:

- `Reimbursement_Requests\POST_TYPE`, defined in `includes/reimbursement-request.php`
- `WCP_Payment_Request::POST_TYPE`, defined in `includes/payment-request.php`

`bootstrap.php` loads both of those files under `if ( is_admin() )` only. So any request that runs an exporter outside `wp-admin` fatals. `data-erase-preflight` is exactly that path.

`reimbursements_exporter()` is registered first, which is why line 458 is what surfaces; `vendor_payment_exporter()` would have hit the same wall on `WCP_Payment_Request` a few lines up.

## Fix

Declare the two slugs as constants local to the `Privacy` namespace and use them throughout the file, so `privacy.php` depends on nothing that loads conditionally:

```php
const REIMBURSEMENT_POST_TYPE   = 'wcb_reimbursement';
const PAYMENT_REQUEST_POST_TYPE = 'wcp_payment_request';
```

`get_budget_request_post_types()` now returns those instead of repeating the literals a third time. The `use` statements for the two admin-only symbols are gone.

No behavior change beyond not fataling -- every replaced reference resolved to the same string.

## How this was tested

### Reproduced the fatal, then confirmed the fix clears it

WP-CLI runs outside `is_admin()`, so `bootstrap.php` skips the admin-only requires -- the same condition a REST request is under. That makes it a faithful stand-in for the failing endpoint. On a local multisite (`seattle.wordcamp.test/2023`):

Non-admin context genuinely lacks both symbols:

```
$ wp eval 'var_dump( defined( "WordCamp\\Budgets\\Reimbursement_Requests\\POST_TYPE" ) );' --url=...
bool(false)
$ wp eval 'var_dump( class_exists( "WCP_Payment_Request" ) );' --url=...
bool(false)
```

Evaluating the expression from line 458 in that context reproduces the production error character-for-character:

```
$ wp eval 'echo constant( "WordCamp\\Budgets\\Reimbursement_Requests\\POST_TYPE" );' --url=...
Fatal error: Uncaught Error: Undefined constant "WordCamp\Budgets\Reimbursement_Requests\POST_TYPE"
```

With this branch applied, both exporters run to completion even though neither symbol is defined:

```
$ wp eval '$r = WordCamp\Budgets\Privacy\reimbursements_exporter( "test@example.com", 1 ); ...' --url=...
OK done=true items=0
$ wp eval '$r = WordCamp\Budgets\Privacy\vendor_payment_exporter( "test@example.com", 1 ); ...' --url=...
bool(false)          <- class_exists( 'WCP_Payment_Request' )
OK done=true
```

### PHPCS

Run in the PHPUnit container against the repo ruleset. Clean on both changed files -- full-file, which is stricter than the changed-lines check CI runs:

```
$ phpcs --standard=./phpcs.xml.dist -snq includes/privacy.php tests/test-privacy.php
(no output)
```

### The new test

`Test_Privacy::test_budget_request_post_types_match_the_constants()` already pins the duplicated slugs against the originals, so a rename on one side still fails loudly.

Added `test_privacy_does_not_reference_admin_only_symbols()`, which reads the source of `privacy.php` and asserts none of the admin-only symbols appear in it. **A runtime test cannot catch this class of bug**: `wordcamp-payments-network/tests/bootstrap.php` requires `payment-request.php` and `reimbursement-request.php`, so under PHPUnit the constants are always defined and the exporters always work. That blind spot is exactly why this shipped. Reading the source is the only way to assert the constraint the file is actually under.

Checked that the test is not a vacuous pass -- it fails against the current `production` copy of the file and passes against this branch:

```
current privacy.php:    absent
production privacy.php: FOUND -> test catches the regression
```

## Verification gaps

- **PHPUnit has not been run end-to-end by me.** The local container holds a stale snapshot of the tree and its bootstrap would not pick up the suite, so the CI jobs are the real check. The first push did fail PHPUnit -- `WORDCAMP_PAYMENTS_PATH` is defined in `bootstrap.php`, which the payments test bootstrap never loads -- now fixed by resolving the path with `dirname( __DIR__ )`. Please confirm the three PHP Tests jobs are green before merging.
- The `wporg/v1/data-erase-preflight` route is registered on the WordPress.org side, not in this repo, so it could not be exercised directly. The WP-CLI path above reproduces the same conditions but is not literally that request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
