### PR TITLE
CampTix: add Activity Tickets for capacity-limited side events

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -111,6 +111,7 @@ require_once WP_PLUGIN_DIR . '/wordcamp-speaker-feedback/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-payments-network/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-payments/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-reports/tests/bootstrap.php';
+require_once WP_PLUGIN_DIR . '/camptix-companion-tickets/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/wporg-groups-frontend/tests/bootstrap.php';
 require_once SUT_WPMU_PLUGIN_DIR . '/gatherpress-recurring-events/tests/bootstrap.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,6 +32,12 @@
 			</directory>
 		</testsuite>
 
+		<testsuite name="CampTix Activity Tickets">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/camptix-companion-tickets/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="WordCamp Organizer Reminders">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/

--- a/public_html/wp-content/plugins/camptix-companion-tickets/addons/companion-tickets.php
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/addons/companion-tickets.php
@@ -1,0 +1,1735 @@
+<?php
+/**
+ * Companion Tickets addon for CampTix.
+ *
+ * Designate one or more tickets as "companion" tickets — free, capacity-limited
+ * (via each ticket's own `tix_quantity`) extras such as Contributor Day or a
+ * Social Dinner. Registration for any companion ticket is self-service and
+ * gated: only an attendee who is logged in AND already holds a published
+ * qualifying main ticket may register themselves, once per companion ticket.
+ * Each companion attendee record is linked to that attendee's main attendee
+ * record. Refunding/cancelling the main ticket cascades a cancel to ALL of its
+ * linked companion seats, returning them to their pools.
+ *
+ * Note on naming: internally the concept is "companion" (class, option keys,
+ * meta) but the user-facing label is "Activity ticket" — the two are decoupled
+ * on purpose, so the display name can change without touching stored config.
+ *
+ * Hard dependency: this addon relies on the `require-login` addon's
+ * `tix_username` meta and confirmed-attendee identity (enabled by default on
+ * WordCamp.org). When `require-login` is inactive an admin notice is shown and
+ * the gate fails closed (companion registration is blocked), since the attendee
+ * identity it needs is unavailable.
+ *
+ * Note: refunding/cancelling the main ticket is terminal for the linked
+ * companion seats. Re-publishing the main ticket later does not restore them
+ * (it would risk overselling the capacity-limited tickets); the attendee must
+ * register again while a seat is available.
+ */
+class CampTix_Companion_Tickets_Addon extends CampTix_Addon {
+
+	const REQUIRES_FLAG      = 'companion_ticket_requires_main';
+	const DUPLICATE_FLAG     = 'companion_ticket_already_registered';
+	const SELF_ONLY_FLAG     = 'companion_ticket_self_only';
+	const IN_PROGRESS_FLAG   = 'companion_ticket_in_progress';
+	const ONE_AT_A_TIME_FLAG = 'companion_ticket_one_at_a_time';
+
+	const UNCONFIRMED_USERNAME = '[[ unconfirmed ]]';
+
+	// The camptix-admin-flags addon's attendee meta key: one row per set flag,
+	// meta_value = the flag slug (must be a key in its parsed config to show).
+	const ADMIN_FLAG_META = 'camptix-admin-flag';
+
+	// The flag slug written for a seat, recorded so removal cannot be defeated by a
+	// later change to the ticket's post_name.
+	const ACTIVITY_FLAG_META = 'tix_companion_activity_flag';
+
+	/**
+	 * Per-request cache of companion ticket IDs a username already holds.
+	 *
+	 * @var array<string,int[]>
+	 */
+	private $held_companion_cache = array();
+
+	/**
+	 * Attendee IDs queued for release (cancel) at shutdown.
+	 *
+	 * A transfer is detected mid-save, while CampTix still holds a stale copy of
+	 * the post it will rewrite when the save finishes — cancelling inline would
+	 * be clobbered. Deferring to shutdown runs after the whole save completes.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $deferred_releases = array();
+
+	/**
+	 * Register self with CampTix.
+	 */
+	public static function register_addon() {
+		camptix_register_addon( __CLASS__ );
+	}
+
+	/**
+	 * Constructor: defer wiring until CampTix is initialised.
+	 */
+	public function __construct() {
+		add_action( 'camptix_init', array( $this, 'camptix_init' ) );
+	}
+
+	/**
+	 * Runs during camptix_init: wire config UI + checkout/runtime hooks.
+	 */
+	public function camptix_init() {
+		global $camptix;
+
+		// Hard dependency: the require-login addon supplies the attendee
+		// identity (tix_username) this addon gates on. Warn if it's missing.
+		// The gate still fails closed without it (no identity => not eligible).
+		if ( ! $this->require_login_active() ) {
+			add_action( 'admin_notices', array( $this, 'render_dependency_notice' ) );
+		}
+
+		// Admin: Setup screen configuration.
+		if ( current_user_can( $camptix->caps['manage_options'] ) ) {
+			add_filter( 'camptix_setup_sections',      array( $this, 'setup_sections' ) );
+			add_action( 'camptix_menu_setup_controls', array( $this, 'setup_controls' ), 10, 1 );
+			add_filter( 'camptix_validate_options',    array( $this, 'validate_options' ), 10, 2 );
+		}
+
+		// Public ticket-selection screen: tell not-yet-eligible visitors what's
+		// needed, and show already-held tickets as "already registered" instead
+		// of letting them appear to silently vanish.
+		add_action( 'camptix_notices',                  array( $this, 'maybe_show_eligibility_notice' ), 9 );
+		add_filter( 'camptix_form_start_tix_remaining', array( $this, 'maybe_label_already_registered' ), 10, 2 );
+
+		// Public checkout: gate ineligible registrations, link, and cascade.
+		add_filter( 'camptix_form_register_complete_attendee_object', array( $this, 'gate_companion_attendee' ), 20, 3 );
+		add_action( 'camptix_form_attendee_info_errors',              array( $this, 'render_gate_errors' ), 10, 1 );
+		add_action( 'camptix_checkout_update_post_meta',              array( $this, 'link_companion_attendee' ), 20, 2 );
+		add_action( 'transition_post_status',                         array( $this, 'maybe_cascade_cancel' ), 10, 3 );
+
+		// Force-delete bypasses transition_post_status entirely, so a deleted
+		// attendee needs its own hook: release the seats a deleted main was
+		// justifying, and unflag a deleted seat's (surviving) main.
+		add_action( 'before_delete_post', array( $this, 'maybe_release_on_delete' ), 10, 2 );
+		add_action( 'admin_init', array( $this, 'maybe_heal_activity_admin_flag_config' ) );
+
+		// Email each attendee a confirmation when their companion seat is confirmed.
+		add_action( 'transition_post_status', array( $this, 'maybe_send_activity_confirmation' ), 10, 3 );
+
+		// Attendee export/report: expose the main<->companion link as columns.
+		add_filter( 'camptix_attendee_report_extra_columns',                  array( $this, 'export_extra_columns' ) );
+		add_filter( 'camptix_attendee_report_column_value_companion_of',      array( $this, 'export_column_companion_of' ), 10, 2 );
+		add_filter( 'camptix_attendee_report_column_value_companion_tickets', array( $this, 'export_column_companion_tickets' ), 10, 2 );
+
+		// Auto admin-flag: the flag is set on the main attendee when a companion
+		// seat links to it (see link_companion_attendee); remove it again when
+		// that seat reaches any terminal status. Display needs camptix-admin-flags.
+		add_action( 'transition_post_status', array( $this, 'maybe_remove_activity_admin_flag' ), 12, 3 );
+
+		// Public Attendees page: list each person once. A companion seat's holder
+		// always also has a main-ticket listing, so hide the companion seats.
+		add_filter( 'camptix_attendees_shortcode_query_args', array( $this, 'exclude_companion_attendees_from_listing' ), 10, 2 );
+
+		// Ownership transfer: when a ticket's confirmed identity changes hands
+		// (require-login reassigns tix_username via the edit-attendee flow),
+		// release the companion seats that were personal to the old owner.
+		add_action( 'update_post_meta', array( $this, 'detect_ownership_change' ), 10, 4 );
+
+		// "Your tickets" links on the selection screen + a throttled
+		// email-me-my-links action, for holders who lost their receipt email.
+		add_action( 'camptix_notices',   array( $this, 'maybe_show_my_ticket_links' ), 8 );
+		add_action( 'template_redirect', array( $this, 'process_links_email_request' ), 9 );
+
+		// Admin: show the main<->companion links on the Edit Attendee screen.
+		if ( current_user_can( $camptix->caps['manage_attendees'] ) ) {
+			add_action( 'camptix_attendee_submitdiv_misc', array( $this, 'render_link_metabox' ), 10, 1 );
+		}
+	}
+
+	/**
+	 * Whether the require-login addon (this addon's hard dependency) is active.
+	 *
+	 * @return bool
+	 */
+	public function require_login_active() {
+		return class_exists( 'CampTix_Require_Login' );
+	}
+
+	/**
+	 * Admin notice shown when the require-login dependency is not active.
+	 */
+	public function render_dependency_notice() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p>%s</p></div>',
+			esc_html__( 'CampTix Activity Tickets requires the CampTix "require login" addon, which is not active. Activity ticket registration is disabled until it is enabled.', 'wordcamporg' )
+		);
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Configuration
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * The configured companion ticket IDs.
+	 *
+	 * @return int[]
+	 */
+	public function get_companion_ticket_ids() {
+		global $camptix;
+		$options = $camptix->get_options();
+		$ids     = isset( $options['camptix-companion-ticket-ids'] ) ? (array) $options['camptix-companion-ticket-ids'] : array();
+		return array_values( array_filter( array_map( 'absint', $ids ) ) );
+	}
+
+	/**
+	 * Whether a ticket ID is one of the configured companion tickets.
+	 *
+	 * @param int $ticket_id Ticket post ID.
+	 * @return bool
+	 */
+	public function is_companion_ticket( $ticket_id ) {
+		return in_array( absint( $ticket_id ), $this->get_companion_ticket_ids(), true );
+	}
+
+	/**
+	 * Whitelist of ticket IDs that count as a "qualifying main ticket".
+	 * Empty config = any published ticket that is not a companion ticket.
+	 *
+	 * @return int[] Empty array means "any non-companion ticket".
+	 */
+	public function get_qualifying_ticket_ids() {
+		global $camptix;
+		$options = $camptix->get_options();
+		$ids     = isset( $options['camptix-companion-qualifying-ticket-ids'] ) ? (array) $options['camptix-companion-qualifying-ticket-ids'] : array();
+		return array_values( array_filter( array_map( 'absint', $ids ) ) );
+	}
+
+	/**
+	 * Add an "Activity Tickets" tab to CampTix > Setup.
+	 *
+	 * @param array $sections Existing Setup tab sections.
+	 * @return array Sections with the Activity Tickets tab added.
+	 */
+	public function setup_sections( $sections ) {
+		$sections['companion-tickets'] = __( 'Activity Tickets', 'wordcamporg' );
+		return $sections;
+	}
+
+	/**
+	 * Render the controls for the Activity Tickets setup section.
+	 *
+	 * @param string $section The Setup section currently being rendered.
+	 */
+	public function setup_controls( $section ) {
+		if ( 'companion-tickets' !== $section ) {
+			return;
+		}
+
+		add_settings_section( 'companion-tickets', __( 'Activity Tickets', 'wordcamporg' ), '__return_false', 'camptix_options' );
+
+		add_settings_field(
+			'camptix-companion-ticket-ids',
+			__( 'Activity tickets', 'wordcamporg' ),
+			array( $this, 'render_companion_select' ),
+			'camptix_options',
+			'companion-tickets'
+		);
+
+		add_settings_field(
+			'camptix-companion-qualifying-ticket-ids',
+			__( 'Qualifying tickets', 'wordcamporg' ),
+			array( $this, 'render_qualifying_select' ),
+			'camptix_options',
+			'companion-tickets'
+		);
+	}
+
+	/**
+	 * All ticket posts (publish + draft), title-sorted, for the admin checkboxes.
+	 *
+	 * @return WP_Post[]
+	 */
+	private function get_all_tickets() {
+		return get_posts( array(
+			'post_type'        => 'tix_ticket',
+			'post_status'      => array( 'publish', 'draft' ),
+			// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Admin-only list, bounded by the number of ticket types for the event.
+			'posts_per_page'   => 200,
+			'orderby'          => 'title',
+			'order'            => 'ASC',
+			'suppress_filters' => false,
+		) );
+	}
+
+	/**
+	 * Render checkboxes choosing which tickets are activity (free add-on) tickets.
+	 */
+	public function render_companion_select() {
+		$selected = $this->get_companion_ticket_ids();
+		$tickets  = $this->get_all_tickets();
+
+		// Marker so an all-unchecked save is recognised as "clear".
+		echo '<input type="hidden" name="camptix_options[camptix-companion-tickets-rendered]" value="1" />';
+
+		if ( empty( $tickets ) ) {
+			echo '<p class="description">' . esc_html__( 'No ticket types found. Create a free activity ticket (e.g. Contributor Day) first.', 'wordcamporg' ) . '</p>';
+			return;
+		}
+
+		foreach ( $tickets as $ticket ) {
+			printf(
+				'<label style="display:block;"><input type="checkbox" name="camptix_options[camptix-companion-ticket-ids][]" value="%d" %s /> %s</label>',
+				absint( $ticket->ID ),
+				checked( in_array( absint( $ticket->ID ), $selected, true ), true, false ),
+				esc_html( $ticket->post_title )
+			);
+		}
+		echo '<p class="description">' . esc_html__( 'Checked tickets are free, capacity-limited extras that only existing ticket-holders may register for (one each).', 'wordcamporg' ) . '</p>';
+	}
+
+	/**
+	 * Render checkboxes choosing which main tickets qualify a holder.
+	 *
+	 * Leaving every box unchecked = any non-companion published ticket qualifies.
+	 */
+	public function render_qualifying_select() {
+		$companion_ids = $this->get_companion_ticket_ids();
+		$selected      = $this->get_qualifying_ticket_ids();
+		$tickets       = array_filter(
+			$this->get_all_tickets(),
+			function ( $ticket ) use ( $companion_ids ) {
+				return ! in_array( absint( $ticket->ID ), $companion_ids, true );
+			}
+		);
+
+		// Marker so an all-unchecked save is recognised as "clear".
+		echo '<input type="hidden" name="camptix_options[camptix-companion-qualifying-rendered]" value="1" />';
+
+		if ( empty( $tickets ) ) {
+			echo '<p class="description">' . esc_html__( 'No non-activity ticket types exist yet.', 'wordcamporg' ) . '</p>';
+			return;
+		}
+
+		foreach ( $tickets as $ticket ) {
+			printf(
+				'<label style="display:block;"><input type="checkbox" name="camptix_options[camptix-companion-qualifying-ticket-ids][]" value="%d" %s /> %s</label>',
+				absint( $ticket->ID ),
+				checked( in_array( absint( $ticket->ID ), $selected, true ), true, false ),
+				esc_html( $ticket->post_title )
+			);
+		}
+		echo '<p class="description">' . esc_html__( 'Holders of the checked tickets may register for activity tickets. Leave all unchecked to allow holders of any other (non-activity) published ticket.', 'wordcamporg' ) . '</p>';
+	}
+
+	/**
+	 * Sanitise our options on save.
+	 *
+	 * @param array $output Validated options so far.
+	 * @param array $input  Raw submitted options.
+	 * @return array
+	 */
+	public function validate_options( $output, $input ) {
+		// Companion tickets. Accept the array when present, or treat an all-
+		// unchecked UI save (marker present, no array) as "clear".
+		if ( isset( $input['camptix-companion-ticket-ids'] ) || isset( $input['camptix-companion-tickets-rendered'] ) ) {
+			$raw                                    = isset( $input['camptix-companion-ticket-ids'] ) ? (array) $input['camptix-companion-ticket-ids'] : array();
+			$ids                                    = array_filter( array_map( 'absint', $raw ) );
+			$output['camptix-companion-ticket-ids'] = array_values( array_unique( $ids ) );
+		}
+
+		// Qualifying main tickets. Same accept/clear behaviour, and a companion
+		// ticket can never also be a qualifying ticket.
+		if ( isset( $input['camptix-companion-qualifying-ticket-ids'] ) || isset( $input['camptix-companion-qualifying-rendered'] ) ) {
+			$raw = isset( $input['camptix-companion-qualifying-ticket-ids'] ) ? (array) $input['camptix-companion-qualifying-ticket-ids'] : array();
+			$ids = array_filter( array_map( 'absint', $raw ) );
+
+			$companion_ids = isset( $output['camptix-companion-ticket-ids'] ) ? (array) $output['camptix-companion-ticket-ids'] : $this->get_companion_ticket_ids();
+			$ids           = array_diff( $ids, $companion_ids );
+
+			$output['camptix-companion-qualifying-ticket-ids'] = array_values( $ids );
+		}
+
+		// When the companion set changes: make sure each companion ticket has a
+		// visible admin-flag definition, and flush the public Attendees listing
+		// cache (its cache key ignores our query filter, so stale HTML would
+		// keep showing companion seats until the transient expired).
+		if ( isset( $input['camptix-companion-ticket-ids'] ) || isset( $input['camptix-companion-tickets-rendered'] ) ) {
+			$output = $this->sync_activity_admin_flag_config( $output );
+			$this->flush_attendees_shortcode_cache();
+		}
+
+		return $output;
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Eligibility
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Find a published, confirmed main-ticket attendee for the given username.
+	 *
+	 * "Confirmed" means tix_username is a real login (not the require-login
+	 * UNCONFIRMED sentinel). A companion ticket never qualifies as a main ticket.
+	 *
+	 * @param string $username WP.org login.
+	 * @return int Attendee post ID, or 0 if none.
+	 */
+	public function get_user_main_attendee( $username ) {
+		$username = (string) $username;
+		if ( '' === $username || self::UNCONFIRMED_USERNAME === $username ) {
+			return 0;
+		}
+
+		$meta_query = array(
+			array(
+				'key'   => 'tix_username',
+				'value' => $username,
+			),
+		);
+
+		$qualifying = $this->get_qualifying_ticket_ids();
+		if ( ! empty( $qualifying ) ) {
+			$meta_query[] = array(
+				'key'     => 'tix_ticket_id',
+				'value'   => $qualifying,
+				'compare' => 'IN',
+			);
+		}
+
+		$attendees = get_posts( array(
+			'post_type'        => 'tix_attendee',
+			'post_status'      => 'publish',
+			'posts_per_page'   => 50,
+			'fields'           => 'ids',
+			'meta_query'       => $meta_query,
+			'suppress_filters' => false,
+		) );
+
+		$companion_ids = $this->get_companion_ticket_ids();
+		foreach ( $attendees as $attendee_id ) {
+			$ticket_id = absint( get_post_meta( $attendee_id, 'tix_ticket_id', true ) );
+			if ( $ticket_id && ! in_array( $ticket_id, $companion_ids, true ) ) {
+				return (int) $attendee_id;
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Attendee statuses that hold a seat.
+	 *
+	 * Exactly the statuses CampTix counts against a ticket's quantity
+	 * (`get_purchased_tickets_count()`, camptix.php): a `pending` seat is
+	 * awaiting payment confirmation but has already drained the pool, so the
+	 * duplicate gate has to see it too. Everything else has either not claimed
+	 * the seat yet (`draft`, see `user_has_in_flight_registration()`) or has
+	 * released it (`cancel`, `refund`, `failed`, `timeout`).
+	 *
+	 * @return string[]
+	 */
+	private function held_statuses() {
+		return array( 'publish', 'pending' );
+	}
+
+	/**
+	 * Whether this username already holds a seat for a ticket.
+	 *
+	 * @param string $username  WP.org login.
+	 * @param int    $ticket_id Companion ticket ID.
+	 * @return bool
+	 */
+	public function user_has_registration( $username, $ticket_id ) {
+		$username = (string) $username;
+		if ( '' === $username || self::UNCONFIRMED_USERNAME === $username ) {
+			return false;
+		}
+
+		$existing = get_posts( array(
+			'post_type'        => 'tix_attendee',
+			'post_status'      => $this->held_statuses(),
+			'posts_per_page'   => 1,
+			'fields'           => 'ids',
+			'meta_query'       => array(
+				'relation' => 'AND',
+				array(
+					'key'   => 'tix_username',
+					'value' => $username,
+				),
+				array(
+					'key'   => 'tix_ticket_id',
+					'value' => absint( $ticket_id ),
+				),
+			),
+			'suppress_filters' => false,
+		) );
+
+		return ! empty( $existing );
+	}
+
+	/**
+	 * Whether this username has an order for a ticket still in flight.
+	 *
+	 * A seat sits in `draft` between the attendee form being submitted and the
+	 * gateway resolving the order — minutes, for a redirect gateway. It has not
+	 * drained the pool yet, but it will the moment the payment completes, so a
+	 * second (free, instantly published) registration in that window would
+	 * oversell a capacity-limited ticket and leave the attendee with two seats.
+	 *
+	 * The window matches CampTix's own: `review_timeout_payments()` leaves a
+	 * draft live for 24 hours before flipping it to `timeout`. Inside it the
+	 * order can still publish, so block; outside it the draft is abandoned and
+	 * must not keep the attendee out of a seat they never received.
+	 *
+	 * @param string $username  WP.org login.
+	 * @param int    $ticket_id Companion ticket ID.
+	 * @return bool
+	 */
+	public function user_has_in_flight_registration( $username, $ticket_id ) {
+		$username = (string) $username;
+		if ( '' === $username || self::UNCONFIRMED_USERNAME === $username ) {
+			return false;
+		}
+
+		/**
+		 * Filters how long a draft seat counts as an order still in flight.
+		 *
+		 * Defaults to CampTix's own draft-timeout window. Shortening it trades
+		 * a smaller double-registration window for a smaller retry delay after
+		 * an abandoned checkout.
+		 *
+		 * @param int $window Seconds.
+		 */
+		$window = absint( apply_filters( 'camptix_companion_in_flight_window', DAY_IN_SECONDS ) );
+
+		$in_flight = get_posts( array(
+			'post_type'        => 'tix_attendee',
+			'post_status'      => 'draft',
+			'posts_per_page'   => 1,
+			'fields'           => 'ids',
+			'meta_query'       => array(
+				'relation' => 'AND',
+				array(
+					'key'   => 'tix_username',
+					'value' => $username,
+				),
+				array(
+					'key'   => 'tix_ticket_id',
+					'value' => absint( $ticket_id ),
+				),
+				// Set on every checkout draft, immediately before the hook this
+				// addon links seats on (camptix.php).
+				array(
+					'key'     => 'tix_timestamp',
+					'value'   => time() - $window,
+					'compare' => '>',
+					'type'    => 'NUMERIC',
+				),
+			),
+			'suppress_filters' => false,
+		) );
+
+		return ! empty( $in_flight );
+	}
+
+	/**
+	 * Companion ticket IDs the given username already holds (per-request cached).
+	 *
+	 * @param string $username WP.org login.
+	 * @return int[]
+	 */
+	private function get_held_companion_ticket_ids( $username ) {
+		$username = (string) $username;
+		if ( '' === $username || self::UNCONFIRMED_USERNAME === $username ) {
+			return array();
+		}
+		if ( isset( $this->held_companion_cache[ $username ] ) ) {
+			return $this->held_companion_cache[ $username ];
+		}
+
+		$held = array();
+		foreach ( $this->get_companion_ticket_ids() as $ticket_id ) {
+			if ( $this->user_has_registration( $username, $ticket_id ) ) {
+				$held[] = absint( $ticket_id );
+			}
+		}
+
+		$this->held_companion_cache[ $username ] = $held;
+		return $held;
+	}
+
+	/**
+	 * Pure decision: should this attendee's companion registration be blocked?
+	 *
+	 * Companion tickets are self-service and one-per-attendee per ticket: the
+	 * registrant must be a confirmed (logged-in) attendee who already holds a
+	 * published qualifying main ticket, and may register for each companion
+	 * ticket only once.
+	 *
+	 * @param int    $ticket_id Ticket being purchased for this seat.
+	 * @param string $username  Confirmed username for this seat (the
+	 *                          require-login UNCONFIRMED sentinel or '' means
+	 *                          the seat is not the buyer's own confirmed seat).
+	 * @return string '' to allow, or an error-flag constant to block.
+	 */
+	public function should_block_companion_attendee( $ticket_id, $username ) {
+		$ticket_id = absint( $ticket_id );
+		if ( ! $this->is_companion_ticket( $ticket_id ) ) {
+			return ''; // Not a companion ticket — never our concern.
+		}
+
+		$username = (string) $username;
+
+		// Companion tickets must be registered by the attendee themselves, while
+		// logged in. Reject the buyer's "additional attendee" seats (marked
+		// unconfirmed by require-login) and any anonymous seat. This also stops a
+		// single buyer draining several capacity-limited seats in one order.
+		if ( '' === $username || self::UNCONFIRMED_USERNAME === $username ) {
+			/*
+			 * Both cases are refused; the only question is which message is true.
+			 * require-login gives the real username to seat #1 only and marks every
+			 * later seat in the order unconfirmed, so an eligible attendee who selected
+			 * two activities together lands here having done nothing wrong -- telling
+			 * them to log in and register for themselves would be false.
+			 *
+			 * The current user is used to CLASSIFY the refusal, never to decide it: the
+			 * outcome is identical on both branches, so the fail-closed identity rule
+			 * this gate depends on is untouched.
+			 */
+			if ( self::UNCONFIRMED_USERNAME === $username ) {
+				$current_user = (string) wp_get_current_user()->user_login;
+				if ( '' !== $current_user && $this->get_user_main_attendee( $current_user ) ) {
+					return self::ONE_AT_A_TIME_FLAG;
+				}
+			}
+
+			return self::SELF_ONLY_FLAG;
+		}
+
+		// One registration per attendee per companion ticket. A held seat
+		// (published, or pending payment) is a duplicate; an order still in
+		// flight at the gateway is not yet a registration, so it gets its own
+		// accurate message rather than "you are already registered".
+		if ( $this->user_has_registration( $username, $ticket_id ) ) {
+			return self::DUPLICATE_FLAG;
+		}
+
+		if ( $this->user_has_in_flight_registration( $username, $ticket_id ) ) {
+			return self::IN_PROGRESS_FLAG;
+		}
+
+		// Eligible only if they already hold a published qualifying main ticket.
+		if ( $this->get_user_main_attendee( $username ) ) {
+			return '';
+		}
+
+		return self::REQUIRES_FLAG;
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Checkout hooks
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Checkout hook: flag ineligible companion registrations so checkout aborts.
+	 *
+	 * Setting any error flag causes CampTix to abort checkout and redisplay the
+	 * attendee-info form.
+	 *
+	 * @param object $attendee      Attendee object (has ->ticket_id, ->username).
+	 * @param array  $attendee_info Submitted info for this seat.
+	 * @param int    $i             Seat index.
+	 * @return object
+	 */
+	public function gate_companion_attendee( $attendee, $attendee_info, $i ) {
+		global $camptix;
+
+		$reason = $this->should_block_companion_attendee(
+			isset( $attendee->ticket_id ) ? $attendee->ticket_id : 0,
+			$this->resolve_attendee_username( $attendee )
+		);
+
+		if ( '' !== $reason ) {
+			$camptix->error_flag( $reason );
+		}
+
+		return $attendee;
+	}
+
+	/**
+	 * Resolve the confirmed username for an attendee seat.
+	 *
+	 * Prefers the per-seat identity require-login sets on the attendee object
+	 * (so the buyer's "additional attendee" seats correctly read as
+	 * unconfirmed), falling back to post meta for a seat that already exists.
+	 *
+	 * There is deliberately no current-user fallback. `$attendee->username` is
+	 * set only by require-login's `camptix_form_register_complete_attendee_object`
+	 * filter, so an absent one means the identity this addon depends on is
+	 * unavailable — require-login is inactive, or this is not the buyer's own
+	 * seat. Attributing such a seat to whoever happens to be logged in would
+	 * let one buyer pass the gate for every seat in a quantity-N order and
+	 * would write seats the duplicate gate can never see again. Returning ''
+	 * makes the gate fail closed, which is what this addon documents.
+	 *
+	 * @param object $attendee Attendee object.
+	 * @param int    $post_id  Optional attendee post ID for the meta fallback.
+	 * @return string Confirmed username, or '' when there is no per-seat identity.
+	 */
+	private function resolve_attendee_username( $attendee, $post_id = 0 ) {
+		if ( isset( $attendee->username ) && '' !== $attendee->username ) {
+			return (string) $attendee->username;
+		}
+
+		if ( $post_id ) {
+			$meta = (string) get_post_meta( $post_id, 'tix_username', true );
+			if ( '' !== $meta ) {
+				return $meta;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Print the user-facing message for our error flags.
+	 *
+	 * @param array $error_flags Active error flags.
+	 */
+	public function render_gate_errors( $error_flags ) {
+		global $camptix;
+
+		if ( isset( $error_flags[ self::REQUIRES_FLAG ] ) ) {
+			$camptix->error( __( 'That ticket is only available to attendees who already have an event ticket. Please buy your ticket first.', 'wordcamporg' ) );
+		}
+		if ( isset( $error_flags[ self::DUPLICATE_FLAG ] ) ) {
+			$camptix->error( __( 'You are already registered for that ticket.', 'wordcamporg' ) );
+		}
+		if ( isset( $error_flags[ self::SELF_ONLY_FLAG ] ) ) {
+			$camptix->error( __( 'These tickets must be registered by each attendee from their own account. Please log in and register for yourself.', 'wordcamporg' ) );
+		}
+		if ( isset( $error_flags[ self::ONE_AT_A_TIME_FLAG ] ) ) {
+			$camptix->error( __( 'Activity tickets are registered one at a time. Please complete this order, then come back to register for the next activity.', 'wordcamporg' ) );
+		}
+		if ( isset( $error_flags[ self::IN_PROGRESS_FLAG ] ) ) {
+			$camptix->error( __( 'You already have an order for that ticket waiting on payment. Please finish that order — if the payment is never completed, the seat is released automatically and you can register again.', 'wordcamporg' ) );
+		}
+	}
+
+	/**
+	 * On the ticket-selection screen, surface two advisory notices:
+	 *  - "already registered for X", so a ticket the visitor already holds is
+	 *    shown as such rather than appearing to silently vanish; and
+	 *  - "buy your ticket first" for visitors who do not yet hold a qualifying
+	 *    main ticket, so they learn the requirement before the checkout gate.
+	 */
+	public function maybe_show_eligibility_notice() {
+		global $camptix;
+
+		// Only the initial selection screen — later steps surface the gate error.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only display gate, no state change.
+		$action = isset( $_REQUEST['tix_action'] ) ? sanitize_key( wp_unslash( $_REQUEST['tix_action'] ) ) : '';
+		if ( '' !== $action ) {
+			return;
+		}
+
+		$username = (string) wp_get_current_user()->user_login;
+		$held     = $this->get_held_companion_ticket_ids( $username );
+
+		// Split the companion tickets into "already registered" vs. "still
+		// available to this visitor".
+		$registered_titles = array();
+		$available_titles  = array();
+		foreach ( $this->get_companion_ticket_ids() as $ticket_id ) {
+			if ( in_array( absint( $ticket_id ), $held, true ) ) {
+				$registered_titles[] = get_the_title( $ticket_id );
+			} elseif ( (int) $camptix->get_remaining_tickets( $ticket_id ) > 0 ) {
+				$available_titles[] = get_the_title( $ticket_id );
+			}
+		}
+
+		// Advisory: name the tickets the visitor already holds, so an
+		// already-registered ticket reads as such instead of seeming to vanish.
+		if ( ! empty( $registered_titles ) ) {
+			$camptix->notice( sprintf(
+				/* translators: %s: comma-separated list of activity ticket names. */
+				__( 'You are already registered for: %s.', 'wordcamporg' ),
+				implode( ', ', $registered_titles )
+			) );
+		}
+
+		// Prompt only visitors who cannot yet register (no qualifying main ticket).
+		if ( ! empty( $available_titles ) && ! $this->get_user_main_attendee( $username ) ) {
+			$camptix->notice( sprintf(
+				/* translators: %s: comma-separated list of activity ticket names. */
+				__( '%s can only be registered by attendees who already have an event ticket. Buy your ticket first, then come back to register.', 'wordcamporg' ),
+				implode( ', ', $available_titles )
+			) );
+		}
+
+		/*
+		 * An eligible visitor looking at more than one available activity would
+		 * otherwise only learn about the one-per-order limit by hitting it at
+		 * checkout. Say it here instead.
+		 */
+		if ( count( $available_titles ) > 1 && $this->get_user_main_attendee( $username ) ) {
+			$camptix->notice( __( 'Activity tickets are registered one at a time. Register for one, then come back for the next.', 'wordcamporg' ) );
+		}
+	}
+
+	/**
+	 * Replace a companion ticket's "remaining" cell with an "Already registered"
+	 * label for a logged-in visitor who already holds it. Advisory only — the
+	 * checkout DUPLICATE gate remains the authoritative enforcement.
+	 *
+	 * @param mixed  $remaining The remaining-count value CampTix would display.
+	 * @param object $ticket    The ticket post being rendered.
+	 * @return mixed
+	 */
+	public function maybe_label_already_registered( $remaining, $ticket ) {
+		if ( ! isset( $ticket->ID ) || ! $this->is_companion_ticket( $ticket->ID ) ) {
+			return $remaining;
+		}
+
+		$username = (string) wp_get_current_user()->user_login;
+		if ( in_array( absint( $ticket->ID ), $this->get_held_companion_ticket_ids( $username ), true ) ) {
+			return __( 'Already registered', 'wordcamporg' );
+		}
+
+		return $remaining;
+	}
+
+	/**
+	 * When a companion attendee is created, link it to the buyer's main attendee.
+	 *
+	 * Because registration requires an already-published qualifying main ticket,
+	 * the main attendee resolves here at checkout time.
+	 *
+	 * @param int    $post_id  New attendee post ID.
+	 * @param object $attendee Attendee object (has ->ticket_id, ->username).
+	 */
+	public function link_companion_attendee( $post_id, $attendee ) {
+		if ( ! isset( $attendee->ticket_id ) || ! $this->is_companion_ticket( $attendee->ticket_id ) ) {
+			return;
+		}
+
+		$username = $this->resolve_attendee_username( $attendee, $post_id );
+
+		$main_id = $this->get_user_main_attendee( $username );
+		if ( ! $main_id ) {
+			return; // Defensive: gate guarantees a published main ticket exists.
+		}
+
+		update_post_meta( $post_id, 'tix_companion_primary_attendee_id', $main_id );
+		$this->add_activity_admin_flag( $main_id, absint( $attendee->ticket_id ), $post_id );
+	}
+
+	/**
+	 * Attendee statuses that end a ticket's life.
+	 *
+	 * A companion seat is only justified while its main ticket is live, and the
+	 * flag on the main is only justified while the seat is. Both the cascade and
+	 * the flag removal key off the same list so they can't drift apart:
+	 *
+	 *  - `refund`, `cancel` — the original two.
+	 *  - `trash`  — reachable from the organiser UI (`tix_attendee` has `show_ui`
+	 *               and mapped delete caps), and `wp_trash_post()` does fire
+	 *               `transition_post_status`. Duplicate/fraud cleanup lands here.
+	 *  - `failed` — a declined or abandoned payment (`payment_result()`).
+	 *  - `timeout`— where CampTix's daily `review_timeout_payments()` parks a
+	 *               draft nobody ever paid for. Both matter because the flag is
+	 *               added while the seat is still a draft, before payment.
+	 *
+	 * Force-delete fires none of these; see `maybe_release_on_delete()`.
+	 *
+	 * @return string[]
+	 */
+	private function terminal_statuses() {
+		return array( 'refund', 'cancel', 'trash', 'failed', 'timeout' );
+	}
+
+	/**
+	 * Whether a status transition ends the life of an attendee ticket.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post being transitioned.
+	 * @return bool
+	 */
+	private function is_terminal_attendee_transition( $new_status, $old_status, $post ) {
+		if ( ! $post || 'tix_attendee' !== $post->post_type ) {
+			return false;
+		}
+		if ( $new_status === $old_status ) {
+			return false;
+		}
+
+		return in_array( $new_status, $this->terminal_statuses(), true );
+	}
+
+	/**
+	 * Cascade a terminal main-ticket status to ALL of its linked companion seats.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post being transitioned.
+	 */
+	public function maybe_cascade_cancel( $new_status, $old_status, $post ) {
+		if ( ! $this->is_terminal_attendee_transition( $new_status, $old_status, $post ) ) {
+			return;
+		}
+
+		$this->cancel_linked_companion_seats( $post->ID );
+	}
+
+	/**
+	 * Cancel every live companion seat linked to a main attendee.
+	 *
+	 * Querying by the forward pointer means the relationship is inherently
+	 * mutual. Cancelling (rather than trashing or deleting alongside the main)
+	 * is what returns the seat to its capacity-limited pool.
+	 *
+	 * @param int $main_id Main attendee post ID.
+	 */
+	private function cancel_linked_companion_seats( $main_id ) {
+		$companions = $this->get_linked_companion_ids( $main_id, array( 'publish' ) );
+		foreach ( $companions as $companion_id ) {
+			if ( ! $this->is_companion_ticket( get_post_meta( $companion_id, 'tix_ticket_id', true ) ) ) {
+				continue;
+			}
+			wp_update_post( array(
+				'ID'          => $companion_id,
+				'post_status' => 'cancel',
+			) );
+		}
+	}
+
+	/**
+	 * Release what a force-deleted attendee was holding.
+	 *
+	 * `wp_delete_post( $id, true )` fires only `before_delete_post`/`deleted_post`
+	 * — never `transition_post_status` — so neither the cascade nor the flag
+	 * removal would otherwise run. Both directions are handled, and both are
+	 * no-ops for the direction that doesn't apply: a main has no flag of its own
+	 * to drop, and a seat has no linked seats of its own.
+	 *
+	 * Runs `before` the delete so the post and its meta are still readable.
+	 *
+	 * @param int          $post_id Post being deleted.
+	 * @param WP_Post|null $post    Post object (passed since WP 5.5).
+	 */
+	public function maybe_release_on_delete( $post_id, $post = null ) {
+		$post = $post ? $post : get_post( $post_id );
+		if ( ! $post || 'tix_attendee' !== $post->post_type ) {
+			return;
+		}
+
+		// A deleted seat would leave its flag stranded on a main that survives.
+		$this->remove_activity_admin_flag_for_seat( $post->ID );
+
+		// A deleted main takes its seats' justification with it.
+		$this->cancel_linked_companion_seats( $post->ID );
+	}
+
+	/**
+	 * Companion attendee IDs linked to a given main attendee.
+	 *
+	 * @param int      $main_id  Main attendee post ID.
+	 * @param string[] $statuses Post statuses to include.
+	 * @return int[]
+	 */
+	private function get_linked_companion_ids( $main_id, $statuses = array( 'publish' ) ) {
+		return get_posts( array(
+			'post_type'        => 'tix_attendee',
+			'post_status'      => $statuses,
+			'posts_per_page'   => 50,
+			'fields'           => 'ids',
+			'meta_query'       => array(
+				array(
+					'key'   => 'tix_companion_primary_attendee_id',
+					'value' => absint( $main_id ),
+				),
+			),
+			'suppress_filters' => false,
+		) );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Auto admin-flag (integrates with the camptix-admin-flags addon)
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Whether the camptix-admin-flags addon (the flags' display layer) is active.
+	 *
+	 * @return bool
+	 */
+	public function admin_flags_active() {
+		return class_exists( 'CampTix_Admin_Flags_Addon' );
+	}
+
+	/**
+	 * The admin-flag slug for a companion ticket.
+	 *
+	 * Sanitized exactly like the admin-flags settings parser, so the stored
+	 * meta value matches its config key (a mismatch would make the flag
+	 * invisible in the admin filter, column, and export).
+	 *
+	 * @param int $ticket_id Companion ticket post ID.
+	 * @return string
+	 */
+	public function get_activity_flag_slug( $ticket_id ) {
+		$ticket_id = absint( $ticket_id );
+		$slug      = get_post_field( 'post_name', $ticket_id );
+		if ( ! $slug ) {
+			$slug = 'ticket-' . $ticket_id;
+		}
+
+		return sanitize_html_class( sanitize_title_with_dashes( 'activity-' . $slug ) );
+	}
+
+	/**
+	 * Flag the main attendee as holding a given companion ticket (idempotent).
+	 *
+	 * The flag lives on the MAIN attendee — "this person also has X" is what
+	 * organisers filter and export by; the companion seat itself already
+	 * carries the ticket type.
+	 *
+	 * The slug is derived from the ticket's `post_name`, which is mutable: empty on a
+	 * draft, written on publish, and editable afterwards. So the value actually used is
+	 * recorded on the seat, and removal deletes exactly that rather than recomputing a
+	 * slug that may since have changed and orphaning the real flag.
+	 *
+	 * @param int $main_id   Main attendee post ID.
+	 * @param int $ticket_id Companion ticket post ID.
+	 * @param int $seat_id   Optional. Companion seat post ID, to record the slug on.
+	 */
+	public function add_activity_admin_flag( $main_id, $ticket_id, $seat_id = 0 ) {
+		if ( ! $this->admin_flags_active() ) {
+			return;
+		}
+
+		$slug     = $this->get_activity_flag_slug( $ticket_id );
+		$existing = (array) get_post_meta( $main_id, self::ADMIN_FLAG_META, false );
+		if ( ! in_array( $slug, $existing, true ) ) {
+			add_post_meta( $main_id, self::ADMIN_FLAG_META, $slug );
+		}
+
+		if ( $seat_id ) {
+			update_post_meta( absint( $seat_id ), self::ACTIVITY_FLAG_META, $slug );
+		}
+	}
+
+	/**
+	 * Remove the flag from the linked main when a companion seat ends.
+	 *
+	 * Any terminal status, not just refund/cancel: the flag is added from
+	 * `camptix_checkout_update_post_meta` while the seat is still a draft, so an
+	 * order that never gets paid (`failed`, `timeout`) or an attendee an
+	 * organiser trashes would otherwise leave the flag behind permanently —
+	 * corrupting the very filter, column and export the flag exists to power.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post being transitioned.
+	 */
+	public function maybe_remove_activity_admin_flag( $new_status, $old_status, $post ) {
+		if ( ! $this->is_terminal_attendee_transition( $new_status, $old_status, $post ) ) {
+			return;
+		}
+
+		$this->remove_activity_admin_flag_for_seat( $post->ID );
+	}
+
+	/**
+	 * Drop a companion seat's flag from the main attendee it linked to.
+	 *
+	 * One-per-ticket-per-attendee means no other live seat can re-justify the
+	 * flag. Deleting is safe even if the admin-flags addon is inactive, and a
+	 * no-op for an attendee that is not a companion seat.
+	 *
+	 * @param int $seat_id Companion attendee post ID.
+	 */
+	private function remove_activity_admin_flag_for_seat( $seat_id ) {
+		$ticket_id = absint( get_post_meta( $seat_id, 'tix_ticket_id', true ) );
+		if ( ! $this->is_companion_ticket( $ticket_id ) ) {
+			return;
+		}
+
+		$main_id = absint( get_post_meta( $seat_id, 'tix_companion_primary_attendee_id', true ) );
+		if ( ! $main_id ) {
+			return;
+		}
+
+		/*
+		 * Prefer the slug recorded when the flag was written: the ticket's post_name may
+		 * have changed since (draft -> publish, or a manual edit), and recomputing would
+		 * delete a value that was never stored, leaving the real flag behind forever.
+		 * Seats linked before the slug was recorded fall back to recomputing.
+		 */
+		$slug = (string) get_post_meta( $seat_id, self::ACTIVITY_FLAG_META, true );
+		if ( '' === $slug ) {
+			$slug = $this->get_activity_flag_slug( $ticket_id );
+		}
+
+		delete_post_meta( $main_id, self::ADMIN_FLAG_META, $slug );
+	}
+
+	/**
+	 * Ensure each companion ticket has an admin-flags config entry, so the auto
+	 * flags actually render (admin-flags registers nothing for unknown slugs).
+	 *
+	 * Runs inside the Setup save ($output is the full options blob), and also
+	 * rewrites the addon's raw textarea value so a later save of the Admin
+	 * Flags section round-trips these entries instead of dropping them.
+	 * Organiser-defined flags are preserved; stale entries for tickets that are
+	 * no longer companions are left alone (they may still mark past attendees).
+	 *
+	 * @param array $output The full validated camptix options.
+	 * @return array
+	 */
+	private function sync_activity_admin_flag_config( $output ) {
+		if ( ! $this->admin_flags_active() ) {
+			return $output;
+		}
+
+		$ids = isset( $output['camptix-companion-ticket-ids'] )
+			? (array) $output['camptix-companion-ticket-ids']
+			: $this->get_companion_ticket_ids();
+
+		$parsed = isset( $output['camptix-admin-flags-data-parsed'] ) ? (array) $output['camptix-admin-flags-data-parsed'] : array();
+		$added  = false;
+
+		foreach ( $ids as $ticket_id ) {
+			$slug = $this->get_activity_flag_slug( $ticket_id );
+			if ( isset( $parsed[ $slug ] ) ) {
+				continue;
+			}
+
+			/* translators: %s: activity ticket name. */
+			$parsed[ $slug ] = sprintf( __( 'Activity: %s', 'wordcamporg' ), get_the_title( $ticket_id ) );
+			$added           = true;
+		}
+
+		if ( $added ) {
+			$output['camptix-admin-flags-data-parsed'] = $parsed;
+
+			$lines = array();
+			foreach ( $parsed as $slug => $label ) {
+				$lines[] = sprintf( '%s: %s', $slug, $label );
+			}
+			$output['camptix-admin-flags-data'] = implode( "\n", $lines );
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Repair a missing admin-flags config entry for any configured activity ticket.
+	 *
+	 * `sync_activity_admin_flag_config()` only runs inside a Setup save, and early-returns
+	 * when the admin-flags addon is inactive -- so a site that configured Activity Tickets
+	 * first and enabled admin-flags later ends up writing flag meta whose slug the
+	 * admin-flags config does not know about. Its own `save_post` (admin-flags.php:251)
+	 * then deletes every flag row and re-adds only configured slugs, silently destroying
+	 * the activity flags on the first manual save of that attendee.
+	 *
+	 * Re-checking in wp-admin closes that window without touching the checkout path, and
+	 * writes only when something is actually missing.
+	 */
+	public function maybe_heal_activity_admin_flag_config() {
+		if ( ! $this->admin_flags_active() ) {
+			return;
+		}
+
+		$options = (array) get_option( 'camptix_options', array() );
+		$healed  = $this->sync_activity_admin_flag_config( $options );
+
+		if ( $healed !== $options ) {
+			update_option( 'camptix_options', $healed );
+		}
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Public Attendees listing
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Hide companion seats from the public [camptix_attendees] listing.
+	 *
+	 * Every companion holder also holds a main ticket, so this is a dedupe (the
+	 * person still lists once), not a removal — see upstream issue #623. An
+	 * explicit tickets="…" attribute is an organiser's deliberate choice (e.g.
+	 * a Contributor Day attendees page), so it is left untouched.
+	 *
+	 * @param array $query_args WP_Query args for the listing.
+	 * @param array $attr       Shortcode attributes.
+	 * @return array
+	 */
+	public function exclude_companion_attendees_from_listing( $query_args, $attr ) {
+		if ( ! empty( $attr['tickets'] ) ) {
+			return $query_args;
+		}
+
+		$ids = $this->get_companion_ticket_ids();
+		if ( ! $ids ) {
+			return $query_args;
+		}
+
+		if ( ! isset( $query_args['meta_query'] ) ) {
+			$query_args['meta_query'] = array();
+		}
+
+		$query_args['meta_query'][] = array(
+			'key'     => 'tix_ticket_id',
+			'value'   => $ids,
+			'compare' => 'NOT IN',
+		);
+
+		return $query_args;
+	}
+
+	/**
+	 * Delete all cached [camptix_attendees] renders.
+	 *
+	 * The shortcode's cache key hashes only the shortcode attributes — not the
+	 * output of its query-args filter — so a config change here must flush the
+	 * transients directly or stale listings persist for hours.
+	 */
+	private function flush_attendees_shortcode_cache() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No API exists for finding these transients; runs only on Setup save.
+		$transients = $wpdb->get_col( $wpdb->prepare(
+			"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
+			$wpdb->esc_like( '_transient_camptix-attendees-' ) . '%'
+		) );
+
+		foreach ( $transients as $option_name ) {
+			delete_transient( str_replace( '_transient_', '', $option_name ) );
+		}
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Ownership transfer
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Detect a ticket changing hands via require-login's identity reassignment.
+	 *
+	 * Fires on the update_post_meta PRE-action, which WordPress only fires on a
+	 * genuine value change — at that moment get_post_meta() still returns the
+	 * OLD username while $meta_value carries the NEW one. A first claim of an
+	 * "[[ unconfirmed ]]" group-purchase seat is first ownership, not a
+	 * transfer, and is ignored.
+	 *
+	 * @param int    $meta_id    Meta row ID.
+	 * @param int    $object_id  Attendee post ID.
+	 * @param string $meta_key   Meta key being updated.
+	 * @param mixed  $meta_value New meta value.
+	 */
+	public function detect_ownership_change( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( 'tix_username' !== $meta_key ) {
+			return;
+		}
+
+		$post = get_post( $object_id );
+		if ( ! $post || 'tix_attendee' !== $post->post_type ) {
+			return;
+		}
+
+		$old = (string) get_post_meta( $object_id, 'tix_username', true );
+		$new = is_scalar( $meta_value ) ? (string) $meta_value : '';
+
+		if ( '' === $old || self::UNCONFIRMED_USERNAME === $old || '' === $new || $old === $new ) {
+			return;
+		}
+
+		$this->handle_ownership_transfer( $post, $old, $new );
+	}
+
+	/**
+	 * React to a real ownership transfer: release the personal companion seats.
+	 *
+	 * Companion seats are free, self-service, and personal, so "release" (the
+	 * seat returns to its pool; the new owner can register themselves) is the
+	 * default policy — it also stops a capacity-limited seat being hijacked via
+	 * a shared edit link. Re-linking to another main ticket the old owner may
+	 * still hold is deliberately future work.
+	 *
+	 * @param WP_Post $post         The attendee post whose owner changed.
+	 * @param string  $old_username Previous owner login.
+	 * @param string  $new_username New owner login.
+	 */
+	public function handle_ownership_transfer( $post, $old_username, $new_username ) {
+		/**
+		 * Filter the companion-seat policy applied on an ownership transfer.
+		 *
+		 * @param string  $policy       'release' (default) cancels the affected
+		 *                              companion seats; anything else leaves them.
+		 * @param WP_Post $post         The attendee post whose owner changed.
+		 * @param string  $old_username Previous owner login.
+		 * @param string  $new_username New owner login.
+		 */
+		$policy = apply_filters( 'camptix_companion_transfer_policy', 'release', $post, $old_username, $new_username );
+		if ( 'release' !== $policy ) {
+			return;
+		}
+
+		$ticket_id = absint( get_post_meta( $post->ID, 'tix_ticket_id', true ) );
+
+		if ( $this->is_companion_ticket( $ticket_id ) ) {
+			// The companion seat itself changed hands.
+			$this->queue_seat_release( $post->ID );
+			return;
+		}
+
+		// A main ticket changed hands: the old owner no longer holds a
+		// qualifying ticket, so their linked companion seats no longer qualify.
+		foreach ( $this->get_linked_companion_ids( $post->ID, array( 'publish' ) ) as $companion_id ) {
+			if ( $this->is_companion_ticket( get_post_meta( $companion_id, 'tix_ticket_id', true ) ) ) {
+				$this->queue_seat_release( $companion_id );
+			}
+		}
+	}
+
+	/**
+	 * Queue an attendee post to be cancelled once the current save finishes.
+	 *
+	 * @param int $attendee_id Attendee post ID.
+	 */
+	public function queue_seat_release( $attendee_id ) {
+		if ( empty( $this->deferred_releases ) ) {
+			add_action( 'shutdown', array( $this, 'process_deferred_releases' ) );
+		}
+
+		$this->deferred_releases[ absint( $attendee_id ) ] = true;
+	}
+
+	/**
+	 * Cancel the queued seats. Runs on shutdown, after the triggering save has
+	 * fully completed (cancelling mid-save would be overwritten by it).
+	 */
+	public function process_deferred_releases() {
+		$ids                     = array_keys( $this->deferred_releases );
+		$this->deferred_releases = array();
+
+		foreach ( $ids as $attendee_id ) {
+			if ( 'publish' === get_post_status( $attendee_id ) ) {
+				wp_update_post( array(
+					'ID'          => $attendee_id,
+					'post_status' => 'cancel',
+				) );
+			}
+		}
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Confirmation email
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Email an attendee a confirmation when their companion seat is confirmed.
+	 *
+	 * Fires once per companion attendee, when it transitions to "publish"; a
+	 * dedupe meta flag prevents repeat sends (e.g. on later admin edits). This is
+	 * a dedicated note about the companion registration — its link to the main
+	 * ticket and the limited capacity — in addition to CampTix's order receipt.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post being transitioned.
+	 */
+	public function maybe_send_activity_confirmation( $new_status, $old_status, $post ) {
+		global $camptix;
+
+		if ( ! $post || 'tix_attendee' !== $post->post_type ) {
+			return;
+		}
+		if ( 'publish' !== $new_status || 'publish' === $old_status ) {
+			return;
+		}
+		$ticket_id = absint( get_post_meta( $post->ID, 'tix_ticket_id', true ) );
+		if ( ! $this->is_companion_ticket( $ticket_id ) ) {
+			return;
+		}
+		if ( get_post_meta( $post->ID, 'tix_companion_confirmation_sent', true ) ) {
+			return; // Already emailed for this registration.
+		}
+
+		$to = get_post_meta( $post->ID, 'tix_email', true );
+		if ( ! is_email( $to ) ) {
+			return;
+		}
+
+		$options    = $camptix->get_options();
+		$event_name = ! empty( $options['event_name'] ) ? $options['event_name'] : get_bloginfo( 'name' );
+		$first_name = (string) get_post_meta( $post->ID, 'tix_first_name', true );
+		$ticket     = get_the_title( $ticket_id );
+		$edit_token = get_post_meta( $post->ID, 'tix_edit_token', true );
+		$edit_url   = $camptix->get_edit_attendee_link( $post->ID, $edit_token );
+
+		$subject = apply_filters(
+			'camptix_companion_confirmation_subject',
+			sprintf(
+				/* translators: 1: activity ticket name, 2: event name. */
+				__( 'You are registered for %1$s at %2$s', 'wordcamporg' ),
+				$ticket,
+				$event_name
+			),
+			$post->ID
+		);
+
+		$message = apply_filters(
+			'camptix_companion_confirmation_message',
+			sprintf(
+				/* translators: 1: attendee first name, 2: activity ticket name, 3: event name, 4: manage-registration URL. */
+				__( "Hi %1\$s,\n\nGreat news — your spot for %2\$s is confirmed. It is tied to your main %3\$s ticket, which is what makes you eligible for it.\n\nA couple of things worth knowing:\n- Spots are limited, so please only hold one if you plan to attend, and let us know early if your plans change.\n- This registration is connected to your event ticket. If your event ticket is cancelled or refunded, this registration is released automatically.\n\nYou can view or cancel just this registration here at any time:\n%4\$s\n\nThanks, and see you at %3\$s!", 'wordcamporg' ),
+				$first_name,
+				$ticket,
+				$event_name,
+				$edit_url
+			),
+			$post->ID
+		);
+
+		$camptix->wp_mail( $to, $subject, $message );
+		update_post_meta( $post->ID, 'tix_companion_confirmation_sent', 1 );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * "Your tickets" links + email-me-my-links
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * All of a username's published attendee seats, main tickets before
+	 * activity seats.
+	 *
+	 * @param string $username WP.org login.
+	 * @return int[] Attendee post IDs.
+	 */
+	public function get_user_seat_ids( $username ) {
+		$username = (string) $username;
+		if ( '' === $username || self::UNCONFIRMED_USERNAME === $username ) {
+			return array();
+		}
+
+		$attendees = get_posts( array(
+			'post_type'        => 'tix_attendee',
+			'post_status'      => 'publish',
+			'posts_per_page'   => 100,
+			'fields'           => 'ids',
+			'orderby'          => 'ID',
+			'order'            => 'ASC',
+			'meta_query'       => array(
+				array(
+					'key'   => 'tix_username',
+					'value' => $username,
+				),
+			),
+			'suppress_filters' => false,
+		) );
+
+		$mains      = array();
+		$companions = array();
+		foreach ( $attendees as $attendee_id ) {
+			$ticket_id = absint( get_post_meta( $attendee_id, 'tix_ticket_id', true ) );
+			if ( $this->is_companion_ticket( $ticket_id ) ) {
+				$companions[] = (int) $attendee_id;
+			} else {
+				$mains[] = (int) $attendee_id;
+			}
+		}
+
+		return array_merge( $mains, $companions );
+	}
+
+	/**
+	 * Email a user one message listing the manage link for each of their seats.
+	 *
+	 * Throttled per username so the request link can't pepper an inbox. The
+	 * request path is login-gated and the address is always the requester's
+	 * own account email — never visitor input, so it can't be used to probe
+	 * whether an address holds a ticket.
+	 *
+	 * @param string $username WP.org login whose seats to list.
+	 * @param string $to       Destination address.
+	 * @return bool Whether an email was sent.
+	 */
+	public function send_ticket_links_email( $username, $to ) {
+		global $camptix;
+
+		if ( ! is_email( $to ) ) {
+			return false;
+		}
+
+		$seat_ids = $this->get_user_seat_ids( $username );
+		if ( empty( $seat_ids ) ) {
+			return false;
+		}
+
+		$throttle_key = 'tix_companion_links_mail_' . md5( strtolower( $username ) );
+		if ( get_transient( $throttle_key ) ) {
+			return false;
+		}
+
+		$lines = array();
+		foreach ( $seat_ids as $seat_id ) {
+			$ticket_id  = absint( get_post_meta( $seat_id, 'tix_ticket_id', true ) );
+			$edit_token = get_post_meta( $seat_id, 'tix_edit_token', true );
+			$lines[]    = sprintf( '- %1$s: %2$s', get_the_title( $ticket_id ), $camptix->get_edit_attendee_link( $seat_id, $edit_token ) );
+		}
+
+		$options    = $camptix->get_options();
+		$event_name = ! empty( $options['event_name'] ) ? $options['event_name'] : get_bloginfo( 'name' );
+
+		$subject = apply_filters(
+			'camptix_companion_links_email_subject',
+			sprintf(
+				/* translators: %s: event name. */
+				__( 'Your ticket links for %s', 'wordcamporg' ),
+				$event_name
+			),
+			$username
+		);
+
+		$message = apply_filters(
+			'camptix_companion_links_email_message',
+			sprintf(
+				/* translators: 1: event name, 2: list of ticket manage links. */
+				__( "Here are the links to view or manage each of your tickets for %1\$s:\n\n%2\$s\n\nEach link opens that ticket's manage page directly, so keep this email handy.", 'wordcamporg' ),
+				$event_name,
+				implode( "\n", $lines )
+			),
+			$username
+		);
+
+		$sent = $camptix->wp_mail( $to, $subject, $message );
+		if ( $sent ) {
+			set_transient( $throttle_key, 1, 15 * MINUTE_IN_SECONDS );
+		}
+
+		return (bool) $sent;
+	}
+
+	/**
+	 * Pure handler for the email-me-my-links request; the template_redirect
+	 * wrapper turns the outcome into a redirect.
+	 *
+	 * @return string '' when this isn't a links request, otherwise
+	 *                'sent' | 'throttled' | 'invalid'.
+	 */
+	public function handle_links_email_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- presence check only; the nonce is verified just below.
+		if ( ! isset( $_GET['tix_companion_email_links'] ) ) {
+			return '';
+		}
+
+		$nonce = isset( $_GET['_wpnonce'] ) ? sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+		if ( ! is_user_logged_in() || ! wp_verify_nonce( $nonce, 'tix-companion-email-links' ) ) {
+			return 'invalid';
+		}
+
+		$user = wp_get_current_user();
+		$sent = $this->send_ticket_links_email( (string) $user->user_login, (string) $user->user_email );
+
+		return $sent ? 'sent' : 'throttled';
+	}
+
+	/**
+	 * Process the email-me-my-links request, then redirect back to the tickets
+	 * page (PRG) with an outcome flag so a refresh can't re-trigger the send.
+	 */
+	public function process_links_email_request() {
+		global $camptix;
+
+		$status = $this->handle_links_email_request();
+		if ( '' === $status ) {
+			return;
+		}
+
+		wp_safe_redirect( add_query_arg( 'tix_companion_links_sent', rawurlencode( $status ), $camptix->get_tickets_url() ) );
+		exit;
+	}
+
+	/**
+	 * On the ticket-selection screen, list the visitor's existing seats with
+	 * their manage links, plus the email-me-these-links action.
+	 */
+	public function maybe_show_my_ticket_links() {
+		global $camptix;
+
+		// Only the initial selection screen — later steps have their own flow.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only display gate, no state change.
+		$action = isset( $_REQUEST['tix_action'] ) ? sanitize_key( wp_unslash( $_REQUEST['tix_action'] ) ) : '';
+		if ( '' !== $action ) {
+			return;
+		}
+
+		// Outcome notice after the request's PRG redirect.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- display-only outcome flag.
+		$outcome = isset( $_GET['tix_companion_links_sent'] ) ? sanitize_key( wp_unslash( $_GET['tix_companion_links_sent'] ) ) : '';
+		if ( 'sent' === $outcome ) {
+			$camptix->notice( __( 'Check your inbox — we emailed you the links to your tickets.', 'wordcamporg' ) );
+		} elseif ( 'throttled' === $outcome ) {
+			$camptix->notice( __( 'We emailed you your ticket links recently — please check your inbox (and spam folder) before requesting them again.', 'wordcamporg' ) );
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		$user     = wp_get_current_user();
+		$seat_ids = $this->get_user_seat_ids( (string) $user->user_login );
+		if ( empty( $seat_ids ) ) {
+			return;
+		}
+
+		$links = array();
+		foreach ( $seat_ids as $seat_id ) {
+			$ticket_id  = absint( get_post_meta( $seat_id, 'tix_ticket_id', true ) );
+			$edit_token = get_post_meta( $seat_id, 'tix_edit_token', true );
+			$links[]    = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( $camptix->get_edit_attendee_link( $seat_id, $edit_token ) ),
+				esc_html( get_the_title( $ticket_id ) )
+			);
+		}
+
+		$email_url = wp_nonce_url(
+			add_query_arg( 'tix_companion_email_links', '1', $camptix->get_tickets_url() ),
+			'tix-companion-email-links'
+		);
+
+		$camptix->notice( sprintf(
+			/* translators: 1: list of ticket manage links, 2: request-email URL. */
+			__( 'Your tickets: %1$s. <a href="%2$s">Email me these links</a>.', 'wordcamporg' ),
+			implode( ', ', $links ),
+			esc_url( $email_url )
+		) );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Attendee export
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Add the main<->companion link columns to the attendee CSV/XML export.
+	 *
+	 * @param array $columns Existing extra export columns (key => label).
+	 * @return array
+	 */
+	public function export_extra_columns( $columns ) {
+		$columns['companion_of']      = __( 'Activity of (main ticket #)', 'wordcamporg' );
+		$columns['companion_tickets'] = __( 'Activity tickets', 'wordcamporg' );
+		return $columns;
+	}
+
+	/**
+	 * Export cell: for a companion row, the linked main attendee ID; else ''.
+	 *
+	 * @param string  $value    Default cell value.
+	 * @param WP_Post $attendee Attendee post for this row.
+	 * @return string
+	 */
+	public function export_column_companion_of( $value, $attendee ) {
+		$main_id = absint( get_post_meta( $attendee->ID, 'tix_companion_primary_attendee_id', true ) );
+		return $main_id ? (string) $main_id : '';
+	}
+
+	/**
+	 * Export cell: for a main row, its live companion registrations; else ''.
+	 *
+	 * @param string  $value    Default cell value.
+	 * @param WP_Post $attendee Attendee post for this row.
+	 * @return string
+	 */
+	public function export_column_companion_tickets( $value, $attendee ) {
+		$labels = array();
+		foreach ( $this->get_linked_companion_ids( $attendee->ID, array( 'publish' ) ) as $companion_id ) {
+			$ticket_id = absint( get_post_meta( $companion_id, 'tix_ticket_id', true ) );
+			$labels[]  = sprintf( '%s (#%d)', get_the_title( $ticket_id ), $companion_id );
+		}
+		return implode( ' | ', $labels );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Admin display
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Human-readable description of the main<->companion links for an attendee.
+	 *
+	 * Only reports links to still-live (published) counterparts, so a cancelled
+	 * companion seat is never shown as an active registration.
+	 *
+	 * @param int $attendee_id Attendee post ID.
+	 * @return string '' if there is no live link.
+	 */
+	public function get_link_label( $attendee_id ) {
+		// This attendee is itself a companion registration.
+		$primary = absint( get_post_meta( $attendee_id, 'tix_companion_primary_attendee_id', true ) );
+		if ( $primary && 'publish' === get_post_status( $primary ) ) {
+			/* translators: %d: main attendee post ID. */
+			return sprintf( __( 'Activity registration linked to ticket #%d.', 'wordcamporg' ), $primary );
+		}
+
+		// This attendee is a main ticket with companion registrations.
+		$labels = array();
+		foreach ( $this->get_linked_companion_ids( $attendee_id, array( 'publish' ) ) as $companion_id ) {
+			$ticket_id = absint( get_post_meta( $companion_id, 'tix_ticket_id', true ) );
+			$labels[]  = sprintf( '%s (#%d)', get_the_title( $ticket_id ), $companion_id );
+		}
+		if ( ! empty( $labels ) ) {
+			/* translators: %s: comma-separated list of "Ticket name (#attendee id)". */
+			return sprintf( __( 'Registered for activity tickets: %s.', 'wordcamporg' ), implode( ', ', $labels ) );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Show the link on the Edit Attendee screen's Publish metabox.
+	 *
+	 * @param WP_Post $post The attendee post being edited (passed by the hook).
+	 */
+	public function render_link_metabox( $post = null ) {
+		if ( ! $post instanceof WP_Post ) {
+			$post = get_post();
+		}
+		if ( ! $post ) {
+			return;
+		}
+
+		$label = $this->get_link_label( $post->ID );
+		if ( '' !== $label ) {
+			echo '<div class="misc-pub-section"><span class="dashicons dashicons-groups"></span> ' . esc_html( $label ) . '</div>';
+		}
+	}
+}
+
+CampTix_Companion_Tickets_Addon::register_addon();

--- a/public_html/wp-content/plugins/camptix-companion-tickets/camptix-companion-tickets.php
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/camptix-companion-tickets.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: CampTix - Activity Tickets
+ * Description: Lets confirmed event-ticket holders self-register for free, capacity-limited activity tickets (e.g. Contributor Day, Social Dinner), gated to ticket-holders and linked to their main ticket.
+ * Version:     1.0.0
+ * Author:      WordCamp.org
+ * License:     GPLv2 or later
+ */
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Register this addon with CampTix.
+ *
+ * Runs on `camptix_load_addons`, which fires before `camptix_init`, so the
+ * `register_addon()` call inside the addon file is in time.
+ */
+function camptix_companion_tickets_register() {
+	require_once plugin_dir_path( __FILE__ ) . 'addons/companion-tickets.php';
+}
+add_action( 'camptix_load_addons', 'camptix_companion_tickets_register' );

--- a/public_html/wp-content/plugins/camptix-companion-tickets/phpunit-standalone.xml.dist
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/phpunit-standalone.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/standalone-bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+
+	<testsuites>
+		<testsuite name="companion-tickets">
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/public_html/wp-content/plugins/camptix-companion-tickets/readme.txt
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/readme.txt
@@ -1,0 +1,58 @@
+=== CampTix - Activity Tickets ===
+Contributors: wordcamp
+Requires at least: 6.8
+Tested up to: 6.8
+Requires PHP: 7.4
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Lets confirmed event-ticket holders self-register for free, capacity-limited activity tickets (e.g. Contributor Day, Social Dinner), gated to ticket-holders and linked to their main ticket.
+
+== Description ==
+
+An add-on for CampTix. An organiser designates one or more tickets as **activity tickets** — free, capacity-limited extras (each by its own Quantity) such as Contributor Day or a Social Dinner. Then, for every activity ticket:
+
+* **Gated** — only an attendee who is logged in AND already holds a published qualifying main ticket may register. (A combined "main + activity" purchase in one cart is not allowed; buy the main ticket first.)
+* **Self-service, one per ticket per attendee** — each attendee registers themselves; the buyer's additional-attendee seats cannot be used, and a person can register for each activity ticket only once.
+* **Linked** — each activity attendee record is linked to the attendee's main ticket record (via post meta).
+* **Refund-aware** — refunding or cancelling the main ticket auto-cancels **all** of that attendee's linked activity seats and returns them to their pools. (Refund is terminal — re-publishing the main ticket does not auto-restore the seats.)
+
+= Configuration =
+
+CampTix → Setup → **Activity Tickets**:
+
+* **Activity tickets** — which tickets are the free, capacity-limited activity tickets.
+* **Qualifying tickets** — which main tickets make a holder eligible. Leave all unchecked to allow holders of any other (non-activity) published ticket. An activity ticket never qualifies as a main ticket.
+
+= Requirements =
+
+This add-on depends on the CampTix **require-login** add-on (it uses the `tix_username` identity that require-login provides). On WordCamp.org `require-login` is enabled by default. If it is inactive, an admin notice is shown and activity registration is disabled (fails closed).
+
+= Integrations =
+
+* **Admin Flags** — when the CampTix Admin Flags add-on is active, registering an activity seat automatically flags the attendee's main ticket (e.g. `activity-contributor-day`), so the admin attendee list and export can filter by it; the flag is removed if the seat is cancelled. Flag definitions are kept in sync on the Activity Tickets setup save.
+* **Attendees page** — activity seats are hidden from the public `[camptix_attendees]` listing so each person lists once (their main ticket entry). A shortcode with an explicit `tickets="…"` attribute is not filtered, so a dedicated per-activity attendees page still works.
+
+== Changelog ==
+
+= 1.0.0 =
+* First release in this repository. The entries below are the local development history that
+  preceded it, kept because they describe what each layer of the add-on does; none of those
+  versions were ever released.
+
+= 0.4.0 =
+* The ticket-selection screen now lists a logged-in attendee's existing tickets (main and activity) with a manage link for each, plus a throttled "Email me these links" action for attendees who lost their receipt email. The request is login-gated and always mails the requester's own account address (filterable subject/body).
+
+= 0.3.0 =
+* Automatically admin-flag the main attendee per held activity ticket (with the CampTix Admin Flags add-on); flags are removed again when the seat is cancelled.
+* Hide activity seats from the public [camptix_attendees] listing so each person appears once (explicit tickets="…" attributes are respected).
+* Ownership transfers (a ticket's confirmed identity changing hands via the edit-attendee flow) now release the affected activity seats back to their pools — a transferred main ticket releases the old owner's seats; a transferred activity seat is released itself. Filterable via camptix_companion_transfer_policy.
+
+= 0.2.0 =
+* Renamed the user-facing concept to "Activity ticket" (stored config/identifiers unchanged).
+* Tickets-page now shows an attendee's already-held activity tickets as "already registered" instead of letting them appear to vanish.
+* Added "Activity of" and "Activity tickets" columns to the attendee CSV/XML export, exposing the main↔activity link.
+* Each attendee now receives a confirmation email when their activity registration is confirmed (filterable subject/body).
+
+= 0.1.0 =
+* Initial version: configurable activity tickets, ticket-holder eligibility gate, self-service one-per-ticket-per-attendee rule, attendee linking, refund/cancel cascade across all linked seats, qualifying-ticket whitelist UI, and a selection-screen eligibility notice.

--- a/public_html/wp-content/plugins/camptix-companion-tickets/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/tests/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CampTix\CompanionTickets\Tests;
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/**
+ * Load this addon plugin for the test run.
+ *
+ * CampTix core itself is loaded by camptix/tests/bootstrap.php (required last
+ * in phpunit-bootstrap.php). This bootstrapper only needs to register our
+ * plugin so its `camptix_load_addons` hook is in place before CampTix inits.
+ */
+function manually_load_plugin() {
+	require_once dirname( __DIR__, 2 ) . '/camptix/tests/trait-wordcamp-root-blog.php';
+	require_once dirname( __DIR__, 2 ) . '/camptix-admin-flags/camptix-admin-flags.php';
+	require_once dirname( __DIR__ ) . '/camptix-companion-tickets.php';
+}
+tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugin' );

--- a/public_html/wp-content/plugins/camptix-companion-tickets/tests/standalone-bootstrap.php
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/tests/standalone-bootstrap.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Standalone PHPUnit bootstrap for running ONLY the Companion Tickets suite.
+ *
+ * The repo-wide phpunit-bootstrap.php loads every plugin's test bootstrap,
+ * some of which require third-party plugins (e.g. Jetpack) that aren't present
+ * in every local checkout. This bootstrap loads just CampTix core + this addon
+ * so the suite can run in isolation. CI uses the integrated harness.
+ *
+ * Usage (inside the phpunit_wp container, from /app):
+ *   phpunit -c public_html/wp-content/plugins/camptix-companion-tickets/phpunit-standalone.xml.dist
+ *
+ * NOTE: intentionally NOT namespaced, so the get_wordcamp_post() shim below is
+ * declared in the global namespace where CampTix calls it.
+ */
+
+if ( 'cli' !== php_sapi_name() ) {
+	return;
+}
+
+/*
+ * CampTix calls this WordCamp.org helper (normally provided by the wcpt /
+ * wc-post-types plugins) during ticket/attendee save, via is_wordcamp_closed().
+ * In this isolated CampTix-only run those plugins aren't loaded, so provide a
+ * no-op meaning "no WordCamp post" — is_wordcamp_closed() handles false safely.
+ */
+if ( ! function_exists( 'get_wordcamp_post' ) ) {
+	/**
+	 * Test shim for the WordCamp.org helper (see the note above). Returns false
+	 * so is_wordcamp_closed() treats this run as "no WordCamp post".
+	 *
+	 * @return false
+	 */
+	function get_wordcamp_post() {
+		return false;
+	}
+}
+
+$core_tests_directory = getenv( 'WP_TESTS_DIR' );
+if ( ! $core_tests_directory ) {
+	$core_tests_directory = '/tmp/wp/wordpress-tests-lib';
+}
+
+require_once $core_tests_directory . '/includes/functions.php';
+
+/**
+ * Load CampTix core, the admin-flags addon (the auto-flag feature's display
+ * layer — loading it makes those code paths testable), then this addon.
+ */
+function camptix_companion_standalone_load_plugins() {
+	require_once dirname( __DIR__, 2 ) . '/camptix/camptix.php';
+	require_once dirname( __DIR__, 2 ) . '/camptix-admin-flags/camptix-admin-flags.php';
+	require_once dirname( __DIR__ ) . '/camptix-companion-tickets.php';
+}
+tests_add_filter( 'muplugins_loaded', 'camptix_companion_standalone_load_plugins' );
+
+require $core_tests_directory . '/includes/bootstrap.php';

--- a/public_html/wp-content/plugins/camptix-companion-tickets/tests/test-companion-tickets.php
+++ b/public_html/wp-content/plugins/camptix-companion-tickets/tests/test-companion-tickets.php
@@ -1,0 +1,1814 @@
+<?php
+
+namespace CampTix\CompanionTickets\Tests;
+
+use WP_UnitTestCase;
+use CampTix_Companion_Tickets_Addon;
+
+/**
+ * Unit/integration tests for the Companion Tickets addon.
+ */
+class Test_Companion_Tickets extends WP_UnitTestCase {
+	use \CampTix_Root_Blog_Fixture;
+
+	/**
+	 * Provision the central WordCamp.org root blog.
+	 *
+	 * Saving a `tix_attendee` runs `CampTix_Plugin::is_wordcamp_closed()`, which calls
+	 * `get_wordcamp_post()` and switches to `WORDCAMP_ROOT_BLOG_ID`. Without the site
+	 * existing, every attendee save emits "table doesn't exist" DB errors -- which the
+	 * repo's PHPUnit bootstrap treats as a build failure even when assertions pass.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::create_wordcamp_root_blog( $factory );
+	}
+
+	/**
+	 * Tears down the shared fixtures created in wpSetUpBeforeClass().
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_wordcamp_root_blog();
+	}
+
+	/**
+	 * Create a published tix_ticket with a price and quantity.
+	 */
+	private function make_ticket( $title = 'Main', $price = 0, $quantity = 100 ) {
+		$id = self::factory()->post->create( array(
+			'post_type'   => 'tix_ticket',
+			'post_status' => 'publish',
+			'post_title'  => $title,
+		) );
+		update_post_meta( $id, 'tix_price', $price );
+		update_post_meta( $id, 'tix_quantity', $quantity );
+		return $id;
+	}
+
+	/**
+	 * Create a tix_attendee for a ticket + username with the given status.
+	 */
+	private function make_attendee( $ticket_id, $username, $status = 'publish' ) {
+		$id = self::factory()->post->create( array(
+			'post_type'   => 'tix_attendee',
+			'post_status' => $status,
+		) );
+		update_post_meta( $id, 'tix_ticket_id', $ticket_id );
+		update_post_meta( $id, 'tix_username', $username );
+		return $id;
+	}
+
+	/**
+	 * Configure the companion tickets (+ optional qualifying whitelist).
+	 * get_options() caches in CampTix's protected $options, so refresh it.
+	 */
+	private function set_companion_config( $companion_ids, $qualifying = array() ) {
+		global $camptix;
+		$options                                 = get_option( 'camptix_options', array() );
+		$options['camptix-companion-ticket-ids'] = array_map( 'absint', (array) $companion_ids );
+		if ( ! empty( $qualifying ) ) {
+			$options['camptix-companion-qualifying-ticket-ids'] = array_map( 'absint', $qualifying );
+		}
+		update_option( 'camptix_options', $options );
+		$camptix->load_options();
+	}
+
+	/**
+	 * Reset CampTix's notice buffers between assertions (global singleton).
+	 */
+	private function reset_notices() {
+		global $camptix;
+
+		// These reflection helpers deliberately omit setAccessible(): it is a no-op as of
+		// PHP 8.1 and deprecated in 8.5, where the notice would trip this repo's
+		// unexpected-error-log check. This repo targets 8.3+.
+		$ref = new \ReflectionObject( $camptix );
+		foreach ( array( 'notices', 'errors', 'infos' ) as $prop ) {
+			if ( $ref->hasProperty( $prop ) ) {
+				$p = $ref->getProperty( $prop );
+				$p->setValue( $camptix, array() );
+			}
+		}
+	}
+
+	/**
+	 * Read CampTix's buffered front-end notices (global singleton).
+	 */
+	private function get_notices() {
+		global $camptix;
+		$ref = new \ReflectionObject( $camptix );
+		if ( ! $ref->hasProperty( 'notices' ) ) {
+			return array();
+		}
+		$p = $ref->getProperty( 'notices' );
+		return (array) $p->getValue( $camptix );
+	}
+
+	/**
+	 * The addon class loads and registers.
+	 */
+	public function test_addon_class_exists() {
+		$this->assertTrue( class_exists( 'CampTix_Companion_Tickets_Addon' ) );
+	}
+
+	/**
+	 * The companion-ticket check reflects the configured set.
+	 */
+	public function test_is_companion_ticket() {
+		$main   = $this->make_ticket( 'Main' );
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertTrue( $addon->is_companion_ticket( $cd ) );
+		$this->assertTrue( $addon->is_companion_ticket( $dinner ) );
+		$this->assertFalse( $addon->is_companion_ticket( $main ) );
+	}
+
+	/**
+	 * A user holding a published non-companion ticket is eligible.
+	 */
+	public function test_user_with_published_main_ticket_is_eligible() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$found = $addon->get_user_main_attendee( 'alice' );
+		$this->assertNotEmpty( $found );
+		$this->assertSame( 'alice', get_post_meta( $found, 'tix_username', true ) );
+	}
+
+	/**
+	 * A user with no main ticket is not eligible.
+	 */
+	public function test_user_without_published_main_ticket_is_not_eligible() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 0, $addon->get_user_main_attendee( 'nobody' ) );
+	}
+
+	/**
+	 * A draft main ticket does not count as held.
+	 */
+	public function test_draft_main_ticket_is_not_eligible() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'draft' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 0, $addon->get_user_main_attendee( 'alice' ) );
+	}
+
+	/**
+	 * The require-login "unconfirmed" sentinel never counts as a holder.
+	 */
+	public function test_unconfirmed_username_does_not_count() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, '[[ unconfirmed ]]', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 0, $addon->get_user_main_attendee( '[[ unconfirmed ]]' ) );
+	}
+
+	/**
+	 * Holding only a companion ticket does not make a user eligible.
+	 */
+	public function test_companion_ticket_does_not_qualify_as_main() {
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+		// User holds a companion ticket but no real main ticket.
+		$this->make_attendee( $cd, 'bob', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 0, $addon->get_user_main_attendee( 'bob' ) );
+	}
+
+	/**
+	 * A qualifying-ticket whitelist restricts which holders are eligible.
+	 */
+	public function test_qualifying_whitelist_restricts_eligibility() {
+		$allowed = $this->make_ticket( 'VIP' );
+		$other   = $this->make_ticket( 'Other' );
+		$cd      = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ), array( $allowed ) );
+
+		$this->make_attendee( $other, 'erin', 'publish' );
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 0, $addon->get_user_main_attendee( 'erin' ) );
+
+		$this->make_attendee( $allowed, 'frank', 'publish' );
+		$this->assertNotEmpty( $addon->get_user_main_attendee( 'frank' ) );
+	}
+
+	/**
+	 * Registration detection is per companion ticket.
+	 */
+	public function test_user_has_registration_is_per_ticket() {
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+		$this->make_attendee( $cd, 'carol', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertTrue( $addon->user_has_registration( 'carol', $cd ) );
+		$this->assertFalse( $addon->user_has_registration( 'carol', $dinner ) );
+	}
+
+	/**
+	 * Submitted companion ids are sanitised to ints.
+	 */
+	public function test_validate_options_sanitizes_companion_ids() {
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$out   = $addon->validate_options(
+			array(),
+			array( 'camptix-companion-ticket-ids' => array( '7', 0, 'x', '9' ) )
+		);
+		$this->assertSame( array( 7, 9 ), $out['camptix-companion-ticket-ids'] );
+	}
+
+	/**
+	 * A companion ticket is never saved into the qualifying whitelist.
+	 */
+	public function test_validate_options_strips_companion_from_qualifying() {
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$out   = $addon->validate_options(
+			array(),
+			array(
+				'camptix-companion-ticket-ids'            => array( 5, 6 ),
+				'camptix-companion-qualifying-ticket-ids' => array( 5, 7, 9 ),
+			)
+		);
+		$this->assertSame( array( 5, 6 ), $out['camptix-companion-ticket-ids'] );
+		$this->assertSame( array( 7, 9 ), $out['camptix-companion-qualifying-ticket-ids'] );
+	}
+
+	/**
+	 * An all-unchecked UI save clears the companion list (marker present, no array).
+	 */
+	public function test_validate_options_clears_companions_on_empty_ui_save() {
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$out   = $addon->validate_options(
+			array( 'camptix-companion-ticket-ids' => array( 7, 9 ) ),
+			array( 'camptix-companion-tickets-rendered' => '1' )
+		);
+		$this->assertSame( array(), $out['camptix-companion-ticket-ids'] );
+	}
+
+	/**
+	 * The gate blocks a companion registration when the user has no main ticket.
+	 */
+	public function test_gate_blocks_when_no_main_ticket() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( CampTix_Companion_Tickets_Addon::REQUIRES_FLAG, $addon->should_block_companion_attendee( $cd, 'stranger' ) );
+	}
+
+	/**
+	 * The gate allows a companion registration for a qualifying ticket-holder.
+	 */
+	public function test_gate_allows_when_user_holds_main_ticket() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( '', $addon->should_block_companion_attendee( $cd, 'alice' ) );
+	}
+
+	/**
+	 * The gate rejects an unconfirmed / non-buyer seat (self-service only).
+	 */
+	public function test_gate_blocks_unconfirmed_attendee() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( CampTix_Companion_Tickets_Addon::SELF_ONLY_FLAG, $addon->should_block_companion_attendee( $cd, '[[ unconfirmed ]]' ) );
+	}
+
+	/**
+	 * The gate rejects an anonymous (empty-username) seat.
+	 */
+	public function test_gate_blocks_empty_username() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( CampTix_Companion_Tickets_Addon::SELF_ONLY_FLAG, $addon->should_block_companion_attendee( $cd, '' ) );
+	}
+
+	/**
+	 * The gate blocks a duplicate registration, per companion ticket.
+	 */
+	public function test_gate_blocks_duplicate_per_ticket() {
+		$main   = $this->make_ticket( 'Main' );
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		$this->make_attendee( $cd, 'alice', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		// Already has Contributor Day → blocked for it...
+		$this->assertSame( CampTix_Companion_Tickets_Addon::DUPLICATE_FLAG, $addon->should_block_companion_attendee( $cd, 'alice' ) );
+		// ...but still allowed for the Social Dinner (independent).
+		$this->assertSame( '', $addon->should_block_companion_attendee( $dinner, 'alice' ) );
+	}
+
+	/**
+	 * The gate never interferes with non-companion tickets.
+	 */
+	public function test_gate_ignores_non_companion_tickets() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( '', $addon->should_block_companion_attendee( $main, 'anyone' ) );
+	}
+
+	/**
+	 * Linking a companion attendee writes the forward pointer to the main.
+	 */
+	public function test_link_writes_primary_pointer() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+
+		$cd_id = self::factory()->post->create( array(
+			'post_type'   => 'tix_attendee',
+			'post_status' => 'draft',
+		) );
+		update_post_meta( $cd_id, 'tix_ticket_id', $cd );
+		update_post_meta( $cd_id, 'tix_username', 'alice' );
+
+		$addon    = new CampTix_Companion_Tickets_Addon();
+		$attendee = (object) array( 'ticket_id' => $cd );
+		$addon->link_companion_attendee( $cd_id, $attendee );
+
+		$this->assertSame( $main_id, absint( get_post_meta( $cd_id, 'tix_companion_primary_attendee_id', true ) ) );
+	}
+
+	/**
+	 * Linking resolves the username from the attendee object, not stale meta.
+	 */
+	public function test_link_prefers_attendee_object_username() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+
+		$cd_id = self::factory()->post->create( array(
+			'post_type'   => 'tix_attendee',
+			'post_status' => 'draft',
+		) );
+		update_post_meta( $cd_id, 'tix_ticket_id', $cd );
+		update_post_meta( $cd_id, 'tix_username', 'mallory' );
+
+		$addon    = new CampTix_Companion_Tickets_Addon();
+		$attendee = (object) array(
+			'ticket_id' => $cd,
+			'username'  => 'alice',
+		);
+		$addon->link_companion_attendee( $cd_id, $attendee );
+
+		$this->assertSame( $main_id, absint( get_post_meta( $cd_id, 'tix_companion_primary_attendee_id', true ) ) );
+	}
+
+	/**
+	 * Linking is a no-op for a non-companion attendee.
+	 */
+	public function test_link_ignores_non_companion_attendee() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+
+		$addon    = new CampTix_Companion_Tickets_Addon();
+		$attendee = (object) array( 'ticket_id' => $main );
+		$addon->link_companion_attendee( $main_id, $attendee );
+
+		$this->assertSame( '', (string) get_post_meta( $main_id, 'tix_companion_primary_attendee_id', true ) );
+	}
+
+	/**
+	 * Refunding the main attendee cancels ALL of its linked companion seats.
+	 */
+	public function test_refunding_main_cancels_all_linked_companions() {
+		$main   = $this->make_ticket( 'Main' );
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+		$main_id   = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id     = $this->make_attendee( $cd, 'alice', 'publish' );
+		$dinner_id = $this->make_attendee( $dinner, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+		update_post_meta( $dinner_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		add_action( 'transition_post_status', array( $addon, 'maybe_cascade_cancel' ), 10, 3 );
+
+		wp_update_post( array(
+			'ID'          => $main_id,
+			'post_status' => 'refund',
+		) );
+
+		$this->assertSame( 'cancel', get_post_status( $cd_id ) );
+		$this->assertSame( 'cancel', get_post_status( $dinner_id ) );
+
+		remove_action( 'transition_post_status', array( $addon, 'maybe_cascade_cancel' ), 10 );
+	}
+
+	/**
+	 * Cancelling a companion attendee does not recurse into the cascade.
+	 */
+	public function test_cancelling_companion_does_not_recurse() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$cd_id = $this->make_attendee( $cd, 'alice', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_cascade_cancel( 'cancel', 'publish', get_post( $cd_id ) );
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * The admin label reads correctly from the companion side and lists the
+	 * companion registrations from the main side.
+	 */
+	public function test_link_label_both_sides() {
+		$main   = $this->make_ticket( 'Main' );
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+		$main_id   = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id     = $this->make_attendee( $cd, 'alice', 'publish' );
+		$dinner_id = $this->make_attendee( $dinner, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+		update_post_meta( $dinner_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		// Companion side points at the main attendee id.
+		$this->assertStringContainsString( (string) $main_id, $addon->get_link_label( $cd_id ) );
+
+		// Main side lists both companion registrations.
+		$main_label = $addon->get_link_label( $main_id );
+		$this->assertStringContainsString( (string) $cd_id, $main_label );
+		$this->assertStringContainsString( (string) $dinner_id, $main_label );
+
+		// Unrelated attendee → no label.
+		$this->assertSame( '', $addon->get_link_label( $this->make_attendee( $main, 'bob', 'publish' ) ) );
+	}
+
+	/**
+	 * A cancelled companion seat is not listed on the main attendee's label.
+	 */
+	public function test_link_label_excludes_cancelled_companion() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'cancel' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( '', $addon->get_link_label( $main_id ) );
+	}
+
+	/**
+	 * The whitelist UI offers non-companion tickets but never companion ones.
+	 */
+	public function test_render_qualifying_select_excludes_companions() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		ob_start();
+		$addon->render_qualifying_select();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'camptix-companion-qualifying-rendered', $html );
+		$this->assertStringContainsString( 'camptix-companion-qualifying-ticket-ids][]" value="' . $main . '"', $html );
+		$this->assertStringNotContainsString( 'camptix-companion-qualifying-ticket-ids][]" value="' . $cd . '"', $html );
+	}
+
+	/**
+	 * The companion-tickets UI offers every ticket and carries the clear marker.
+	 */
+	public function test_render_companion_select_lists_tickets() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		ob_start();
+		$addon->render_companion_select();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'camptix-companion-tickets-rendered', $html );
+		$this->assertStringContainsString( 'camptix-companion-ticket-ids][]" value="' . $main . '"', $html );
+		$this->assertStringContainsString( 'camptix-companion-ticket-ids][]" value="' . $cd . '"', $html );
+	}
+
+	/**
+	 * The selection-screen notice prompts a visitor with no qualifying ticket.
+	 */
+	public function test_eligibility_notice_shown_for_ineligible_user() {
+		global $camptix;
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		unset( $_REQUEST['tix_action'] );
+		wp_set_current_user( 0 );
+		$this->reset_notices();
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_show_eligibility_notice();
+
+		ob_start();
+		$camptix->do_notices();
+		$html = ob_get_clean();
+		$this->assertStringContainsString( 'already have an event ticket', $html );
+		$this->assertStringContainsString( 'Contributor Day', $html );
+	}
+
+	/**
+	 * The selection-screen notice is suppressed for an eligible ticket-holder.
+	 */
+	public function test_eligibility_notice_hidden_for_eligible_user() {
+		global $camptix;
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$uid = self::factory()->user->create( array( 'user_login' => 'gwen' ) );
+		$this->make_attendee( $main, 'gwen', 'publish' );
+		unset( $_REQUEST['tix_action'] );
+		wp_set_current_user( $uid );
+		$this->reset_notices();
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_show_eligibility_notice();
+
+		ob_start();
+		$camptix->do_notices();
+		$html = ob_get_clean();
+		$this->assertStringNotContainsString( 'already have an event ticket', $html );
+	}
+
+	/**
+	 * An eligible holder who already registered sees an "already registered"
+	 * notice for that activity ticket, not a "buy a ticket first" prompt.
+	 */
+	public function test_eligibility_notice_shows_already_registered() {
+		global $camptix;
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$uid = self::factory()->user->create( array( 'user_login' => 'hank' ) );
+		$this->make_attendee( $main, 'hank', 'publish' );
+		$this->make_attendee( $cd, 'hank', 'publish' );
+		unset( $_REQUEST['tix_action'] );
+		wp_set_current_user( $uid );
+		$this->reset_notices();
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_show_eligibility_notice();
+
+		ob_start();
+		$camptix->do_notices();
+		$html = ob_get_clean();
+		$this->assertStringContainsString( 'already registered for', $html );
+		$this->assertStringContainsString( 'Contributor Day', $html );
+		$this->assertStringNotContainsString( 'already have an event ticket', $html );
+	}
+
+	/**
+	 * The remaining-column label reads "Already registered" for a held activity
+	 * ticket, and is left untouched otherwise.
+	 */
+	public function test_remaining_label_for_held_companion() {
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$main   = $this->make_ticket( 'Main' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+		$uid = self::factory()->user->create( array( 'user_login' => 'ivy' ) );
+		$this->make_attendee( $cd, 'ivy', 'publish' );
+		wp_set_current_user( $uid );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		// Held companion ticket → label replaced.
+		$this->assertSame( 'Already registered', $addon->maybe_label_already_registered( 5, (object) array( 'ID' => $cd ) ) );
+		// Companion ticket not held → unchanged.
+		$this->assertSame( 5, $addon->maybe_label_already_registered( 5, (object) array( 'ID' => $dinner ) ) );
+		// Non-companion ticket → unchanged.
+		$this->assertSame( 5, $addon->maybe_label_already_registered( 5, (object) array( 'ID' => $main ) ) );
+	}
+
+	/**
+	 * The export declares the two link columns.
+	 */
+	public function test_export_extra_columns_added() {
+		$addon   = new CampTix_Companion_Tickets_Addon();
+		$columns = $addon->export_extra_columns( array() );
+		$this->assertArrayHasKey( 'companion_of', $columns );
+		$this->assertArrayHasKey( 'companion_tickets', $columns );
+	}
+
+	/**
+	 * The "Activity of" export cell holds the linked main attendee ID for a
+	 * companion row, and is empty for a main row.
+	 */
+	public function test_export_column_companion_of() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( (string) $main_id, $addon->export_column_companion_of( '', get_post( $cd_id ) ) );
+		$this->assertSame( '', $addon->export_column_companion_of( '', get_post( $main_id ) ) );
+	}
+
+	/**
+	 * The "Activity tickets" export cell lists a main attendee's live companions.
+	 */
+	public function test_export_column_companion_tickets() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$value = $addon->export_column_companion_tickets( '', get_post( $main_id ) );
+		$this->assertStringContainsString( 'Contributor Day', $value );
+		$this->assertStringContainsString( (string) $cd_id, $value );
+		// A companion row has no sub-companions → empty.
+		$this->assertSame( '', $addon->export_column_companion_tickets( '', get_post( $cd_id ) ) );
+	}
+
+	/**
+	 * Confirming a companion attendee records that its confirmation email was sent.
+	 */
+	public function test_confirmation_email_sets_sent_flag() {
+		$cd                 = $this->make_ticket( 'Contributor Day' );
+		$opts               = get_option( 'camptix_options', array() );
+		$opts['event_name'] = 'Test Event';
+		update_option( 'camptix_options', $opts );
+		$this->set_companion_config( array( $cd ) );
+
+		$cd_id = $this->make_attendee( $cd, 'alice', 'draft' );
+		update_post_meta( $cd_id, 'tix_email', 'alice@example.test' );
+		update_post_meta( $cd_id, 'tix_first_name', 'Alice' );
+		update_post_meta( $cd_id, 'tix_edit_token', 'tok123' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_send_activity_confirmation( 'publish', 'draft', get_post( $cd_id ) );
+
+		$this->assertSame( '1', (string) get_post_meta( $cd_id, 'tix_companion_confirmation_sent', true ) );
+	}
+
+	/**
+	 * No confirmation email is sent for a non-companion attendee.
+	 */
+	public function test_confirmation_email_skipped_for_non_companion() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$main_id = $this->make_attendee( $main, 'alice', 'draft' );
+		update_post_meta( $main_id, 'tix_email', 'alice@example.test' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_send_activity_confirmation( 'publish', 'draft', get_post( $main_id ) );
+
+		$this->assertSame( '', (string) get_post_meta( $main_id, 'tix_companion_confirmation_sent', true ) );
+	}
+
+	/**
+	 * The flag slug matches the admin-flags settings parser's sanitization, so
+	 * the stored meta value equals the config key.
+	 */
+	public function test_activity_flag_slug_matches_admin_flags_sanitization() {
+		$cd = $this->make_ticket( 'Contributor Day (TEST)' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$slug  = $addon->get_activity_flag_slug( $cd );
+
+		$this->assertSame( sanitize_html_class( sanitize_title_with_dashes( $slug ) ), $slug );
+		$this->assertStringStartsWith( 'activity-', $slug );
+	}
+
+	/**
+	 * Linking a companion seat flags the MAIN attendee, exactly once.
+	 */
+	public function test_flag_added_to_main_on_link() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+
+		$addon    = new CampTix_Companion_Tickets_Addon();
+		$attendee = (object) array( 'ticket_id' => $cd );
+		$addon->link_companion_attendee( $cd_id, $attendee );
+		$addon->link_companion_attendee( $cd_id, $attendee ); // Idempotent.
+
+		$slug  = $addon->get_activity_flag_slug( $cd );
+		$flags = get_post_meta( $main_id, CampTix_Companion_Tickets_Addon::ADMIN_FLAG_META, false );
+		$this->assertSame( array( $slug ), $flags );
+	}
+
+	/**
+	 * Cancelling the companion seat removes the flag from its main again.
+	 */
+	public function test_flag_removed_when_companion_seat_cancelled() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->add_activity_admin_flag( $main_id, $cd );
+		$this->assertNotEmpty( get_post_meta( $main_id, CampTix_Companion_Tickets_Addon::ADMIN_FLAG_META, false ) );
+
+		$addon->maybe_remove_activity_admin_flag( 'cancel', 'publish', get_post( $cd_id ) );
+
+		$this->assertSame( array(), get_post_meta( $main_id, CampTix_Companion_Tickets_Addon::ADMIN_FLAG_META, false ) );
+	}
+
+	/**
+	 * Saving the companion config syncs flag definitions into the admin-flags
+	 * config — preserving organiser-defined flags.
+	 */
+	public function test_flag_config_synced_on_options_save() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+
+		$addon  = new CampTix_Companion_Tickets_Addon();
+		$output = array(
+			'camptix-admin-flags-data-parsed' => array( 'vip' => 'VIP' ),
+			'camptix-admin-flags-data'        => 'vip: VIP',
+		);
+		$input  = array( 'camptix-companion-ticket-ids' => array( $cd ) );
+
+		$output = $addon->validate_options( $output, $input );
+
+		$slug = $addon->get_activity_flag_slug( $cd );
+		$this->assertArrayHasKey( 'vip', $output['camptix-admin-flags-data-parsed'] );
+		$this->assertArrayHasKey( $slug, $output['camptix-admin-flags-data-parsed'] );
+		$this->assertStringContainsString( 'vip: VIP', $output['camptix-admin-flags-data'] );
+		$this->assertStringContainsString( $slug . ': ', $output['camptix-admin-flags-data'] );
+	}
+
+	/**
+	 * The public attendees listing excludes companion seats by default.
+	 */
+	public function test_attendees_listing_excludes_companion_tickets() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$args  = $addon->exclude_companion_attendees_from_listing( array(), array( 'tickets' => '' ) );
+
+		$this->assertSame( 'tix_ticket_id', $args['meta_query'][0]['key'] );
+		$this->assertSame( 'NOT IN', $args['meta_query'][0]['compare'] );
+		$this->assertContains( $cd, $args['meta_query'][0]['value'] );
+	}
+
+	/**
+	 * An explicit tickets="…" attribute (an organiser's deliberate choice, e.g.
+	 * a Contributor Day attendees page) disables the exclusion.
+	 */
+	public function test_attendees_listing_respects_explicit_tickets_attr() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$args  = $addon->exclude_companion_attendees_from_listing( array(), array( 'tickets' => (string) $cd ) );
+
+		$this->assertArrayNotHasKey( 'meta_query', $args );
+	}
+
+	/**
+	 * Transferring a MAIN ticket to a new owner releases the old owner's
+	 * linked companion seats (after the deferred queue runs).
+	 */
+	public function test_transfer_of_main_releases_linked_seats() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		add_action( 'update_post_meta', array( $addon, 'detect_ownership_change' ), 10, 4 );
+		update_post_meta( $main_id, 'tix_username', 'bob' );
+		remove_action( 'update_post_meta', array( $addon, 'detect_ownership_change' ), 10 );
+
+		$this->assertSame( 'publish', get_post_status( $cd_id ), 'Release is deferred, not inline' );
+		$addon->process_deferred_releases();
+
+		$this->assertSame( 'cancel', get_post_status( $cd_id ) );
+		$this->assertSame( 'publish', get_post_status( $main_id ), 'The transferred main itself stays live' );
+	}
+
+	/**
+	 * Transferring the companion seat itself releases it back to the pool.
+	 */
+	public function test_transfer_of_companion_seat_releases_it() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		add_action( 'update_post_meta', array( $addon, 'detect_ownership_change' ), 10, 4 );
+		update_post_meta( $cd_id, 'tix_username', 'bob' );
+		remove_action( 'update_post_meta', array( $addon, 'detect_ownership_change' ), 10 );
+
+		$addon->process_deferred_releases();
+
+		$this->assertSame( 'cancel', get_post_status( $cd_id ) );
+	}
+
+	/**
+	 * Claiming an "[[ unconfirmed ]]" group-purchase seat is first ownership,
+	 * not a transfer — nothing is released.
+	 */
+	public function test_claiming_unconfirmed_seat_is_not_a_transfer() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME, 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		add_action( 'update_post_meta', array( $addon, 'detect_ownership_change' ), 10, 4 );
+		update_post_meta( $main_id, 'tix_username', 'bob' );
+		remove_action( 'update_post_meta', array( $addon, 'detect_ownership_change' ), 10 );
+
+		$addon->process_deferred_releases();
+
+		$this->assertSame( 'publish', get_post_status( $cd_id ) );
+	}
+
+	/**
+	 * The transfer policy filter can opt out of releasing seats.
+	 */
+	public function test_transfer_policy_filter_can_keep_seats() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $cd_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$keep = function () {
+			return 'keep';
+		};
+		add_filter( 'camptix_companion_transfer_policy', $keep );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->handle_ownership_transfer( get_post( $main_id ), 'alice', 'bob' );
+		$addon->process_deferred_releases();
+
+		remove_filter( 'camptix_companion_transfer_policy', $keep );
+
+		$this->assertSame( 'publish', get_post_status( $cd_id ) );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * v0.4.0 — "Your tickets" links + email-me-my-links (dd32's #1371 ask)
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * All of a user's published seats are returned, main tickets first.
+	 */
+	public function test_get_user_seat_ids_returns_published_seats_mains_first() {
+		$main   = $this->make_ticket( 'Main' );
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$this->make_attendee( $dinner, 'alice', 'draft' );
+		$this->make_attendee( $main, 'bob', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertSame( array( $main_id, $cd_id ), $addon->get_user_seat_ids( 'alice' ) );
+	}
+
+	/**
+	 * Anonymous and unconfirmed identities hold no seats.
+	 */
+	public function test_get_user_seat_ids_empty_for_anonymous_and_unconfirmed() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME, 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertSame( array(), $addon->get_user_seat_ids( '' ) );
+		$this->assertSame( array(), $addon->get_user_seat_ids( CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME ) );
+	}
+
+	/**
+	 * The links email goes to the given address and lists every seat's manage link.
+	 */
+	public function test_ticket_links_email_lists_every_seat() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$cd_id   = $this->make_attendee( $cd, 'alice', 'publish' );
+		update_post_meta( $main_id, 'tix_edit_token', 'tok-main-123' );
+		update_post_meta( $cd_id, 'tix_edit_token', 'tok-cd-456' );
+
+		reset_phpmailer_instance();
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$sent  = $addon->send_ticket_links_email( 'alice', 'alice@example.org' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertTrue( $sent );
+		$this->assertSame( 'alice@example.org', $mailer->get_recipient( 'to' )->address );
+		$body = $mailer->get_sent()->body;
+		$this->assertStringContainsString( 'Main', $body );
+		$this->assertStringContainsString( 'Contributor Day', $body );
+		$this->assertStringContainsString( 'tok-main-123', $body );
+		$this->assertStringContainsString( 'tok-cd-456', $body );
+	}
+
+	/**
+	 * No seats — nothing to send.
+	 */
+	public function test_ticket_links_email_requires_seats() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		reset_phpmailer_instance();
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertFalse( $addon->send_ticket_links_email( 'alice', 'alice@example.org' ) );
+		$this->assertFalse( tests_retrieve_phpmailer_instance()->get_sent() );
+	}
+
+	/**
+	 * Repeat requests inside the throttle window do not send again.
+	 */
+	public function test_ticket_links_email_throttled_on_repeat() {
+		$main = $this->make_ticket( 'Main' );
+		$this->set_companion_config( array( $this->make_ticket( 'Contributor Day' ) ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		update_post_meta( $main_id, 'tix_edit_token', 'tok-1' );
+
+		reset_phpmailer_instance();
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertTrue( $addon->send_ticket_links_email( 'alice', 'alice@example.org' ) );
+		$this->assertFalse( $addon->send_ticket_links_email( 'alice', 'alice@example.org' ) );
+		$this->assertCount( 1, tests_retrieve_phpmailer_instance()->mock_sent );
+	}
+
+	/**
+	 * The request handler ignores unrelated requests and rejects bad nonces.
+	 */
+	public function test_links_request_handler_guards() {
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertSame( '', $addon->handle_links_email_request() );
+
+		$_GET['tix_companion_email_links'] = '1';
+		$_GET['_wpnonce']                  = 'bad';
+		$this->assertSame( 'invalid', $addon->handle_links_email_request() );
+		unset( $_GET['tix_companion_email_links'], $_GET['_wpnonce'] );
+	}
+
+	/**
+	 * A logged-in seat-holder's request sends the email to their account address.
+	 */
+	public function test_links_request_handler_sends_for_logged_in_holder() {
+		$main = $this->make_ticket( 'Main' );
+		$this->set_companion_config( array( $this->make_ticket( 'Contributor Day' ) ) );
+
+		$user_id = self::factory()->user->create( array(
+			'user_login' => 'alice',
+			'user_email' => 'alice@example.org',
+		) );
+		wp_set_current_user( $user_id );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		update_post_meta( $main_id, 'tix_edit_token', 'tok-1' );
+
+		reset_phpmailer_instance();
+		$_GET['tix_companion_email_links'] = '1';
+		$_GET['_wpnonce']                  = wp_create_nonce( 'tix-companion-email-links' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 'sent', $addon->handle_links_email_request() );
+		$this->assertSame( 'alice@example.org', tests_retrieve_phpmailer_instance()->get_recipient( 'to' )->address );
+
+		unset( $_GET['tix_companion_email_links'], $_GET['_wpnonce'] );
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * The "Your tickets" notice lists the visitor's seats; anonymous visitors get nothing.
+	 */
+	public function test_my_ticket_links_notice_lists_seats() {
+		$main = $this->make_ticket( 'Main' );
+		$this->set_companion_config( array( $this->make_ticket( 'Contributor Day' ) ) );
+
+		$user_id = self::factory()->user->create( array(
+			'user_login' => 'alice',
+			'user_email' => 'alice@example.org',
+		) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		update_post_meta( $main_id, 'tix_edit_token', 'tok-main-123' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->reset_notices();
+		wp_set_current_user( 0 );
+		$addon->maybe_show_my_ticket_links();
+		$this->assertSame( array(), $this->get_notices() );
+
+		$this->reset_notices();
+		wp_set_current_user( $user_id );
+		$addon->maybe_show_my_ticket_links();
+		$notices = implode( ' ', $this->get_notices() );
+		$this->assertStringContainsString( 'Main', $notices );
+		$this->assertStringContainsString( 'tok-main-123', $notices );
+
+		$this->reset_notices();
+		wp_set_current_user( 0 );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Regression tests for the 2026-08-20 code review — H1 and H2
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Read (and reset) CampTix's checkout error flags (global singleton).
+	 */
+	private function reset_error_flags() {
+		global $camptix;
+		$camptix->error_flags = array();
+	}
+
+	/**
+	 * H1: a `pending` seat drains ticket capacity (camptix.php
+	 * get_purchased_tickets_count), so it must count as a registration too —
+	 * otherwise a mixed-cart seat awaiting payment is invisible to the gate.
+	 */
+	public function test_user_has_registration_counts_pending_seat() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $cd, 'carol', 'pending' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertTrue( $addon->user_has_registration( 'carol', $cd ) );
+	}
+
+	/**
+	 * H1: the duplicate gate must see a pending mixed-cart seat, so a second
+	 * (free, instantly published) checkout cannot double-register and
+	 * double-drain the capacity-limited pool.
+	 */
+	public function test_gate_blocks_duplicate_when_seat_is_pending() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		$this->make_attendee( $cd, 'alice', 'pending' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame(
+			CampTix_Companion_Tickets_Addon::DUPLICATE_FLAG,
+			$addon->should_block_companion_attendee( $cd, 'alice' )
+		);
+	}
+
+	/**
+	 * H1: terminal statuses release the seat, so they must never block a fresh
+	 * registration (the cascade relies on this).
+	 */
+	public function test_user_has_registration_ignores_terminal_seats() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		foreach ( array( 'cancel', 'refund', 'failed', 'timeout' ) as $status ) {
+			$id = $this->make_attendee( $cd, 'dave', $status );
+			$this->assertFalse(
+				$addon->user_has_registration( 'dave', $cd ),
+				"status {$status} must not count as a registration"
+			);
+			wp_delete_post( $id, true );
+		}
+	}
+
+	/**
+	 * H1: a `draft` seat is an order still in flight at the gateway — it has
+	 * not drained capacity yet, but it will if the payment completes, so a
+	 * second registration must be blocked with its own accurate reason.
+	 */
+	public function test_gate_blocks_in_flight_draft_seat() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		$draft_id = $this->make_attendee( $cd, 'alice', 'draft' );
+		update_post_meta( $draft_id, 'tix_timestamp', time() - 60 );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame(
+			CampTix_Companion_Tickets_Addon::IN_PROGRESS_FLAG,
+			$addon->should_block_companion_attendee( $cd, 'alice' )
+		);
+	}
+
+	/**
+	 * H1: past CampTix's own draft-timeout window (review_timeout_payments,
+	 * 24h) an abandoned draft must stop blocking, or the attendee is locked
+	 * out of a seat they never got.
+	 */
+	public function test_gate_allows_when_draft_seat_is_stale() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		$draft_id = $this->make_attendee( $cd, 'alice', 'draft' );
+		update_post_meta( $draft_id, 'tix_timestamp', time() - ( DAY_IN_SECONDS + 60 ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( '', $addon->should_block_companion_attendee( $cd, 'alice' ) );
+	}
+
+	/**
+	 * H1: the in-flight window is filterable, so a camp can tighten it.
+	 */
+	public function test_in_flight_window_is_filterable() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		$draft_id = $this->make_attendee( $cd, 'alice', 'draft' );
+		update_post_meta( $draft_id, 'tix_timestamp', time() - ( 10 * MINUTE_IN_SECONDS ) );
+
+		$addon  = new CampTix_Companion_Tickets_Addon();
+		$shrink = function () {
+			return MINUTE_IN_SECONDS;
+		};
+		add_filter( 'camptix_companion_in_flight_window', $shrink );
+		$this->assertSame( '', $addon->should_block_companion_attendee( $cd, 'alice' ) );
+		remove_filter( 'camptix_companion_in_flight_window', $shrink );
+	}
+
+	/**
+	 * H1: the advisory "Already registered" label describes confirmed seats —
+	 * an in-flight draft is not one, and must not claim otherwise.
+	 */
+	public function test_remaining_label_ignores_in_flight_draft() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$uid      = self::factory()->user->create( array( 'user_login' => 'ivy' ) );
+		$draft_id = $this->make_attendee( $cd, 'ivy', 'draft' );
+		update_post_meta( $draft_id, 'tix_timestamp', time() - 60 );
+		wp_set_current_user( $uid );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->assertSame( 5, $addon->maybe_label_already_registered( 5, (object) array( 'ID' => $cd ) ) );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * H2: the addon header promises the gate fails CLOSED when require-login is
+	 * inactive. require-login is the only thing that sets `$attendee->username`
+	 * during checkout, so a seat without one must be blocked — never attributed
+	 * to whoever happens to be logged in (which would let one buyer take
+	 * quantity N of a capacity-limited seat).
+	 */
+	public function test_gate_fails_closed_when_attendee_object_has_no_username() {
+		global $camptix;
+
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$uid = self::factory()->user->create( array( 'user_login' => 'alice' ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		wp_set_current_user( $uid );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->reset_error_flags();
+		// No ->username: exactly what CampTix passes with require-login inactive.
+		$addon->gate_companion_attendee( (object) array( 'ticket_id' => $cd ), array(), 0 );
+
+		$this->assertArrayHasKey(
+			CampTix_Companion_Tickets_Addon::SELF_ONLY_FLAG,
+			(array) $camptix->error_flags
+		);
+
+		$this->reset_error_flags();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * H2: with a real per-seat identity the gate still allows an eligible seat
+	 * (the fail-closed fix must not block legitimate registrations).
+	 */
+	public function test_gate_allows_seat_with_confirmed_username() {
+		global $camptix;
+
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$this->reset_error_flags();
+		$addon->gate_companion_attendee(
+			(object) array(
+				'ticket_id' => $cd,
+				'username'  => 'alice',
+			),
+			array(),
+			0
+		);
+
+		$this->assertSame( array(), (array) $camptix->error_flags );
+		$this->reset_error_flags();
+	}
+
+	/**
+	 * H2: the linker must not attribute an unidentified seat to whoever is
+	 * logged in — no identity, no link (and so no admin flag either).
+	 */
+	public function test_link_does_not_fall_back_to_current_user() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$uid = self::factory()->user->create( array( 'user_login' => 'alice' ) );
+		$this->make_attendee( $main, 'alice', 'publish' );
+		wp_set_current_user( $uid );
+
+		$cd_id = self::factory()->post->create( array(
+			'post_type'   => 'tix_attendee',
+			'post_status' => 'draft',
+		) );
+		update_post_meta( $cd_id, 'tix_ticket_id', $cd );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->link_companion_attendee( $cd_id, (object) array( 'ticket_id' => $cd ) );
+
+		$this->assertSame( '', (string) get_post_meta( $cd_id, 'tix_companion_primary_attendee_id', true ) );
+
+		wp_set_current_user( 0 );
+	}
+
+	/*
+	 * -------------------------------------------------------------------------
+	 * Regression tests for the 2026-08-20 code review — M1 and M2
+	 * -------------------------------------------------------------------------
+	 */
+
+	/**
+	 * Set up one main attendee, one linked+flagged companion seat.
+	 *
+	 * @param string $seat_status Status to create the companion seat in.
+	 * @return array{addon:CampTix_Companion_Tickets_Addon,main_id:int,seat_id:int,ticket_id:int,slug:string}
+	 */
+	private function make_linked_seat( $seat_status = 'publish' ) {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$seat_id = $this->make_attendee( $cd, 'alice', $seat_status );
+		update_post_meta( $seat_id, 'tix_companion_primary_attendee_id', $main_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->add_activity_admin_flag( $main_id, $cd );
+		$this->assertNotEmpty(
+			get_post_meta( $main_id, CampTix_Companion_Tickets_Addon::ADMIN_FLAG_META, false ),
+			'fixture: the flag should be on the main attendee to start with'
+		);
+
+		return array(
+			'addon'     => $addon,
+			'main_id'   => $main_id,
+			'seat_id'   => $seat_id,
+			'ticket_id' => $cd,
+			'slug'      => $addon->get_activity_flag_slug( $cd ),
+		);
+	}
+
+	/**
+	 * The flags currently on an attendee.
+	 *
+	 * @param int $post_id Attendee post ID.
+	 * @return string[]
+	 */
+	private function get_admin_flags( $post_id ) {
+		return (array) get_post_meta( $post_id, CampTix_Companion_Tickets_Addon::ADMIN_FLAG_META, false );
+	}
+
+	/**
+	 * M1: trash is reachable from the organiser UI (tix_attendee has show_ui and
+	 * mapped delete caps), so trashing a main attendee — duplicate or fraud
+	 * cleanup — must release its companion seats, not leave them live and
+	 * holding capacity.
+	 */
+	public function test_trashing_main_cancels_linked_companions() {
+		$f = $this->make_linked_seat();
+
+		add_action( 'transition_post_status', array( $f['addon'], 'maybe_cascade_cancel' ), 10, 3 );
+		wp_trash_post( $f['main_id'] );
+		remove_action( 'transition_post_status', array( $f['addon'], 'maybe_cascade_cancel' ), 10 );
+
+		$this->assertSame( 'cancel', get_post_status( $f['seat_id'] ) );
+	}
+
+	/**
+	 * M1: force-delete fires only `before_delete_post`/`deleted_post`, which the
+	 * addon did not hook at all — so a deleted main left its seats live forever.
+	 */
+	public function test_force_deleting_main_cancels_linked_companions() {
+		$f = $this->make_linked_seat();
+
+		add_action( 'before_delete_post', array( $f['addon'], 'maybe_release_on_delete' ), 10, 2 );
+		wp_delete_post( $f['main_id'], true );
+		remove_action( 'before_delete_post', array( $f['addon'], 'maybe_release_on_delete' ), 10 );
+
+		$this->assertSame( 'cancel', get_post_status( $f['seat_id'] ) );
+	}
+
+	/**
+	 * M1: trashing the companion seat itself must take the flag off its main,
+	 * or the organiser filter/column/export the flag exists to power lies.
+	 */
+	public function test_trashing_companion_seat_removes_flag() {
+		$f = $this->make_linked_seat();
+
+		$f['addon']->maybe_remove_activity_admin_flag( 'trash', 'publish', get_post( $f['seat_id'] ) );
+
+		$this->assertSame( array(), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * M1: same for a force-deleted companion seat — the flag lives on the main,
+	 * which survives, so nothing else would ever clean it up.
+	 */
+	public function test_force_deleting_companion_seat_removes_flag() {
+		$f = $this->make_linked_seat();
+
+		add_action( 'before_delete_post', array( $f['addon'], 'maybe_release_on_delete' ), 10, 2 );
+		wp_delete_post( $f['seat_id'], true );
+		remove_action( 'before_delete_post', array( $f['addon'], 'maybe_release_on_delete' ), 10 );
+
+		$this->assertSame( array(), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * M2: the flag is added from `camptix_checkout_update_post_meta`, while the
+	 * seat is still a draft — i.e. before payment. An abandoned or declined
+	 * mixed-cart order ends at `failed`, which must clear the flag again.
+	 */
+	public function test_failed_order_removes_activity_flag() {
+		$f = $this->make_linked_seat( 'draft' );
+
+		$f['addon']->maybe_remove_activity_admin_flag( 'failed', 'draft', get_post( $f['seat_id'] ) );
+
+		$this->assertSame( array(), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * M2: and `timeout`, which is where CampTix's daily
+	 * `review_timeout_payments()` parks a draft nobody ever paid for.
+	 */
+	public function test_timed_out_order_removes_activity_flag() {
+		$f = $this->make_linked_seat( 'draft' );
+
+		$f['addon']->maybe_remove_activity_admin_flag( 'timeout', 'draft', get_post( $f['seat_id'] ) );
+
+		$this->assertSame( array(), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * M2 guard against over-fixing: the happy path — a draft seat confirming to
+	 * publish — must KEEP the flag.
+	 */
+	public function test_confirming_companion_seat_keeps_flag() {
+		$f = $this->make_linked_seat( 'draft' );
+
+		$f['addon']->maybe_remove_activity_admin_flag( 'publish', 'draft', get_post( $f['seat_id'] ) );
+		$f['addon']->maybe_remove_activity_admin_flag( 'publish', 'pending', get_post( $f['seat_id'] ) );
+
+		$this->assertSame( array( $f['slug'] ), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * M1/M2 guard: a live main ticket must never have its seats cascaded away by
+	 * an ordinary status change.
+	 */
+	public function test_non_terminal_transition_does_not_cascade() {
+		$f = $this->make_linked_seat();
+
+		$f['addon']->maybe_cascade_cancel( 'publish', 'pending', get_post( $f['main_id'] ) );
+
+		$this->assertSame( 'publish', get_post_status( $f['seat_id'] ) );
+	}
+
+	/**
+	 * M1: deleting a post that is not an attendee at all is a no-op.
+	 */
+	public function test_delete_handler_ignores_other_post_types() {
+		$f       = $this->make_linked_seat();
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		add_action( 'before_delete_post', array( $f['addon'], 'maybe_release_on_delete' ), 10, 2 );
+		wp_delete_post( $page_id, true );
+		remove_action( 'before_delete_post', array( $f['addon'], 'maybe_release_on_delete' ), 10 );
+
+		$this->assertSame( 'publish', get_post_status( $f['seat_id'] ) );
+		$this->assertSame( array( $f['slug'] ), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * Read CampTix's buffered front-end errors (global singleton).
+	 */
+	private function get_errors() {
+		global $camptix;
+		$ref = new \ReflectionObject( $camptix );
+		if ( ! $ref->hasProperty( 'errors' ) ) {
+			return array();
+		}
+		$p = $ref->getProperty( 'errors' );
+		return (array) $p->getValue( $camptix );
+	}
+
+	/**
+	 * H3: a second activity seat in the buyer's OWN order must not be told to
+	 * "log in and register for yourself" -- they did exactly that.
+	 *
+	 * The require-login addon gives the real username only to seat #1 and marks every
+	 * later seat in the order `[[ unconfirmed ]]`, so an eligible logged-in attendee who
+	 * selects two activities together trips the self-only branch on seat #2.
+	 */
+	public function test_h3_second_seat_of_own_order_reports_one_at_a_time() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$user_id = self::factory()->user->create( array( 'user_login' => 'dana' ) );
+		$this->make_attendee( $main, 'dana', 'publish' );
+		wp_set_current_user( $user_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertSame(
+			CampTix_Companion_Tickets_Addon::ONE_AT_A_TIME_FLAG,
+			$addon->should_block_companion_attendee( $cd, CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME )
+		);
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * H3: an unconfirmed seat with nobody logged in is still a self-only case.
+	 */
+	public function test_h3_anonymous_unconfirmed_seat_still_reports_self_only() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		wp_set_current_user( 0 );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertSame(
+			CampTix_Companion_Tickets_Addon::SELF_ONLY_FLAG,
+			$addon->should_block_companion_attendee( $cd, CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME )
+		);
+	}
+
+	/**
+	 * H3: "one at a time" is only accurate for someone who could register at all.
+	 *
+	 * A logged-in visitor with no qualifying main ticket keeps the self-only message
+	 * rather than being told to finish an order they cannot place.
+	 */
+	public function test_h3_logged_in_without_a_main_ticket_still_reports_self_only() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$user_id = self::factory()->user->create( array( 'user_login' => 'erin' ) );
+		wp_set_current_user( $user_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertSame(
+			CampTix_Companion_Tickets_Addon::SELF_ONLY_FLAG,
+			$addon->should_block_companion_attendee( $cd, CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME )
+		);
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * H3: the fix changes the message, never the decision -- every unconfirmed or
+	 * anonymous seat is still refused.
+	 */
+	public function test_h3_gate_decision_is_unchanged_for_unconfirmed_seats() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$user_id = self::factory()->user->create( array( 'user_login' => 'fred' ) );
+		$this->make_attendee( $main, 'fred', 'publish' );
+		wp_set_current_user( $user_id );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+
+		$this->assertNotSame( '', $addon->should_block_companion_attendee( $cd, CampTix_Companion_Tickets_Addon::UNCONFIRMED_USERNAME ) );
+		$this->assertNotSame( '', $addon->should_block_companion_attendee( $cd, '' ) );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * H3: the new message says what to do and drops the false "log in" advice.
+	 */
+	public function test_h3_one_at_a_time_error_copy_is_accurate() {
+		$this->reset_notices();
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->render_gate_errors( array( CampTix_Companion_Tickets_Addon::ONE_AT_A_TIME_FLAG => true ) );
+
+		$errors = implode( ' ', $this->get_errors() );
+
+		$this->assertStringContainsString( 'one at a time', $errors );
+		$this->assertStringNotContainsString( 'log in', $errors );
+
+		$this->reset_notices();
+	}
+
+	/**
+	 * H3: an eligible visitor is told up front that activities go one per order,
+	 * instead of discovering it as a wrong error at checkout.
+	 */
+	public function test_h3_notice_tells_an_eligible_visitor_to_register_one_at_a_time() {
+		$main   = $this->make_ticket( 'Main' );
+		$cd     = $this->make_ticket( 'Contributor Day' );
+		$dinner = $this->make_ticket( 'Social Dinner' );
+		$this->set_companion_config( array( $cd, $dinner ) );
+
+		$user_id = self::factory()->user->create( array( 'user_login' => 'gina' ) );
+		$this->make_attendee( $main, 'gina', 'publish' );
+		wp_set_current_user( $user_id );
+
+		$this->reset_notices();
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_show_eligibility_notice();
+
+		$notices = implode( ' ', $this->get_notices() );
+
+		$this->assertStringContainsString( 'one at a time', $notices );
+
+		$this->reset_notices();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * M4: the flag slug used at link time is recorded on the seat.
+	 *
+	 * `get_activity_flag_slug()` derives from the ticket's `post_name`, which is
+	 * mutable -- empty on a draft, rewritten on publish, editable at any time. Without
+	 * recording what was actually written, removal has to guess.
+	 */
+	public function test_m4_flag_slug_is_recorded_on_the_seat() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$seat_id = $this->make_attendee( $cd, 'alice', 'publish' );
+
+		$addon    = new CampTix_Companion_Tickets_Addon();
+		$attendee = (object) array(
+			'ticket_id' => $cd,
+			'username'  => 'alice',
+		);
+		$addon->link_companion_attendee( $seat_id, $attendee );
+
+		$this->assertSame(
+			$addon->get_activity_flag_slug( $cd ),
+			get_post_meta( $seat_id, 'tix_companion_activity_flag', true )
+		);
+	}
+
+	/**
+	 * M4: a ticket slug that changes after the seat was linked must not orphan the flag.
+	 *
+	 * A draft ticket has no `post_name`, so it flags as `activity-ticket-{ID}` and
+	 * becomes `activity-contributor-day` on publish. Recomputing at removal time then
+	 * deletes a value that was never stored and leaves the real flag forever.
+	 */
+	public function test_m4_removal_survives_a_ticket_slug_change() {
+		$main = $this->make_ticket( 'Main' );
+		$cd   = self::factory()->post->create( array(
+			'post_type'   => 'tix_ticket',
+			'post_status' => 'publish',
+			'post_title'  => 'Contributor Day',
+			'post_name'   => 'contributor-day',
+		) );
+		update_post_meta( $cd, 'tix_price', 0 );
+		update_post_meta( $cd, 'tix_quantity', 100 );
+		$this->set_companion_config( array( $cd ) );
+
+		$main_id = $this->make_attendee( $main, 'alice', 'publish' );
+		$seat_id = $this->make_attendee( $cd, 'alice', 'publish' );
+
+		$addon    = new CampTix_Companion_Tickets_Addon();
+		$attendee = (object) array(
+			'ticket_id' => $cd,
+			'username'  => 'alice',
+		);
+		$addon->link_companion_attendee( $seat_id, $attendee );
+
+		$flag_at_link_time = $addon->get_activity_flag_slug( $cd );
+		$this->assertSame( array( $flag_at_link_time ), $this->get_admin_flags( $main_id ) );
+
+		// The organiser renames the ticket slug.
+		wp_update_post( array(
+			'ID' => $cd, 'post_name' => 'contributor-day-2027',
+		) );
+		$this->assertNotSame( $flag_at_link_time, $addon->get_activity_flag_slug( $cd ) );
+
+		$addon->maybe_remove_activity_admin_flag( 'cancel', 'publish', get_post( $seat_id ) );
+
+		$this->assertSame( array(), $this->get_admin_flags( $main_id ) );
+	}
+
+	/**
+	 * M4: a seat linked before the slug was recorded still has its flag removed.
+	 */
+	public function test_m4_removal_falls_back_for_a_seat_with_no_recorded_slug() {
+		$f = $this->make_linked_seat();
+
+		delete_post_meta( $f['seat_id'], 'tix_companion_activity_flag' );
+		$this->assertSame( array( $f['slug'] ), $this->get_admin_flags( $f['main_id'] ) );
+
+		$f['addon']->maybe_remove_activity_admin_flag( 'cancel', 'publish', get_post( $f['seat_id'] ) );
+
+		$this->assertSame( array(), $this->get_admin_flags( $f['main_id'] ) );
+	}
+
+	/**
+	 * M3: an activity flag with no admin-flags config entry is destroyed on the next
+	 * manual save of that attendee.
+	 *
+	 * The admin-flags addon's own `save_post` (admin-flags.php:251) deletes EVERY
+	 * `camptix-admin-flag` row and re-adds only slugs present in its parsed config, so
+	 * any activity flag missing from that config is silently lost. The reachable trigger
+	 * is saving the Activity Tickets config while admin-flags is inactive, which makes
+	 * `sync_activity_admin_flag_config()` early-return.
+	 *
+	 * The config is therefore re-checked in wp-admin and repaired.
+	 */
+	public function test_m3_missing_config_entry_is_healed() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$slug  = $addon->get_activity_flag_slug( $cd );
+
+		// As if the config had been saved while admin-flags was inactive.
+		$this->set_admin_flags_config( array() );
+		$this->assertArrayNotHasKey( $slug, $this->get_admin_flags_config() );
+
+		$addon->maybe_heal_activity_admin_flag_config();
+
+		$this->assertArrayHasKey(
+			$slug,
+			$this->get_admin_flags_config(),
+			'admin-flags re-adds only configured slugs, so the flag needs an entry to survive a save.'
+		);
+	}
+
+	/**
+	 * M3: healing must not trample flags an organiser defined by hand.
+	 */
+	public function test_m3_healing_preserves_organiser_defined_flags() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$this->set_admin_flags_config( array( 'vip' => 'VIP guest' ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_heal_activity_admin_flag_config();
+
+		$config = $this->get_admin_flags_config();
+
+		$this->assertSame( 'VIP guest', $config['vip'] );
+		$this->assertArrayHasKey( $addon->get_activity_flag_slug( $cd ), $config );
+	}
+
+	/**
+	 * M3: the raw textarea value has to stay in step with the parsed config, or the
+	 * next save of the Admin Flags section drops the entries again.
+	 */
+	public function test_m3_healing_keeps_the_raw_config_in_step() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+		$this->set_admin_flags_config( array() );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_heal_activity_admin_flag_config();
+
+		$options = (array) get_option( 'camptix_options', array() );
+		$slug    = $addon->get_activity_flag_slug( $cd );
+
+		$this->assertStringContainsString( $slug, (string) $options['camptix-admin-flags-data'] );
+	}
+
+	/**
+	 * M3: a complete config is left exactly as it is.
+	 */
+	public function test_m3_healing_is_a_no_op_when_the_config_is_complete() {
+		$cd = $this->make_ticket( 'Contributor Day' );
+		$this->set_companion_config( array( $cd ) );
+
+		$addon = new CampTix_Companion_Tickets_Addon();
+		$addon->maybe_heal_activity_admin_flag_config();
+
+		$before = get_option( 'camptix_options' );
+
+		$addon->maybe_heal_activity_admin_flag_config();
+
+		$this->assertSame( $before, get_option( 'camptix_options' ) );
+	}
+
+	/**
+	 * Replace the admin-flags parsed config.
+	 *
+	 * @param array $flags slug => label.
+	 */
+	private function set_admin_flags_config( $flags ) {
+		global $camptix;
+		$options                                    = (array) get_option( 'camptix_options', array() );
+		$options['camptix-admin-flags-data-parsed'] = $flags;
+
+		$lines = array();
+		foreach ( $flags as $slug => $label ) {
+			$lines[] = sprintf( '%s: %s', $slug, $label );
+		}
+		$options['camptix-admin-flags-data'] = implode( "\n", $lines );
+
+		update_option( 'camptix_options', $options );
+		$camptix->load_options();
+	}
+
+	/**
+	 * The admin-flags parsed config.
+	 *
+	 * @return array
+	 */
+	private function get_admin_flags_config() {
+		$options = (array) get_option( 'camptix_options', array() );
+
+		return isset( $options['camptix-admin-flags-data-parsed'] ) ? (array) $options['camptix-admin-flags-data-parsed'] : array();
+	}
+}


### PR DESCRIPTION
**Implements #1371** — "Tickets: Add the ability to handle secondary event tickets". See #1954 for the proposal and its open questions. Also **resolves the structural need in #598**, and **addresses the #623 double-listing** for activity seats specifically.

One PR rather than two: the test suite covers the whole add-on in one file, and the gate fixes touch the earliest code, so a split would divide the suite without making either half easier to review. Happy to restage if reviewers prefer it.

## What this adds

A CampTix add-on, `camptix-companion-tickets`, that lets a confirmed event-ticket holder register themselves for **free, capacity-limited side events** — Contributor Day, a social dinner, a workshop — without an organizer handling it.

Organizers pick which tickets are activity tickets under **CampTix → Setup → Activity Tickets**, and optionally restrict which main tickets qualify. Everything else follows from that:

- **A configurable set**, not a single extra. Each activity ticket keeps its own capacity, and one person can hold one of each.
- **Gated to ticket holders.** Eligible only while logged in and already holding a qualifying main ticket. A combined main-plus-activity cart is refused, and an activity ticket never itself qualifies as a main.
- **Linked both ways.** Each activity seat stores `tix_companion_primary_attendee_id` pointing at its main attendee; the reverse is a meta query, so a main can carry any number of activities.
- **Refund-aware.** A main ticket reaching a terminal status cancels every linked activity seat and returns them to their pools. Refund is terminal by design — no auto-restore, because restoring into a capacity-limited pool oversells it.
- **Honest UI.** The selection screen tells an ineligible visitor what the requirement is, and tells a holder they are already registered — with a per-row label — instead of letting a held ticket appear to vanish. These are advisory; the checkout gate stays authoritative.
- **Organizer visibility.** Attendee CSV/XML exports gain "Activity of (main ticket #)" and "Activity tickets" columns. With the Admin Flags add-on active, the main attendee is flagged per held activity (`activity-<ticket-slug>`) for list filtering, exports, and integrations (#1383, #1351) — a soft dependency that writes nothing when admin-flags is absent.
- **Dedupe on the public Attendees page.** Activity seats are excluded from `[camptix_attendees]` so each person lists once; an explicit `tickets="…"` attribute is respected, so a per-activity attendees page still works.
- **Transfer-aware.** A ticket changing hands releases the affected activity seats back to their pools (`camptix_companion_transfer_policy`, default `release`).
- **"Email me my ticket links"** — dd32's ask in #1371: a logged-in attendee can have their own seat links mailed to their account address, throttled.

**Naming:** the user-facing label is "Activity ticket". The directory, class, option keys and meta stay `companion-tickets`, so stored configuration and existing links are unaffected — only display strings changed. The label was endorsed in the make/community thread.

## Dependency

Requires the CampTix **require-login** add-on, whose `tix_username` is the identity this whole gate rests on. It is default-on for WordCamps. If it is inactive an admin notice shows and registration **fails closed** — which is now true, having been the substance of one of the fixed defects rather than a claim in a readme.

## The gate

| Rule | Why |
|---|---|
| Must be logged in; no resolvable username means blocked | This is the identity the one-per-attendee and ownership rules depend on. There is deliberately no current-user fallback: falling back would let an unidentified seat be linked to whoever happened to be logged in. |
| Must already hold a qualifying main ticket, counted across `publish` **and** `pending` | `pending` seats hold capacity in CampTix's own `get_purchased_tickets_count()`, so ignoring them let one person register twice and drain a limited pool twice. |
| A `draft` order still inside `camptix_companion_in_flight_window` (default `DAY_IN_SECONDS`) blocks under its own message | An order at the gateway is not yet a registration, but it can still complete, so it cannot be treated as absent either. |
| One seat per attendee per activity ticket | Capacity is the point. |
| A buyer's "additional attendee" seats are refused | Otherwise one buyer drains several capacity-limited seats in a single order. |
| An activity ticket never qualifies as a main | Otherwise activities bootstrap each other. |

**Deliberate trade-off, stated rather than buried:** someone who abandons a gateway redirect is blocked from re-registering for up to 24 hours. The message says the seat releases itself and when. The alternative — treating an in-flight order as absent — oversells the pool the moment that payment completes. The window is filterable.

## Failure modes → end states

| Failure | End state |
|---|---|
| Gateway reports the same completed payment twice | One seat, one confirmation email. Dedupe is a flag on the attendee, not a guess about timing. |
| Attendee abandons the gateway redirect | Seat blocked under `IN_PROGRESS`, with copy naming the release. After the window it is registerable again; if the payment does complete, the seat is theirs and no capacity was oversold. |
| `require-login` inactive | Admin notice, and registration fails closed. No seat is created and nothing is linked to an unidentified user. |
| Main ticket refunded, cancelled, trashed, failed or timed out | Every linked activity seat is cancelled and its admin flag removed, through one shared terminal-status list so the two paths cannot drift apart. |
| Main ticket force-deleted (`wp_delete_post( $id, true )`) | Same release, via `before_delete_post` — which is the only hook that fires on a force-delete. |
| Ticket changes hands | Affected seats released to their pools, deferred to `shutdown` because CampTix rewrites the attendee post immediately after the hook and an inline cancel would be clobbered. |
| Admin Flags add-on absent | Nothing is written. The feature degrades to "no flags", not to an error. |
| Two activities selected in one checkout | Refused, and told plainly that activities are registered one at a time — the selection screen says so before checkout too. Whether the cart *should* accept both is #1954 q1. |
| Admin Flags config missing an activity slug | Repaired in wp-admin before it can bite. Admin Flags deletes every flag row on save and re-adds only configured slugs, so a missing entry meant the flag was destroyed on the next manual save of that attendee. |
| An activity ticket's slug changes after publish | The flag still comes off. The slug used at link time is recorded on the seat, so removal is not at the mercy of a `post_name` that has since changed. |

## Implementation notes

- **No CampTix core changes.** The add-on hangs off existing hooks; the Tools screen already dispatches unknown sections via `do_action( 'camptix_menu_tools_' . $section )`, and the attendees listing is filtered through `camptix_attendees_shortcode_query_args`.
- **One shared terminal-status list** drives both the cascade and the flag removal, with the workers extracted so the force-delete handler reuses them rather than reimplementing the same walk.
- **Attendees transients are flushed on setup save**, because the shortcode's cache key hashes only its attributes and would otherwise serve a listing computed under the old configuration.
- **Reverse lookups are meta queries**, not a stored array, so the number of activities per main is not capped by a schema decision.
- **Transfer detection uses the `update_post_meta` pre-action** so the old username is still readable, and ignores a first claim of an `[[ unconfirmed ]]` seat, which is first ownership rather than a transfer.
- **The links email only ever goes to the requester's own account address**, never to an address from the request, so it cannot be used to enumerate or to mail-bomb.

## What this does not include

- **Multi-activity checkout.** One activity per order in v1 — see #1954 q1.
- **Re-linking a released seat** to another qualifying main the same person still holds.
- **Per-activity eligibility** (a workshop that requires Contributor Day). The qualifying set is currently global, which the community thread asked about twice.
- **A truly non-selectable row** for an activity the visitor already holds. The current label is advisory; making the row unselectable needs a small CampTix core filter and belongs in its own proposal.
- **The general #623 case** — two independent main tickets held by one person. Only the activity-seat half is addressed here.

## i18n

All strings are in the `wordcamporg` domain, matching the rest of the CampTix add-ons — 30 uses.

## Tests

**86 tests / 153 assertions**, in a new `CampTix Activity Tickets` suite wired into the repo harness
(`phpunit.xml.dist` testsuite plus the add-on's `tests/bootstrap.php` required from
`phpunit-bootstrap.php`). Zero PHPUnit warnings, zero database-error noise.

Attendee-creating tests provision the central WordCamp root blog through camptix's
`CampTix_Root_Blog_Fixture`, because saving a `tix_attendee` reaches
`CampTix_Plugin::is_wordcamp_closed()` → `get_wordcamp_post()` → `switch_to_blog()`. Without it the
run emits "table doesn't exist" errors, which this repo's PHPUnit bootstrap treats as a build
failure even when every assertion passes — so the suite was green locally and would have been red
in CI.

Coverage, by concern:

| Concern | What is pinned |
|---|---|
| **The gate** | Per-ticket independence; one seat per attendee per activity; a `pending` seat counted as held, because it holds capacity in CampTix's own count; an in-flight `draft` order refused under its own message; an activity ticket never qualifying as a main; a combined cart refused; no resolvable username failing closed; and an eligible seat still allowed, so the fail-closed fix cannot over-block |
| **The refusal messages** | A second seat in the buyer's own order is told activities go one at a time, not to log in; an anonymous seat still gets the self-only message; a logged-in visitor with no main ticket still gets the self-only message, because "one at a time" would be false for them; the selection screen says so up front; and the decision is identical on every branch |
| **Linking and cascade** | Two-way links; cancel-all on every terminal status (`refund`, `cancel`, `trash`, `failed`, `timeout`); a non-terminal transition not cascading; flag removal on the same shared list; force-delete released through `before_delete_post`; a non-attendee delete a no-op |
| **The admin flag** | Recorded on the seat at link time; removal surviving a ticket-slug change after linking; a seat with no recorded slug still cleaned up; config repair adding a missing entry, preserving organizer-defined flags, keeping the raw textarea in step, and doing nothing when the config is already complete |
| **Organizer surface** | Export columns in both directions; listing exclusion and the explicit `tickets="…"` bypass |
| **Transfer** | Main transferred, seat transferred, an unconfirmed first claim ignored as first ownership rather than a transfer, and the policy filter honoured |
| **Links email** | Throttling; the requester's own address only; the nonce'd request path; and the notice offering it |

Thirteen of these tests are new with this change, all red before their fix. Nineteen more were added
on 2026-08-27 for the earlier four, twelve of them red first. That matters as a statement about the
suite this replaces: **54 tests were green while all seven defects were present.**

## Verified / not verified

- **Test suite**: `OK (86 tests, 153 assertions)` on PHP 8.4, zero warnings, zero DB-error noise.
- **Whole-repo suite, measured both ways on the same base and the same container**: **1,308 tests
  with this branch, 1,222 without it** — a difference of exactly **86 tests and 153 assertions**,
  which is this add-on's suite and nothing else. Both runs end on an **identical** failure set: 16
  errors, 42 failures, 6 skipped, and the 64 named cases diff clean against each other. None of them
  belong to this add-on; they are a docker image without `intl`, a missing `wp-cldr`, and unbuilt
  Groups JS. So this branch adds tests and regresses nothing.
- **phpcs**: 0 errors and 0 warnings across the add-on, against this repo's `phpcs.xml.dist` on the
  current base.
- **Live smoke, 40/40**, on a sandbox multisite with **require-login and camptix-admin-flags actually
  active** and two activity tickets configured: the gate, per-ticket independence, two-way links,
  capacity exhaustion, cascade cancelling both seats and returning both to their pools, flags set and
  removed live, the attendees-listing filter coexisting with require-login's own query clause,
  deferred transfer releases for both a main and a seat, and the whole links-email path including
  throttling and nonce rejection.
- **Not verified yet: the manual browser pass.** _(To be added, with screenshots: the selection
  screen for an ineligible visitor, for an eligible one, and for a holder; and the admin attendee
  screen showing the activity flag.)_

## Open questions carried over from #1954

1. **Multi-activity checkout, or one per order?** This is the H3 scope half. One per order is what the code does and what the corrected copy will say; accepting N distinct activities for a confirmed buyer is the alternative, and the per-ticket duplicate gate would still apply.
2. **Confirmation email wording** — currently a dedicated send; it could instead be an organizer-editable template.
3. **Advisory label or unselectable row** for an already-held activity, given the core filter that the stricter version needs.
4. **The Contributor Day data requirement** raised in the community thread — interested teams, main team, prior contribution, prior CD attendance, skill level, for splitting tables and printing signs. Out of scope here; it wants its own issue, and this add-on making activity attendees real CampTix attendees is what makes it addressable at all.

## How to test

1. On a test camp site with CampTix, **require-login** and (optionally) **camptix-admin-flags** active, create a paid main ticket and two free, quantity-limited tickets — say Contributor Day and Social Dinner.
2. Under **CampTix → Setup → Activity Tickets**, mark both as activity tickets and set the main ticket as qualifying.
3. While logged out, open the tickets page: the activity tickets explain the requirement rather than offering themselves.
4. Buy the main ticket as a logged-in user. Return to the tickets page and register for Contributor Day; confirm the seat is created, linked to the main ticket, and confirmed by email.
5. Register for Social Dinner separately and confirm both seats are held independently.
6. Try registering for Contributor Day again: refused as already registered, and the row says so.
7. Exhaust one activity's quantity from another account and confirm it sells out without affecting the other.
8. Refund or cancel the main ticket. Confirm **both** activity seats are cancelled, returned to their pools, and their admin flags removed. Repeat with Trash, and with a permanent delete.
9. Check the attendee export for both new columns, and the public `[camptix_attendees]` page for a single listing per person.
10. Deactivate **require-login** and confirm the admin notice appears and registration is refused.

## Post-merge follow-ups (not in this PR)

- The #1954 q1 answer, if it is "allow N per cart".
- Re-linking a released seat; per-activity eligibility; a self-service "my tickets" area.
- The Contributor Day data fields, as its own issue against #598.
- An add/remove API on camptix-admin-flags, which is what would let M3 be fixed at the root rather than worked around.
