### PR TITLE
Event List: encode event values before building the block's markup

### DIFF
--- a/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-meetup/class-meetup-admin.php
@@ -186,7 +186,7 @@ if ( ! class_exists( 'Meetup_Admin' ) ) :
 		 */
 		protected function print_clickable_link( $link ) {
 			?>
-		<a href="<?php echo esc_attr( $link ); ?>" target="_blank">
+		<a href="<?php echo esc_url( $link ); ?>" target="_blank">
 			<?php echo esc_html( $link ); ?>
 		</a>
 			<?php

--- a/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
+++ b/public_html/wp-content/plugins/wordcamp-reports/views/html/wordcamp-counts.php
@@ -201,7 +201,7 @@ $first_time_legend = '<span class="description small">Y / N / ?</span>';
 
 		<?php foreach ( $data['wordcamps'] as $event ) : ?>
 			<tr>
-				<td><a href="<?php echo esc_attr( $event['info']['URL'] ); ?>"><?php echo esc_html( $event['info']['Name'] ); ?></a></td>
+				<td><a href="<?php echo esc_url( $event['info']['URL'] ); ?>"><?php echo esc_html( $event['info']['Name'] ); ?></a></td>
 				<td><?php echo esc_html( $event['info']['Start Date (YYYY-mm-dd)'] ); ?></td>
 				<td><?php echo esc_html( $event['info']['Status'] ); ?></td>
 

--- a/public_html/wp-content/themes/wporg-events-2023/package.json
+++ b/public_html/wp-content/themes/wporg-events-2023/package.json
@@ -7,6 +7,7 @@
 		"@wordpress/block-editor": "15.21.0",
 		"@wordpress/blocks": "15.21.0",
 		"@wordpress/components": "35.0.0",
+		"@wordpress/escape-html": "3.48.0",
 		"@wordpress/scripts": "^32.4.0",
 		"@wordpress/server-side-render": "6.24.0",
 		"@wordpress/env": "11.8.0",

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
@@ -77,16 +77,48 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	}
 
 	/**
-	 * Encode any HTML in a string to prevent XSS.
+	 * Encode any HTML in a string.
+	 *
+	 * Quotes are encoded along with the tag delimiters, so the result can be used
+	 * both in element content and inside a quoted attribute value.
 	 *
 	 * @param {string} unsafe
 	 *
 	 * @return {string}
 	 */
 	function escapeHtml( unsafe ) {
-		const safe = document.createTextNode( unsafe ).textContent;
+		return String( unsafe ?? '' )
+			.replace( /&/g, '&amp;' )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' )
+			.replace( /"/g, '&quot;' )
+			.replace( /'/g, '&#039;' );
+	}
 
-		return safe;
+	/**
+	 * Reduce a URL to one that is safe to place in an `href` attribute.
+	 *
+	 * Encoding alone isn't enough for a URL, since the scheme matters as much as
+	 * the characters. Anything that isn't HTTP(S) is dropped.
+	 *
+	 * @param {string} unsafe
+	 *
+	 * @return {string} The encoded URL, or an empty string if it isn't linkable.
+	 */
+	function escapeUrl( unsafe ) {
+		let parsed;
+
+		try {
+			parsed = new URL( String( unsafe ?? '' ), window.location.href );
+		} catch {
+			return '';
+		}
+
+		if ( 'http:' !== parsed.protocol && 'https:' !== parsed.protocol ) {
+			return '';
+		}
+
+		return escapeHtml( parsed.href );
 	}
 
 	/**
@@ -144,7 +176,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		const markup = `
 			<li class="wporg-marker-list-item">
 				<h3 class="wporg-marker-list-item__title">
-					<a class="external-link" href="${ escapeHtml( url ) }">
+					<a class="external-link" href="${ escapeUrl( url ) }">
 						${ escapeHtml( title ) }
 					</a>
 				</h3>

--- a/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
+++ b/public_html/wp-content/themes/wporg-events-2023/src/event-list/view.js
@@ -1,5 +1,10 @@
 /* global globalEventsPayload */
 
+/**
+ * WordPress dependencies
+ */
+import { escapeAttribute, escapeHTML } from '@wordpress/escape-html';
+
 document.addEventListener( 'DOMContentLoaded', function () {
 	const speak = wp.a11y.speak;
 
@@ -77,29 +82,12 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	}
 
 	/**
-	 * Encode any HTML in a string.
-	 *
-	 * Quotes are encoded along with the tag delimiters, so the result can be used
-	 * both in element content and inside a quoted attribute value.
-	 *
-	 * @param {string} unsafe
-	 *
-	 * @return {string}
-	 */
-	function escapeHtml( unsafe ) {
-		return String( unsafe ?? '' )
-			.replace( /&/g, '&amp;' )
-			.replace( /</g, '&lt;' )
-			.replace( />/g, '&gt;' )
-			.replace( /"/g, '&quot;' )
-			.replace( /'/g, '&#039;' );
-	}
-
-	/**
 	 * Reduce a URL to one that is safe to place in an `href` attribute.
 	 *
 	 * Encoding alone isn't enough for a URL, since the scheme matters as much as
-	 * the characters. Anything that isn't HTTP(S) is dropped.
+	 * the characters. Anything that isn't HTTP(S) is dropped. Values arrive
+	 * absolute from `index.php`, so no base is passed -- that way a value which
+	 * isn't a whole URL fails the parse rather than resolving against this page.
 	 *
 	 * @param {string} unsafe
 	 *
@@ -109,7 +97,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		let parsed;
 
 		try {
-			parsed = new URL( String( unsafe ?? '' ), window.location.href );
+			parsed = new URL( String( unsafe ?? '' ) );
 		} catch {
 			return '';
 		}
@@ -118,7 +106,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			return '';
 		}
 
-		return escapeHtml( parsed.href );
+		return escapeAttribute( parsed.href );
 	}
 
 	/**
@@ -134,7 +122,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			<h2
 				class="wp-block-heading has-charcoal-1-color has-text-color has-link-color has-inter-font-family has-medium-font-size"
 				style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--20);font-style:normal;font-weight:700">
-				${ escapeHtml( month ) }
+				${ escapeHTML( month ) }
 			</h2>`;
 
 		markup += renderEventList( group );
@@ -177,12 +165,12 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			<li class="wporg-marker-list-item">
 				<h3 class="wporg-marker-list-item__title">
 					<a class="external-link" href="${ escapeUrl( url ) }">
-						${ escapeHtml( title ) }
+						${ escapeHTML( title ) }
 					</a>
 				</h3>
 
 				<div class="wporg-marker-list-item__location">
-					${ escapeHtml( location ) }
+					${ escapeHTML( location ) }
 				</div>
 
 				${ getEventDateTime( title, timestamp ) }
@@ -227,7 +215,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			<time
 			    class="wporg-marker-list-item__date-time"
 			    datetime="${ eventDate.toISOString() }"
-			    title="${ escapeHtml( title ) }"
+			    title="${ escapeAttribute( title ) }"
 		    >
 				<span class="wporg-google-map__date">${ localeDate }</span>
 				<span class="wporg-google-map__time">${ localeTime }</span>


### PR DESCRIPTION
## Summary

- `wporg-events-2023`'s event list block builds markup as a string and assigns
  it to `innerHTML`. The `escapeHtml()` helper it routed values through
  returned its input unchanged, so titles and locations reached the DOM as
  written. Values now go through `@wordpress/escape-html`, which skips
  already-encoded entities — `wporg_events` rows carry plenty of them — and
  distinguishes element-text from attribute context.
- Adds `escapeUrl()` for the `href`. Encoding says nothing about a URL's
  scheme, so it's the wrong tool there. No base is passed to `URL`, so empty,
  malformed and protocol-relative values fail the parse instead of resolving
  against the current page.
- `esc_attr()` -> `esc_url()` on two links fed by organiser-supplied meta: the
  WordCamp Counts report and the meetup admin's clickable link. `esc_attr()`
  quotes without constraining the scheme.

`block.json` is deliberately untouched — its `viewScript` handles are
positional and `index.php` hardcodes the index. The new dependency is
externalised by wp-scripts into `view.asset.php` instead.

## Test plan

- [x] phpunit — `WordCamp Reports` 18/18, `WordCamp Post Types` 52/52
- [x] phpcs — no new errors in either PHP file (86 and 7 pre-existing, unchanged)
- [x] `npm run build` / `npm run lint:js` — clean
- [x] DOM pass on the built bundle, with the pre-change bundle as a control

### Manual test steps

1. Build the theme and load a page carrying the event list block.
2. Give an event row a title containing markup, a title containing a quote,
   and a `javascript:` URL. All three render as text / an empty `href`, and
   every row still renders.
3. Give a row an already-encoded title and location (`&#8211;`, `&amp;` — the
   dev fixture has thousands). They render as the characters they stand for,
   not as literal entities.
4. Give a row an empty, malformed, and protocol-relative URL. Each yields an
   empty `href` rather than a link.

Verified in a real browser and in a DOM harness. The harness was run against
the pre-change bundle first as a control, to confirm the assertions actually
discriminate — two did not (an image is never fetched and inline handlers
don't run there), so only the structural assertions are relied on.
