### PR TITLE
Blocks: honour post visibility in the Sessions, Speakers, Sponsors and Organizers blocks

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/includes/content.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/content.php
@@ -24,8 +24,13 @@ function get_all_the_content( $post ) {
 	/*
 	 * `get_the_content()` holds the password check, and the `the_content`
 	 * filter runs after it, so reading the stored content directly has to
-	 * repeat the check. Return what `get_the_content()` returns here, so a
-	 * listing behaves the way one built on core's loop would.
+	 * repeat the check.
+	 *
+	 * This returns the form ahead of the filters below, where a core loop
+	 * would run them over it. That is deliberate: `wc-post-types` appends
+	 * speaker, slide, video and category markup on `the_content`, none of
+	 * which belongs on a password form. The cost is the paragraph wrapping
+	 * `wpautop()` would have added.
 	 */
 	if ( post_password_required( $post ) ) {
 		return get_the_password_form( $post );
@@ -55,10 +60,14 @@ function get_trimmed_content( $post, $excerpt_length = 55 ) {
 	 * The fallback below reads `post_content` directly, so this needs the
 	 * same check as `get_all_the_content()`. `get_the_excerpt()` applies it
 	 * to both the manual excerpt and the fallback, and stands this sentence
-	 * in their place; the wording matches core's so the two read alike.
+	 * in their place.
+	 *
+	 * Take it from core's catalogue rather than restating it under this
+	 * plugin's domain, so that a listing and the post's own page read alike
+	 * in every locale instead of only in English.
 	 */
 	if ( post_password_required( $post ) ) {
-		return esc_html__( 'There is no excerpt because this is a protected post.', 'wordcamporg' );
+		return esc_html__( 'There is no excerpt because this is a protected post.', 'default' );
 	}
 
 	$post_excerpt = $post->post_excerpt;

--- a/public_html/wp-content/mu-plugins/blocks/includes/content.php
+++ b/public_html/wp-content/mu-plugins/blocks/includes/content.php
@@ -21,6 +21,16 @@ defined( 'WPINC' ) || die();
 function get_all_the_content( $post ) {
 	$post = get_post( $post );
 
+	/*
+	 * `get_the_content()` holds the password check, and the `the_content`
+	 * filter runs after it, so reading the stored content directly has to
+	 * repeat the check. Return what `get_the_content()` returns here, so a
+	 * listing behaves the way one built on core's loop would.
+	 */
+	if ( post_password_required( $post ) ) {
+		return get_the_password_form( $post );
+	}
+
 	$content = wp_kses_post( $post->post_content );
 
 	/** This filter is documented in wp-includes/post-template.php */
@@ -40,6 +50,16 @@ function get_all_the_content( $post ) {
  */
 function get_trimmed_content( $post, $excerpt_length = 55 ) {
 	$post = get_post( $post );
+
+	/*
+	 * The fallback below reads `post_content` directly, so this needs the
+	 * same check as `get_all_the_content()`. `get_the_excerpt()` applies it
+	 * to both the manual excerpt and the fallback, and stands this sentence
+	 * in their place; the wording matches core's so the two read alike.
+	 */
+	if ( post_password_required( $post ) ) {
+		return esc_html__( 'There is no excerpt because this is a protected post.', 'wordcamporg' );
+	}
 
 	$post_excerpt = $post->post_excerpt;
 	if ( ! ( $post_excerpt ) ) {

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/view.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/organizers/view.php
@@ -11,7 +11,9 @@ defined( 'WPINC' ) || die();
 /** @var array   $attributes */
 /** @var WP_Post $organizer */
 
-// Note that organizer posts are not 'public', so there are no permalinks.
+// This block doesn't link organizer titles, unlike the sibling blocks.
+// The post type gained permalinks when it became 'public' in 2020; the
+// block was never changed to use them.
 
 setup_postdata( $organizer ); // This is necessary for generating an excerpt from content if the excerpt field is empty.
 ?>

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-content.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-content.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+use function WordCamp\Blocks\Utilities\{ get_all_the_content, get_trimmed_content };
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/blocks/blocks.php';
+require_once dirname( __DIR__ ) . '/blocks/includes/definitions.php';
+require_once dirname( __DIR__ ) . '/blocks/includes/content.php';
+require_once dirname( __DIR__ ) . '/blocks/source/components/item/controller.php';
+require_once dirname( __DIR__ ) . '/blocks/source/components/image/controller.php';
+require_once dirname( __DIR__ ) . '/blocks/source/components/post-list/controller.php';
+require_once dirname( __DIR__ ) . '/blocks/source/blocks/organizers/controller.php';
+require_once dirname( __DIR__ ) . '/blocks/source/blocks/sessions/controller.php';
+require_once dirname( __DIR__ ) . '/blocks/source/blocks/speakers/controller.php';
+require_once dirname( __DIR__ ) . '/blocks/source/blocks/sponsors/controller.php';
+
+/**
+ * Tests for how the listing blocks treat password-protected posts.
+ *
+ * The content helpers read the stored content rather than going through
+ * `get_the_content()`, which is where the password check lives. The post itself
+ * stays in the list, the way core's loop shows it on an archive -- only the body
+ * is withheld.
+ *
+ * @group blocks
+ */
+class Test_Blocks_Content extends WP_UnitTestCase {
+	/**
+	 * The body that should never reach an anonymous visitor.
+	 *
+	 * @var string
+	 */
+	const PROTECTED_BODY = 'Unannounced keynote, still under embargo.';
+
+	/**
+	 * Render blocks as a logged-out visitor, from a page rather than a session.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( 0 );
+
+		// The suite runs as admin by default, where core suppresses the
+		// "Protected:" title prefix. These blocks only ever render on the
+		// front end.
+		set_current_screen( 'front' );
+
+		// The blocks read their current post from the global, and refuse to
+		// render inside a session.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restored in tear_down().
+		$GLOBALS['post'] = get_post(
+			self::factory()->post->create( array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Schedule',
+			) )
+		);
+	}
+
+	/**
+	 * Reset the global the blocks read their current post from.
+	 */
+	public function tear_down() {
+		unset( $GLOBALS['post'] );
+
+		set_current_screen( 'dashboard' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a published, password-protected post of the given type.
+	 *
+	 * @param string $post_type Post type to create.
+	 * @return int The new post's ID.
+	 */
+	private function create_protected_post( string $post_type ): int {
+		return self::factory()->post->create( array(
+			'post_type'     => $post_type,
+			'post_status'   => 'publish',
+			'post_title'    => 'Protected item',
+			// The factory fills in a placeholder excerpt, which would mask
+			// the helper's fallback to `post_content`.
+			'post_excerpt'  => '',
+			'post_content'  => self::PROTECTED_BODY,
+			'post_password' => 'hunter2',
+		) );
+	}
+
+	/**
+	 * The full-content helper withholds a password-protected body, and
+	 * stands the password form in its place the way `get_the_content()`
+	 * does. The `the_content` filter runs after core's password check, so a
+	 * caller that applies the filter to the stored content has to repeat it.
+	 */
+	public function test_get_all_the_content_withholds_protected_body() {
+		$post_id = $this->create_protected_post( 'wcb_session' );
+		$output  = get_all_the_content( $post_id );
+
+		$this->assertStringNotContainsString( self::PROTECTED_BODY, $output );
+		$this->assertStringContainsString( 'post-password-form', $output );
+	}
+
+	/**
+	 * The excerpt helper withholds it too, standing in the same sentence
+	 * `get_the_excerpt()` uses. Posts rarely carry a manual excerpt, so the
+	 * helper's fallback would otherwise serve the first 55 words of the
+	 * protected body.
+	 */
+	public function test_get_trimmed_content_withholds_protected_body() {
+		$post_id = $this->create_protected_post( 'wcb_session' );
+		$output  = get_trimmed_content( $post_id );
+
+		$this->assertStringNotContainsString( self::PROTECTED_BODY, $output );
+		$this->assertSame( 'There is no excerpt because this is a protected post.', $output );
+	}
+
+	/**
+	 * A manual excerpt on a protected post is withheld as well, matching
+	 * `get_the_excerpt()`.
+	 */
+	public function test_get_trimmed_content_withholds_protected_manual_excerpt() {
+		$post_id = self::factory()->post->create( array(
+			'post_type'     => 'wcb_session',
+			'post_status'   => 'publish',
+			'post_excerpt'  => 'Manual excerpt of the embargoed talk.',
+			'post_content'  => self::PROTECTED_BODY,
+			'post_password' => 'hunter2',
+		) );
+
+		$this->assertStringNotContainsString( 'Manual excerpt of the embargoed talk.', get_trimmed_content( $post_id ) );
+	}
+
+	/**
+	 * A post with no password is unaffected.
+	 */
+	public function test_helpers_still_return_unprotected_content() {
+		$post_id = self::factory()->post->create( array(
+			'post_type'    => 'wcb_session',
+			'post_status'  => 'publish',
+			'post_excerpt' => '',
+			'post_content' => 'Public talk description.',
+		) );
+
+		$this->assertStringContainsString( 'Public talk description.', get_all_the_content( $post_id ) );
+		$this->assertStringContainsString( 'Public talk description.', get_trimmed_content( $post_id ) );
+	}
+
+	/**
+	 * A visitor holding the page's password sees the content, the same way
+	 * they would on the post itself.
+	 */
+	public function test_helpers_return_content_for_visitor_holding_the_password() {
+		$post_id = $this->create_protected_post( 'wcb_session' );
+
+		// Core matches the cookie against the password with phpass, the same
+		// way `wp-login.php?action=postpass` writes it.
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher = new \PasswordHash( 8, true );
+
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( 'hunter2' );
+
+		$content = get_all_the_content( $post_id );
+		$excerpt = get_trimmed_content( $post_id );
+
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		$this->assertStringContainsString( self::PROTECTED_BODY, $content );
+		$this->assertStringContainsString( self::PROTECTED_BODY, $excerpt );
+	}
+
+	/**
+	 * The queries behind the four listing blocks keep protected posts, the
+	 * way core's archive queries do. Withholding the body is the content
+	 * helpers' job; the post's existence is not the secret.
+	 *
+	 * @dataProvider data_listing_queries
+	 *
+	 * @param string $post_type The post type the block lists.
+	 * @param string $callback  The controller function that queries it.
+	 */
+	public function test_listing_queries_keep_protected_posts( string $post_type, string $callback ) {
+		$protected_id = $this->create_protected_post( $post_type );
+		$public_id    = self::factory()->post->create( array(
+			'post_type'   => $post_type,
+			'post_status' => 'publish',
+			'post_title'  => 'Public item',
+		) );
+
+		$posts = $callback( array(
+			'mode' => 'all',
+			'sort' => 'title_asc',
+		) );
+		$found = wp_list_pluck( $posts, 'ID' );
+
+		$this->assertContains( $public_id, $found );
+		$this->assertContains( $protected_id, $found );
+	}
+
+	/**
+	 * Post types and the controller functions that query them.
+	 *
+	 * @return array
+	 */
+	public function data_listing_queries(): array {
+		return array(
+			'sessions'   => array( 'wcb_session', 'WordCamp\Blocks\Sessions\get_session_posts' ),
+			'speakers'   => array( 'wcb_speaker', 'WordCamp\Blocks\Speakers\get_speaker_posts' ),
+			'sponsors'   => array( 'wcb_sponsor', 'WordCamp\Blocks\Sponsors\get_sponsor_posts' ),
+			'organizers' => array( 'wcb_organizer', 'WordCamp\Blocks\Organizers\get_organizer_posts' ),
+		);
+	}
+
+	/**
+	 * End to end: an anonymous render of each block lists the protected post
+	 * without its body. The title stays, carrying core's "Protected:"
+	 * prefix, and the body is replaced the way core's loop replaces it.
+	 *
+	 * @dataProvider data_rendered_blocks
+	 *
+	 * @param string $post_type The post type the block lists.
+	 * @param string $callback  The block's render callback.
+	 * @param string $content   The block's `content` attribute.
+	 */
+	public function test_rendered_block_lists_protected_post_without_its_body( string $post_type, string $callback, string $content ) {
+		$this->create_protected_post( $post_type );
+
+		self::factory()->post->create( array(
+			'post_type'    => $post_type,
+			'post_status'  => 'publish',
+			'post_title'   => 'Public item',
+			'post_excerpt' => '',
+			'post_content' => 'Public body.',
+		) );
+
+		$output = $callback( array(
+			'mode'    => 'all',
+			'sort'    => 'title_asc',
+			'content' => $content,
+		) );
+
+		$this->assertStringContainsString( 'Public item', $output );
+		$this->assertStringNotContainsString( self::PROTECTED_BODY, $output );
+
+		// Core's `protected_title_format`, so the item is still listed.
+		$this->assertStringContainsString( 'Protected: Protected item', $output );
+
+		if ( 'full' === $content ) {
+			$this->assertStringContainsString( 'post-password-form', $output );
+		} else {
+			$this->assertStringContainsString( 'this is a protected post', $output );
+		}
+	}
+
+	/**
+	 * Each listing block in each content mode.
+	 *
+	 * @return array
+	 */
+	public function data_rendered_blocks(): array {
+		$blocks = array(
+			'sessions'   => array( 'wcb_session', 'WordCamp\Blocks\Sessions\render' ),
+			'speakers'   => array( 'wcb_speaker', 'WordCamp\Blocks\Speakers\render' ),
+			'sponsors'   => array( 'wcb_sponsor', 'WordCamp\Blocks\Sponsors\render' ),
+			'organizers' => array( 'wcb_organizer', 'WordCamp\Blocks\Organizers\render' ),
+		);
+
+		$cases = array();
+
+		foreach ( $blocks as $name => $block ) {
+			foreach ( array( 'full', 'excerpt' ) as $content ) {
+				$cases[ "$name, $content" ] = array( $block[0], $block[1], $content );
+			}
+		}
+
+		return $cases;
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-theme-templates-offline.php
+++ b/public_html/wp-content/mu-plugins/tests/test-theme-templates-offline.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+use function WordCamp\Theme_Templates\get_offline_page;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/theme-templates/bootstrap.php';
+
+/**
+ * Tests for the page the offline template is built from.
+ *
+ * Unlike a listing, this page is pre-cached by the service worker and shown
+ * with no connection, so a password-protected one is passed over in favour of
+ * the default offline message.
+ *
+ * @group blocks
+ */
+class Test_Theme_Templates_Offline extends WP_UnitTestCase {
+	/**
+	 * Create a published page flagged as the offline page.
+	 *
+	 * @param array $args Extra arguments for the page.
+	 * @return int The new page's ID.
+	 */
+	private function create_offline_page( array $args = array() ): int {
+		$page_id = self::factory()->post->create(
+			array_merge(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+					'post_title'  => 'Offline',
+				),
+				$args
+			)
+		);
+
+		update_post_meta( $page_id, 'wc_page_offline', 'yes' );
+
+		return $page_id;
+	}
+
+	/**
+	 * The ordinary case still resolves.
+	 */
+	public function test_returns_the_offline_page() {
+		$page_id = $this->create_offline_page();
+
+		$this->assertSame( $page_id, get_offline_page()->ID );
+	}
+
+	/**
+	 * A password-protected offline page is not used, so `get_offline_content()`
+	 * falls back to the default message rather than pre-caching a password
+	 * form that could not be submitted with no connection.
+	 */
+	public function test_skips_a_password_protected_offline_page() {
+		$this->create_offline_page( array( 'post_password' => 'hunter2' ) );
+
+		$this->assertFalse( get_offline_page() );
+	}
+
+	/**
+	 * With both, the usable one is chosen rather than the protected one that
+	 * happens to be older.
+	 */
+	public function test_prefers_an_unprotected_offline_page() {
+		$this->create_offline_page( array(
+			'post_password' => 'hunter2',
+			'post_date'     => '2020-01-01 00:00:00',
+		) );
+		$usable_id = $this->create_offline_page( array( 'post_date' => '2021-01-01 00:00:00' ) );
+
+		$this->assertSame( $usable_id, get_offline_page()->ID );
+	}
+}

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -56,6 +56,10 @@ function get_offline_page() {
 		'order'          => 'asc',
 		'meta_key'       => 'wc_page_offline',
 		'meta_value'     => 'yes',
+		// Unlike a listing, this page is pre-cached by the service worker
+		// and shown with no connection, where a password form could not be
+		// submitted. A protected one falls back to the default message.
+		'has_password'   => false,
 	) );
 	if ( count( $found_pages ) ) {
 		return $found_pages[0];


### PR DESCRIPTION
The Sessions, Speakers, Sponsors and Organizers blocks render their items through `get_all_the_content()` and `get_trimmed_content()` in `mu-plugins/blocks/includes/content.php`. Both read the stored post content directly rather than going through `get_the_content()` / `get_the_excerpt()`, which is where core handles the editor's "Password protected" visibility setting. The blocks therefore treated every published post alike, whatever its visibility. `theme-templates/bootstrap.php` passes a page into the same helper.

This adds the handling, following core's own behaviour rather than inventing something for these blocks:

| Content setting | What the item shows |
| --- | --- |
| `full` | The password form, as `get_the_content()` returns |
| `excerpt` | "There is no excerpt because this is a protected post.", as `get_the_excerpt()` returns |

The post stays in the listing either way, and its title carries core's "Protected:" prefix — `get_the_title()` already applies that, so the views needed no change. A visitor who has entered the password sees the content as before. Submitting the form takes you to the single post, which is core's behaviour: `get_the_password_form()` embeds a hidden `redirect_to` set to the permalink, and `wp-login.php?action=postpass` prefers it over the referer.

The block queries are deliberately unchanged. Password protection guards the body, not the post's existence — an organizer who wants a post out of the listing entirely has "Private" for that — so excluding protected posts from the queries would conflate the two settings and break what people expect these controls to do.

### The offline page is the one exception

`get_offline_page()` now skips a password-protected page, so `get_offline_content()` falls back to its default message. That page is not a listing: the service worker pre-caches it and shows it with no connection, where a password form could not be submitted. Serving a dead form there would be worse than the default message, so this one resolves at the query instead. The helper covers it regardless; the query argument just picks the better of the two outcomes.

### Also here

`organizers/view.php` carried a comment saying organizer posts are not `public` and have no permalinks. That was true when it was written in 968094e7 (2019); the post type became `public` in 3cafe4a9 (2020) and the comment was never updated. It misled a reviewer of this PR, so it is corrected here.

### How to test the changes in this Pull Request

No build is needed — the blocks render from PHP in `source/`, and `build/` holds only compiled JS and CSS.

1. Run the tests:

   ```bash
   ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist --group blocks
   ```

2. On a local camp site, open a session at `/wp-admin/edit.php?post_type=wcb_session`, give it some body text you will recognise, and set Status & visibility → Visibility to "Password protected" with a password.
3. Add a page holding the Sessions block, set to list all sessions with the content setting on "Full":

   ```
   <!-- wp:wordcamp/sessions {"mode":"all","content":"full"} /-->
   ```

4. Load that page in a logged-out browser or private window. The session should still be listed, its title reading "Protected: <title>", with the password form where its body would be. The body text itself should not appear anywhere on the page.
<img width="962" height="549" alt="Password-test___WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/604b5c9d-ec92-4947-a214-2ef7d9911e47" />

5. Enter the password. You land on the session's own page with its content shown. Go back to the listing — the body now renders inline there too.
6. Clear the `wp-postpass_*` cookie, switch the block's content setting to "Excerpt", and reload logged out. The item should now read "There is no excerpt because this is a protected post." in place of the body. Confirm this with a session that has no manual excerpt, and again with one that has a manual excerpt filled in.
<img width="969" height="450" alt="Password-test___WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/61838df0-e2c5-4e2f-a963-cea5cc4abe87" />

7. Repeat steps 3–6 for the Speakers, Sponsors and Organizers blocks, e.g. `https://seattle.wordcamp.test/2023/speakers/`.
8. Set the post's visibility back to Public and confirm the listing renders exactly as it did before this branch, in both content settings.
9. Optionally, set a password on the site's Offline page (the one with the `wc_page_offline` meta) and confirm the offline template falls back to its default message rather than showing a form.
