### PR TITLE
Budgets: ask the same question of the file as of the request it joins

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -549,19 +549,17 @@ function save_request( $post_id, $post ) {
 	validate_and_save_notes( $post, $_POST['wcbrr_new_note'] );
 
 	/*
-	 * We need to determine if the user is allowed to modify the request -- in terms of this plugin's post_status
-	 * restrictions, not in terms of current_user_can( 'edit_post', N ) -- but at this point in the execution
-	 * the status has already changed from the original one to the new one, so user_can_edit_request() would often
-	 * return an incorrect result, because it would be evaluating the new status, when it should use the old one.
-	 * That would result in all the meta fields the user entered being ignored when going from `draft` to
-	 * `submitted`, `info_requested` to `submitted`, etc.
+	 * The status this reads is the stored one, which by now is the status the save just wrote. That used to be
+	 * worked around with a stub post built from `$_POST['original_post_status']`, so the check saw the status the
+	 * request had before the save -- otherwise a `draft` being submitted would be judged as `wcb-pending-approval`
+	 * and the fields entered alongside it dropped.
 	 *
-	 * To avoid that, we create a stub WP_Post with the original post status, and give that to
-	 * user_can_edit_request() instead.
+	 * That's no longer what decides it. `post_edit_is_actionable()` above asks `edit_post`, which this post type's
+	 * `map_meta_cap` callback refuses for a request past the editable statuses, so a save that would have needed
+	 * the stub has already returned. What's left here is a request still in those statuses, which reads the same
+	 * either way -- and reading the real post keeps the decision out of the request body.
 	 */
-	$original_post = new WP_Post( (object) array( 'post_status' => $_POST['original_post_status'] ) );
-
-	if ( user_can_edit_request( $original_post ) ) {
+	if ( user_can_edit_request( $post ) ) {
 		$text_fields = array( 'name_of_payer', 'currency', 'reason', 'reason_other' );
 		validate_and_save_text_fields( $post_id, $text_fields, $_POST );
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -893,6 +893,15 @@ class WordCamp_Budgets {
 			return;
 		}
 
+		/*
+		 * Both callers reach this from `save_post`, behind `post_edit_is_actionable()`, which asks the same
+		 * question -- but this is a public helper that writes to whatever request it's handed, so it shouldn't
+		 * depend on a caller having asked.
+		 */
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
 		foreach ( $files as $file_id ) {
 			if ( ! self::is_file_attachable( $file_id, $post_id ) ) {
 				continue;
@@ -909,8 +918,12 @@ class WordCamp_Budgets {
 	 * Whether one of the files a request names may be attached to it.
 	 *
 	 * The Files metabox only offers files that are unattached, or already on this request, but it assembles that
-	 * list in the browser. `wp_update_post()` checks nothing of its own, so the same rule has to hold here for
-	 * whatever comes back in the field -- a file already sitting on another post keeps the post it has.
+	 * list in the browser. `wp_update_post()` checks nothing of its own, so the same rules have to hold here for
+	 * whatever comes back in the field.
+	 *
+	 * Two of them. A file already sitting on another post keeps the post it has. And attaching a file is an edit
+	 * to it -- `post_parent` is the field `privacy.php` reads to decide who sees a payment file -- so it takes
+	 * the same capability any other route to that field would, which is where the guard in `privacy.php` applies.
 	 *
 	 * @param mixed $file_id An entry from the field, which is whatever JSON the browser sent.
 	 * @param int   $post_id The request the file would be attached to.
@@ -925,6 +938,10 @@ class WordCamp_Budgets {
 		$file = get_post( absint( $file_id ) );
 
 		if ( ! $file instanceof WP_Post || 'attachment' !== $file->post_type ) {
+			return false;
+		}
+
+		if ( ! current_user_can( 'edit_post', $file->ID ) ) {
 			return false;
 		}
 

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -27,6 +27,14 @@ class Test_Privacy extends WP_UnitTestCase {
 	/** @var int A network admin, who reviews requests and so sees every file. */
 	protected static $network_admin;
 
+	/**
+	 * @var int A volunteer who can file a request but can't edit anybody else's posts.
+	 *
+	 * The budget post types gate creation on `publish_posts`, which an Author has, while `edit_others_posts`,
+	 * which decides who may edit somebody else's upload, is an Editor capability. This is the gap between them.
+	 */
+	protected static $volunteer;
+
 	/** @var int Organizer A's vendor payment request. */
 	protected static $payment_request_id;
 
@@ -51,6 +59,7 @@ class Test_Privacy extends WP_UnitTestCase {
 		self::$organizer_a   = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$organizer_b   = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$network_admin = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$volunteer     = $factory->user->create( array( 'role' => 'author' ) );
 
 		grant_super_admin( self::$network_admin );
 
@@ -586,5 +595,75 @@ class Test_Privacy extends WP_UnitTestCase {
 
 		$this->assertContains( self::$payment_file_id, $visible );
 		$this->assertContains( self::$reimbursement_file_id, $visible );
+	}
+
+	/**
+	 * Attaching a file writes its `post_parent`, which is the field the rules above read.
+	 *
+	 * So it takes the capability any other route to that field takes, and the guard on `edit_post` decides it
+	 * here as well -- rather than the field being a way around the guard.
+	 */
+	public function test_existing_files_field_leaves_a_file_the_caller_cant_edit_alone() {
+		wp_set_current_user( self::$volunteer );
+
+		$their_request = self::factory()->post->create( array(
+			'post_type'   => Reimbursement_Requests\POST_TYPE,
+			'post_author' => self::$volunteer,
+			'post_status' => 'draft',
+		) );
+
+		$someone_elses = self::create_file( 'notes-9z8y7x6w5v4u3t2s.pdf', 0, self::$organizer_a );
+
+		$this->assertFalse( current_user_can( 'edit_post', $someone_elses ) );
+
+		\WordCamp_Budgets::attach_existing_files(
+			$their_request,
+			array( 'wcb_existing_files_to_attach' => wp_json_encode( array( $someone_elses ) ) )
+		);
+
+		$this->assertSame( 0, (int) get_post( $someone_elses )->post_parent );
+	}
+
+	/**
+	 * An organizer who may edit the file still attaches it, so the rule doesn't cost the shared-upload case.
+	 *
+	 * One organizer uploading the receipts and another filing the request is a supported way to work: the rules
+	 * above show the file to both of them.
+	 */
+	public function test_existing_files_field_attaches_a_co_organizers_unattached_file() {
+		wp_set_current_user( self::$organizer_b );
+
+		$own_request = self::factory()->post->create( array(
+			'post_type'   => Reimbursement_Requests\POST_TYPE,
+			'post_author' => self::$organizer_b,
+			'post_status' => 'draft',
+		) );
+
+		$uploaded_by_a = self::create_file( 'receipt-2s3t4u5v6w7x8y9z.pdf', 0, self::$organizer_a );
+
+		\WordCamp_Budgets::attach_existing_files(
+			$own_request,
+			array( 'wcb_existing_files_to_attach' => wp_json_encode( array( $uploaded_by_a ) ) )
+		);
+
+		$this->assertSame( $own_request, (int) get_post( $uploaded_by_a )->post_parent );
+	}
+
+	/**
+	 * The helper is public and writes to whatever request it's handed, so it asks about that request too.
+	 */
+	public function test_existing_files_field_ignores_a_request_the_caller_cant_edit() {
+		wp_set_current_user( self::$volunteer );
+
+		$unattached = self::create_file( 'receipt-1a2b3c4d5e6f7g8h.pdf', 0, self::$volunteer );
+
+		$this->assertFalse( current_user_can( 'edit_post', self::$payment_request_id ) );
+
+		\WordCamp_Budgets::attach_existing_files(
+			self::$payment_request_id,
+			array( 'wcb_existing_files_to_attach' => wp_json_encode( array( $unattached ) ) )
+		);
+
+		$this->assertSame( 0, (int) get_post( $unattached )->post_parent );
 	}
 }

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-reimbursement-request.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace WordCamp\Budgets\Tests;
+
+use WP_UnitTestCase;
+use WordCamp\Budgets\Reimbursement_Requests;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * What the save handler is allowed to write, and what it decides that from.
+ *
+ * A reimbursement request is only editable by the organizer who filed it while it's still a draft, or marked
+ * incomplete. Past that it belongs to the reviewers, and the fields on it are what a payment gets made from.
+ * These pin where that line is read.
+ *
+ * @group budgets
+ */
+class Test_Reimbursement_Request extends WP_UnitTestCase {
+	/** @var int The organizer who files the request. */
+	protected static $organizer;
+
+	/**
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$organizer = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Clear the request the tests fill, so one test's body can't reach the next.
+	 */
+	public function tear_down() {
+		unset( $_REQUEST['action'] );
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Fill the request body the Edit screen posts, with valid nonces for the current user.
+	 *
+	 * @param array $overrides Values to add or replace.
+	 */
+	protected function populate_request( array $overrides = array() ) {
+		$nonces = array(
+			'status_nonce'              => 'status',
+			'notes_nonce'               => 'notes',
+			'general_information_nonce' => 'general_information',
+			'payment_details_nonce'     => 'payment_details',
+			'expenses_nonce'            => 'expenses',
+		);
+
+		$_POST = array(
+			'wcbrr_new_note'       => '',
+			'wcbrr-expenses-data'  => '[]',
+			'_wcbrr_name_of_payer' => 'Original Payer',
+			'_wcbrr_currency'      => 'USD',
+			'_wcbrr_reason'        => 'other',
+			'_wcbrr_reason_other'  => '',
+		);
+
+		foreach ( $nonces as $field => $action ) {
+			$_POST[ $field ] = wp_create_nonce( $action );
+		}
+
+		$_POST = array_merge( $_POST, $overrides );
+
+		// `post.php` submits as `editpost`, which is what tells this post type's `map_meta_cap` callback that
+		// the request is being written to rather than opened.
+		$_REQUEST           = $_POST;
+		$_REQUEST['action'] = 'editpost';
+	}
+
+	/**
+	 * Create a request owned by the organizer, at a given status.
+	 *
+	 * @param string $status
+	 *
+	 * @return int
+	 */
+	protected function create_request( $status ) {
+		return self::factory()->post->create( array(
+			'post_type'   => Reimbursement_Requests\POST_TYPE,
+			'post_author' => self::$organizer,
+			'post_status' => $status,
+		) );
+	}
+
+	/**
+	 * The status the handler reads is the stored one, not one named in the request body.
+	 *
+	 * The body carries a field holding the status the request had before the save, which the handler used to
+	 * take this decision from. A draft is editable whatever that field says.
+	 */
+	public function test_editable_request_is_saved_whatever_the_body_claims() {
+		wp_set_current_user( self::$organizer );
+
+		$post_id = $this->create_request( 'draft' );
+
+		$this->populate_request( array(
+			'original_post_status' => 'wcb-paid',
+			'_wcbrr_name_of_payer' => 'Saved Payer',
+		) );
+
+		Reimbursement_Requests\save_request( $post_id, get_post( $post_id ) );
+
+		$this->assertSame( 'Saved Payer', get_post_meta( $post_id, '_wcbrr_name_of_payer', true ) );
+	}
+
+	/**
+	 * And the other way round: naming an editable status doesn't make a request editable.
+	 */
+	public function test_request_past_the_editable_statuses_is_not_saved() {
+		wp_set_current_user( self::$organizer );
+
+		$post_id = $this->create_request( 'wcb-approved' );
+
+		update_post_meta( $post_id, '_wcbrr_name_of_payer', 'Original Payer' );
+
+		$this->populate_request( array(
+			'original_post_status' => 'draft',
+			'_wcbrr_name_of_payer' => 'Rewritten Payer',
+		) );
+
+		Reimbursement_Requests\save_request( $post_id, get_post( $post_id ) );
+
+		$this->assertSame( 'Original Payer', get_post_meta( $post_id, '_wcbrr_name_of_payer', true ) );
+	}
+
+	/**
+	 * A request marked incomplete goes back to the organizer to correct, so it's editable again.
+	 */
+	public function test_incomplete_request_is_saved() {
+		wp_set_current_user( self::$organizer );
+
+		$post_id = $this->create_request( 'wcb-incomplete' );
+
+		$this->populate_request( array( '_wcbrr_name_of_payer' => 'Corrected Payer' ) );
+
+		Reimbursement_Requests\save_request( $post_id, get_post( $post_id ) );
+
+		$this->assertSame( 'Corrected Payer', get_post_meta( $post_id, '_wcbrr_name_of_payer', true ) );
+	}
+}


### PR DESCRIPTION
## Summary

Follow-on to #1975, which brought the Files metabox's field into line with the rule the metabox itself applies -- a file already on another post keeps the post it has. That covered the file's parent but not the file, so an unattached upload could still be moved onto a request by someone with no claim on it.

- `is_file_attachable()` now takes `edit_post` on the file as well. `post_parent` is the field `privacy.php` reads to decide who sees a payment file, so writing it takes the capability any other route to that field takes -- which runs #1975's `map_meta_cap` guard for payment files and ordinary post capabilities for everything else. Same answer the Media Library would give the same person, rather than a second rule.
- `attach_existing_files()` asks `edit_post` about the request it's writing to. Both callers already sit behind `post_edit_is_actionable()`, which asks the same thing, so nothing changes today -- it's a public helper that writes to whatever request it's handed, and shouldn't depend on a caller having asked.
- `save_request()` no longer builds a stub post out of `$_POST['original_post_status']` to decide whether the request is still editable. See below.

An organizer attaching a co-organizer's unattached receipt still works -- that's a supported way to file a request, and `privacy.php` shows the file to both of them. Covered by a test.

## How to review this PR

`includes/wordcamp-budgets.php` first, then `includes/reimbursement-request.php`.

- **Why `edit_post` and not "own uploads only".** The stricter rule reads well but breaks the shared-upload workflow: one organizer uploads the receipts, another files the request. `privacy.php` explicitly supports that (the requester sees files on their own request), so the picker would keep offering files the server then silently dropped. `edit_post` is the rule that already governs `post_parent` everywhere else.
- **The `original_post_status` stub is safe to drop, and this was measured, not assumed.** The comment on it said it existed because the stored status is already the new one by the time `save_request()` runs, so `draft` → submitted would be judged on the status it moved to and the fields entered with it dropped. That is no longer what decides it: `post_edit_is_actionable()` asks `edit_post` first, and this post type's `map_meta_cap` callback adds `manage_network` to that for a request past `draft`/`auto-draft`/`wcb-incomplete` when `action` isn't `edit`. So a save that would have needed the stub returns before reaching it. Confirmed on the test stack: at `save_post` after a `draft` → `wcb-pending-approval` transition, `post_edit_is_actionable()` is already `false`. What reaches the check is a request still in the editable statuses, which reads the same either way.
- **Unrelated observation, not addressed here.** The above also means editing fields *and* submitting in one click drops those edits, since the handler bails before writing them. That predates this branch and isn't touched by it — happy to look at it separately if it's worth a ticket.
- `tests/test-reimbursement-request.php` is new: `save_request()` had no coverage, and the status boundary is what these three tests pin.

## Test plan

- [x] phpunit — `WordCamp Payments` 38/38, `WordCamp Budgets Dashboard` 54/54, `WordCamp Post Types` 52/52
- [x] Each new guard verified to fail without its fix (reverted the check, watched the test go red, restored)
- [x] phpcs — no new violations on any changed file (error/warning counts identical to the pre-change baseline on the two `includes/` files; both test files clean)
- [ ] npm run build — n/a, no JS changed
- [x] Manual browser pass on the local stack (below)

### Manual test steps

On `seattle.wordcamp.test`, with an unattached PDF owned by an Editor standing in for a co-organizer's upload.

1. **Author-role volunteer, low-privilege actor.** Logged in as an Author and opened `post-new.php?post_type=wcb_reimbursement`. Reachable, as expected — the post types gate creation on `publish_posts`.
2. **The attack shape.** Set `wcb_existing_files_to_attach` to the Editor's file id on their own draft and submitted the form directly (the hidden input is populated in the browser, so this is the realistic shape). The draft saved — status went `auto-draft` → `Draft` — and the file was refused: `post_parent` still `0` in the DB, "You haven't uploaded any files yet" on the screen.
3. **Negative control.** Removed the new check, repeated step 2 unchanged: the file was taken (`post_parent` → the volunteer's draft) and `victim-auth.pdf` was listed on their own request, directly under the "Files uploaded by other users are hidden to protect privacy" note. Restored the check, reset `post_parent`, repeated again — refused.
4. **Editor, no regression.** Logged in as an Editor and attached both their own unattached file and a second Editor's unattached file to a new request. Both attached, both listed in the metabox.
5. **The `original_post_status` change.** Same save also set Name of Payer; confirmed `_wcbrr_name_of_payer` persisted, so dropping the stub doesn't cost the legitimate draft save. Then moved the request to `wcb-approved` and resubmitted with `original_post_status` forced back to `draft` and a rewritten payer name: nothing was written, meta unchanged. Verified the same POST behaves identically on an unmodified checkout, so the refusal is pre-existing and not introduced here.
6. Fixtures (users, attachments, requests) deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGUDuVhzdUeLnMNxTW7z6T

