### PR TITLE
Budgets: offer the privacy exporters to the personal data tools only

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/privacy.php
@@ -40,6 +40,20 @@ function is_cli_request() {
 
 
 /**
+ * Whether the request is one that runs WordPress' personal data tools.
+ *
+ * Matches the branch of `bootstrap.php` that used to load this whole file, before the attachment guards above
+ * needed it everywhere: the admin screens, the Ajax callbacks behind them, and cron. See
+ * `register_personal_data_exporters()` for what turns on it.
+ *
+ * @return bool
+ */
+function is_personal_data_tool_request() {
+	return is_admin() || wp_doing_cron() || wp_doing_ajax();
+}
+
+
+/**
  * The post types this file acts on.
  *
  * Duplicates the `POST_TYPE` constants in `reimbursement-request.php` and `payment-request.php` rather than
@@ -464,11 +478,23 @@ function register_personal_data_erasers( $erasers ) {
 /**
  * Registers the personal data exporter for each WordCamp post type.
  *
+ * Only offered to the requests that run WordPress' personal data tools, because a registered exporter is not
+ * free: WordPress.org's erasure preflight crawls the network over REST, runs every exporter each site offers,
+ * and stops the erasure with a `has_exportable` warning for any that answers with data. Budget requests are
+ * kept for accounting, so `register_personal_data_erasers()` is a deliberate stub and that warning has nothing
+ * to clear it -- an erasure request from anyone who ever filed a reimbursement or was paid as a vendor would
+ * sit in the DPO queue for good. This file loading on every request is what the attachment guards above need;
+ * it wasn't a decision to start declaring budget data to the network's privacy tooling.
+ *
  * @param array $exporters
  *
  * @return array
  */
 function register_personal_data_exporters( $exporters ) {
+	if ( ! is_personal_data_tool_request() ) {
+		return $exporters;
+	}
+
 	$exporters['wcb-reimbursements'] = array(
 		'exporter_friendly_name' => __( 'WordCamp Reimbursement Requests', 'wordcamporg' ),
 		'callback'               => __NAMESPACE__ . '\reimbursements_exporter',

--- a/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/tests/test-privacy.php
@@ -572,6 +572,43 @@ class Test_Privacy extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The exporters stay out of every request that isn't running the personal data tools.
+	 *
+	 * WordPress.org's erasure preflight crawls the network over REST and runs whatever exporters each site
+	 * offers. Anything that answers with data stops the erasure with a `has_exportable` warning, and budget
+	 * requests are kept for accounting, so the eraser is a stub and that warning has nothing to clear it --
+	 * every former organizer's erasure request would sit in the DPO queue for good.
+	 *
+	 * @dataProvider data_screens_and_the_exporters_they_see
+	 *
+	 * @param string $screen    The screen to run the filter under. `front` is the shape the preflight
+	 *                          arrives in; `dashboard` is the personal data tools themselves.
+	 * @param array  $expected  The exporter keys the filter should add.
+	 */
+	public function test_exporters_are_offered_to_the_personal_data_tools_only( $screen, array $expected ) {
+		set_current_screen( $screen );
+
+		$exporters = \WordCamp\Budgets\Privacy\register_personal_data_exporters( array() );
+
+		set_current_screen( 'front' );
+
+		$this->assertSame( $expected, array_keys( $exporters ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function data_screens_and_the_exporters_they_see() {
+		return array(
+			'a front-end request, as the preflight arrives' => array( 'front', array() ),
+			'the admin, where the tools run'                => array(
+				'dashboard',
+				array( 'wcb-reimbursements', 'wcb-vendor-payments' ),
+			),
+		);
+	}
+
+	/**
 	 * The people who are supposed to see the files.
 	 *
 	 * @return array


### PR DESCRIPTION
Fixes the data erasure requests that have been stopping with `has_exportable` warnings for `wcb-reimbursements` / `wcb-vendor-payments`.

## Cause

#1959 moved `privacy.php` out of the admin-only branch of `bootstrap.php`, so the payment file visibility guards would cover REST and XML-RPC. That also registered its two personal data exporters outside `wp-admin` for the first time. WordPress.org's erasure preflight collects whatever exporters a site offers and blocks on any that returns content it has no erasure handler for. Budget records are deliberately kept for accounting, so nothing can clear that — the requests stop permanently.

#1971 fixed a fatal on the same path, which is why the failures changed shape rather than started there.

## Fix

Scope the exporters back to the requests that run the personal data tools, which is where they were before #1959.

The attachment guards are untouched — `privacy.php` still loads on every request, and all six of #1959's hooks are unchanged.

## Testing

Verified on a sandbox against production data, calling the preflight callback directly for one of the affected addresses. Read-only — it only computes a verdict. Needs a sandbox shell:

```bash
for SITE in central.wordcamp.org maine.wordcamp.org/2014/ switzerland.wordcamp.org/2015/ chicago.wordcamp.org/2016/; do
  echo "=== $SITE"
  wp --url=$SITE eval \
    '$routes = rest_get_server()->get_routes();
     $cb  = $routes["/wporg/v1/data-erase-preflight"][0]["callback"];
     $req = new WP_REST_Request( "POST", "/wporg/v1/data-erase-preflight" );
     $req->set_param( "email", "<an affected address>" );
     print_r( call_user_func( $cb, $req ) );'
done
```

Before, on each of the four sites in the report:

```
[can_erase] =>
[code]      => has_exportable
[reason]    => This user has exportable wcb-reimbursements content on https://central.wordcamp.org/.
```

After:

```
[can_erase] => 1
```

The same result without editing anything, by unhooking the filter in the eval:

```php
remove_filter( 'wp_privacy_personal_data_exporters', 'WordCamp\Budgets\Privacy\register_personal_data_exporters' );
```

And the registration side on any WordCamp site:

```bash
wp --url=central.wordcamp.org eval \
  'print_r( array_keys( apply_filters( "wp_privacy_personal_data_exporters", array() ) ) );'
```

`wcb-reimbursements` and `wcb-vendor-payments` are present before, absent after; both still present in `wp-admin` (Tools → Export Personal Data).

PHPUnit: `WordCamp Payments` suite green, 40 tests / 61 assertions, including #1959's file visibility matrix. New test pins both directions.

## Follow-ups, not in this PR

- Budget data is now again absent from personal data exports. Declaring it with a retention exemption on the WordPress.org side would be the more complete answer, but that's a DPO call — this restores the previous behaviour and unblocks the queue.
- `wcb_sponsor` (`wc-post-types`) and `multi-event-sponsors` are in the same position and predate #1959. They'd block erasure the same way for anyone they return data for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNhqKvNpTTVpBw3h5vdUUB
