### PR TITLE
Post Types, Blocks: let organisers list volunteers on the front end

### DIFF
--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/avatar/edit.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/avatar/edit.js
@@ -22,6 +22,8 @@ function getPostLabel( postType ) {
 			return __( 'Speaker', 'wordcamporg' );
 		case 'wcb_organizer':
 			return __( 'Organizer', 'wordcamporg' );
+		case 'wcb_volunteer':
+			return __( 'Volunteer', 'wordcamporg' );
 		default:
 			return __( 'post', 'wordcamporg' );
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/index.js
@@ -5,3 +5,4 @@ import './organizers-list';
 import './sessions-list';
 import './speakers-list';
 import './sponsors-list';
+import './volunteers-list';

--- a/public_html/wp-content/mu-plugins/blocks/source/variations/volunteers-list/index.js
+++ b/public_html/wp-content/mu-plugins/blocks/source/variations/volunteers-list/index.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+
+const NAMESPACE = 'wordcamp/volunteers-query';
+const POST_TYPE = 'wcb_volunteer';
+
+registerBlockVariation( 'core/query', {
+	name: NAMESPACE,
+	title: __( 'Volunteers List', 'wordcamporg' ),
+	description: 'Display a list of volunteers',
+	isActive: [ 'namespace' ],
+	icon: 'hammer',
+	attributes: {
+		namespace: NAMESPACE,
+		query: {
+			perPage: 10,
+			pages: 0,
+			offset: 0,
+			postType: POST_TYPE,
+			order: 'asc',
+			orderBy: 'title',
+			author: '',
+			search: '',
+			exclude: [],
+			sticky: '',
+			inherit: false,
+		},
+	},
+	innerBlocks: [
+		[
+			'core/post-template',
+			{},
+			[
+				[
+					'core/group',
+					{ layout: { type: 'flex', flexWrap: 'nowrap' } },
+					[
+						[ 'wordcamp/avatar', { size: 96 } ],
+						[ 'core/post-title', { isLink: true } ],
+					],
+				],
+				[ 'core/post-excerpt' ],
+				[
+					'core/group',
+					{ layout: { type: 'flex', flexWrap: 'wrap' } },
+					[
+						[
+							'core/paragraph',
+							{ content: __( 'Team:', 'wordcamporg' ) },
+						],
+						[ 'core/post-terms', { term: 'wcb_volunteer_team' } ],
+					],
+				],
+			],
+		],
+		[ 'core/query-pagination' ],
+	],
+	allowedControls: [
+		'inherit',
+		'order',
+		'taxQuery',
+		'search',
+		'postCount',
+		'offset',
+		'pages',
+	],
+	scope: [ 'inserter' ],
+} );

--- a/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_volunteer.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/block-templates/single-wcb_volunteer.php
@@ -1,0 +1,26 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * Template: Single Volunteer
+ */
+?>
+
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)"><!-- wp:wordcamp/avatar {"className":"is-style-rounded"} /-->
+
+<!-- wp:post-title {"level":1} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+<!-- wp:spacer {"height":"0px","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|70"}}}} -->
+<div style="margin-bottom:var(--wp--preset--spacing--70);height:0px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/theme-templates/bootstrap.php
@@ -136,7 +136,7 @@ function inject_templates( $query_result, $query, $template_type ) {
 
 	$existing_templates = wp_list_pluck( $query_result, 'slug' );
 
-	foreach ( array( 'wcb_organizer', 'wcb_session', 'wcb_speaker', 'wcb_sponsor' ) as $type ) {
+	foreach ( array( 'wcb_organizer', 'wcb_session', 'wcb_speaker', 'wcb_sponsor', 'wcb_volunteer' ) as $type ) {
 		if (
 			// If there are no existing (user-created) templates.
 			! in_array( 'single-' . $type, $existing_templates, true ) &&
@@ -183,7 +183,7 @@ function inject_template( $block_template, $id, $template_type ) {
 		return $block_template;
 	}
 
-	foreach ( array( 'wcb_organizer', 'wcb_session', 'wcb_speaker', 'wcb_sponsor' ) as $type ) {
+	foreach ( array( 'wcb_organizer', 'wcb_session', 'wcb_speaker', 'wcb_sponsor', 'wcb_volunteer' ) as $type ) {
 		// For example, this matches `twentytwentythree//single-wcb_organizer`.
 		if ( str_ends_with( $id, 'single-' . $type ) ) {
 			$template = get_wordcamp_block_template( $type );
@@ -210,6 +210,7 @@ function get_wordcamp_block_template( $post_type = '' ) {
 		'wcb_session' => __( 'Single item: Session', 'wordcamporg' ),
 		'wcb_speaker' => __( 'Single item: Speaker', 'wordcamporg' ),
 		'wcb_sponsor' => __( 'Single item: Sponsor', 'wordcamporg' ),
+		'wcb_volunteer' => __( 'Single item: Volunteer', 'wordcamporg' ),
 	);
 
 	$template_file = __DIR__ . "/block-templates/single-{$post_type}.php";

--- a/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/rest-api.php
@@ -525,7 +525,7 @@ function register_user_validation_route() {
  */
 function register_additional_rest_fields() {
 	/**
-	 * Speaker/organizer avatars.
+	 * Speaker/organizer/volunteer avatars.
 	 *
 	 * We can't expose a Speaker's e-mail address in the API response, but can we go ahead
 	 * and derive their Gravatar URL and expose that instead.
@@ -562,6 +562,15 @@ function register_additional_rest_fields() {
 
 	register_rest_field(
 		'wcb_organizer',
+		'avatar_urls',
+		array(
+			'get_callback' => __NAMESPACE__ . '\get_avatar_urls_from_username_email',
+			'schema'       => $avatar_schema,
+		)
+	);
+
+	register_rest_field(
+		'wcb_volunteer',
 		'avatar_urls',
 		array(
 			'get_callback' => __NAMESPACE__ . '\get_avatar_urls_from_username_email',

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-volunteer-public.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-volunteer-public.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace WordCamp\WC_Post_Types\Tests;
+use WP_UnitTestCase, WP_REST_Request;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Front-end exposure of the Volunteer post type.
+ *
+ * `wcb_volunteer` was registered as non-public, which kept it out of the Query Loop block and left organisers
+ * with no way to list volunteers on the site (see #1282). Making it public is only safe as long as the
+ * contact details stay behind the `edit` context, so both halves are asserted here.
+ *
+ * @group wc-post-types
+ * @group rest-api
+ */
+class Test_Volunteer_Public extends WP_UnitTestCase {
+	/**
+	 * Register the REST routes and fields once for the whole class.
+	 */
+	public static function wpSetUpBeforeClass(): void {
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Create a published volunteer linked to a wp.org account.
+	 *
+	 * @return int The volunteer post ID.
+	 */
+	private function create_volunteer(): int {
+		return self::factory()->post->create(
+			array(
+				'post_type'   => 'wcb_volunteer',
+				'post_status' => 'publish',
+				'post_title'  => 'Test Volunteer',
+			)
+		);
+	}
+
+	/**
+	 * Dispatch a REST request for a single volunteer and return the response data.
+	 *
+	 * @param int    $post_id The volunteer post ID.
+	 * @param string $context The REST context to request.
+	 *
+	 * @return array The response data.
+	 */
+	private function get_volunteer_response( int $post_id, string $context = 'view' ): array {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/volunteers/' . $post_id );
+		$request->set_param( 'context', $context );
+
+		return rest_get_server()->dispatch( $request )->get_data();
+	}
+
+	/**
+	 * The Query Loop block only offers post types that `is_post_type_viewable()` accepts.
+	 */
+	public function test_volunteer_post_type_is_viewable(): void {
+		$this->assertTrue( is_post_type_viewable( get_post_type_object( 'wcb_volunteer' ) ) );
+	}
+
+	/**
+	 * Volunteers are served from the same style of route as the sibling participant post types.
+	 */
+	public function test_volunteer_rest_route_is_registered(): void {
+		$this->assertArrayHasKey( '/wp/v2/volunteers', rest_get_server()->get_routes() );
+	}
+
+	/**
+	 * The `wordcamp/avatar` block inside the Volunteers List variation reads `avatar_urls`.
+	 */
+	public function test_volunteer_response_includes_avatar_urls(): void {
+		$data = $this->get_volunteer_response( $this->create_volunteer() );
+
+		$this->assertArrayHasKey( 'avatar_urls', $data );
+
+		foreach ( rest_get_avatar_sizes() as $size ) {
+			$this->assertArrayHasKey( $size, $data['avatar_urls'] );
+		}
+	}
+
+	/**
+	 * Making the post type public must not turn the volunteer's contact details into public data.
+	 */
+	public function test_volunteer_contact_meta_is_not_exposed_to_anonymous_readers(): void {
+		$post_id = $this->create_volunteer();
+
+		update_post_meta( $post_id, '_wcb_volunteer_email', 'volunteer@example.org' );
+		update_post_meta( $post_id, '_wcb_volunteer_first_time', 'yes' );
+
+		wp_set_current_user( 0 );
+		$data = $this->get_volunteer_response( $post_id );
+		$meta = $data['meta'] ?? array();
+
+		$this->assertArrayNotHasKey( '_wcb_volunteer_email', $meta );
+		$this->assertArrayNotHasKey( '_wcb_volunteer_first_time', $meta );
+		$this->assertStringNotContainsString( 'volunteer@example.org', wp_json_encode( $data ) );
+	}
+}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -1697,15 +1697,16 @@ class WordCamp_Post_Types_Plugin {
 					'slug'       => 'volunteer',
 					'with_front' => false,
 				),
-				'supports'        => array( 'title', 'editor', 'excerpt', 'revisions', 'custom-fields', 'thumbnail' ),
+				'supports'        => array( 'title', 'editor', 'excerpt', 'revisions', 'custom-fields', 'thumbnail', 'shortlinks' ),
 				'menu_position'   => 22,
-				'public'          => false,
+				'public'          => true,
 				'show_ui'         => true,
 				'can_export'      => true,
 				'capability_type' => 'post',
 				'hierarchical'    => false,
 				'query_var'       => true,
 				'show_in_rest'    => true,
+				'rest_base'       => 'volunteers',
 				'menu_icon'       => 'dashicons-hammer',
 			)
 		);


### PR DESCRIPTION
## Summary

Fixes #1282.

`wcb_volunteer` is the only participant post type registered as non-public. Two consequences, both reported in the issue:

- The Query Loop block's post-type control only offers types that `is_post_type_viewable()` accepts, so volunteers never appear in it.
- No block or variation covers volunteers, unlike Speakers / Sessions / Sponsors / Organizers.

The workaround organisers are pointed at today is to abandon the CPT entirely and tag attendees with a CampTix admin flag instead.

This registers volunteers the same way organisers are registered, and adds the pieces that make them renderable:

- `wcb_volunteer` becomes `'public' => true`, gains `'rest_base' => 'volunteers'` and `shortlinks` support.
- New **Volunteers List** `core/query` variation, mirroring `organizers-list` (avatar + title, excerpt, `wcb_volunteer_team` terms, pagination).
- `avatar_urls` registered on `wcb_volunteer` in the REST API — the `wordcamp/avatar` block inside the variation reads it.
- `wcb_volunteer` case added to the avatar block's post label.
- `single-wcb_volunteer.php` block template, registered in `theme-templates/bootstrap.php`.

## How to review this PR

Suggested order: `wc-post-types.php` → `inc/rest-api.php` → the new variation → `theme-templates`.

Three decisions worth surfacing rather than making you reverse-engineer them:

- **Why it's safe to publish the post type.** `_wcb_volunteer_email` and `_wcb_volunteer_first_time` are registered with `'context' => array( 'edit' )` (`inc/rest-api.php`), so publishing the CPT does not put volunteer contact details into anonymous REST responses. `test_volunteer_contact_meta_is_not_exposed_to_anonymous_readers` pins that invariant. This is the half of the change most worth a second opinion.
- **Why `public => true` rather than a narrower flag.** `wcb_volunteer_team` has been registered with `'public' => true` against a private post type since it was introduced, so the data model already assumed public exposure. @o-samaras noted on the issue that no rationale for the private registration could be found; I couldn't find one either. If the meta team knows of a deliberate reason, that changes this PR substantially — say so and I'll rework it to keep the CPT private.
- **`rest_base` is a route change.** `/wp/v2/wcb_volunteer` becomes `/wp/v2/volunteers`, matching the four sibling post types. Low risk while the CPT is non-public and undocumented, but it is a behaviour change and I'd rather flag it than bury it. Happy to drop it if you'd prefer.

The variation uses the `hammer` dashicon (the CPT's own `menu_icon`) rather than a custom SVG, since the four sibling variations use bespoke artwork I'm not in a position to design. A matching icon from design would be a welcome follow-up.

## Test plan

- [x] phpunit — `WordCamp Post Types` suite 56/56 passing (4 new)
- [x] phpunit — full run shows no new failures vs. `production` (identical failure set; the 39 pre-existing failures are environmental: missing `intl` extension and the private `wporg-mu-plugins` repo)
- [x] phpcs — no new violations introduced (diffed sniff output against `production` per file)
- [x] `npm run build` in `mu-plugins/blocks` — clean; `eslint` clean on changed files
- [ ] **Manual browser pass — not done.** My local dev stack isn't provisioned, so this has not been verified in a rendered editor or front end.

### New tests

`public_html/wp-content/plugins/wc-post-types/tests/test-volunteer-public.php`:

1. `wcb_volunteer` passes `is_post_type_viewable()` — the gate the Query Loop control uses.
2. `/wp/v2/volunteers` is registered.
3. A published volunteer's REST response carries `avatar_urls` for every `rest_get_avatar_sizes()` size.
4. Volunteer contact meta stays out of an anonymous `view`-context response.

Tests 1–3 fail against `production` and pass with this change. Test 4 passes both before and after by design — it's a regression guard on the invariant that makes publishing the post type safe, not a demonstration of new behaviour.

### Manual test steps (not yet executed)

1. As an organiser, create two published Volunteers with wp.org usernames set, assigned to different Volunteer Teams.
2. Edit a page, insert **Volunteers List** from the inserter; confirm avatars, titles, excerpts and team terms render in the editor.
3. Confirm `wcb_volunteer` now also appears in a plain Query Loop's post-type control.
4. View the page logged out; confirm the list renders and volunteer titles link to a working single page.
5. Request `/wp-json/wp/v2/volunteers` logged out; confirm `avatar_urls` is present and no email address appears anywhere in the payload.
