### PR TITLE
Budgets: scope payment file edits to the people who can see them

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -12,6 +12,7 @@ if ( ! is_cli_request() ) {
 	add_action( 'pre_get_posts',                  __NAMESPACE__ . '\unsuppress_attachment_query_filters', PHP_INT_MAX );
 	add_filter( 'posts_clauses',                  __NAMESPACE__ . '\exclude_others_payment_files', 10, 2 );
 	add_filter( 'the_posts',                      __NAMESPACE__ . '\hide_others_payment_files' );
+	add_filter( 'map_meta_cap',                   __NAMESPACE__ . '\restrict_others_payment_file_caps', 10, 4 );
 }
 
 add_filter( 'xmlrpc_prepare_media_item',          __NAMESPACE__ . '\redact_others_payment_files', 10, 2 );
@@ -233,14 +234,16 @@ function get_attachments_from_results( $posts ) {
 }
 
 /**
- * Which of the given attachments are payment files the current user may not see.
+ * Which of the given attachments are payment files the given user may not see.
  *
  * @param WP_Post[] $attachments
+ * @param int|null  $user_id     Defaults to the current user. Named explicitly by callers that are asked about
+ *                               somebody else, like a `map_meta_cap` callback.
  *
  * @return int[]
  */
-function get_hidden_payment_file_ids( $attachments ) {
-	$user_id           = get_current_user_id();
+function get_hidden_payment_file_ids( $attachments, $user_id = null ) {
+	$user_id           = is_null( $user_id ) ? get_current_user_id() : (int) $user_id;
 	$payment_posts_ids = get_payment_file_parent_ids( $attachments );
 	$hidden            = array();
 
@@ -291,6 +294,85 @@ function redact_others_payment_files( $media_item_struct, $media_item ) {
 	}
 
 	return $media_item_struct;
+}
+
+/**
+ * Withhold editing rights over a payment file from everyone the rules above hide it from.
+ *
+ * Those rules read the attachment's parent, so whoever may edit an attachment decides who sees it. Core has no
+ * reason to treat that as sensitive -- `post_parent` is an ordinary field to it, and an organizer is an Editor
+ * here, so `edit_others_posts` already covers another organizer's uploads. Several routes reach the field: the
+ * media REST endpoints, the Media Library's Attach and Detach actions, XML-RPC. Declining the capability closes
+ * all of them at once, instead of each one separately.
+ *
+ * Note that `wp_update_post()` checks no capabilities at all, so anything that reparents through it needs its
+ * own check as well -- the Files metabox does that where it handles the field it posts.
+ *
+ * @param string[] $required_capabilities The primitive capabilities the requested one maps to.
+ * @param string   $requested_capability  The requested meta capability.
+ * @param int      $user_id               The user being asked about, who isn't always the current one.
+ * @param array    $args                  The context the capability was requested with, typically the post ID.
+ *
+ * @return string[]
+ */
+function restrict_others_payment_file_caps( $required_capabilities, $requested_capability, $user_id, $args ) {
+	// `map_meta_cap` runs for every capability check, so skip the post lookup for the ones this ignores.
+	if ( ! in_array( $requested_capability, array( 'edit_post', 'delete_post' ), true ) ) {
+		return $required_capabilities;
+	}
+
+	$attachment = get_capability_subject( $args );
+
+	if ( ! $attachment instanceof WP_Post || 'attachment' !== $attachment->post_type ) {
+		return $required_capabilities;
+	}
+
+	/*
+	 * A file that isn't attached to anything can't be one of these, so say so before spending a query on it --
+	 * `get_payment_file_parent_ids()` drops unattached files for the same reason. This is the common case on the
+	 * Media Library screens, where `map_meta_cap` runs once per attachment in the list.
+	 */
+	if ( ! $attachment->post_parent ) {
+		return $required_capabilities;
+	}
+
+	// As in the rules above, don't run the lookup for someone it can't apply to.
+	if ( user_can( $user_id, 'manage_options' ) ) {
+		return $required_capabilities;
+	}
+
+	if ( get_hidden_payment_file_ids( array( $attachment ), $user_id ) ) {
+		return array( 'do_not_allow' );
+	}
+
+	return $required_capabilities;
+}
+
+/**
+ * Resolve the post a `map_meta_cap` callback is being asked about.
+ *
+ * `$args[0]` is whatever was handed to `current_user_can()`, so an ID can arrive as an int or as a string. The
+ * numeric check and the cast mirror `get_post()`'s own contract.
+ *
+ * Naming no post at all resolves to nothing, and needs no fallback to the global `$post`: Core's own
+ * `map_meta_cap()` denies `edit_post` and `delete_post` outright in that case, so there's nothing left to guard.
+ * The budget post types have their own copy of this, one that does carry that fallback, because it runs for
+ * screens that leave the post implicit. This file can't share it -- see `get_budget_request_post_types()`.
+ *
+ * @param array $args The $args that was passed to the `map_meta_cap` callback.
+ *
+ * @return WP_Post|null
+ */
+function get_capability_subject( $args ) {
+	if ( ! isset( $args[0] ) ) {
+		return null;
+	}
+
+	if ( $args[0] instanceof WP_Post ) {
+		return $args[0];
+	}
+
+	return is_numeric( $args[0] ) ? get_post( (int) $args[0] ) : null;
 }
 
 /**

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -305,6 +305,9 @@ function redact_others_payment_files( $media_item_struct, $media_item ) {
  * media REST endpoints, the Media Library's Attach and Detach actions, XML-RPC. Declining the capability closes
  * all of them at once, instead of each one separately.
  *
+ * Only `edit_post`, because that is the capability every one of those routes checks before it writes the field.
+ * Deletion is a separate question and isn't answered here.
+ *
  * Note that `wp_update_post()` checks no capabilities at all, so anything that reparents through it needs its
  * own check as well -- the Files metabox does that where it handles the field it posts.
  *
@@ -317,7 +320,7 @@ function redact_others_payment_files( $media_item_struct, $media_item ) {
  */
 function restrict_others_payment_file_caps( $required_capabilities, $requested_capability, $user_id, $args ) {
 	// `map_meta_cap` runs for every capability check, so skip the post lookup for the ones this ignores.
-	if ( ! in_array( $requested_capability, array( 'edit_post', 'delete_post' ), true ) ) {
+	if ( 'edit_post' !== $requested_capability ) {
 		return $required_capabilities;
 	}
 
@@ -328,11 +331,16 @@ function restrict_others_payment_file_caps( $required_capabilities, $requested_c
 	}
 
 	/*
-	 * A file that isn't attached to anything can't be one of these, so say so before spending a query on it --
-	 * `get_payment_file_parent_ids()` drops unattached files for the same reason. This is the common case on the
-	 * Media Library screens, where `map_meta_cap` runs once per attachment in the list.
+	 * Two cheap ways to a "no", before the lookup that costs a query. `map_meta_cap` runs once per attachment on
+	 * the Media Library screens, and on most sites none of those attachments is a payment file at all -- these
+	 * settle that from the post cache. Both restate a condition `get_hidden_payment_file_ids()` applies itself,
+	 * so they only ever return early where it would have found nothing; the rule itself still lives there.
 	 */
-	if ( ! $attachment->post_parent ) {
+	if ( (int) $attachment->post_author === (int) $user_id ) {
+		return $required_capabilities;
+	}
+
+	if ( ! in_array( get_post_type( $attachment->post_parent ), get_budget_request_post_types(), true ) ) {
 		return $required_capabilities;
 	}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -887,16 +887,48 @@ class WordCamp_Budgets {
 			return;
 		}
 
-		if ( ! $files = json_decode( $request['wcb_existing_files_to_attach'] ) ) {
+		$files = json_decode( $request['wcb_existing_files_to_attach'] );
+
+		if ( ! is_array( $files ) ) {
 			return;
 		}
 
 		foreach ( $files as $file_id ) {
+			if ( ! self::is_file_attachable( $file_id, $post_id ) ) {
+				continue;
+			}
+
 			wp_update_post( array(
-				'ID'          => $file_id,
+				'ID'          => absint( $file_id ),
 				'post_parent' => $post_id,
 			) );
 		}
+	}
+
+	/**
+	 * Whether one of the files a request names may be attached to it.
+	 *
+	 * The Files metabox only offers files that are unattached, or already on this request, but it assembles that
+	 * list in the browser. `wp_update_post()` checks nothing of its own, so the same rule has to hold here for
+	 * whatever comes back in the field -- a file already sitting on another post keeps the post it has.
+	 *
+	 * @param mixed $file_id An entry from the field, which is whatever JSON the browser sent.
+	 * @param int   $post_id The request the file would be attached to.
+	 *
+	 * @return bool
+	 */
+	protected static function is_file_attachable( $file_id, $post_id ) {
+		if ( ! is_numeric( $file_id ) ) {
+			return false;
+		}
+
+		$file = get_post( absint( $file_id ) );
+
+		if ( ! $file instanceof WP_Post || 'attachment' !== $file->post_type ) {
+			return false;
+		}
+
+		return 0 === (int) $file->post_parent || (int) $file->post_parent === (int) $post_id;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/bootstrap.php
@@ -10,10 +10,12 @@ if ( 'cli' !== php_sapi_name() ) {
  * Load the parts of the plugin that the tests exercise.
  *
  * The budget CPTs themselves are registered by `wordcamp-payments-network/tests/bootstrap.php`, which runs
- * first; this only adds the privacy layer that guards their attachments.
+ * first; this adds the privacy layer that guards their attachments, and the class holding the file handling
+ * those guards back up. Neither has side effects at load, so nothing is instantiated here.
  */
 function manually_load_plugin() {
 	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/privacy.php';
+	require_once WP_PLUGIN_DIR . '/wordcamp-payments/includes/wordcamp-budgets.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin', 20 );

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -312,6 +312,174 @@ class Test_Privacy extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The rules read the attachment's parent, so nobody they hide a file from may edit it.
+	 *
+	 * That capability is what the media REST endpoints and the Media Library's Attach action check before they
+	 * write `post_parent`, and moving a file onto a request of your own is what would otherwise make it visible.
+	 *
+	 * @dataProvider data_editable_capabilities
+	 *
+	 * @param string $capability
+	 */
+	public function test_others_payment_files_cannot_be_edited( $capability ) {
+		wp_set_current_user( self::$organizer_b );
+
+		$this->assertFalse( current_user_can( $capability, self::$payment_file_id ) );
+		$this->assertFalse( current_user_can( $capability, self::$reimbursement_file_id ) );
+	}
+
+	/**
+	 * The capabilities the guard covers, and so the routes that check them.
+	 *
+	 * @return array
+	 */
+	public function data_editable_capabilities() {
+		return array(
+			'edit_post'   => array( 'edit_post' ),
+			'delete_post' => array( 'delete_post' ),
+		);
+	}
+
+	/**
+	 * The guard is about payment files, so it has to leave the rest of the Media Library alone.
+	 *
+	 * An Editor edits other people's uploads as a matter of course, and an organizer is an Editor here.
+	 *
+	 * @dataProvider data_editable_capabilities
+	 *
+	 * @param string $capability
+	 */
+	public function test_ordinary_media_is_still_editable( $capability ) {
+		wp_set_current_user( self::$organizer_b );
+
+		$this->assertTrue( current_user_can( $capability, self::$public_file_id ) );
+	}
+
+	/**
+	 * The people the file isn't hidden from keep editing it.
+	 *
+	 * @dataProvider data_users_who_see_payment_files
+	 *
+	 * @param string $user_property
+	 */
+	public function test_payment_files_stay_editable_for_the_people_who_see_them( $user_property ) {
+		wp_set_current_user( self::${$user_property} );
+
+		$this->assertTrue( current_user_can( 'edit_post', self::$payment_file_id ) );
+	}
+
+	/**
+	 * The requester sees files other people uploaded onto their request, so they can edit those too.
+	 */
+	public function test_requester_can_edit_a_file_uploaded_onto_their_request() {
+		$their_request = self::factory()->post->create( array(
+			'post_type'   => WCP_Payment_Request::POST_TYPE,
+			'post_author' => self::$organizer_b,
+			'post_status' => 'draft',
+		) );
+
+		$uploaded_by_a = self::create_file( 'quote-2s3t4u5v6w7x8y9z.pdf', $their_request, self::$organizer_a );
+
+		wp_set_current_user( self::$organizer_b );
+
+		$this->assertTrue( current_user_can( 'edit_post', $uploaded_by_a ) );
+	}
+
+	/**
+	 * `map_meta_cap` is asked about a named user as often as about the current one.
+	 */
+	public function test_guard_answers_for_the_named_user_not_the_current_one() {
+		wp_set_current_user( self::$organizer_a );
+
+		$this->assertFalse( user_can( self::$organizer_b, 'edit_post', self::$payment_file_id ) );
+		$this->assertTrue( user_can( self::$organizer_a, 'edit_post', self::$payment_file_id ) );
+	}
+
+	/**
+	 * `wp_update_post()` checks no capabilities, so the field the Files metabox posts is checked where it's read.
+	 *
+	 * The metabox only offers files that are unattached or already on this request, but it builds that list in
+	 * the browser, and the field arrives as whatever was submitted.
+	 */
+	public function test_existing_files_field_leaves_another_requests_file_alone() {
+		$their_request = self::factory()->post->create( array(
+			'post_type'   => Reimbursement_Requests\POST_TYPE,
+			'post_author' => self::$organizer_b,
+			'post_status' => 'draft',
+		) );
+
+		wp_set_current_user( self::$organizer_b );
+
+		\WordCamp_Budgets::attach_existing_files(
+			$their_request,
+			array( 'wcb_existing_files_to_attach' => wp_json_encode( array( self::$payment_file_id ) ) )
+		);
+
+		$this->assertSame(
+			self::$payment_request_id,
+			(int) get_post( self::$payment_file_id )->post_parent
+		);
+	}
+
+	/**
+	 * The files the metabox really does offer still get attached.
+	 */
+	public function test_existing_files_field_attaches_an_unattached_file() {
+		$own_request = self::factory()->post->create( array(
+			'post_type'   => Reimbursement_Requests\POST_TYPE,
+			'post_author' => self::$organizer_b,
+			'post_status' => 'draft',
+		) );
+
+		$unattached = self::create_file( 'receipt-3t4u5v6w7x8y9z1a.pdf', 0, self::$organizer_b );
+
+		wp_set_current_user( self::$organizer_b );
+
+		\WordCamp_Budgets::attach_existing_files(
+			$own_request,
+			array( 'wcb_existing_files_to_attach' => wp_json_encode( array( $unattached ) ) )
+		);
+
+		$this->assertSame( $own_request, (int) get_post( $unattached )->post_parent );
+	}
+
+	/**
+	 * The field holds whatever JSON the browser sent, which isn't always a list of IDs.
+	 *
+	 * @dataProvider data_malformed_existing_files_fields
+	 *
+	 * @param string $field
+	 */
+	public function test_existing_files_field_survives_malformed_input( $field ) {
+		$own_request = self::factory()->post->create( array(
+			'post_type'   => Reimbursement_Requests\POST_TYPE,
+			'post_author' => self::$organizer_b,
+			'post_status' => 'draft',
+		) );
+
+		wp_set_current_user( self::$organizer_b );
+
+		\WordCamp_Budgets::attach_existing_files( $own_request, array( 'wcb_existing_files_to_attach' => $field ) );
+
+		$this->assertSame( self::$payment_request_id, (int) get_post( self::$payment_file_id )->post_parent );
+	}
+
+	/**
+	 * Shapes `json_decode()` returns that aren't a list of attachment IDs.
+	 *
+	 * @return array
+	 */
+	public function data_malformed_existing_files_fields() {
+		return array(
+			'not JSON'          => array( 'not json at all' ),
+			'a bare number'     => array( '5' ),
+			'a string'          => array( '"5"' ),
+			'a list of objects' => array( '[{"ID":5}]' ),
+			'a list of strings' => array( '["not an id"]' ),
+		);
+	}
+
+	/**
 	 * `privacy.php` can't reference the `POST_TYPE` constants, because it loads on requests where the files that
 	 * define them don't. Fail loudly if a slug is ever renamed on one side only.
 	 */

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -39,6 +39,9 @@ class Test_Privacy extends WP_UnitTestCase {
 	/** @var int An ordinary attachment, unrelated to any budget request. */
 	protected static $public_file_id;
 
+	/** @var int An ordinary attachment on an ordinary post, which is most of the media on the network. */
+	protected static $blog_post_file_id;
+
 	/**
 	 * Create the users and the posts they own.
 	 *
@@ -72,6 +75,9 @@ class Test_Privacy extends WP_UnitTestCase {
 		self::$payment_file_id       = self::create_file( 'invoice-a1b2c3d4e5f6g7h8.pdf', self::$payment_request_id, self::$organizer_a );
 		self::$reimbursement_file_id = self::create_file( 'receipt-h8g7f6e5d4c3b2a1.pdf', $reimbursement_id, self::$organizer_a );
 		self::$public_file_id        = self::create_file( 'sponsor-logo.png', 0, self::$organizer_a );
+
+		$blog_post               = $factory->post->create( array( 'post_author' => self::$organizer_a ) );
+		self::$blog_post_file_id = self::create_file( 'header.png', $blog_post, self::$organizer_a );
 
 		wp_set_current_user( 0 );
 	}
@@ -316,43 +322,80 @@ class Test_Privacy extends WP_UnitTestCase {
 	 *
 	 * That capability is what the media REST endpoints and the Media Library's Attach action check before they
 	 * write `post_parent`, and moving a file onto a request of your own is what would otherwise make it visible.
-	 *
-	 * @dataProvider data_editable_capabilities
-	 *
-	 * @param string $capability
 	 */
-	public function test_others_payment_files_cannot_be_edited( $capability ) {
+	public function test_others_payment_files_cannot_be_edited() {
 		wp_set_current_user( self::$organizer_b );
 
-		$this->assertFalse( current_user_can( $capability, self::$payment_file_id ) );
-		$this->assertFalse( current_user_can( $capability, self::$reimbursement_file_id ) );
+		$this->assertFalse( current_user_can( 'edit_post', self::$payment_file_id ) );
+		$this->assertFalse( current_user_can( 'edit_post', self::$reimbursement_file_id ) );
 	}
 
 	/**
-	 * The capabilities the guard covers, and so the routes that check them.
-	 *
-	 * @return array
+	 * Deletion is left where it was. Withholding it isn't needed to keep the parent from being rewritten, and
+	 * the guard runs on every site on the network, so it takes no more than it has a reason to.
 	 */
-	public function data_editable_capabilities() {
-		return array(
-			'edit_post'   => array( 'edit_post' ),
-			'delete_post' => array( 'delete_post' ),
-		);
+	public function test_deletion_rights_are_left_alone() {
+		wp_set_current_user( self::$organizer_b );
+
+		$this->assertTrue( current_user_can( 'delete_post', self::$payment_file_id ) );
 	}
 
 	/**
 	 * The guard is about payment files, so it has to leave the rest of the Media Library alone.
 	 *
-	 * An Editor edits other people's uploads as a matter of course, and an organizer is an Editor here.
+	 * An Editor edits other people's uploads as a matter of course, and an organizer is an Editor here. This is
+	 * every attachment on every site that has no budget requests at all, so it's the case that has to stay put.
 	 *
-	 * @dataProvider data_editable_capabilities
+	 * @dataProvider data_ordinary_attachments
 	 *
-	 * @param string $capability
+	 * @param string $file_property
 	 */
-	public function test_ordinary_media_is_still_editable( $capability ) {
+	public function test_ordinary_media_is_still_editable( $file_property ) {
 		wp_set_current_user( self::$organizer_b );
 
-		$this->assertTrue( current_user_can( $capability, self::$public_file_id ) );
+		$this->assertTrue( current_user_can( 'edit_post', self::${$file_property} ) );
+	}
+
+	/**
+	 * Attachments that aren't payment files, in both the shapes the guard has to tell apart.
+	 *
+	 * @return array
+	 */
+	public function data_ordinary_attachments() {
+		return array(
+			'attached to nothing'            => array( 'public_file_id' ),
+			'attached to an ordinary post'   => array( 'blog_post_file_id' ),
+		);
+	}
+
+	/**
+	 * Ordinary media has to reach a "yes" without a lookup, because every attachment on the network goes through
+	 * this guard.
+	 *
+	 * `map_meta_cap` runs once per attachment on the Media Library screens. Letting ordinary media reach
+	 * `get_hidden_payment_file_ids()` would put a query behind every row of every list, on sites that have never
+	 * filed a budget request.
+	 */
+	public function test_ordinary_media_reaches_a_verdict_without_a_query() {
+		global $wpdb;
+
+		wp_set_current_user( self::$organizer_b );
+
+		/*
+		 * A fresh post and attachment, so the lookup can't be answered from the result `WP_Query` cached for an
+		 * earlier one -- measuring a repeat check would pass whether the guard ran the query or not.
+		 */
+		$ordinary_post = self::factory()->post->create( array( 'post_author' => self::$organizer_a ) );
+		$ordinary_file = self::create_file( 'diagram.png', $ordinary_post, self::$organizer_a );
+
+		// Warm everything the check reads that isn't the guard: the user and their roles, the post and its parent.
+		current_user_can( 'edit_post', self::$blog_post_file_id );
+		_prime_post_caches( array( $ordinary_file, $ordinary_post ), false, false );
+
+		$before = $wpdb->num_queries;
+
+		$this->assertTrue( current_user_can( 'edit_post', $ordinary_file ) );
+		$this->assertSame( $before, $wpdb->num_queries );
 	}
 
 	/**
@@ -372,6 +415,10 @@ class Test_Privacy extends WP_UnitTestCase {
 	 * The requester sees files other people uploaded onto their request, so they can edit those too.
 	 */
 	public function test_requester_can_edit_a_file_uploaded_onto_their_request() {
+		// Before the request is created: the budget CPTs log the save against the current user, and read its ID
+		// unconditionally, so every one of these has to be filed by somebody.
+		wp_set_current_user( self::$organizer_b );
+
 		$their_request = self::factory()->post->create( array(
 			'post_type'   => WCP_Payment_Request::POST_TYPE,
 			'post_author' => self::$organizer_b,
@@ -379,8 +426,6 @@ class Test_Privacy extends WP_UnitTestCase {
 		) );
 
 		$uploaded_by_a = self::create_file( 'quote-2s3t4u5v6w7x8y9z.pdf', $their_request, self::$organizer_a );
-
-		wp_set_current_user( self::$organizer_b );
 
 		$this->assertTrue( current_user_can( 'edit_post', $uploaded_by_a ) );
 	}
@@ -402,13 +447,13 @@ class Test_Privacy extends WP_UnitTestCase {
 	 * the browser, and the field arrives as whatever was submitted.
 	 */
 	public function test_existing_files_field_leaves_another_requests_file_alone() {
+		wp_set_current_user( self::$organizer_b );
+
 		$their_request = self::factory()->post->create( array(
 			'post_type'   => Reimbursement_Requests\POST_TYPE,
 			'post_author' => self::$organizer_b,
 			'post_status' => 'draft',
 		) );
-
-		wp_set_current_user( self::$organizer_b );
 
 		\WordCamp_Budgets::attach_existing_files(
 			$their_request,
@@ -425,6 +470,8 @@ class Test_Privacy extends WP_UnitTestCase {
 	 * The files the metabox really does offer still get attached.
 	 */
 	public function test_existing_files_field_attaches_an_unattached_file() {
+		wp_set_current_user( self::$organizer_b );
+
 		$own_request = self::factory()->post->create( array(
 			'post_type'   => Reimbursement_Requests\POST_TYPE,
 			'post_author' => self::$organizer_b,
@@ -432,8 +479,6 @@ class Test_Privacy extends WP_UnitTestCase {
 		) );
 
 		$unattached = self::create_file( 'receipt-3t4u5v6w7x8y9z1a.pdf', 0, self::$organizer_b );
-
-		wp_set_current_user( self::$organizer_b );
 
 		\WordCamp_Budgets::attach_existing_files(
 			$own_request,
@@ -451,13 +496,13 @@ class Test_Privacy extends WP_UnitTestCase {
 	 * @param string $field
 	 */
 	public function test_existing_files_field_survives_malformed_input( $field ) {
+		wp_set_current_user( self::$organizer_b );
+
 		$own_request = self::factory()->post->create( array(
 			'post_type'   => Reimbursement_Requests\POST_TYPE,
 			'post_author' => self::$organizer_b,
 			'post_status' => 'draft',
 		) );
-
-		wp_set_current_user( self::$organizer_b );
 
 		\WordCamp_Budgets::attach_existing_files( $own_request, array( 'wcb_existing_files_to_attach' => $field ) );
 


### PR DESCRIPTION
## Summary

`privacy.php` decides who may see a reimbursement or vendor payment attachment from the request it hangs off — `get_hidden_payment_file_ids()` keeps it visible to the uploader, to the person who filed the request, and to network admins. That makes `post_parent` the field that grants access to the file.

Core treats `post_parent` as an ordinary field, though: whoever holds `edit_post` on an attachment may set it. An organizer is an Editor on their camp site, so `edit_others_posts` covers another organizer's uploads. The rules and the capabilities disagree.

- **Capability layer.** A `map_meta_cap` callback declines `edit_post` on a payment file the visibility rules already hide. One choke point covers everything that checks capabilities before writing that field — the media REST endpoints, the Media Library's Attach/Detach actions (`wp_media_attach_action()`), XML-RPC — instead of a guard per route. It matches the `map_meta_cap` callbacks the budget post types already use.

  Only `edit_post`: that is the capability every one of those routes checks, so it is the whole of what this needs. Deletion is a separate question and isn't answered here — a co-organizer can delete another organizer's payment file, as they could before this PR.
- **The one caller that checks nothing.** `wp_update_post()` performs no capability check, so `WordCamp_Budgets::attach_existing_files()` needs its own. The Files metabox only offers files that are unattached or already on this request, but it assembles that list in the browser; the same rule now holds where the field it posts is read. The field's JSON is treated as whatever was submitted rather than as a list of IDs, which also clears a PHP 8 warning on non-numeric entries.

Nothing changes for the people the rules already let through: the uploader, the requester, and `manage_options` keep the file and their rights over it.

### Cost, since this runs everywhere

`privacy.php` loads on every request, and `map_meta_cap` runs once per attachment on the Media Library screens — including on sites that have never filed a budget request. So the guard settles the two common cases from the post cache before it reaches the lookup that costs a query: you own the file, or its parent isn't a budget request. Both restate a condition `get_hidden_payment_file_ids()` applies itself, so neither can change an answer.

`test_ordinary_media_reaches_a_verdict_without_a_query` pins that. Removing the pre-filters makes it fail with one extra query per ordinary attachment, which on a twenty-row `upload.php` is twenty.

## How to review this PR

Suggested order: `includes/privacy.php` → `includes/wordcamp-budgets.php` → `tests/test-privacy.php`.

- The callback lives in `privacy.php` rather than alongside the other `map_meta_cap` callbacks because it has to run outside the admin, and `wordcamp-budgets.php` only loads on admin, cron, and Ajax requests.
- For the same reason it can't call `WordCamp_Budgets::get_map_meta_cap_post()` and carries its own small resolver. That one falls back to the global `$post` for screens that leave it implicit; this one doesn't need to, because Core's `map_meta_cap()` denies `edit_post` outright when no post is named. `test_privacy_does_not_reference_admin_only_symbols` is what pins the separation.
- `get_hidden_payment_file_ids()` takes an optional user ID now. `map_meta_cap` is asked about a named user as often as about the current one, and `user_can( $other, ... )` would otherwise have been answered for whoever was logged in.
- The two early returns before the lookup are cost guards, not rule changes — see "Cost" above. `get_post_type( $attachment->post_parent )` also covers the unattached case, since it returns `false` for parent `0`.
- `tests/bootstrap.php` now also loads `wordcamp-budgets.php`. It defines a class and nothing else, so nothing is instantiated.

## Test plan

- [x] phpunit — 1114 tests, 1 pre-existing unrelated failure (`Test_QuickBooks_OAuth_State::test_authorize_url_carries_the_stored_state`, confirmed failing on `production` with these changes stashed)
- [x] `WordCamp Payments` suite — 32/32 passing, 20 of them new
- [x] No PHP warnings or notices in the error log, which is what CI asserts on top of the suite
- [x] Negative control on every new guard: disabled, the matching tests fail; restored, all pass
- [x] phpcs clean — no new violations, and one pre-existing error removed
- [x] npm run build — not applicable, no JS changed

### Manual test steps

Two Editors on `shinynew.wordcamp.test/2023/`, each with a draft reimbursement request. Organizer A's request carried a PDF they uploaded; Organizer B's started empty. Every end state was cross-checked with `wp post list --post_type=attachment --fields=ID,post_author,post_parent` rather than read off the UI.

1. **Organizer B, Media Library** — Organizer A's file is absent, as before this change.
2. **Organizer B, REST** — `POST wp/v2/media/<A's file>` with `{"post": <B's request>}` returns `403 rest_cannot_edit`.
3. **Organizer B, Media Library Attach** — posting `action=attach`, `media[]=<A's file>`, `found_post_id=<B's request>` to `upload.php` with a valid nonce leaves the parent where it was. (This is the route a post-save filter can't reach; `wp_media_attach_action()` writes `post_parent` with direct SQL.)
4. **Organizer B, Files metabox** — setting `#wcb_existing_files_to_attach` to A's file ID and saving the draft: "Post updated", and A's file stays on A's request.
5. **Organizer B, happy path** — added their own unattached PDF through the Add files modal and saved. It attaches, the file shows under Attached files, and "Submit for Review" becomes available.
6. **Organizer A** — still sees their file on their own request, and still holds `edit_post` on it (`wp/v2/media/<id>?context=edit` → 200).
7. **Network admin** — sees both organizers' files in the Media Library and keeps edit rights over them.

Test users, requests, and attachments were deleted afterwards.
