### PR TITLE
Groups: honour page visibility in the page-content block

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/page-content/render.php
@@ -71,6 +71,40 @@ if ( ! $target_page || 'publish' !== $target_page->post_status ) {
 
 $can_edit = current_user_can( 'edit_page', $target_page->ID );
 
+/*
+ * Password protection lives in `get_the_content()`, not in the
+ * `the_content` filter, so rendering the stored content here has to
+ * repeat the check.
+ *
+ * Visitors get nothing rather than the password form: this block embeds one
+ * page inside another, where a prompt for a different page's password would
+ * be confusing in that position. Organizers keep the heading and the edit
+ * link, the way the missing- and draft-page states above do, with a notice
+ * standing in for the content so the front page doesn't look broken to the
+ * person who can change it.
+ */
+if ( post_password_required( $target_page ) ) {
+	if ( ! $can_edit ) {
+		return;
+	}
+
+	$edit_url = get_edit_post_link( $target_page->ID );
+
+	printf(
+		'<div %1$s><div class="wporg-page-content__header">%2$s%3$s</div><p class="wporg-page-content__notice">%4$s</p></div>',
+		get_block_wrapper_attributes(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by core.
+		$wporg_get_heading( true ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the callback.
+		$edit_url ? sprintf(
+			'<a class="wporg-page-content__edit" href="%1$s">&#9998; %2$s</a>',
+			esc_url( $edit_url ),
+			esc_html__( 'Edit this content', 'wporg-groups-frontend' )
+		) : '',
+		esc_html__( 'This content is password-protected.', 'wporg-groups-frontend' )
+	);
+
+	return;
+}
+
 if ( '' === trim( (string) $target_page->post_content ) && ! $can_edit ) {
 	return;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-blocks.php
@@ -497,16 +497,20 @@ class Test_Groups_Blocks extends Groups_TestCase {
 	 * @param string $slug    Page slug, unique per test to dodge path caching.
 	 * @param string $content Block markup for the page content.
 	 * @param bool   $excerpt Whether to render the block in excerpt mode.
+	 * @param array  $args    Extra arguments for the target page.
 	 * @return string Rendered block output.
 	 */
-	private function render_page_content_block( string $slug, string $content, bool $excerpt = true ): string {
+	private function render_page_content_block( string $slug, string $content, bool $excerpt = true, array $args = array() ): string {
 		self::factory()->post->create(
-			array(
-				'post_type'    => 'page',
-				'post_status'  => 'publish',
-				'post_name'    => $slug,
-				'post_title'   => 'About',
-				'post_content' => $content,
+			array_merge(
+				array(
+					'post_type'    => 'page',
+					'post_status'  => 'publish',
+					'post_name'    => $slug,
+					'post_title'   => 'About',
+					'post_content' => $content,
+				),
+				$args
 			)
 		);
 
@@ -664,6 +668,94 @@ class Test_Groups_Blocks extends Groups_TestCase {
 		$this->assertStringContainsString( '<img', $output );
 		$this->assertStringContainsString( 'Full-page prose.', $output );
 		$this->assertStringNotContainsString( 'Read more', $output );
+	}
+
+	/**
+	 * A password-protected target page is not rendered by the block. The
+	 * password gate lives in `get_the_content()` rather than in the
+	 * `the_content` filter, so rendering the stored content has to repeat
+	 * the check.
+	 */
+	public function test_page_content_excerpt_hides_password_protected_page() {
+		$content = '<!-- wp:paragraph --><p>Staged copy that is not public yet.</p><!-- /wp:paragraph -->';
+
+		$output = $this->render_page_content_block(
+			'about-protected-excerpt',
+			$content,
+			true,
+			array( 'post_password' => 'hunter2' )
+		);
+
+		$this->assertStringNotContainsString( 'Staged copy that is not public yet.', $output );
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * Full mode applies the same gate as excerpt mode.
+	 */
+	public function test_page_content_full_mode_hides_password_protected_page() {
+		$content = '<!-- wp:paragraph --><p>Staged copy that is not public yet.</p><!-- /wp:paragraph -->';
+
+		$output = $this->render_page_content_block(
+			'about-protected-full',
+			$content,
+			false,
+			array( 'post_password' => 'hunter2' )
+		);
+
+		$this->assertStringNotContainsString( 'Staged copy that is not public yet.', $output );
+		$this->assertSame( '', trim( $output ) );
+	}
+
+	/**
+	 * Organizers keep the heading and the edit link for a password-protected
+	 * page, matching the missing- and draft-page states, with a notice in
+	 * place of the content. The body itself still stays hidden.
+	 */
+	public function test_page_content_password_protected_page_offers_edit_link_to_organizers() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$content = '<!-- wp:paragraph --><p>Staged copy that is not public yet.</p><!-- /wp:paragraph -->';
+
+		$output = $this->render_page_content_block(
+			'about-protected-organizer',
+			$content,
+			true,
+			array( 'post_password' => 'hunter2' )
+		);
+
+		wp_set_current_user( 0 );
+
+		$this->assertStringNotContainsString( 'Staged copy that is not public yet.', $output );
+		$this->assertStringContainsString( 'About this group', $output );
+		$this->assertStringContainsString( 'wporg-page-content__edit', $output );
+		$this->assertStringContainsString( 'This content is password-protected.', $output );
+	}
+
+	/**
+	 * A visitor who has entered the page's password still sees the content,
+	 * the same way they would on the page itself.
+	 */
+	public function test_page_content_renders_for_visitor_holding_the_password() {
+		$content = '<!-- wp:paragraph --><p>Staged copy that is not public yet.</p><!-- /wp:paragraph -->';
+
+		// Core matches the cookie against the password with phpass, the same
+		// way `wp-login.php?action=postpass` writes it.
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher = new \PasswordHash( 8, true );
+
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( 'hunter2' );
+
+		$output = $this->render_page_content_block(
+			'about-protected-unlocked',
+			$content,
+			true,
+			array( 'post_password' => 'hunter2' )
+		);
+
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		$this->assertStringContainsString( 'Staged copy that is not public yet.', $output );
 	}
 
 	/**

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -859,7 +859,7 @@ body.error404 .site-content-container h1 {
    so the leading stays in px like the hero's. The 20px margins collapse
    against each other, which is what makes the gap 20px and not 40px. */
 
-.groups-site-about > p:not(.wporg-page-content__more) {
+.groups-site-about > p:not(.wporg-page-content__more, .wporg-page-content__notice) {
 	line-height: 30px;
 	margin-block: 20px;
 }
@@ -889,6 +889,16 @@ body.error404 .site-content-container h1 {
 
 .wporg-page-content__edit {
 	font-size: var(--wp--preset--font-size--small);
+}
+
+/* Stands in for the body of a password-protected page, and only organizers
+   ever see it. Quiet like the edit link it sits under: it explains a state,
+   it isn't the section's content. */
+
+.wporg-page-content__notice {
+	font-size: var(--wp--preset--font-size--small);
+	color: var(--wp--preset--color--charcoal-4);
+	margin: 0;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
The `wporg/page-content` block embeds a page's body into another template by slug. It handles two states for the target page — missing and draft — but treats every published page alike, without consulting the page's visibility
setting. This adds handling for a page set to "Password protected" in the editor.

Both of the block's modes need the check, since each reads the stored content directly rather than going through `get_the_content()`: excerpt mode parses and renders the leading blocks, and full mode passes the content to the
`the_content` filter.

This adds the visibility check. The block now has a third target state alongside the two it already handled:

| Target page | Visitor | Organizer |
| --- | --- | --- |
| Missing | nothing | heading + "Create" button |
| Draft | nothing | heading + "Finish the draft" button |
| Password protected | nothing | heading + edit link + notice |

Keeping the heading and the edit link matches the two existing states, so the front page stays consistent for organizers rather than dropping a section. The notice reuses core's own wording from `get_the_password_form()`, without the part prompting for a password — the block sits inside another page's template, where a password field for a different page would be confusing. A visitor who has entered the page's password sees the content as before.

### How to test the changes in this Pull Request:

Requires a build, as the block renders from `build/`:

```bash
npm run build --workspace=public_html/wp-content/mu-plugins/wporg-groups-frontend
```

1. Open the local groups site, https://events.wordpress.test/group/sunshine-coast-qld/
2. Click the button to create an About page, add some content, set Status & visibility →Visibility to "Password protected", give it a password, and publish.
3. Load the group's front page in a logged-out browser or private window. The About section should not appear at all.
<img width="1408" height="723" alt="WordPress_Sunshine_Coast_–_Community_group_for_WordPress_users_of_all_levels_—_beginners__business_owners__and_developers__Free_monthly_meetups_covering_WordPress_topics__networking__and_skill-building_" src="https://github.com/user-attachments/assets/cfa109d9-d98d-4862-834d-065b00b913a4" />

4. Load the same front page as an organizer. The "About this group" heading and the "Edit this content" link should both be present, with the notice "This content is password-protected." in place of the page body. Confirm the page's actual text is not shown.
<img width="1426" height="737" alt="WordPress_Sunshine_Coast_–_Community_group_for_WordPress_users_of_all_levels_—_beginners__business_owners__and_developers__Free_monthly_meetups_covering_WordPress_topics__networking__and_skill-building_" src="https://github.com/user-attachments/assets/aa5a0080-1de9-46d1-a2ca-2018d6763906" />

5. Visit the About page directly at `/about/`, enter the password, then return to the front page. The section should now render its content normally.
6. Set the page's visibility back to Public. The front page should render the excerpt and the "Read more" link exactly as before this change.
<img width="1422" height="859" alt="WordPress_Sunshine_Coast_–_Community_group_for_WordPress_users_of_all_levels_—_beginners__business_owners__and_developers__Free_monthly_meetups_covering_WordPress_topics__networking__and_skill-building_" src="https://github.com/user-attachments/assets/e83c973f-5a5c-405d-a8f8-4c6a00096bff" />

7. Confirm the two existing states still behave: with no About page at all the organizer sees the "Create" button, and with it in draft/private the "Finish the draft" button.

