### PR TITLE
Budgets: judge a request's editability on the status it had before the save

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-submit-transition.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-submit-transition.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace WordCamp\Budgets_Dashboard\Tests;
+
+use WP_UnitTestCase, WordCamp_Budgets;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * What a budget request's `save_post` handler is allowed to do as the request is submitted.
+ *
+ * Submitting moves the request out of the statuses its requester may edit, and the row carries the new status
+ * by the time `save_post` runs. The editability checks have to keep reading the status the request held before
+ * that save, or the handler that writes the fields entered alongside the submission is refused and the request
+ * arrives empty.
+ *
+ * @group budgets-dashboard
+ */
+class Test_Submit_Transition extends WP_UnitTestCase {
+	/**
+	 * A subsite administrator: authors requests, but is not a network admin.
+	 *
+	 * @var int
+	 */
+	protected static $requester_id;
+
+	/**
+	 * The status each budget CPT moves to when its requester submits it.
+	 *
+	 * @var array<string, string>
+	 */
+	const SUBMITTED_STATUSES = array(
+		'wcb_sponsor_invoice' => 'wcbsi_submitted',
+		'wcp_payment_request' => 'wcb-pending-approval',
+		'wcb_reimbursement'   => 'wcb-pending-approval',
+	);
+
+	/**
+	 * Create the shared user.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$requester_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * The `save_post` handlers run nonce checks that `wp_die()` outside a real request, so keep them off while
+	 * the fixtures are built. Tests that want one attach it themselves.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$_POST    = array();
+		$_REQUEST = array();
+
+		wp_set_current_user( self::$requester_id );
+
+		$this->detach_save_handlers();
+		$this->detach_status_filters();
+	}
+
+	/**
+	 * Re-attach the `save_post` handlers detached in `set_up()`.
+	 */
+	public function tear_down() {
+		$this->attach_save_handlers();
+		$this->attach_status_filters();
+
+		unset( $GLOBALS['post'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Detach every budget CPT's `save_post` handler.
+	 */
+	protected function detach_save_handlers() {
+		remove_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10 );
+		remove_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10 );
+		remove_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10 );
+	}
+
+	/**
+	 * Re-attach every budget CPT's `save_post` handler.
+	 */
+	protected function attach_save_handlers() {
+		add_action( 'save_post', 'WordCamp\Budgets\Sponsor_Invoices\save_invoice', 10, 2 );
+		add_action( 'save_post', 'WordCamp\Budgets\Reimbursement_Requests\save_request', 10, 2 );
+		add_action( 'save_post', array( $GLOBALS['wcp_payment_request'], 'save_payment' ), 10, 2 );
+	}
+
+	/**
+	 * Detach the `wp_insert_post_data` filters that normalise each CPT's status.
+	 *
+	 * They read the request body to decide the status, so a test that stores a status directly has to set it
+	 * aside. The end-to-end test attaches them again.
+	 */
+	protected function detach_status_filters() {
+		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10 );
+		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status', 10 );
+		remove_filter( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ), 10 );
+	}
+
+	/**
+	 * Re-attach the `wp_insert_post_data` filters detached above.
+	 */
+	protected function attach_status_filters() {
+		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10, 2 );
+		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Reimbursement_Requests\set_request_status', 10, 2 );
+		add_filter( 'wp_insert_post_data', array( $GLOBALS['wcp_payment_request'], 'wp_insert_post_data' ), 10, 2 );
+	}
+
+	/**
+	 * Create a stored draft request of the given type, authored by the requester.
+	 *
+	 * @param string $post_type
+	 *
+	 * @return int
+	 */
+	protected function create_draft( $post_type ) {
+		return self::factory()->post->create( array(
+			'post_type'   => $post_type,
+			'post_status' => 'draft',
+			'post_author' => self::$requester_id,
+		) );
+	}
+
+	/**
+	 * Put the request into the state `wp-admin/post.php` leaves before `edit_post()` updates the row.
+	 *
+	 * @param int $post_id
+	 */
+	protected function simulate_edit_form_submission( $post_id ) {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- `post.php` sets this before it saves.
+		$GLOBALS['post']    = get_post( $post_id );
+		$_REQUEST['action'] = 'editpost';
+		$_POST['action']    = 'editpost';
+	}
+
+	/**
+	 * @return array<string, array>
+	 */
+	public function data_budget_post_types() {
+		$data = array();
+
+		foreach ( self::SUBMITTED_STATUSES as $post_type => $submitted_status ) {
+			$data[ $post_type ] = array( $post_type, $submitted_status );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * A `save_post` handler may still act on the request that this save submitted.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 * @param string $submitted_status
+	 */
+	public function test_save_handler_may_act_while_submitting( $post_type, $submitted_status ) {
+		$post_id = $this->create_draft( $post_type );
+
+		$this->simulate_edit_form_submission( $post_id );
+
+		$actionable = null;
+
+		add_action(
+			'save_post',
+			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
+				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
+			},
+			10,
+			2
+		);
+
+		wp_update_post( array(
+			'ID' => $post_id, 'post_status' => $submitted_status,
+		) );
+
+		$this->assertSame( $submitted_status, get_post_status( $post_id ) );
+		$this->assertTrue( $actionable );
+	}
+
+	/**
+	 * A request that was already past the editable statuses before the save stays closed to its requester.
+	 *
+	 * This is the restriction the check above has to keep: the requester may submit, but may not then edit
+	 * what they submitted.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 * @param string $submitted_status
+	 */
+	public function test_save_handler_may_not_act_on_an_already_submitted_request( $post_type, $submitted_status ) {
+		$post_id = $this->create_draft( $post_type );
+
+		wp_update_post( array(
+			'ID' => $post_id, 'post_status' => $submitted_status,
+		) );
+
+		$this->simulate_edit_form_submission( $post_id );
+
+		$actionable = null;
+
+		add_action(
+			'save_post',
+			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
+				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
+			},
+			10,
+			2
+		);
+
+		wp_update_post( array(
+			'ID' => $post_id, 'post_title' => 'Edited after submission',
+		) );
+
+		$this->assertFalse( $actionable );
+	}
+
+	/**
+	 * A network admin may act on a submitted request, as before.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 * @param string $submitted_status
+	 */
+	public function test_network_admin_may_act_on_a_submitted_request( $post_type, $submitted_status ) {
+		$network_admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $network_admin_id );
+
+		$post_id = $this->create_draft( $post_type );
+		wp_update_post( array(
+			'ID' => $post_id, 'post_status' => $submitted_status,
+		) );
+
+		wp_set_current_user( $network_admin_id );
+		$this->simulate_edit_form_submission( $post_id );
+
+		$actionable = null;
+
+		add_action(
+			'save_post',
+			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
+				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
+			},
+			10,
+			2
+		);
+
+		wp_update_post( array(
+			'ID' => $post_id, 'post_title' => 'Corrected by Central',
+		) );
+
+		$this->assertTrue( $actionable );
+	}
+
+	/**
+	 * The recorded status only describes the save it belongs to.
+	 */
+	public function test_recorded_status_does_not_outlive_the_save() {
+		$post_id = $this->create_draft( 'wcb_sponsor_invoice' );
+
+		wp_update_post( array(
+			'ID' => $post_id, 'post_status' => 'wcbsi_submitted',
+		) );
+
+		$this->assertSame(
+			'wcbsi_submitted',
+			WordCamp_Budgets::get_status_for_edit_check( get_post( $post_id ) )
+		);
+	}
+
+	/**
+	 * A request that isn't being saved reads its stored status.
+	 */
+	public function test_status_for_edit_check_falls_back_to_the_stored_status() {
+		$post_id = $this->create_draft( 'wcb_sponsor_invoice' );
+
+		$this->assertSame( 'draft', WordCamp_Budgets::get_status_for_edit_check( get_post( $post_id ) ) );
+	}
+
+	/**
+	 * Submitting a sponsor invoice stores the values entered alongside the submission.
+	 *
+	 * The end-to-end version of the checks above, through the real `save_invoice()` handler: an invoice
+	 * submitted straight from the editor has to arrive at Central with its sponsor, community, description,
+	 * currency and amount, not as an empty record.
+	 */
+	public function test_submitting_a_sponsor_invoice_stores_its_fields() {
+		$sponsor_id = $this->create_complete_sponsor();
+		$invoice_id = $this->create_draft( 'wcb_sponsor_invoice' );
+
+		$this->simulate_edit_form_submission( $invoice_id );
+
+		$_POST['send-invoice']          = 'Send to WordCamp Central';
+		$_POST['_wcbsi_sponsor_id']     = (string) $sponsor_id;
+		$_POST['_wcbsi_qbo_class_id']   = '42';
+		$_POST['_wcbsi_description']    = 'Gold sponsorship';
+		$_POST['_wcbsi_currency']       = 'ZAR';
+		$_POST['_wcbsi_amount']         = '5000';
+		$_POST['status_nonce']          = wp_create_nonce( 'status' );
+		$_POST['sponsor_invoice_nonce'] = wp_create_nonce( 'sponsor_invoice' );
+		$_REQUEST                       = array_merge( $_REQUEST, $_POST );
+
+		$this->attach_save_handlers();
+		$this->attach_status_filters();
+
+		wp_update_post( array(
+			'ID' => $invoice_id, 'post_status' => 'draft',
+		) );
+
+		$this->assertSame( 'wcbsi_submitted', get_post_status( $invoice_id ) );
+		$this->assertSame( (string) $sponsor_id, get_post_meta( $invoice_id, '_wcbsi_sponsor_id', true ) );
+		$this->assertSame( '42', get_post_meta( $invoice_id, '_wcbsi_qbo_class_id', true ) );
+		$this->assertSame( 'Gold sponsorship', get_post_meta( $invoice_id, '_wcbsi_description', true ) );
+		$this->assertSame( 'ZAR', get_post_meta( $invoice_id, '_wcbsi_currency', true ) );
+		$this->assertSame( 5000.0, (float) get_post_meta( $invoice_id, '_wcbsi_amount', true ) );
+	}
+
+	/**
+	 * Create a sponsor with every field `prepare_sponsor_data()` treats as required.
+	 *
+	 * @return int
+	 */
+	protected function create_complete_sponsor() {
+		$sponsor_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+			'post_title'  => 'Example Sponsor',
+		) );
+
+		$fields = array(
+			'company_name'    => 'Example Sponsor',
+			'first_name'      => 'Example',
+			'last_name'       => 'Person',
+			'email_address'   => 'sponsor@example.org',
+			'phone_number'    => '555 0100',
+			'street_address1' => '123 Example Street',
+			'city'            => 'Johannesburg',
+			'state'           => 'Gauteng',
+			'zip_code'        => '2000',
+			'country'         => 'South Africa',
+		);
+
+		foreach ( $fields as $field => $value ) {
+			update_post_meta( $sponsor_id, "_wcpt_sponsor_$field", $value );
+		}
+
+		return $sponsor_id;
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-submit-transition.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-submit-transition.php
@@ -2,17 +2,17 @@
 
 namespace WordCamp\Budgets_Dashboard\Tests;
 
