### PR TITLE
Post Types: honour post visibility in the single session and speaker views

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/test-blocks-content.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-content.php
@@ -67,6 +67,11 @@ class Test_Blocks_Content extends WP_UnitTestCase {
 	public function tear_down() {
 		unset( $GLOBALS['post'] );
 
+		// Cleared here rather than inline, so a test that fails part way
+		// through cannot leave a later one thinking the visitor holds the
+		// password.
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
 		set_current_screen( 'dashboard' );
 
 		parent::tear_down();
@@ -166,8 +171,6 @@ class Test_Blocks_Content extends WP_UnitTestCase {
 
 		$content = get_all_the_content( $post_id );
 		$excerpt = get_trimmed_content( $post_id );
-
-		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
 
 		$this->assertStringContainsString( self::PROTECTED_BODY, $content );
 		$this->assertStringContainsString( self::PROTECTED_BODY, $excerpt );

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
@@ -37,6 +37,13 @@ class Test_Content_Appenders extends WP_UnitTestCase {
 
 		$this->plugin = new WordCamp_Post_Types_Plugin();
 
+		// `is_single_cpt_post()` reads the post type's own query var, which a
+		// plain permalink carries directly. Set the structure here rather than
+		// inheriting whatever an earlier test left behind -- a pretty one needs
+		// rewrite rules this run doesn't have, and `go_to()` would then match
+		// nothing. Core restores the original in `tear_down()`.
+		$this->set_permalink_structure( '' );
+
 		// `go_to()` fires `wp`, where this mu-plugin looks up the camp's other
 		// sites. Those don't exist in the test network, and the failed queries
 		// are only noise here.

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace WordCamp\WC_Post_Types\Tests;
+
+use WordCamp_Post_Types_Plugin;
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+// Two of the callbacks call `has_block_with_attrs()`, which lives in the
+// blocks mu-plugin and is always loaded alongside this plugin in production.
+if ( ! function_exists( 'WordCamp\Blocks\has_block_with_attrs' ) ) {
+	require_once SUT_WPMU_PLUGIN_DIR . '/blocks/blocks.php';
+}
+
+/**
+ * Tests for the material appended to a single session's or speaker's content.
+ *
+ * These callbacks run on `the_content`, which core applies to the password
+ * form it substitutes for a protected post's body.
+ *
+ * @group wc-post-types
+ */
+class Test_Content_Appenders extends WP_UnitTestCase {
+	/**
+	 * The plugin instance whose callbacks are under test.
+	 *
+	 * @var WordCamp_Post_Types_Plugin
+	 */
+	protected $plugin;
+
+	/**
+	 * Boot the plugin and open the site-id gates the callbacks check.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->plugin = new WordCamp_Post_Types_Plugin();
+
+		// `go_to()` fires `wp`, where this mu-plugin looks up the camp's other
+		// sites. Those don't exist in the test network, and the failed queries
+		// are only noise here.
+		remove_action( 'wp', 'WordCamp\\Latest_Site_Hints\\maybe_add_latest_site_hints' );
+
+		// The callbacks are limited to sites created after they shipped. This
+		// site's id is far below those defaults, so open them for the test.
+		foreach ( array(
+			'wcpt_speaker_post_avatar_min_site_id',
+			'wcpt_session_post_speaker_info_min_site_id',
+			'wcpt_session_post_slides_info_min_site_id',
+			'wcpt_session_post_video_info_min_site_id',
+			'wcpt_speaker_post_session_info_min_site_id',
+		) as $filter ) {
+			add_filter( $filter, '__return_zero' );
+		}
+	}
+
+	/**
+	 * Clear the password cookie, so a test that fails part way through cannot
+	 * leave a later one thinking the visitor holds the password.
+	 */
+	public function tear_down() {
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Hold the password the way `wp-login.php?action=postpass` does.
+	 *
+	 * @param string $password The post's password.
+	 */
+	private function hold_the_password( string $password ) {
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+		$hasher = new \PasswordHash( 8, true );
+
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = $hasher->HashPassword( $password );
+	}
+
+	/**
+	 * Create a session with a speaker, slides, video and a category, then make
+	 * it the queried post the way a request for its permalink would.
+	 *
+	 * @param array $args Extra arguments for the session.
+	 * @return int The session's ID.
+	 */
+	private function go_to_session( array $args = array() ): int {
+		$speaker_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_speaker',
+			'post_status' => 'publish',
+			'post_title'  => 'Speaker Name',
+		) );
+
+		$session_id = self::factory()->post->create( array_merge(
+			array(
+				'post_type'    => 'wcb_session',
+				'post_status'  => 'publish',
+				'post_title'   => 'Session Title',
+				'post_content' => 'Session body.',
+			),
+			$args
+		) );
+
+		add_post_meta( $session_id, '_wcpt_speaker_id', $speaker_id );
+		add_post_meta( $session_id, '_wcpt_session_slides', 'https://example.org/slides' );
+		// The meta is sanitized to '' unless the host is wordpress.tv.
+		add_post_meta( $session_id, '_wcpt_session_video', 'https://wordpress.tv/session-video' );
+
+		wp_set_object_terms( $session_id, 'Unannounced Track', 'wcb_session_category' );
+
+		$this->go_to( get_permalink( $session_id ) );
+
+		return $session_id;
+	}
+
+	/**
+	 * Run every session callback over the content the post would render with.
+	 *
+	 * @param int    $session_id The session.
+	 * @param string $content    The content core would hand the filters.
+	 * @return string
+	 */
+	private function apply_session_appenders( int $session_id, string $content ): string {
+		foreach ( array(
+			'add_speaker_info_to_session_posts',
+			'add_slides_info_to_session_posts',
+			'add_video_info_to_session_posts',
+			'add_session_categories_to_session_posts',
+		) as $callback ) {
+			$content = $this->plugin->$callback( $content );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * The ordinary case: everything is appended to a public session.
+	 */
+	public function test_appends_to_a_public_session() {
+		$session_id = $this->go_to_session();
+
+		$output = $this->apply_session_appenders( $session_id, 'Session body.' );
+
+		$this->assertStringContainsString( 'Speaker Name', $output );
+		$this->assertStringContainsString( 'https://example.org/slides', $output );
+		$this->assertStringContainsString( 'https://wordpress.tv/session-video', $output );
+		$this->assertStringContainsString( 'Unannounced Track', $output );
+	}
+
+	/**
+	 * A protected session keeps the password form on its own. Core has already
+	 * replaced the body by the time these run, so appending would put the
+	 * session's own material back beneath the form.
+	 */
+	public function test_appends_nothing_to_a_protected_session() {
+		$session_id = $this->go_to_session( array( 'post_password' => 'hunter2' ) );
+
+		$form   = get_the_password_form( $session_id );
+		$output = $this->apply_session_appenders( $session_id, $form );
+
+		$this->assertSame( $form, $output );
+		$this->assertStringNotContainsString( 'Speaker Name', $output );
+		$this->assertStringNotContainsString( 'https://example.org/slides', $output );
+		$this->assertStringNotContainsString( 'https://wordpress.tv/session-video', $output );
+		$this->assertStringNotContainsString( 'Unannounced Track', $output );
+	}
+
+	/**
+	 * A visitor holding the password sees the appended material again.
+	 */
+	public function test_appends_to_a_protected_session_for_the_password_holder() {
+		$session_id = $this->go_to_session( array( 'post_password' => 'hunter2' ) );
+
+		$this->hold_the_password( 'hunter2' );
+
+		$output = $this->apply_session_appenders( $session_id, 'Session body.' );
+
+		$this->assertStringContainsString( 'Speaker Name', $output );
+		$this->assertStringContainsString( 'https://wordpress.tv/session-video', $output );
+	}
+
+	/**
+	 * Create a speaker with a session referencing them, then make the speaker
+	 * the queried post the way a request for its permalink would.
+	 *
+	 * @param array $args Extra arguments for the speaker.
+	 * @return int The speaker's ID.
+	 */
+	private function go_to_speaker( array $args = array() ): int {
+		$speaker_id = self::factory()->post->create( array_merge(
+			array(
+				'post_type'   => 'wcb_speaker',
+				'post_status' => 'publish',
+				'post_title'  => 'Speaker Name',
+			),
+			$args
+		) );
+
+		$session_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'publish',
+			'post_title'  => 'Unannounced Session',
+		) );
+
+		add_post_meta( $session_id, '_wcpt_speaker_id', $speaker_id );
+
+		$this->go_to( get_permalink( $speaker_id ) );
+
+		return $speaker_id;
+	}
+
+	/**
+	 * Run the speaker callbacks in the order they are hooked, so the avatar
+	 * goes above the content and the session list below it.
+	 *
+	 * @param string $content The content core would hand the filters.
+	 * @return string
+	 */
+	private function apply_speaker_appenders( string $content ): string {
+		$content = $this->plugin->add_avatar_to_speaker_posts( $content );
+
+		return $this->plugin->add_session_info_to_speaker_posts( $content );
+	}
+
+	/**
+	 * The ordinary case: both callbacks add their markup to a public speaker.
+	 *
+	 * Without this, the negative test below could pass because the callbacks
+	 * never ran at all rather than because the password stopped them.
+	 */
+	public function test_appends_to_a_public_speaker() {
+		$this->go_to_speaker();
+
+		$output = $this->apply_speaker_appenders( 'Speaker bio.' );
+
+		$this->assertStringContainsString( 'speaker-avatar', $output );
+		$this->assertStringContainsString( 'Unannounced Session', $output );
+	}
+
+	/**
+	 * The speaker-side callbacks behave the same way as the session ones.
+	 */
+	public function test_appends_nothing_to_a_protected_speaker() {
+		$speaker_id = $this->go_to_speaker( array( 'post_password' => 'hunter2' ) );
+
+		$form   = get_the_password_form( $speaker_id );
+		$output = $this->apply_speaker_appenders( $form );
+
+		$this->assertSame( $form, $output );
+		$this->assertStringNotContainsString( 'Unannounced Session', $output );
+		$this->assertStringNotContainsString( 'speaker-avatar', $output );
+	}
+
+	/**
+	 * A visitor holding the speaker's password sees both again.
+	 */
+	public function test_appends_to_a_protected_speaker_for_the_password_holder() {
+		$this->go_to_speaker( array( 'post_password' => 'hunter2' ) );
+
+		$this->hold_the_password( 'hunter2' );
+
+		$output = $this->apply_speaker_appenders( 'Speaker bio.' );
+
+		$this->assertStringContainsString( 'speaker-avatar', $output );
+		$this->assertStringContainsString( 'Unannounced Session', $output );
+	}
+}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -807,6 +807,19 @@ class WordCamp_Post_Types_Plugin {
 	}
 
 	/**
+	 * Whether the callbacks below should add their markup to a post's content.
+	 *
+	 * @param string $post_type The post type the caller adds to.
+	 *
+	 * @return bool
+	 */
+	protected function should_add_to_content( $post_type ) {
+		return $this->is_single_cpt_post( $post_type )
+			&& ! site_supports_block_templates()
+			&& ! post_password_required( get_post() );
+	}
+
+	/**
 	 * Add the speaker's avatar to their post
 	 *
 	 * We don't enable it for sites that were created before it was committed, because it may need custom CSS
@@ -820,7 +833,7 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$enabled_site_ids = apply_filters( 'wcpt_speaker_post_avatar_enabled_site_ids', array( 364 ) );    // 2014.sf
 
-		if ( ! $this->is_single_cpt_post( 'wcb_speaker' ) || site_supports_block_templates() ) {
+		if ( ! $this->should_add_to_content( 'wcb_speaker' ) ) {
 			return $content;
 		}
 
@@ -854,7 +867,7 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$enabled_site_ids = apply_filters( 'wcpt_session_post_speaker_info_enabled_site_ids', array( 364 ) );    // 2014.sf
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) || site_supports_block_templates() ) {
+		if ( ! $this->should_add_to_content( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -934,7 +947,7 @@ class WordCamp_Post_Types_Plugin {
 			)
 		);
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) || site_supports_block_templates() ) {
+		if ( ! $this->should_add_to_content( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -985,7 +998,7 @@ class WordCamp_Post_Types_Plugin {
 			)
 		);
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) || site_supports_block_templates() ) {
+		if ( ! $this->should_add_to_content( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -1023,7 +1036,7 @@ class WordCamp_Post_Types_Plugin {
 	public function add_session_categories_to_session_posts( $content ) {
 		global $post;
 
-		if ( ! $this->is_single_cpt_post( 'wcb_session' ) || site_supports_block_templates() ) {
+		if ( ! $this->should_add_to_content( 'wcb_session' ) ) {
 			return $content;
 		}
 
@@ -1082,7 +1095,7 @@ class WordCamp_Post_Types_Plugin {
 		global $post;
 		$enabled_site_ids = apply_filters( 'wcpt_speaker_post_session_info_enabled_site_ids', array( 364 ) );    // 2014.sf
 
-		if ( ! $this->is_single_cpt_post( 'wcb_speaker' ) || site_supports_block_templates() ) {
+		if ( ! $this->should_add_to_content( 'wcb_speaker' ) ) {
 			return $content;
 		}
 


### PR DESCRIPTION
Follow-up to #1980, from [this review comment](https://github.com/WordPress/wordcamp.org/pull/1980#pullrequestreview-5067383317).

#1980 handled the listing blocks. The single post view has the same shape one level down. `wc-post-types` hooks six callbacks onto `the_content` that add material to single session and speaker posts — the speaker list, slides link, video link and session categories on a session, and the avatar and session list on a speaker. Core applies the `the_content` filters to the password form it substitutes for a protected post's body, and none of the six consulted the post's visibility, so they added their markup around the form.

All six already shared the same guard:

```php
if ( ! $this->is_single_cpt_post( 'wcb_session' ) || site_supports_block_templates() ) {
	return $content;
}
```

This moves that into `should_add_to_content()` next to `is_single_cpt_post()`, with the visibility check alongside the two conditions it already had, and routes all six through it. Consolidating rather than repeating the check six times means the next callback added here inherits it instead of having to remember it.

Nothing changes for a post with no password: `post_password_required()` returns false immediately, and the four tests covering the ordinary case pass with and without this change.

`add_nofollow_to_sponsor_links` is left alone — it only rewrites links already present in the content it is handed, so it adds nothing to a password form.

### Also here

`mu-plugins/tests/test-blocks-content.php` from #1980 set the `wp-postpass_*` cookie and cleared it inline, so a test failing part way through left the cookie set for later tests. It is cleared in `tear_down()` now. This surfaced while writing the tests below: a leaked cookie made one of them pass for the wrong reason.

### How to test the changes in this Pull Request

1. Run the tests:

   ```bash
   ./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist --testsuite "WordCamp Post Types"
   ```

2. These callbacks only run on sites using a classic theme, and only above the site-id gates each one checks, so a local camp site needs both. Activate a classic theme, then drop this in `public_html/wp-content/mu-plugins/` to open the gates:

   ```php
   <?php
   add_filter( 'wcpt_session_post_speaker_info_min_site_id', '__return_zero' );
   add_filter( 'wcpt_session_post_slides_info_min_site_id',  '__return_zero' );
   add_filter( 'wcpt_session_post_video_info_min_site_id',   '__return_zero' );
   add_filter( 'wcpt_speaker_post_avatar_min_site_id',       '__return_zero' );
   add_filter( 'wcpt_speaker_post_session_info_min_site_id', '__return_zero' );
   ```

3. Edit a session at `/wp-admin/edit.php?post_type=wcb_session`: give it body text, assign a speaker, a session category, a slides URL, and a video URL. The video field only accepts a `wordpress.tv` host — anything else is stored empty.
4. View the session's own page logged out. The body, the speaker list, the slides link, the video link and the categories should all be there. This is the baseline; confirm it before step 5, because the rest of the check is meaningless if these were never rendering.
<img width="509" height="605" alt="Protected_session___WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/48f1c980-296f-4c21-a0fb-9cf0a82af9f5" />

5. Set Status & visibility → Visibility to "Password protected", give it a password, and reload logged out. The page should show the password form on its own — no speaker list, no slides link, no video link, no categories.
<img width="637" height="550" alt="Protected_session___WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/ed491ec5-6537-4287-b082-d32b335ed6c6" />

6. Enter the password. The body and all four additions should come back.
7. Repeat on a speaker post, which has its own two: the avatar above the content and the session list below it.

| Public | Protected |
| --- | --- |
| <img width="449" height="444" alt="Awesome_Author___WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/c5cce331-53a6-4494-a4bd-6453bdc0b6fc" /> | <img width="609" height="453" alt="Awesome_Author___WordCamp_Seattle_2023" src="https://github.com/user-attachments/assets/d7002e09-ca82-422f-b0ac-a00543581a96" /> |

8. Set visibility back to Public and confirm both pages render exactly as they did in step 4.
9. Remove the mu-plugin file from step 2.