-use WP_UnitTestCase, WordCamp_Budgets;
+use WP_UnitTestCase, WP_Post, WordCamp_Budgets;
 
 defined( 'WPINC' ) || die();
 
 /**
- * What a budget request's `save_post` handler is allowed to do as the request is submitted.
+ * What a budget request's `save_post` handler may do as the request is submitted, and what it still may not.
  *
- * Submitting moves the request out of the statuses its requester may edit, and the row carries the new status
- * by the time `save_post` runs. The editability checks have to keep reading the status the request held before
- * that save, or the handler that writes the fields entered alongside the submission is refused and the request
- * arrives empty.
+ * Submitting moves a request out of the statuses its requester may edit, and the row carries the new status by
+ * the time `save_post` runs. The editability checks have to read the status the request held before that save,
+ * or the handler that writes the values entered alongside the submission is refused and the request arrives
+ * empty. They must keep refusing everything else, which is what the second half of this file is about.
  *
  * @group budgets-dashboard
  */
@@ -25,28 +25,46 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	protected static $requester_id;
 
 	/**
-	 * The status each budget CPT moves to when its requester submits it.
+	 * An Editor on the subsite: holds `edit_others_posts`, holds no network capability.
 	 *
-	 * @var array<string, string>
+	 * @var int
 	 */
-	const SUBMITTED_STATUSES = array(
-		'wcb_sponsor_invoice' => 'wcbsi_submitted',
-		'wcp_payment_request' => 'wcb-pending-approval',
-		'wcb_reimbursement'   => 'wcb-pending-approval',
+	protected static $editor_id;
+
+	/**
+	 * How each budget CPT is submitted, and what it becomes.
+	 *
+	 * The request body key is the one the CPT's own `wp_insert_post_data` callback looks for.
+	 *
+	 * @var array<string, array{0: string, 1: string}>
+	 */
+	const SUBMISSIONS = array(
+		'wcb_sponsor_invoice' => array( 'wcbsi_submitted', 'send-invoice' ),
+		'wcp_payment_request' => array( 'wcb-pending-approval', 'wcb-update' ),
+		'wcb_reimbursement'   => array( 'wcb-pending-approval', 'wcb-update' ),
 	);
 
 	/**
-	 * Create the shared user.
+	 * A status past submission, which only a network admin may act on.
+	 *
+	 * @var string
+	 */
+	const APPROVED_STATUS = 'wcb-approved';
+
+	/**
+	 * Create the shared users.
 	 *
 	 * @param \WP_UnitTest_Factory $factory
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$requester_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id    = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	/**
-	 * The `save_post` handlers run nonce checks that `wp_die()` outside a real request, so keep them off while
-	 * the fixtures are built. Tests that want one attach it themselves.
+	 * Fixtures are built with the hooks off, because the `save_post` handlers run nonce checks that `wp_die()`
+	 * outside a real request, and the status filters would rewrite a status stored directly. Tests attach back
+	 * whichever half they are about.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -61,7 +79,7 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Re-attach the `save_post` handlers detached in `set_up()`.
+	 * Put the hooks back, so other suites are unaffected.
 	 */
 	public function tear_down() {
 		$this->attach_save_handlers();
@@ -91,10 +109,10 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Detach the `wp_insert_post_data` filters that normalise each CPT's status.
+	 * Detach the `wp_insert_post_data` callbacks that set each CPT's status.
 	 *
-	 * They read the request body to decide the status, so a test that stores a status directly has to set it
-	 * aside. The end-to-end test attaches them again.
+	 * These are also where the pre-save status is recorded, so a test about the submit transition has to leave
+	 * them attached -- only fixture building turns them off.
 	 */
 	protected function detach_status_filters() {
 		remove_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10 );
@@ -103,7 +121,7 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Re-attach the `wp_insert_post_data` filters detached above.
+	 * Re-attach the `wp_insert_post_data` callbacks detached above.
 	 */
 	protected function attach_status_filters() {
 		add_filter( 'wp_insert_post_data', 'WordCamp\Budgets\Sponsor_Invoices\set_invoice_status', 10, 2 );
@@ -112,16 +130,17 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Create a stored draft request of the given type, authored by the requester.
+	 * Create a stored request of the given type and status, authored by the requester.
 	 *
 	 * @param string $post_type
+	 * @param string $post_status
 	 *
 	 * @return int
 	 */
-	protected function create_draft( $post_type ) {
+	protected function create_request( $post_type, $post_status = 'draft' ) {
 		return self::factory()->post->create( array(
 			'post_type'   => $post_type,
-			'post_status' => 'draft',
+			'post_status' => $post_status,
 			'post_author' => self::$requester_id,
 		) );
 	}
@@ -133,9 +152,76 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	 */
 	protected function simulate_edit_form_submission( $post_id ) {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- `post.php` sets this before it saves.
-		$GLOBALS['post']    = get_post( $post_id );
+		$GLOBALS['post'] = get_post( $post_id );
+
 		$_REQUEST['action'] = 'editpost';
 		$_POST['action']    = 'editpost';
+	}
+
+	/**
+	 * Run the save that submits a request, the way `edit_post()` does: request body first, then the same array
+	 * handed to `wp_update_post()`.
+	 *
+	 * @param int    $post_id
+	 * @param string $post_type
+	 * @param array  $extra_fields Field values entered alongside the submission.
+	 */
+	protected function submit_request( $post_id, $post_type, $extra_fields = array() ) {
+		list( , $submit_key ) = self::SUBMISSIONS[ $post_type ];
+
+		$this->simulate_edit_form_submission( $post_id );
+
+		$_POST[ $submit_key ] = '1';
+		$_POST                = array_merge( $_POST, $this->default_submission_fields( $post_type ), $extra_fields );
+		$_REQUEST             = array_merge( $_REQUEST, $_POST );
+
+		$this->attach_status_filters();
+
+		wp_update_post( array_merge( $_POST, array( 'ID' => $post_id ) ) );
+	}
+
+	/**
+	 * The request body a complete submission carries.
+	 *
+	 * A sponsor invoice is only promoted when its sponsor and its own fields are complete, so a test about the
+	 * transition has to send a submission the CPT would actually accept. The other two need nothing beyond the
+	 * button.
+	 *
+	 * @param string $post_type
+	 *
+	 * @return array
+	 */
+	protected function default_submission_fields( $post_type ) {
+		if ( 'wcb_sponsor_invoice' !== $post_type ) {
+			return array();
+		}
+
+		return array(
+			'_wcbsi_sponsor_id'     => (string) $this->create_complete_sponsor(),
+			'_wcbsi_qbo_class_id'   => '42',
+			'_wcbsi_description'    => 'Gold sponsorship',
+			'_wcbsi_currency'       => 'ZAR',
+			'_wcbsi_amount'         => '5000',
+			'status_nonce'          => wp_create_nonce( 'status' ),
+			'sponsor_invoice_nonce' => wp_create_nonce( 'sponsor_invoice' ),
+		);
+	}
+
+	/**
+	 * Watch what `post_edit_is_actionable()` answers inside `save_post`, which is where the handlers ask it.
+	 *
+	 * @param string $post_type
+	 * @param mixed  $answer     Set by reference when the save runs.
+	 */
+	protected function watch_save_post_gate( $post_type, &$answer ) {
+		add_action(
+			'save_post',
+			function ( $saved_id, $post ) use ( &$answer, $post_type ) {
+				$answer = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -144,8 +230,8 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	public function data_budget_post_types() {
 		$data = array();
 
-		foreach ( self::SUBMITTED_STATUSES as $post_type => $submitted_status ) {
-			$data[ $post_type ] = array( $post_type, $submitted_status );
+		foreach ( self::SUBMISSIONS as $post_type => $submission ) {
+			$data[ $post_type ] = array( $post_type, $submission[0] );
 		}
 
 		return $data;
@@ -160,34 +246,18 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	 * @param string $submitted_status
 	 */
 	public function test_save_handler_may_act_while_submitting( $post_type, $submitted_status ) {
-		$post_id = $this->create_draft( $post_type );
-
-		$this->simulate_edit_form_submission( $post_id );
-
+		$post_id    = $this->create_request( $post_type );
 		$actionable = null;
 
-		add_action(
-			'save_post',
-			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
-				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
-			},
-			10,
-			2
-		);
+		$this->watch_save_post_gate( $post_type, $actionable );
+		$this->submit_request( $post_id, $post_type );
 
-		wp_update_post( array(
-			'ID' => $post_id, 'post_status' => $submitted_status,
-		) );
-
-		$this->assertSame( $submitted_status, get_post_status( $post_id ) );
-		$this->assertTrue( $actionable );
+		$this->assertSame( $submitted_status, get_post_status( $post_id ), 'the save stored the new status' );
+		$this->assertTrue( $actionable, 'the gate the save handler sees' );
 	}
 
 	/**
 	 * A request that was already past the editable statuses before the save stays closed to its requester.
-	 *
-	 * This is the restriction the check above has to keep: the requester may submit, but may not then edit
-	 * what they submitted.
 	 *
 	 * @dataProvider data_budget_post_types
 	 *
@@ -195,28 +265,28 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	 * @param string $submitted_status
 	 */
 	public function test_save_handler_may_not_act_on_an_already_submitted_request( $post_type, $submitted_status ) {
-		$post_id = $this->create_draft( $post_type );
-
-		wp_update_post( array(
-			'ID' => $post_id, 'post_status' => $submitted_status,
-		) );
-
-		$this->simulate_edit_form_submission( $post_id );
-
+		$post_id    = $this->create_request( $post_type, $submitted_status );
 		$actionable = null;
 
-		add_action(
-			'save_post',
-			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
-				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
-			},
-			10,
-			2
-		);
+		$this->watch_save_post_gate( $post_type, $actionable );
+		$this->submit_request( $post_id, $post_type, array( 'post_title' => 'Edited after submission' ) );
 
-		wp_update_post( array(
-			'ID' => $post_id, 'post_title' => 'Edited after submission',
-		) );
+		$this->assertFalse( $actionable );
+	}
+
+	/**
+	 * Nor may its requester act on one that has been approved for payout.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_save_handler_may_not_act_on_an_approved_request( $post_type ) {
+		$post_id    = $this->create_request( $post_type, self::APPROVED_STATUS );
+		$actionable = null;
+
+		$this->watch_save_post_gate( $post_type, $actionable );
+		$this->submit_request( $post_id, $post_type, array( 'post_title' => 'Edited after approval' ) );
 
 		$this->assertFalse( $actionable );
 	}
@@ -233,53 +303,119 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 		$network_admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		grant_super_admin( $network_admin_id );
 
-		$post_id = $this->create_draft( $post_type );
-		wp_update_post( array(
-			'ID' => $post_id, 'post_status' => $submitted_status,
-		) );
-
-		wp_set_current_user( $network_admin_id );
-		$this->simulate_edit_form_submission( $post_id );
-
+		$post_id    = $this->create_request( $post_type, $submitted_status );
 		$actionable = null;
 
-		add_action(
-			'save_post',
-			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
-				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
-			},
-			10,
-			2
-		);
+		wp_set_current_user( $network_admin_id );
 
-		wp_update_post( array(
-			'ID' => $post_id, 'post_title' => 'Corrected by Central',
-		) );
+		$this->watch_save_post_gate( $post_type, $actionable );
+		$this->submit_request( $post_id, $post_type, array( 'post_title' => 'Corrected by Central' ) );
 
 		$this->assertTrue( $actionable );
 	}
 
 	/**
-	 * The recorded status only describes the save it belongs to.
+	 * An Editor is refused a non-draft request however the capability check names it.
+	 *
+	 * The control from the report that #1966 answered: the reservation must not depend on the argument's type,
+	 * nor on which post happens to be in the global. Repeated here because this file changes what the same
+	 * filters read.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
 	 */
-	public function test_recorded_status_does_not_outlive_the_save() {
-		$post_id = $this->create_draft( 'wcb_sponsor_invoice' );
+	public function test_editor_is_refused_a_non_draft_request_in_every_argument_form( $post_type ) {
+		$post_id = $this->create_request( $post_type, self::APPROVED_STATUS );
 
-		wp_update_post( array(
-			'ID' => $post_id, 'post_status' => 'wcbsi_submitted',
-		) );
+		/*
+		 * The context the report measured: `wp_ajax_upload_attachment()`, which passes `$_REQUEST['post_id']`
+		 * to `current_user_can()` uncast. The reservation reads this to tell opening a request apart from
+		 * writing to one, so a test that leaves it unset is not asking the question.
+		 */
+		$_REQUEST['action'] = 'upload-attachment';
 
+		// A post of another type, as that endpoint and the list tables leave it.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- standing in for an unrelated screen.
+		$GLOBALS['post'] = get_post( self::factory()->post->create() );
+
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertTrue( current_user_can( 'edit_others_posts' ), 'the Editor holds the generic primitive' );
+		$this->assertFalse( current_user_can( 'manage_network' ), 'and holds no network capability' );
+
+		foreach ( array( 'edit_post', 'delete_post' ) as $capability ) {
+			$this->assertFalse( current_user_can( $capability, $post_id ), "$capability, int" );
+			$this->assertFalse( current_user_can( $capability, (string) $post_id ), "$capability, numeric string" );
+			$this->assertFalse( current_user_can( $capability, get_post( $post_id ) ), "$capability, WP_Post" );
+		}
+	}
+
+	/**
+	 * Submitting one request does not open a different one.
+	 *
+	 * The recorded status is keyed by post, so the save that submits the requester's own draft must not change
+	 * the answer for somebody else's approved request while it runs.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_submitting_one_request_does_not_open_another( $post_type ) {
+		$own_draft         = $this->create_request( $post_type );
+		$approved_id       = $this->create_request( $post_type, self::APPROVED_STATUS );
+		$verdict_for_own   = null;
+		$verdict_for_other = null;
+
+		add_action(
+			'save_post',
+			function () use ( &$verdict_for_own, &$verdict_for_other, $own_draft, $approved_id ) {
+				$verdict_for_own   = current_user_can( 'edit_post', $own_draft );
+				$verdict_for_other = current_user_can( 'edit_post', $approved_id );
+			},
+			10
+		);
+
+		$this->submit_request( $own_draft, $post_type );
+
+		$this->assertTrue( $verdict_for_own, 'the request being submitted' );
+		$this->assertFalse( $verdict_for_other, 'a different, approved request' );
+	}
+
+	/**
+	 * The recorded status is not honoured outside the `save_post` it belongs to.
+	 *
+	 * `wp_after_insert_post` clears it, but a caller passing `$fire_after_hooks = false` skips that hook, so an
+	 * entry can outlive its save. It must not widen anything when it does.
+	 */
+	public function test_recorded_status_is_only_honoured_inside_a_save() {
+		$post_id = $this->create_request( 'wcb_sponsor_invoice' );
+
+		add_action(
+			'save_post',
+			function () {
+				// Skip the cleanup, the way a `$fire_after_hooks = false` caller does.
+				remove_action( 'wp_after_insert_post', array( 'WordCamp_Budgets', 'forget_status_before_save' ), PHP_INT_MAX );
+			},
+			5
+		);
+
+		$this->submit_request( $post_id, 'wcb_sponsor_invoice' );
+
+		$this->assertSame( 'wcbsi_submitted', get_post_status( $post_id ), 'the request was submitted' );
 		$this->assertSame(
 			'wcbsi_submitted',
-			WordCamp_Budgets::get_status_for_edit_check( get_post( $post_id ) )
+			WordCamp_Budgets::get_status_for_edit_check( get_post( $post_id ) ),
+			'and reads as submitted once the save is over'
 		);
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
 	}
 
 	/**
 	 * A request that isn't being saved reads its stored status.
 	 */
 	public function test_status_for_edit_check_falls_back_to_the_stored_status() {
-		$post_id = $this->create_draft( 'wcb_sponsor_invoice' );
+		$post_id = $this->create_request( 'wcb_sponsor_invoice' );
 
 		$this->assertSame( 'draft', WordCamp_Budgets::get_status_for_edit_check( get_post( $post_id ) ) );
 	}
@@ -293,26 +429,19 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	 */
 	public function test_submitting_a_sponsor_invoice_stores_its_fields() {
 		$sponsor_id = $this->create_complete_sponsor();
-		$invoice_id = $this->create_draft( 'wcb_sponsor_invoice' );
-
-		$this->simulate_edit_form_submission( $invoice_id );
-
-		$_POST['send-invoice']          = 'Send to WordCamp Central';
-		$_POST['_wcbsi_sponsor_id']     = (string) $sponsor_id;
-		$_POST['_wcbsi_qbo_class_id']   = '42';
-		$_POST['_wcbsi_description']    = 'Gold sponsorship';
-		$_POST['_wcbsi_currency']       = 'ZAR';
-		$_POST['_wcbsi_amount']         = '5000';
-		$_POST['status_nonce']          = wp_create_nonce( 'status' );
-		$_POST['sponsor_invoice_nonce'] = wp_create_nonce( 'sponsor_invoice' );
-		$_REQUEST                       = array_merge( $_REQUEST, $_POST );
+		$invoice_id = $this->create_request( 'wcb_sponsor_invoice' );
 
 		$this->attach_save_handlers();
-		$this->attach_status_filters();
 
-		wp_update_post( array(
-			'ID' => $invoice_id, 'post_status' => 'draft',
-		) );
+		$entered_fields = array(
+			'_wcbsi_sponsor_id'   => (string) $sponsor_id,
+			'_wcbsi_qbo_class_id' => '42',
+			'_wcbsi_description'  => 'Gold sponsorship',
+			'_wcbsi_currency'     => 'ZAR',
+			'_wcbsi_amount'       => '5000',
+		);
+
+		$this->submit_request( $invoice_id, 'wcb_sponsor_invoice', $entered_fields );
 
 		$this->assertSame( 'wcbsi_submitted', get_post_status( $invoice_id ) );
 		$this->assertSame( (string) $sponsor_id, get_post_meta( $invoice_id, '_wcbsi_sponsor_id', true ) );

--- a/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-submit-transition.php
+++ b/public_html/wp-content/plugins/wordcamp-payments-network/tests/test-submit-transition.php
@@ -257,6 +257,34 @@ class Test_Submit_Transition extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A handler on the type-specific `save_post_{$post_type}` sees the same answer as one on plain `save_post`.
+	 *
+	 * The typed hook fires first, so a window that only opened for the untyped one would drop the fields of any
+	 * handler that used it. Nothing in this plugin does today; this keeps that from becoming a trap.
+	 *
+	 * @dataProvider data_budget_post_types
+	 *
+	 * @param string $post_type
+	 */
+	public function test_a_typed_save_post_handler_sees_the_same_answer( $post_type ) {
+		$post_id    = $this->create_request( $post_type );
+		$actionable = null;
+
+		add_action(
+			"save_post_{$post_type}",
+			function ( $saved_id, $post ) use ( &$actionable, $post_type ) {
+				$actionable = WordCamp_Budgets::post_edit_is_actionable( $post, $post_type );
+			},
+			10,
+			2
+		);
+
+		$this->submit_request( $post_id, $post_type );
+
+		$this->assertTrue( $actionable );
+	}
+
+	/**
 	 * A request that was already past the editable statuses before the save stays closed to its requester.
 	 *
 	 * @dataProvider data_budget_post_types

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -604,8 +604,14 @@ class WCP_Payment_Request {
 			return $post_data;
 		}
 
-		// The row still holds the status this save is about to overwrite. See `remember_status_before_save()`.
-		WordCamp_Budgets::remember_status_before_save( $post_data_raw['ID'] ?? null );
+		/*
+		 * The row still holds the status this save is about to overwrite. See `remember_status_before_save()`.
+		 * Behind the same question the other two budget types ask, so none of them records on a trash, bulk or
+		 * autosave path that has no use for it.
+		 */
+		if ( WordCamp_Budgets::post_edit_is_actionable( $post_data, self::POST_TYPE ) ) {
+			WordCamp_Budgets::remember_status_before_save( $post_data_raw['ID'] ?? null );
+		}
 
 		// Ensure that new posts have the `post_date_gmt` field populated.
 		if ( 'auto-draft' !== $post_data['post_status'] ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -999,8 +999,10 @@ Thanks for helping us with these details!",
 			 * They can still open the request (in order to view the status and details), but won't be allowed to make any changes to it.
 			 * They can also edit and re-submit requests that were marked as incomplete.
 			 */
-			if ( ! in_array( $post->post_status, array( 'auto-draft', 'draft' ), true ) ) {
-				if ( 'edit_post' == $requested_capability && 'wcb-incomplete' != $post->post_status ) {
+			$status_for_edit_check = WordCamp_Budgets::get_status_for_edit_check( $post );
+
+			if ( ! in_array( $status_for_edit_check, array( 'auto-draft', 'draft' ), true ) ) {
+				if ( 'edit_post' == $requested_capability && 'wcb-incomplete' != $status_for_edit_check ) {
 					$is_saving_edit = isset( $_REQUEST['action'] ) && 'edit' != $_REQUEST['action'];  // 'edit' is opening the Edit Invoice screen, 'editpost' is when it's submitted
 					$is_bulk_edit   = isset( $_REQUEST['bulk_edit'] );
 

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/payment-request.php
@@ -604,6 +604,9 @@ class WCP_Payment_Request {
 			return $post_data;
 		}
 
+		// The row still holds the status this save is about to overwrite. See `remember_status_before_save()`.
+		WordCamp_Budgets::remember_status_before_save( $post_data_raw['ID'] ?? null );
+
 		// Ensure that new posts have the `post_date_gmt` field populated.
 		if ( 'auto-draft' !== $post_data['post_status'] ) {
 			if ( '0000-00-00 00:00:00' === $post_data['post_date_gmt'] ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -266,7 +266,8 @@ function enqueue_assets() {
  * @return bool
  */
 function user_can_edit_request( $post ) {
-	$editable_status = in_array( $post->post_status ?? '', array( 'auto-draft', 'draft', 'wcb-incomplete' ), true );
+	$status          = \WordCamp_Budgets::get_status_for_edit_check( $post );
+	$editable_status = in_array( $status, array( 'auto-draft', 'draft', 'wcb-incomplete' ), true );
 	return current_user_can( 'manage_network' ) || $editable_status;
 }
 
@@ -928,8 +929,9 @@ function modify_capabilities( $required_capabilities, $requested_capability, $us
 		return $required_capabilities;
 	}
 
-	$drafted_status             = in_array( $post->post_status, array( 'auto-draft', 'draft' ), true );
-	$draft_or_incomplete_status = $drafted_status || 'wcb-incomplete' === $post->post_status;
+	$status_for_edit_check      = \WordCamp_Budgets::get_status_for_edit_check( $post );
+	$drafted_status             = in_array( $status_for_edit_check, array( 'auto-draft', 'draft' ), true );
+	$draft_or_incomplete_status = $drafted_status || 'wcb-incomplete' === $status_for_edit_check;
 	$is_bulk_edit               = isset( $_REQUEST['bulk_edit'] );
 
 	switch ( $requested_capability ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/reimbursement-request.php
@@ -497,6 +497,9 @@ function set_request_status( $post_data, $post_data_raw ) {
 		return $post_data;
 	}
 
+	// The row still holds the status this save is about to overwrite. See `remember_status_before_save()`.
+	\WordCamp_Budgets::remember_status_before_save( $post_data_raw['ID'] ?? null );
+
 	// Requesting to save draft
 	if ( isset( $post_data_raw['wcb-save-draft'] ) ) {
 		if ( current_user_can( 'draft_post', $post_data_raw['ID'] ) ) {

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -410,6 +410,9 @@ function set_invoice_status( $post_data, $post_data_raw ) {
 		return $post_data;
 	}
 
+	// The row still holds the status this save is about to overwrite. See `remember_status_before_save()`.
+	\WordCamp_Budgets::remember_status_before_save( $post_data_raw['ID'] ?? null );
+
 	$sponsor                 = prepare_sponsor_data( $post_data_raw['_wcbsi_sponsor_id'] ?? null );
 	$sponsor                 = array_pop( $sponsor );
 	$sponsor_fields_complete = 'true' === $sponsor['data_attributes']['required-fields-complete'];

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/sponsor-invoice.php
@@ -700,7 +700,7 @@ function modify_capabilities( $required_capabilities, $requested_capability, $us
 		 *
 		 * The organizer can still open the request (in order to view the status and details), but won't be allowed to make any changes to it.
 		 */
-		if ( ! in_array( $post->post_status, array( 'auto-draft', 'draft' ), true ) ) {
+		if ( ! in_array( \WordCamp_Budgets::get_status_for_edit_check( $post ), array( 'auto-draft', 'draft' ), true ) ) {
 			if ( 'edit_post' === $requested_capability ) {
 				$is_saving_edit = isset( $_REQUEST['action'] ) && 'edit' !== $_REQUEST['action'];  // 'edit' is opening the Edit Invoice screen, 'editpost' is when it's submitted
 				$is_bulk_edit   = isset( $_REQUEST['bulk_edit'] );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -34,6 +34,18 @@ class WordCamp_Budgets {
 	);
 
 	/**
+	 * The status each budget request held before the save that is currently running, keyed by post ID.
+	 *
+	 * `save_post` runs after the new status is stored, so a requester submitting a draft would otherwise be
+	 * judged on the status the submission moved it to, and refused the save that writes the fields entered
+	 * alongside it. Populated on `post_updated` and dropped again on `wp_after_insert_post`, so it only
+	 * describes a save that is still in flight.
+	 *
+	 * @var array<int, string>
+	 */
+	protected static $status_before_save = array();
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -745,6 +757,56 @@ class WordCamp_Budgets {
 	}
 
 	/**
+	 * Record the status a budget request held before the save that is currently running.
+	 *
+	 * Runs on `post_updated`, which fires after the row is written but before `save_post`, and is the only
+	 * hook handed both the old post and the new one.
+	 *
+	 * @param int      $post_id
+	 * @param \WP_Post $post_after
+	 * @param \WP_Post $post_before
+	 */
+	public static function remember_status_before_save( $post_id, $post_after, $post_before ) {
+		if ( ! in_array( $post_after->post_type, self::PAYMENT_POST_TYPES, true ) ) {
+			return;
+		}
+
+		self::$status_before_save[ (int) $post_id ] = $post_before->post_status;
+	}
+
+	/**
+	 * Forget the status recorded above, once the save it describes has finished.
+	 *
+	 * Runs on `wp_after_insert_post`, at the lowest priority, so every `save_post` handler has already had its
+	 * answer. Leaving the entry in place would let the rest of the request judge the request on a status it no
+	 * longer holds.
+	 *
+	 * @param int $post_id
+	 */
+	public static function forget_status_before_save( $post_id ) {
+		unset( self::$status_before_save[ (int) $post_id ] );
+	}
+
+	/**
+	 * The status to judge a budget request's editability on.
+	 *
+	 * During a save that's the status the request held before it, so a draft being submitted is judged as the
+	 * draft it was rather than as the status the submission moved it to. Everywhere else it's simply the
+	 * stored status.
+	 *
+	 * @param \WP_Post|object $post
+	 *
+	 * @return string
+	 */
+	public static function get_status_for_edit_check( $post ) {
+		if ( isset( $post->ID ) && isset( self::$status_before_save[ (int) $post->ID ] ) ) {
+			return self::$status_before_save[ (int) $post->ID ];
+		}
+
+		return $post->post_status ?? '';
+	}
+
+	/**
 	 * Determines whether we want to perform actions on the given post based on the current context.
 	 *
 	 * Examples of actions we might perform are saving the meta fields during the `save_post` hook, or send out an
@@ -1185,3 +1247,10 @@ class WordCamp_Budgets {
 		return $dom->saveXML();
 	}
 }
+
+/*
+ * Registered at file scope rather than in the constructor: that only runs in the admin, while the
+ * `map_meta_cap` callbacks that read this also run on cron and Ajax.
+ */
+add_action( 'post_updated',         array( 'WordCamp_Budgets', 'remember_status_before_save' ), 10, 3 );
+add_action( 'wp_after_insert_post', array( 'WordCamp_Budgets', 'forget_status_before_save' ), PHP_INT_MAX );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -38,8 +38,8 @@ class WordCamp_Budgets {
 	 *
 	 * `save_post` runs after the new status is stored, so a requester submitting a draft would otherwise be
 	 * judged on the status the submission moved it to, and refused the save that writes the fields entered
-	 * alongside it. Populated on `post_updated` and dropped again on `wp_after_insert_post`, so it only
-	 * describes a save that is still in flight.
+	 * alongside it. Written as each save begins and dropped as it ends, so it only ever describes a save that
+	 * is still in flight.
 	 *
 	 * @var array<int, string>
 	 */
@@ -757,34 +757,53 @@ class WordCamp_Budgets {
 	}
 
 	/**
-	 * Record the status a budget request held before the save that is currently running.
+	 * Record the status a budget request holds, before the save that is currently running overwrites it.
 	 *
-	 * Runs on `post_updated`, which fires after the row is written but before `save_post`, and is the only
-	 * hook handed both the old post and the new one.
+	 * Called from each budget CPT's own `wp_insert_post_data` callback, past the post-type guard those already
+	 * carry. That hook runs before the row is written, so the stored status is still the one the request had
+	 * when the save began -- and it means this needs no hook of its own. `post_updated` would hand over the old
+	 * post directly, but it, like `wp_after_insert_post`, fires for every post on every site in the network,
+	 * and none of them but these three has any use for it.
 	 *
-	 * @param int      $post_id
-	 * @param \WP_Post $post_after
-	 * @param \WP_Post $post_before
+	 * The cleanup is attached here rather than at file scope for the same reason: until a budget request is
+	 * actually saved there is nothing to clean up, so on the requests that save anything else the hook is
+	 * simply not there.
+	 *
+	 * @param int|string $post_id The request being saved. Absent for a request being created.
 	 */
-	public static function remember_status_before_save( $post_id, $post_after, $post_before ) {
-		if ( ! in_array( $post_after->post_type, self::PAYMENT_POST_TYPES, true ) ) {
+	public static function remember_status_before_save( $post_id ) {
+		if ( ! is_numeric( $post_id ) ) {
 			return;
 		}
 
-		self::$status_before_save[ (int) $post_id ] = $post_before->post_status;
+		$post_id = (int) $post_id;
+		$status  = get_post_status( $post_id );
+
+		if ( ! $status ) {
+			return;
+		}
+
+		if ( ! self::$status_before_save ) {
+			add_action( 'wp_after_insert_post', array( __CLASS__, 'forget_status_before_save' ), PHP_INT_MAX );
+		}
+
+		self::$status_before_save[ $post_id ] = $status;
 	}
 
 	/**
 	 * Forget the status recorded above, once the save it describes has finished.
 	 *
 	 * Runs on `wp_after_insert_post`, at the lowest priority, so every `save_post` handler has already had its
-	 * answer. Leaving the entry in place would let the rest of the request judge the request on a status it no
-	 * longer holds.
+	 * answer, and detaches itself once there is nothing left to forget.
 	 *
 	 * @param int $post_id
 	 */
 	public static function forget_status_before_save( $post_id ) {
 		unset( self::$status_before_save[ (int) $post_id ] );
+
+		if ( ! self::$status_before_save ) {
+			remove_action( 'wp_after_insert_post', array( __CLASS__, 'forget_status_before_save' ), PHP_INT_MAX );
+		}
 	}
 
 	/**
@@ -794,13 +813,24 @@ class WordCamp_Budgets {
 	 * draft it was rather than as the status the submission moved it to. Everywhere else it's simply the
 	 * stored status.
 	 *
+	 * The recorded status is only honoured while a `save_post` is running, which is where every caller that
+	 * needs it sits. That bounds the answer to the handlers this exists for, rather than to whether the
+	 * cleanup below got a chance to run -- `wp_insert_post()` skips `wp_after_insert_post` when a caller
+	 * passes `$fire_after_hooks = false`, and an entry left behind must not widen anything.
+	 *
+	 * What it reports is read off the row itself, so it is always a status the request genuinely held moments
+	 * earlier -- there is no value a caller can put here that the request did not already have. It can widen
+	 * the answer only across the transition the request just made, and only for the request that made it.
+	 *
 	 * @param \WP_Post|object $post
 	 *
 	 * @return string
 	 */
 	public static function get_status_for_edit_check( $post ) {
-		if ( isset( $post->ID ) && isset( self::$status_before_save[ (int) $post->ID ] ) ) {
-			return self::$status_before_save[ (int) $post->ID ];
+		$recorded = isset( $post->ID ) ? self::$status_before_save[ (int) $post->ID ] ?? null : null;
+
+		if ( ! is_null( $recorded ) && doing_action( 'save_post' ) ) {
+			return $recorded;
 		}
 
 		return $post->post_status ?? '';
@@ -1247,10 +1277,3 @@ class WordCamp_Budgets {
 		return $dom->saveXML();
 	}
 }
-
-/*
- * Registered at file scope rather than in the constructor: that only runs in the admin, while the
- * `map_meta_cap` callbacks that read this also run on cron and Ajax.
- */
-add_action( 'post_updated',         array( 'WordCamp_Budgets', 'remember_status_before_save' ), 10, 3 );
-add_action( 'wp_after_insert_post', array( 'WordCamp_Budgets', 'forget_status_before_save' ), PHP_INT_MAX );

--- a/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
+++ b/public_html/wp-content/plugins/wordcamp-payments/includes/wordcamp-budgets.php
@@ -813,8 +813,8 @@ class WordCamp_Budgets {
 	 * draft it was rather than as the status the submission moved it to. Everywhere else it's simply the
 	 * stored status.
 	 *
-	 * The recorded status is only honoured while a `save_post` is running, which is where every caller that
-	 * needs it sits. That bounds the answer to the handlers this exists for, rather than to whether the
+	 * The recorded status is only honoured while a save of this post is running, which is where every caller
+	 * that needs it sits. That bounds the answer to the handlers this exists for, rather than to whether the
 	 * cleanup below got a chance to run -- `wp_insert_post()` skips `wp_after_insert_post` when a caller
 	 * passes `$fire_after_hooks = false`, and an entry left behind must not widen anything.
 	 *
@@ -829,11 +829,33 @@ class WordCamp_Budgets {
 	public static function get_status_for_edit_check( $post ) {
 		$recorded = isset( $post->ID ) ? self::$status_before_save[ (int) $post->ID ] ?? null : null;
 
-		if ( ! is_null( $recorded ) && doing_action( 'save_post' ) ) {
+		if ( ! is_null( $recorded ) && self::is_inside_a_save( $post ) ) {
 			return $recorded;
 		}
 
 		return $post->post_status ?? '';
+	}
+
+	/**
+	 * Whether a `save_post` for the given post is running right now.
+	 *
+	 * Both forms count. `save_post_{$post_type}` fires before the untyped hook, so reading only the latter
+	 * would leave a handler on the typed one judging the request by the status the save had just written --
+	 * the same fields dropped, one hook earlier. Nothing here uses the typed hook today; this keeps it from
+	 * behaving differently if something does.
+	 *
+	 * @param \WP_Post|object $post
+	 *
+	 * @return bool
+	 */
+	protected static function is_inside_a_save( $post ) {
+		if ( doing_action( 'save_post' ) ) {
+			return true;
+		}
+
+		$post_type = $post->post_type ?? '';
+
+		return $post_type && doing_action( "save_post_{$post_type}" );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Budget requests submitted straight from the editor arrive at Central empty — no sponsor, no currency, no amount, no description. Reported for sponsor invoices in #team-orion; vendor payments and reimbursements have the same defect.

- Submitting moves a request out of the statuses its requester may edit, and the row already carries the new status by the time `save_post` runs. The handlers that write the entered values start with `post_edit_is_actionable()` → `edit_post`, so on the very save that submits, the requester is refused and nothing is stored.
- Reachable since #1966: `get_map_meta_cap_post()` now prefers `$args[0]` over the global `$post`. On an edit-form save that global is the object `post.php` read *before* `edit_post()` updated the row, so it still said `draft` and the check passed by accident.
- Fix: record the status each budget request held before the save that's running, and have the three CPTs' `map_meta_cap` callbacks and `user_can_edit_request()` read that instead of the stored status.
- Nothing is loosened: a request already past the editable statuses before the save reads the same either way. Only the transition itself changes.

Nothing was deleted — the values were never written — so invoices already submitted blank have to be redrafted.

Paired with @mcliwanow on this.

## How to review this PR

Read `wordcamp-budgets.php` first — `remember_status_before_save()`, `forget_status_before_save()`, `get_status_for_edit_check()` — then the four call sites.

**Where the reading is taken from.** `post_updated` would hand over the old post directly, but it and `wp_after_insert_post` fire for every post on every site in the network, and only these three post types have any use for them. The reading comes instead from each CPT's own `wp_insert_post_data` callback, past the post-type guard those already carry: that hook runs before the row is written, so the stored status is still the one the request had when the save began. No new always-on hook. The cleanup is attached from there too and detaches itself when the last entry goes, so a request that saves anything else never carries it either.

**How narrow the window is.** The record is honoured only while `doing_action( 'save_post' )`, which is where all four consumers sit. `wp_insert_post()` skips `wp_after_insert_post` when a caller passes `$fire_after_hooks = false`, and an entry left behind by one of those must not be able to widen anything — so the window does not depend on the cleanup having run.

**Why it can't be pushed around.** The value is read off the row with `get_post_status()`, never taken from the caller, so it is always a status the request genuinely held moments earlier. There is nothing an attacker can put here that the request did not already have. It is keyed by post ID, so it says nothing about any other record.

**Other notes.**
- `user_can_edit_request()` needed the same treatment: `save_request()` calls it after `post_edit_is_actionable()` with the post whose status is already the new one, so fixing only the capability layer would still have dropped the reimbursement text fields.
- `daff0185` documented the current behaviour as intentional ("a save that would have needed the stub has already returned"). That comment describes the bug; this replaces the stub's job with something that doesn't read the request body.

## Test plan

- [x] phpunit — 75/75 `WordCamp Budgets Dashboard`, 40/40 `WordCamp Payments`; full suite 1251 tests, only 3 pre-existing `Test_Groups_Blocks` failures (confirmed present on `production` too)
- [x] New tests fail against `origin/production` (7 failures + 2 errors) and pass here
- [x] The access-control assertions below hold on `production` *and* here, and fail against the pre-#1966 helper
- [x] phpcs clean on the new test file; no new findings on any changed line
- [x] Manual browser pass, both roles, before and after — re-run against the final wiring

### Automated coverage

`wordcamp-payments-network/tests/test-submit-transition.php`, 21 cases.

```bash
docker exec wordcamporg-phpunit_wp-1 bash -lc \
  'cd /app && ./public_html/wp-content/mu-plugins/vendor/bin/phpunit \
     -c phpunit.xml.dist --filter Test_Submit_Transition'
```

Each case drives the CPT's real submit path — the request body first, then the same array handed to `wp_update_post()`, the way `edit_post()` does — with the CPT's own status filter attached, so the recording under test is the one that runs in production.

**What has to start working**

| Test | What it pins down |
| --- | --- |
| `test_submitting_a_sponsor_invoice_stores_its_fields` | **The end-to-end one.** Real `save_invoice()` handler, real nonces, `send-invoice` set, `$GLOBALS['post']` staged the way `post.php` leaves it. Asserts the invoice lands at `wcbsi_submitted` **and** that all five `_wcbsi_*` values are stored. The reported bug, in one test. |
| `test_save_handler_may_act_while_submitting` (×3 CPTs) | The gate a `save_post` handler actually sees, asserted from inside a `save_post` callback — not after `wp_update_post()` returns, where the record has already been dropped. |

**What must not start working** — these pass on `production` too, so they are guarding, not demonstrating:

| Test | What it pins down |
| --- | --- |
| `test_editor_is_refused_a_non_draft_request_in_every_argument_form` (×3) | The access-control property #1966 restored: an Editor holding `edit_others_posts` and no network capability is refused `edit_post` **and** `delete_post` on a non-draft request — as an int, a numeric string and a `WP_Post`, with a foreign global `$post` set, in the `wp_ajax_upload_attachment()` request context where that distinction is actually read. Fails on all three post types against the pre-#1966 helper. |
| `test_submitting_one_request_does_not_open_another` (×3) | The record is keyed by post: submitting your own draft leaves the verdict on somebody else's approved request unchanged. |
| `test_save_handler_may_not_act_on_an_already_submitted_request` (×3) | A requester may submit, but may not then edit what they submitted. |
| `test_save_handler_may_not_act_on_an_approved_request` (×3) | Nor touch one approved for payout. |
| `test_recorded_status_is_only_honoured_inside_a_save` | Suppresses the cleanup the way a `$fire_after_hooks = false` caller does, then asserts the request still reads as submitted and `edit_post` is still refused. |
| `test_network_admin_may_act_on_a_submitted_request` (×3) | Central can still correct a submitted request. |
| `test_status_for_edit_check_falls_back_to_the_stored_status` | Outside a save it's just the stored status. |

To watch the first group fail, run the suite with `includes/` checked out from `production`:

```bash
git checkout origin/production -- public_html/wp-content/plugins/wordcamp-payments/includes/
# re-run the phpunit command above  ->  7 failures, 2 errors
git checkout HEAD -- public_html/wp-content/plugins/wordcamp-payments/includes/
```

### Manual test steps

Local docker stack. Two actors, exercised separately.

**Setup** — the Community dropdown reads a network option that is empty on a fresh local install, so the form can't be completed without seeding it:

```bash
docker exec wordcamporg-wordcamp.test-1 bash -lc \
  'wp --path=/usr/src/public_html/mu site option update wordcamp_qbo_classes \
     --format=json --allow-root <<< "{\"42\":\"Seattle, WA\"}"'
```

`seattle.wordcamp.test/2023` already ships a complete sponsor (`ACME Corp`, post 109) and `editorrole` — a subsite administrator who is **not** a network admin, which is the role that reproduces this. `admin` is the super admin.

1. **As `editorrole`, before the fix** (`git checkout origin/production -- .../includes/`) — Budget → Sponsor Invoices → Add New. Set sponsor `ACME Corp`, community `Seattle, WA`, description, currency `USD`, amount. Click *Send Invoice*. → Invoice stored as `wcbsi_submitted` with **zero** `_wcbsi_*` meta. Reopening it shows every field blank under "Status: Submitted".
2. **As `admin`**, `wordcamp.test/wp-admin/network/admin.php?page=sponsor-invoices-dashboard` → the invoice reads "Auto Draft / Error: The item does not have a currency", which is the reported symptom.
3. **As `editorrole`, after the fix** — identical flow, new invoice. → `wcbsi_submitted` with sponsor, class, currency, description and amount all stored. Central shows it complete alongside the broken one from step 1.
4. **Restriction still holds** — still as `editorrole`, on the invoice submitted in step 3, changed the amount and description in the DOM and posted the edit form directly (the Update button is correctly absent). → Refused; meta unchanged.
5. **Normal editing still works** — as `editorrole`, edited an existing *draft* invoice's amount and saved. → "Post updated", new value stored.

Steps 3–5 were re-run against the final wiring after the recording moved off `post_updated`, since that is a different code path from the one the first pass exercised.

Every end state was checked against the database, not just the UI:

```bash
docker exec wordcamporg-wordcamp.test-1 bash -lc \
  'wp --path=/usr/src/public_html/mu --url=https://seattle.wordcamp.test/2023/ \
     post meta list <ID> --keys=_wcbsi_sponsor_id,_wcbsi_qbo_class_id,_wcbsi_description,_wcbsi_currency,_wcbsi_amount --allow-root'
```

Fixtures deleted afterwards (invoices, the `wordcamp_qbo_classes` option, and the `wc_wordcamp_payments_index` rows, which the post deletion already cleaned up).

Vendor payments and reimbursements were **not** exercised in the browser — they're covered by the automated tests only.
