### PR TITLE
Sponsors: store agreement attachments with the private status

### DIFF
--- a/public_html/wp-content/mu-plugins/sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/sponsor-agreements.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace WordCamp\Sponsor_Agreements;
+
+use WP_Post;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'added_post_meta',              __NAMESPACE__ . '\note_sponsor_agreement',      10, 4 );
+add_action( 'updated_post_meta',            __NAMESPACE__ . '\note_sponsor_agreement',      10, 4 );
+add_filter( 'xmlrpc_prepare_media_item',    __NAMESPACE__ . '\redact_agreement',            10, 2 );
+add_filter( 'wp_prepare_attachment_for_js', __NAMESPACE__ . '\redact_agreement_for_js',     10, 2 );
+add_filter( 'wp_unique_filename',           __NAMESPACE__ . '\obscure_sponsor_file_names',  10, 2 );
+
+
+/**
+ * The meta keys that name a sponsor's agreement.
+ *
+ * `_wcpt_sponsor_agreement` sits on a `wcb_sponsor` on an event site, and `mes_sponsor_agreement` on an
+ * `mes_sponsor` on central. Both hold nothing but an attachment ID -- see `save_post_sponsor()` in
+ * `wc-post-types` and `MES_Sponsor::save_post_meta()`.
+ *
+ * Duplicated here rather than referenced, because this file loads on every site in the network and neither
+ * plugin does: `wc-post-types` returns early on central, and `multi-event-sponsors` only runs there.
+ *
+ * @return string[]
+ */
+function get_agreement_meta_keys() {
+	return array( '_wcpt_sponsor_agreement', 'mes_sponsor_agreement' );
+}
+
+/**
+ * The post types a sponsor is stored as, on an event site and on central respectively.
+ *
+ * @return string[]
+ */
+function get_sponsor_post_types() {
+	return array( 'wcb_sponsor', 'mes_sponsor' );
+}
+
+/**
+ * The meta key that marks an attachment as a sponsorship agreement.
+ *
+ * Recorded on the attachment rather than read back off the sponsor each time, so that the answer doesn't
+ * change when the file is detached, reparented, or left behind by a deleted sponsor.
+ */
+const AGREEMENT_MARKER_META_KEY = '_wcorg_sponsor_agreement';
+
+
+/**
+ * Mark the file a sponsor names as its agreement.
+ *
+ * Hooked to the meta write rather than to `save_post`, so that both plugins that store an agreement are
+ * covered from one place, whichever route wrote it.
+ *
+ * @param int    $meta_id
+ * @param int    $object_id
+ * @param string $meta_key
+ * @param mixed  $meta_value
+ */
+function note_sponsor_agreement( $meta_id, $object_id, $meta_key, $meta_value ) {
+	if ( ! in_array( $meta_key, get_agreement_meta_keys(), true ) ) {
+		return;
+	}
+
+	/*
+	 * `mes_sponsor_agreement` carries no underscore, so it isn't protected meta and the Custom Fields box
+	 * will write it to anything. Only a sponsor names its own agreement.
+	 */
+	if ( ! in_array( get_post_type( $object_id ), get_sponsor_post_types(), true ) ) {
+		return;
+	}
+
+	// An array or an object would come out of `absint()` as `1`, which is another post entirely.
+	if ( ! is_scalar( $meta_value ) ) {
+		return;
+	}
+
+	make_agreement_private( absint( $meta_value ) );
+}
+
+/**
+ * Mark one attachment as an agreement and give it the `private` status.
+ *
+ * An agreement is a business document, so it doesn't take the public status its sponsor has. `private` is
+ * the status Core reserves for an attachment that shouldn't follow its parent, and it's what the REST
+ * routes, the front-end queries, the attachment permalink and search all read.
+ *
+ * @param int $attachment_id
+ *
+ * @return bool Whether the attachment needed the status and got it.
+ */
+function make_agreement_private( $attachment_id ) {
+	if ( ! $attachment_id ) {
+		return false;
+	}
+
+	$attachment = get_post( $attachment_id );
+
+	if ( ! $attachment instanceof WP_Post || 'attachment' !== $attachment->post_type ) {
+		return false;
+	}
+
+	update_post_meta( $attachment->ID, AGREEMENT_MARKER_META_KEY, 1 );
+
+	/*
+	 * Only from `inherit`. `private` is already where this is going; moving a file out of `trash` would
+	 * resurrect it; `auto-draft` belongs to an upload that never finished.
+	 */
+	if ( 'inherit' !== $attachment->post_status ) {
+		return false;
+	}
+
+	$updated = wp_update_post( array(
+		'ID'          => $attachment->ID,
+		'post_status' => 'private',
+	) );
+
+	return ! is_wp_error( $updated ) && $updated > 0;
+}
+
+/**
+ * Whether an attachment is a sponsorship agreement.
+ *
+ * @param int $attachment_id
+ *
+ * @return bool
+ */
+function is_agreement( $attachment_id ) {
+	return (bool) get_post_meta( $attachment_id, AGREEMENT_MARKER_META_KEY, true );
+}
+
+/**
+ * Whether an attachment is an agreement the current user isn't one of the readers for.
+ *
+ * Asks Core the same question the queries and the REST routes ask, rather than keeping a second rule in
+ * step with the status. On a WordCamp site it resolves to the organizers, who are Editors.
+ *
+ * @param int $attachment_id
+ *
+ * @return bool
+ */
+function is_hidden_agreement( $attachment_id ) {
+	return is_agreement( $attachment_id ) && ! current_user_can( 'read_post', $attachment_id );
+}
+
+/**
+ * Leave an agreement out of XML-RPC media responses.
+ *
+ * `wp.getMediaItem` resolves an attachment by ID and runs no query, so the status doesn't reach it.
+ * Returning an empty struct keeps the method able to answer without describing the file.
+ *
+ * @param array   $media_item_struct
+ * @param WP_Post $media_item
+ *
+ * @return array
+ */
+function redact_agreement( $media_item_struct, $media_item ) {
+	return is_hidden_agreement( $media_item->ID ) ? array() : $media_item_struct;
+}
+
+/**
+ * Leave an agreement out of the media details the admin hands to JavaScript.
+ *
+ * `wp_ajax_get_attachment()` takes an ID and runs no query either, so this is `redact_agreement()` on the
+ * other route that resolves that way.
+ *
+ * @param array   $response
+ * @param WP_Post $attachment
+ *
+ * @return array
+ */
+function redact_agreement_for_js( $response, $attachment ) {
+	return is_hidden_agreement( $attachment->ID ) ? array() : $response;
+}
+
+/**
+ * Add a CSPRN to the names of files uploaded to a sponsor, as `wordcamp-payments` does for its own files.
+ *
+ * Applies to every upload made against a sponsor, not just the agreement: the agreement is chosen from the
+ * Media modal after the upload has already landed, so nothing at this point tells one file from the other.
+ *
+ * @param string $filename
+ * @param string $extension
+ *
+ * @return string
+ */
+function obscure_sponsor_file_names( $filename, $extension ) {
+	$attached_post = get_post( get_upload_parent_id() );
+
+	if ( ! $attached_post instanceof WP_Post ) {
+		return $filename;
+	}
+
+	if ( ! in_array( $attached_post->post_type, get_sponsor_post_types(), true ) ) {
+		return $filename;
+	}
+
+	return add_csprn_to_filename( $filename, $extension );
+}
+
+/**
+ * The post an upload in progress is being attached to.
+ *
+ * `post_id` is what the Media modal and `async-upload.php` send; `post` is what the REST media route takes,
+ * which is the block editor's path to the same place.
+ *
+ * @return int
+ */
+function get_upload_parent_id() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- reading a name, deciding nothing.
+	return absint( $_REQUEST['post_id'] ?? $_REQUEST['post'] ?? 0 );
+}
+
+/**
+ * Put a CSPRN between a file's name and its extension.
+ *
+ * A length of `16` was chosen because it keeps the name manageable. See
+ * https://core.trac.wordpress.org/ticket/43546#comment:34 for where the technique comes from.
+ *
+ * @param string $filename
+ * @param string $extension Including the leading dot, as `wp_unique_filename()` passes it.
+ *
+ * @return string
+ */
+function add_csprn_to_filename( $filename, $extension ) {
+	$name = $filename;
+
+	// Trim the extension from the end only, so a name that repeats it keeps the copies it meant to have.
+	if ( $extension && str_ends_with( $name, $extension ) ) {
+		$name = substr( $name, 0, - strlen( $extension ) );
+	}
+
+	return sprintf( '%s-%s%s', $name, wp_generate_password( 16, false, false ), $extension );
+}

--- a/public_html/wp-content/mu-plugins/sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/sponsor-agreements.php
@@ -10,7 +10,6 @@ add_action( 'added_post_meta',              __NAMESPACE__ . '\note_sponsor_agree
 add_action( 'updated_post_meta',            __NAMESPACE__ . '\note_sponsor_agreement',      10, 4 );
 add_filter( 'xmlrpc_prepare_media_item',    __NAMESPACE__ . '\redact_agreement',            10, 2 );
 add_filter( 'wp_prepare_attachment_for_js', __NAMESPACE__ . '\redact_agreement_for_js',     10, 2 );
-add_filter( 'wp_unique_filename',           __NAMESPACE__ . '\obscure_sponsor_file_names',  10, 2 );
 
 
 /**
@@ -76,7 +75,20 @@ function note_sponsor_agreement( $meta_id, $object_id, $meta_key, $meta_value ) 
 		return;
 	}
 
-	make_agreement_private( absint( $meta_value ) );
+	$attachment_id = absint( $meta_value );
+
+	// Asked before the mark is written, so the file is renamed once however many sponsors go on to name it.
+	$already_an_agreement = is_agreement( $attachment_id );
+
+	make_agreement_private( $attachment_id );
+
+	/*
+	 * After the status, and never fatal: the status is what closes the REST routes and the queries, so a
+	 * rename that doesn't happen leaves a marked, findable file rather than an unrecorded one.
+	 */
+	if ( ! $already_an_agreement && is_agreement( $attachment_id ) ) {
+		rename_agreement_file( $attachment_id );
+	}
 }
 
 /**
@@ -175,44 +187,6 @@ function redact_agreement_for_js( $response, $attachment ) {
 }
 
 /**
- * Add a CSPRN to the names of files uploaded to a sponsor, as `wordcamp-payments` does for its own files.
- *
- * Applies to every upload made against a sponsor, not just the agreement: the agreement is chosen from the
- * Media modal after the upload has already landed, so nothing at this point tells one file from the other.
- *
- * @param string $filename
- * @param string $extension
- *
- * @return string
- */
-function obscure_sponsor_file_names( $filename, $extension ) {
-	$attached_post = get_post( get_upload_parent_id() );
-
-	if ( ! $attached_post instanceof WP_Post ) {
-		return $filename;
-	}
-
-	if ( ! in_array( $attached_post->post_type, get_sponsor_post_types(), true ) ) {
-		return $filename;
-	}
-
-	return add_csprn_to_filename( $filename, $extension );
-}
-
-/**
- * The post an upload in progress is being attached to.
- *
- * `post_id` is what the Media modal and `async-upload.php` send; `post` is what the REST media route takes,
- * which is the block editor's path to the same place.
- *
- * @return int
- */
-function get_upload_parent_id() {
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- reading a name, deciding nothing.
-	return absint( $_REQUEST['post_id'] ?? $_REQUEST['post'] ?? 0 );
-}
-
-/**
  * Put a CSPRN between a file's name and its extension.
  *
  * A length of `16` was chosen because it keeps the name manageable. See
@@ -232,4 +206,153 @@ function add_csprn_to_filename( $filename, $extension ) {
 	}
 
 	return sprintf( '%s-%s%s', $name, wp_generate_password( 16, false, false ), $extension );
+}
+
+/**
+ * Give an agreement's file a name that isn't the one it was uploaded under.
+ *
+ * Runs when a file is named as an agreement rather than when it's uploaded, so that it covers one chosen
+ * from the Media Library as well as one uploaded from the Sponsor screen, and leaves a sponsor's other
+ * uploads alone.
+ *
+ * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
+ * `wp_get_attachment_url()` -- so the new name reaches every reader.
+ *
+ * Every file Core derives from the upload moves with it, under one new base name:
+ *
+ * - the generated sizes, which for a PDF are renderings of the first page and for an image are copies of
+ *   it at up to 2048px;
+ * - the full-size original, when Core scaled the upload down. `_wp_attached_file` then points at the
+ *   `-scaled` copy while `original_image` holds the name the sizes are derived from, so that -- not the
+ *   attached file -- is what the new base is built from.
+ *
+ * Acts on the current site. `ms_upload_constants()` defines `UPLOADS` for whichever site was current at
+ * bootstrap, so this can't be called inside a `switch_to_blog()`.
+ *
+ * The `guid` is deliberately left alone. It's an identifier rather than the URL anything is served from,
+ * and Core's rule is that it doesn't change once a post has one.
+ *
+ * @param int $attachment_id
+ *
+ * @return array {
+ *     What happened on disk. The metadata always names whatever each file ended up being called.
+ *
+ *     @type int $renamed     Files moved.
+ *     @type int $left_behind Files still under the name they had.
+ * }
+ */
+function rename_agreement_file( $attachment_id ) {
+	$outcome       = array(
+		'renamed'     => 0,
+		'left_behind' => 0,
+	);
+	$attached_path = get_attached_file( $attachment_id );
+
+	if ( ! $attached_path || ! is_file( $attached_path ) ) {
+		return $outcome;
+	}
+
+	$directory = dirname( $attached_path );
+	$metadata  = wp_get_attachment_metadata( $attachment_id );
+	$metadata  = is_array( $metadata ) ? $metadata : array();
+
+	$old_base     = empty( $metadata['original_image'] ) ? wp_basename( $attached_path ) : $metadata['original_image'];
+	$extension    = pathinfo( $old_base, PATHINFO_EXTENSION );
+	$extension    = $extension ? '.' . $extension : '';
+	$new_base     = wp_unique_filename( $directory, add_csprn_to_filename( $old_base, $extension ) );
+	$old_base     = substr( $old_base, 0, strlen( $old_base ) - strlen( $extension ) );
+	$new_base     = substr( $new_base, 0, strlen( $new_base ) - strlen( $extension ) );
+	$already_done = array();
+
+	/**
+	 * Move one of the attachment's files, and answer to what it's now called.
+	 *
+	 * Two sizes can name the same file -- a theme registering a size Core already generates -- so the
+	 * second time one comes round it has already been dealt with. The cache is what keeps its metadata in
+	 * step with the first one's, and what keeps one file from being counted twice.
+	 *
+	 * @param string $name
+	 *
+	 * @return string
+	 */
+	$move = function ( $name ) use ( $directory, $old_base, $new_base, $extension, &$already_done, &$outcome ) {
+		if ( isset( $already_done[ $name ] ) ) {
+			return $already_done[ $name ];
+		}
+
+		$source = $directory . '/' . $name;
+
+		/*
+		 * Core names a derivative `<base>-<width>x<height>.<ext>` or `<base>-scaled.<ext>`, so the
+		 * separator is what tells `photo-150x150.jpg` from `photobooth-150x150.jpg`. Without it the
+		 * second would be rebased into `photo-<random>booth-150x150.jpg`, splicing the name rather than
+		 * replacing what it starts with.
+		 */
+		$derived = $name === $old_base . $extension || str_starts_with( $name, $old_base . '-' );
+
+		if ( ! $derived ) {
+			// Not this attachment's to rename. Count it only if there's a file there to be concerned with.
+			$outcome['left_behind'] += is_file( $source ) ? 1 : 0;
+			$already_done[ $name ]   = $name;
+
+			return $name;
+		}
+
+		$new_name = $new_base . substr( $name, strlen( $old_base ) );
+
+		// A name in the metadata with no file behind it was already stale, and moves nothing either way.
+		if ( ! is_file( $source ) ) {
+			$already_done[ $name ] = $name;
+
+			return $name;
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- WP_Filesystem needs credentials this can't ask for, and a failure is reported rather than fatal.
+		if ( ! @rename( $source, $directory . '/' . $new_name ) ) {
+			++$outcome['left_behind'];
+			$already_done[ $name ] = $name;
+
+			return $name;
+		}
+
+		++$outcome['renamed'];
+		$already_done[ $name ] = $new_name;
+
+		return $new_name;
+	};
+
+	$attached_name = wp_basename( $attached_path );
+	$new_attached  = $move( $attached_name );
+
+	/*
+	 * Carry on when the attached file itself wouldn't move. Everything else is named from `$old_base`
+	 * rather than from it, so those can still go -- and whether they went or not is the whole of what the
+	 * count is for.
+	 */
+	if ( ! empty( $metadata['original_image'] ) ) {
+		$metadata['original_image'] = $move( $metadata['original_image'] );
+	}
+
+	foreach ( $metadata['sizes'] ?? array() as $size => $details ) {
+		if ( empty( $details['file'] ) ) {
+			continue;
+		}
+
+		$metadata['sizes'][ $size ]['file'] = $move( $details['file'] );
+	}
+
+	if ( ! empty( $metadata['file'] ) ) {
+		$path_prefix      = str_contains( $metadata['file'], '/' ) ? dirname( $metadata['file'] ) . '/' : '';
+		$metadata['file'] = $path_prefix . $new_attached;
+	}
+
+	if ( $metadata ) {
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+	}
+
+	if ( $new_attached !== $attached_name ) {
+		update_attached_file( $attachment_id, $directory . '/' . $new_attached );
+	}
+
+	return $outcome;
 }

--- a/public_html/wp-content/mu-plugins/sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/sponsor-agreements.php
@@ -142,7 +142,12 @@ function secure_agreement( $attachment_id ) {
 	 * rename that doesn't happen leaves a marked, findable file rather than an unrecorded one.
 	 */
 	if ( ! $already_an_agreement && is_agreement( $attachment_id ) ) {
-		rename_agreement_file( $attachment_id );
+		$outcome = rename_agreement_file( $attachment_id );
+
+		// A file left under the name it had is a URL that may already be out there.
+		if ( $outcome['left_behind'] ) {
+			log( 'sponsor_agreement_files_not_renamed', array_merge( compact( 'attachment_id' ), $outcome ) );
+		}
 	}
 }
 
@@ -393,8 +398,9 @@ function add_csprn_to_filename( $filename, $extension ) {
  * from the Media Library as well as one uploaded from the Sponsor screen, and leaves a sponsor's other
  * uploads alone.
  *
- * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
- * `wp_get_attachment_url()` -- so the new name reaches every reader.
+ * Both plugins resolve an agreement through `wp_get_attachment_url()`, so the new name reaches them.
+ * Content that embeds a file by URL doesn't follow it, and the rename stays anyway: it is what retires
+ * the URL the file had while it sat in the Library.
  *
  * Every file Core derives from the upload moves with it, under one new base name:
  *

--- a/public_html/wp-content/mu-plugins/sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/sponsor-agreements.php
@@ -4,12 +4,38 @@ namespace WordCamp\Sponsor_Agreements;
 
 use WP_Post;
 
+use function WordCamp\Logger\log;
+
 defined( 'WPINC' ) || die();
+
+/**
+ * The meta key that marks an attachment as a sponsorship agreement.
+ *
+ * Recorded on the attachment rather than read back off the sponsor each time, so that the answer doesn't
+ * change when the file is detached, reparented, or left behind by a deleted sponsor.
+ */
+const AGREEMENT_MARKER_META_KEY = '_wcorg_sponsor_agreement';
+
+/**
+ * The upload field the Sponsor Agreement modal marks its own uploads with.
+ *
+ * A file is recorded as the agreement when the sponsor is saved, which can be a while after it lands and
+ * may never happen at all. The modal sends this alongside the file instead, so the answer arrives in the
+ * request that creates the attachment.
+ *
+ * Only images need it. A PDF uploaded against a sponsor is taken as an agreement whether or not it
+ * arrives -- see `is_agreement_upload()`.
+ */
+const UPLOAD_PARAM = 'wcorg_sponsor_agreement_upload';
 
 add_action( 'added_post_meta',              __NAMESPACE__ . '\note_sponsor_agreement',      10, 4 );
 add_action( 'updated_post_meta',            __NAMESPACE__ . '\note_sponsor_agreement',      10, 4 );
 add_filter( 'xmlrpc_prepare_media_item',    __NAMESPACE__ . '\redact_agreement',            10, 2 );
 add_filter( 'wp_prepare_attachment_for_js', __NAMESPACE__ . '\redact_agreement_for_js',     10, 2 );
+add_filter( 'wp_unique_filename',           __NAMESPACE__ . '\name_agreement_upload',       10, 2 );
+add_filter( 'wp_insert_attachment_data',    __NAMESPACE__ . '\hide_agreement_upload',       10, 1 );
+add_action( 'add_attachment',               __NAMESPACE__ . '\mark_agreement_upload',       10, 1 );
+add_action( 'admin_enqueue_scripts',        __NAMESPACE__ . '\add_agreement_upload_settings', 20 );
 
 
 /**
@@ -36,15 +62,6 @@ function get_agreement_meta_keys() {
 function get_sponsor_post_types() {
 	return array( 'wcb_sponsor', 'mes_sponsor' );
 }
-
-/**
- * The meta key that marks an attachment as a sponsorship agreement.
- *
- * Recorded on the attachment rather than read back off the sponsor each time, so that the answer doesn't
- * change when the file is detached, reparented, or left behind by a deleted sponsor.
- */
-const AGREEMENT_MARKER_META_KEY = '_wcorg_sponsor_agreement';
-
 
 /**
  * Mark the file a sponsor names as its agreement.
@@ -77,6 +94,44 @@ function note_sponsor_agreement( $meta_id, $object_id, $meta_key, $meta_value ) 
 
 	$attachment_id = absint( $meta_value );
 
+	report_unmarked_upload( $attachment_id, $object_id );
+	secure_agreement( $attachment_id );
+}
+
+/**
+ * Note an agreement that reached this point without its upload having been marked.
+ *
+ * The Sponsor Agreement modal marks what it uploads, so a file uploaded against this sponsor should
+ * already be an agreement by the time the sponsor is saved. One that isn't means the marking didn't
+ * happen -- a JavaScript error, or Core's uploader having moved on -- and that failure is otherwise
+ * silent, because saving the sponsor covers it up by securing the file anyway.
+ *
+ * Reads the attachment's parent, which is the only thing separating an upload from this modal from one
+ * made anywhere else. A file already sitting on this sponsor for another reason -- its logo, say -- and
+ * later chosen as the agreement will look the same and be logged too. That's a false alarm in a log line
+ * rather than a wrong decision about the file, so it's left rather than guessed at.
+ *
+ * @param int $attachment_id
+ * @param int $sponsor_id
+ */
+function report_unmarked_upload( $attachment_id, $sponsor_id ) {
+	if ( is_agreement( $attachment_id ) ) {
+		return;
+	}
+
+	if ( (int) get_post_field( 'post_parent', $attachment_id ) !== (int) $sponsor_id ) {
+		return;
+	}
+
+	log( 'sponsor_agreement_upload_not_marked', compact( 'attachment_id', 'sponsor_id' ) );
+}
+
+/**
+ * Mark an attachment as an agreement, take it out of public reach, and name its file.
+ *
+ * @param int $attachment_id
+ */
+function secure_agreement( $attachment_id ) {
 	// Asked before the mark is written, so the file is renamed once however many sponsors go on to name it.
 	$already_an_agreement = is_agreement( $attachment_id );
 
@@ -89,6 +144,129 @@ function note_sponsor_agreement( $meta_id, $object_id, $meta_key, $meta_value ) 
 	if ( ! $already_an_agreement && is_agreement( $attachment_id ) ) {
 		rename_agreement_file( $attachment_id );
 	}
+}
+
+/**
+ * Tell the Sponsor Agreement modal what to mark its uploads with.
+ */
+function add_agreement_upload_settings() {
+	// Registered by `wc-post-types`, which doesn't run on every site in the network.
+	if ( ! wp_script_is( 'wcb-spon', 'registered' ) ) {
+		return;
+	}
+
+	wp_localize_script( 'wcb-spon', 'wcbSponsorAgreement', array( 'param' => UPLOAD_PARAM ) );
+}
+
+/**
+ * Whether the current request is an upload the Sponsor Agreement modal made.
+ *
+ * Everything this decides happens inside `wp_ajax_upload_attachment()`, which has already checked the
+ * nonce, `upload_files`, and `edit_post` against the parent before it creates anything -- so the checks
+ * repeated here confirm what the request is rather than standing in for authorization. The action is read
+ * from `$_REQUEST` because that is what `admin-ajax.php` and `async-upload.php` both dispatch on.
+ *
+ * @return bool
+ */
+function is_sponsor_upload() {
+	// phpcs:disable WordPress.Security.NonceVerification -- `wp_ajax_upload_attachment()` checked it.
+	if ( 'upload-attachment' !== ( $_REQUEST['action'] ?? '' ) ) {
+		return false;
+	}
+
+	$sponsor_id = absint( $_REQUEST['post_id'] ?? 0 );
+	// phpcs:enable WordPress.Security.NonceVerification
+
+	if ( ! in_array( get_post_type( $sponsor_id ), get_sponsor_post_types(), true ) ) {
+		return false;
+	}
+
+	return current_user_can( 'edit_post', $sponsor_id );
+}
+
+/**
+ * Whether the file the current request is uploading is a sponsor's agreement.
+ *
+ * The modal marks what it uploads, which is what tells an agreement from the logo and the body images
+ * that arrive from the same screen. A PDF is taken as one either way: nothing else a sponsor carries is
+ * a PDF, and the mark is the half of this that depends on Core's uploader still working the way the
+ * modal expects.
+ *
+ * @param string $type The file's mime type, or its extension with the leading dot.
+ *
+ * @return bool
+ */
+function is_agreement_upload( $type = '' ) {
+	if ( ! is_sponsor_upload() ) {
+		return false;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- as above.
+	if ( ! empty( $_POST[ UPLOAD_PARAM ] ) ) {
+		return true;
+	}
+
+	return in_array( strtolower( $type ), array( '.pdf', 'application/pdf' ), true );
+}
+
+/**
+ * Name an agreement as it is uploaded, before the file is written.
+ *
+ * Naming here rather than renaming afterwards means the file never exists under the name it arrived
+ * with, and that the generated sizes are built from the name it keeps.
+ *
+ * @param string $filename
+ * @param string $extension
+ *
+ * @return string
+ */
+function name_agreement_upload( $filename, $extension ) {
+	if ( ! is_agreement_upload( $extension ) ) {
+		return $filename;
+	}
+
+	return add_csprn_to_filename( $filename, $extension );
+}
+
+/**
+ * Give an agreement the `private` status as its attachment is written.
+ *
+ * `wp_insert_attachment_data` is the last thing to touch the row before it is inserted, so an agreement
+ * is never stored with the status it would have inherited from its sponsor, even briefly.
+ *
+ * @param array $data The attachment's post fields.
+ *
+ * @return array
+ */
+function hide_agreement_upload( $data ) {
+	if ( 'attachment' !== ( $data['post_type'] ?? '' ) ) {
+		return $data;
+	}
+
+	if ( ! is_agreement_upload( $data['post_mime_type'] ?? '' ) ) {
+		return $data;
+	}
+
+	$data['post_status'] = 'private';
+
+	return $data;
+}
+
+/**
+ * Mark an uploaded agreement, once it has an ID to mark.
+ *
+ * `make_agreement_private()` rather than the marker alone, so that the status is still applied if
+ * `hide_agreement_upload()` didn't reach this file -- it reads the mime type from the row being written,
+ * and this reads it back from the saved attachment.
+ *
+ * @param int $attachment_id
+ */
+function mark_agreement_upload( $attachment_id ) {
+	if ( ! is_agreement_upload( get_post_mime_type( $attachment_id ) ) ) {
+		return;
+	}
+
+	make_agreement_private( $attachment_id );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/sponsor-agreements.php
@@ -17,6 +17,16 @@ defined( 'WPINC' ) || die();
 const AGREEMENT_MARKER_META_KEY = '_wcorg_sponsor_agreement';
 
 /**
+ * The meta key that marks an agreement whose file still carries the name it was uploaded under.
+ *
+ * `AGREEMENT_MARKER_META_KEY` says an attachment is an agreement; this says its file has yet to be
+ * renamed. Two things write it: the one-time migration, which sets the status and leaves renaming to a
+ * later pass, and `secure_agreement()`, when a rename it attempted couldn't move every file. Whatever
+ * runs that later pass reads this, so it lives here rather than with the migration that is deleted.
+ */
+const NEEDS_RENAME_META_KEY = '_wcorg_sponsor_agreement_needs_rename';
+
+/**
  * The upload field the Sponsor Agreement modal marks its own uploads with.
  *
  * A file is recorded as the agreement when the sponsor is saved, which can be a while after it lands and
@@ -146,6 +156,8 @@ function secure_agreement( $attachment_id ) {
 
 		// A file left under the name it had is a URL that may already be out there.
 		if ( $outcome['left_behind'] ) {
+			update_post_meta( $attachment_id, NEEDS_RENAME_META_KEY, 1 );
+
 			log( 'sponsor_agreement_files_not_renamed', array_merge( compact( 'attachment_id' ), $outcome ) );
 		}
 	}

--- a/public_html/wp-content/mu-plugins/tests/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/tests/bootstrap.php
@@ -37,6 +37,7 @@ function manually_load_plugins() {
 	require_once dirname( __DIR__ ) . '/wcorg-network-theme-control.php';
 	require_once dirname( __DIR__ ) . '/jetpack-tweaks/import-meta.php';
 	require_once dirname( __DIR__ ) . '/importer-tweaks.php';
+	require_once dirname( __DIR__ ) . '/sponsor-agreements.php';
 }
 
 tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\manually_load_plugins' );

--- a/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
@@ -5,10 +5,10 @@ namespace WordCamp\Sponsor_Agreements\Backfill\Tests;
 use WP_UnitTestCase;
 
 use function WordCamp\Sponsor_Agreements\Backfill\get_public_agreement_ids;
-use function WordCamp\Sponsor_Agreements\Backfill\describe_rename;
-use function WordCamp\Sponsor_Agreements\Backfill\rename_agreement_file;
 use function WordCamp\Sponsor_Agreements\is_agreement;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
+
+use const WordCamp\Sponsor_Agreements\AGREEMENT_MARKER_META_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -50,11 +50,10 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 	 * migration has to deal with.
 	 *
 	 * @param string $filename
-	 * @param string $mime_type
 	 *
 	 * @return array The sponsor ID and the attachment ID.
 	 */
-	protected function create_legacy_agreement( $filename = 'sponsorship-agreement-acme-signed.pdf', $mime_type = 'application/pdf' ) {
+	protected function create_legacy_agreement( $filename = 'sponsorship-agreement-acme-signed.pdf' ) {
 		$sponsor_id = self::factory()->post->create( array(
 			'post_type'   => 'wcb_sponsor',
 			'post_status' => 'publish',
@@ -64,7 +63,7 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 			'file'           => $filename,
 			'post_parent'    => $sponsor_id,
 			'post_status'    => 'inherit',
-			'post_mime_type' => $mime_type,
+			'post_mime_type' => 'application/pdf',
 		) );
 
 		add_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
@@ -110,422 +109,33 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A file already on disk gets the name new uploads are given.
+	 * The mark stays on the attachment after the migration has changed its status.
 	 */
-	public function test_an_existing_agreement_is_renamed() {
-		$uploads  = wp_upload_dir();
-		$old_path = trailingslashit( $uploads['path'] ) . 'sponsorship-agreement-acme-signed.pdf';
-
-		file_put_contents( $old_path, '%PDF-1.4' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
-
-		list( , $agreement_id ) = $this->create_legacy_agreement( $old_path );
-
-		try {
-			$this->assertSame(
-				array(
-					'renamed'     => 1,
-					'left_behind' => 0,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-
-			$new_path = get_attached_file( $agreement_id );
-
-			$this->assertFileDoesNotExist( $old_path );
-			$this->assertFileExists( $new_path );
-			$this->assertMatchesRegularExpression(
-				'/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/',
-				wp_basename( $new_path )
-			);
-
-			// The metabox resolves the file through the attachment, so the link follows the rename.
-			$this->assertStringEndsWith( wp_basename( $new_path ), wp_get_attachment_url( $agreement_id ) );
-		} finally {
-			foreach ( array( $old_path, get_attached_file( $agreement_id ) ) as $path ) {
-				if ( $path && is_file( $path ) ) {
-					wp_delete_file( $path );
-				}
-			}
-		}
-	}
-
-	/**
-	 * An attachment whose file has already gone is reported rather than treated as renamed.
-	 */
-	public function test_renaming_a_missing_file_reports_failure() {
+	public function test_a_migrated_agreement_stays_findable_by_its_mark() {
 		list( , $agreement_id ) = $this->create_legacy_agreement();
 
-		$this->assertSame( 0, rename_agreement_file( $agreement_id )['renamed'] );
+		make_agreement_private( $agreement_id );
+
+		$marked = get_posts( array(
+			'post_type'   => 'attachment',
+			'post_status' => 'any',
+			'fields'      => 'ids',
+			'numberposts' => -1,
+			'meta_key'    => AGREEMENT_MARKER_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- a test fixture, on a table with a handful of rows.
+		) );
+
+		$this->assertContains( $agreement_id, array_map( 'intval', $marked ) );
 	}
 
 	/**
-	 * Put an attachment's files on disk and record them in its metadata.
-	 *
-	 * Builds the shape by hand rather than through `wp_generate_attachment_metadata()`, so that the test
-	 * doesn't depend on an image library or on which sizes the site happens to register.
-	 *
-	 * @param int      $attachment_id
-	 * @param string   $attached_name The file `_wp_attached_file` points at.
-	 * @param string[] $size_names    The generated sizes.
-	 * @param string   $original_name The full-size original, when Core scaled the upload down.
-	 *
-	 * @return string The directory the files are in.
+	 * Running twice does nothing the second time.
 	 */
-	protected function create_files_on_disk( $attachment_id, $attached_name, $size_names = array(), $original_name = '' ) {
-		$uploads   = wp_upload_dir();
-		$directory = trailingslashit( $uploads['path'] );
-		$metadata  = array( 'file' => _wp_relative_upload_path( $directory . $attached_name ) );
+	public function test_the_migration_is_safe_to_re_run() {
+		list( , $agreement_id ) = $this->create_legacy_agreement();
 
-		$names = array_merge( array( $attached_name ), $size_names, array_filter( array( $original_name ) ) );
-
-		foreach ( $names as $name ) {
-			file_put_contents( $directory . $name, 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- fixtures on the local disk.
-		}
-
-		foreach ( $size_names as $index => $name ) {
-			$metadata['sizes'][ 'size-' . $index ] = array( 'file' => $name );
-		}
-
-		if ( $original_name ) {
-			$metadata['original_image'] = $original_name;
-		}
-
-		update_attached_file( $attachment_id, $directory . $attached_name );
-		wp_update_attachment_metadata( $attachment_id, $metadata );
-
-		return $directory;
-	}
-
-	/**
-	 * Remove whatever an attachment's files are called now.
-	 *
-	 * @param string $directory
-	 * @param string $pattern
-	 */
-	protected function delete_files_on_disk( $directory, $pattern ) {
-		foreach ( glob( $directory . $pattern ) as $path ) {
-			wp_delete_file( $path );
-		}
-	}
-
-	/**
-	 * A photo of a signed page is the other thing the metabox asks for, and Core scales a large one down.
-	 *
-	 * `_wp_attached_file` then points at the `-scaled` copy, while the full-size original and every
-	 * generated size are named after `original_image`. All of them are legible copies of the document, so
-	 * all of them have to move.
-	 */
-	public function test_a_scaled_image_moves_every_file_it_generated() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'signed-agreement-photo-scaled.jpg', 'image/jpeg' );
-
-		$sizes     = array(
-			'signed-agreement-photo-150x150.jpg',
-			'signed-agreement-photo-1024x1024.jpg',
-			'signed-agreement-photo-2048x2048.jpg',
-		);
-		$directory = $this->create_files_on_disk(
-			$agreement_id,
-			'signed-agreement-photo-scaled.jpg',
-			$sizes,
-			'signed-agreement-photo.jpg'
-		);
-
-		try {
-			// The scaled copy, the full-size original and all three sizes.
-			$this->assertSame(
-				array(
-					'renamed'     => 5,
-					'left_behind' => 0,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-
-			$metadata = wp_get_attachment_metadata( $agreement_id );
-
-			// One new base name, shared by the scaled copy, the original and every size.
-			$this->assertMatchesRegularExpression(
-				'/^signed-agreement-photo-[A-Za-z0-9]{16}-scaled\.jpg$/',
-				wp_basename( get_attached_file( $agreement_id ) )
-			);
-			$this->assertMatchesRegularExpression(
-				'/^signed-agreement-photo-[A-Za-z0-9]{16}\.jpg$/',
-				$metadata['original_image']
-			);
-
-			foreach ( $metadata['sizes'] as $size => $details ) {
-				$this->assertMatchesRegularExpression(
-					'/^signed-agreement-photo-[A-Za-z0-9]{16}-\d+x\d+\.jpg$/',
-					$details['file'],
-					"Size {$size} kept the name it had."
-				);
-				$this->assertFileExists( $directory . $details['file'] );
-			}
-
-			$this->assertFileExists( wp_get_original_image_path( $agreement_id ) );
-
-			// Nothing is left behind under a name that was handed out.
-			foreach ( array_merge( $sizes, array( 'signed-agreement-photo.jpg', 'signed-agreement-photo-scaled.jpg' ) ) as $old_name ) {
-				$this->assertFileDoesNotExist( $directory . $old_name );
-			}
-		} finally {
-			$this->delete_files_on_disk( $directory, 'signed-agreement-photo*' );
-		}
-	}
-
-	/**
-	 * Two registered sizes can name the same file, and the second one has to follow the first.
-	 */
-	public function test_sizes_that_share_a_file_stay_in_step() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'shared-size.jpg', 'image/jpeg' );
-
-		$directory = $this->create_files_on_disk(
-			$agreement_id,
-			'shared-size.jpg',
-			array( 'shared-size-300x300.jpg', 'shared-size-300x300.jpg' )
-		);
-
-		try {
-			// The file behind both sizes is moved once, and counted once.
-			$this->assertSame(
-				array(
-					'renamed'     => 2,
-					'left_behind' => 0,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-
-			$sizes = wp_list_pluck( wp_get_attachment_metadata( $agreement_id )['sizes'], 'file' );
-
-			$this->assertCount( 1, array_unique( $sizes ) );
-			$this->assertFileExists( $directory . reset( $sizes ) );
-		} finally {
-			$this->delete_files_on_disk( $directory, 'shared-size*' );
-		}
-	}
-
-	/**
-	 * A file that can't be moved is reported, rather than counted as done.
-	 */
-	public function test_a_size_left_behind_is_reported() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'stubborn.jpg', 'image/jpeg' );
-
-		$directory = $this->create_files_on_disk( $agreement_id, 'stubborn.jpg', array( 'stubborn-150x150.jpg' ) );
-
-		// A size Core would never have named this way, standing in for one that can't be derived.
-		$metadata                            = wp_get_attachment_metadata( $agreement_id );
-		$metadata['sizes']['size-0']['file'] = 'unrelated-150x150.jpg';
-		wp_update_attachment_metadata( $agreement_id, $metadata );
-		file_put_contents( $directory . 'unrelated-150x150.jpg', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
-
-		try {
-			$this->assertSame(
-				array(
-					'renamed'     => 1,
-					'left_behind' => 1,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-
-			// What could move still moved, and the metadata names each file by what it's actually called.
-			$this->assertMatchesRegularExpression(
-				'/^stubborn-[A-Za-z0-9]{16}\.jpg$/',
-				wp_basename( get_attached_file( $agreement_id ) )
-			);
-			$this->assertSame(
-				'unrelated-150x150.jpg',
-				wp_get_attachment_metadata( $agreement_id )['sizes']['size-0']['file']
-			);
-			$this->assertFileExists( $directory . 'unrelated-150x150.jpg' );
-		} finally {
-			$this->delete_files_on_disk( $directory, 'stubborn*' );
-			$this->delete_files_on_disk( $directory, 'unrelated-*' );
-		}
-	}
-
-	/**
-	 * What the report says about each of those outcomes.
-	 *
-	 * @dataProvider data_rename_descriptions
-	 *
-	 * @param array  $outcome
-	 * @param bool   $dry_run
-	 * @param bool   $skip_rename
-	 * @param string $expected
-	 */
-	public function test_describe_rename( $outcome, $dry_run, $skip_rename, $expected ) {
-		$this->assertSame( $expected, describe_rename( $outcome, $dry_run, $skip_rename ) );
-	}
-
-	/**
-	 * @return array
-	 */
-	public function data_rename_descriptions() {
-		$moved   = array(
-			'renamed'     => 9,
-			'left_behind' => 0,
-		);
-		$partial = array(
-			'renamed'     => 1,
-			'left_behind' => 8,
-		);
-		$nothing = array(
-			'renamed'     => 0,
-			'left_behind' => 0,
-		);
-
-		return array(
-			'every file moved'  => array( $moved, false, false, '9 files' ),
-			'a single file'     => array(
-				array(
-					'renamed'     => 1,
-					'left_behind' => 0,
-				),
-				false,
-				false,
-				'1 file',
-			),
-			'some left behind'  => array( $partial, false, false, '1 moved, 8 left' ),
-			'file already gone' => array( $nothing, false, false, 'file missing' ),
-			'no outcome given'  => array( array(), false, false, 'file missing' ),
-			'dry run'           => array( $nothing, true, false, 'pending' ),
-			'renaming skipped'  => array( array(), false, true, 'skipped' ),
-		);
-	}
-
-	/**
-	 * An empty `original_image` falls back to the attached file, the way the metadata read below assumes.
-	 */
-	public function test_an_empty_original_image_falls_back_to_the_attached_file() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'blank-original.jpg', 'image/jpeg' );
-
-		$directory = $this->create_files_on_disk( $agreement_id, 'blank-original.jpg', array( 'blank-original-150x150.jpg' ) );
-
-		$metadata                   = wp_get_attachment_metadata( $agreement_id );
-		$metadata['original_image'] = '';
-		wp_update_attachment_metadata( $agreement_id, $metadata );
-
-		try {
-			$this->assertSame( 2, rename_agreement_file( $agreement_id )['renamed'] );
-
-			$this->assertMatchesRegularExpression(
-				'/^blank-original-[A-Za-z0-9]{16}\.jpg$/',
-				wp_basename( get_attached_file( $agreement_id ) )
-			);
-			$this->assertMatchesRegularExpression(
-				'/^blank-original-[A-Za-z0-9]{16}-150x150\.jpg$/',
-				wp_get_attachment_metadata( $agreement_id )['sizes']['size-0']['file']
-			);
-		} finally {
-			$this->delete_files_on_disk( $directory, 'blank-original*' );
-		}
-	}
-
-	/**
-	 * Two sizes naming one file that can't be moved report one file left behind, not two.
-	 */
-	public function test_a_shared_file_left_behind_is_counted_once() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'counted-once.jpg', 'image/jpeg' );
-
-		$directory = $this->create_files_on_disk( $agreement_id, 'counted-once.jpg', array( 'a.jpg', 'a.jpg' ) );
-
-		// Neither size can be derived from the attached file's base, so neither moves.
-		try {
-			$this->assertSame(
-				array(
-					'renamed'     => 1,
-					'left_behind' => 1,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-		} finally {
-			$this->delete_files_on_disk( $directory, 'counted-once*' );
-			$this->delete_files_on_disk( $directory, 'a.jpg' );
-		}
-	}
-
-	/**
-	 * A file that won't move doesn't stop the ones named after it, and all of them are counted.
-	 *
-	 * The derivatives take their name from `original_image`, not from the attached file, so a stuck
-	 * attached file leaves them movable -- and the count is what tells the operator how much is left.
-	 */
-	public function test_a_stuck_attached_file_still_reports_every_other_one() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'unrelated-scaled.jpg', 'image/jpeg' );
-
-		$directory = $this->create_files_on_disk(
-			$agreement_id,
-			'unrelated-scaled.jpg',
-			array( 'photo-150x150.jpg', 'photo-300x300.jpg' ),
-			'photo.jpg'
-		);
-
-		try {
-			// The original and its two sizes move; the attached file, named from another base, doesn't.
-			$this->assertSame(
-				array(
-					'renamed'     => 3,
-					'left_behind' => 1,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-
-			$metadata = wp_get_attachment_metadata( $agreement_id );
-
-			$this->assertSame( 'unrelated-scaled.jpg', wp_basename( get_attached_file( $agreement_id ) ) );
-			$this->assertFileExists( $directory . 'unrelated-scaled.jpg' );
-
-			foreach ( $metadata['sizes'] as $details ) {
-				$this->assertMatchesRegularExpression( '/^photo-[A-Za-z0-9]{16}-\d+x\d+\.jpg$/', $details['file'] );
-				$this->assertFileExists( $directory . $details['file'] );
-			}
-
-			$this->assertMatchesRegularExpression( '/^photo-[A-Za-z0-9]{16}\.jpg$/', $metadata['original_image'] );
-			$this->assertFileDoesNotExist( $directory . 'photo.jpg' );
-		} finally {
-			$this->delete_files_on_disk( $directory, 'photo*' );
-			$this->delete_files_on_disk( $directory, 'unrelated-scaled*' );
-		}
-	}
-
-	/**
-	 * A name that merely starts with the base isn't one of this attachment's files.
-	 *
-	 * Core's derivatives are `<base>-<width>x<height>.<ext>` and `<base>-scaled.<ext>`, so the separator
-	 * is the test. Without it `photobooth-150x150.jpg` would be spliced rather than rebased.
-	 */
-	public function test_a_name_that_only_shares_a_prefix_is_left_alone() {
-		list( , $agreement_id ) = $this->create_legacy_agreement( 'photo.jpg', 'image/jpeg' );
-
-		$directory = $this->create_files_on_disk(
-			$agreement_id,
-			'photo.jpg',
-			array( 'photo-150x150.jpg', 'photobooth-150x150.jpg' )
-		);
-
-		try {
-			// The attached file and its real size move; the neighbour is counted, not renamed.
-			$this->assertSame(
-				array(
-					'renamed'     => 2,
-					'left_behind' => 1,
-				),
-				rename_agreement_file( $agreement_id )
-			);
-
-			$sizes = wp_list_pluck( wp_get_attachment_metadata( $agreement_id )['sizes'], 'file' );
-
-			$this->assertContains( 'photobooth-150x150.jpg', $sizes );
-			$this->assertFileExists( $directory . 'photobooth-150x150.jpg' );
-
-			foreach ( array_map( 'wp_basename', glob( $directory . 'photo*' ) ) as $name ) {
-				$this->assertDoesNotMatchRegularExpression(
-					'/^photo-[A-Za-z0-9]{16}booth/',
-					$name,
-					'The neighbour was spliced instead of left alone.'
-				);
-			}
-		} finally {
-			$this->delete_files_on_disk( $directory, 'photo*' );
-		}
+		$this->assertTrue( make_agreement_private( $agreement_id ) );
+		$this->assertSame( array(), get_public_agreement_ids() );
+		$this->assertFalse( make_agreement_private( $agreement_id ), 'A second pass reported a change it did not make.' );
+		$this->assertSame( 'private', get_post_status( $agreement_id ) );
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
@@ -5,6 +5,7 @@ namespace WordCamp\Sponsor_Agreements\Backfill\Tests;
 use WP_UnitTestCase;
 
 use function WordCamp\Sponsor_Agreements\Backfill\get_public_agreement_ids;
+use function WordCamp\Sponsor_Agreements\Backfill\describe_rename;
 use function WordCamp\Sponsor_Agreements\Backfill\rename_agreement_file;
 use function WordCamp\Sponsor_Agreements\is_agreement;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
@@ -49,10 +50,11 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 	 * migration has to deal with.
 	 *
 	 * @param string $filename
+	 * @param string $mime_type
 	 *
 	 * @return array The sponsor ID and the attachment ID.
 	 */
-	protected function create_legacy_agreement( $filename = 'sponsorship-agreement-acme-signed.pdf' ) {
+	protected function create_legacy_agreement( $filename = 'sponsorship-agreement-acme-signed.pdf', $mime_type = 'application/pdf' ) {
 		$sponsor_id = self::factory()->post->create( array(
 			'post_type'   => 'wcb_sponsor',
 			'post_status' => 'publish',
@@ -62,7 +64,7 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 			'file'           => $filename,
 			'post_parent'    => $sponsor_id,
 			'post_status'    => 'inherit',
-			'post_mime_type' => 'application/pdf',
+			'post_mime_type' => $mime_type,
 		) );
 
 		add_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
@@ -119,7 +121,13 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 		list( , $agreement_id ) = $this->create_legacy_agreement( $old_path );
 
 		try {
-			$this->assertTrue( rename_agreement_file( $agreement_id ) );
+			$this->assertSame(
+				array(
+					'renamed'     => 1,
+					'left_behind' => 0,
+				),
+				rename_agreement_file( $agreement_id )
+			);
 
 			$new_path = get_attached_file( $agreement_id );
 
@@ -147,6 +155,377 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 	public function test_renaming_a_missing_file_reports_failure() {
 		list( , $agreement_id ) = $this->create_legacy_agreement();
 
-		$this->assertFalse( rename_agreement_file( $agreement_id ) );
+		$this->assertSame( 0, rename_agreement_file( $agreement_id )['renamed'] );
+	}
+
+	/**
+	 * Put an attachment's files on disk and record them in its metadata.
+	 *
+	 * Builds the shape by hand rather than through `wp_generate_attachment_metadata()`, so that the test
+	 * doesn't depend on an image library or on which sizes the site happens to register.
+	 *
+	 * @param int      $attachment_id
+	 * @param string   $attached_name The file `_wp_attached_file` points at.
+	 * @param string[] $size_names    The generated sizes.
+	 * @param string   $original_name The full-size original, when Core scaled the upload down.
+	 *
+	 * @return string The directory the files are in.
+	 */
+	protected function create_files_on_disk( $attachment_id, $attached_name, $size_names = array(), $original_name = '' ) {
+		$uploads   = wp_upload_dir();
+		$directory = trailingslashit( $uploads['path'] );
+		$metadata  = array( 'file' => _wp_relative_upload_path( $directory . $attached_name ) );
+
+		$names = array_merge( array( $attached_name ), $size_names, array_filter( array( $original_name ) ) );
+
+		foreach ( $names as $name ) {
+			file_put_contents( $directory . $name, 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- fixtures on the local disk.
+		}
+
+		foreach ( $size_names as $index => $name ) {
+			$metadata['sizes'][ 'size-' . $index ] = array( 'file' => $name );
+		}
+
+		if ( $original_name ) {
+			$metadata['original_image'] = $original_name;
+		}
+
+		update_attached_file( $attachment_id, $directory . $attached_name );
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		return $directory;
+	}
+
+	/**
+	 * Remove whatever an attachment's files are called now.
+	 *
+	 * @param string $directory
+	 * @param string $pattern
+	 */
+	protected function delete_files_on_disk( $directory, $pattern ) {
+		foreach ( glob( $directory . $pattern ) as $path ) {
+			wp_delete_file( $path );
+		}
+	}
+
+	/**
+	 * A photo of a signed page is the other thing the metabox asks for, and Core scales a large one down.
+	 *
+	 * `_wp_attached_file` then points at the `-scaled` copy, while the full-size original and every
+	 * generated size are named after `original_image`. All of them are legible copies of the document, so
+	 * all of them have to move.
+	 */
+	public function test_a_scaled_image_moves_every_file_it_generated() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'signed-agreement-photo-scaled.jpg', 'image/jpeg' );
+
+		$sizes     = array(
+			'signed-agreement-photo-150x150.jpg',
+			'signed-agreement-photo-1024x1024.jpg',
+			'signed-agreement-photo-2048x2048.jpg',
+		);
+		$directory = $this->create_files_on_disk(
+			$agreement_id,
+			'signed-agreement-photo-scaled.jpg',
+			$sizes,
+			'signed-agreement-photo.jpg'
+		);
+
+		try {
+			// The scaled copy, the full-size original and all three sizes.
+			$this->assertSame(
+				array(
+					'renamed'     => 5,
+					'left_behind' => 0,
+				),
+				rename_agreement_file( $agreement_id )
+			);
+
+			$metadata = wp_get_attachment_metadata( $agreement_id );
+
+			// One new base name, shared by the scaled copy, the original and every size.
+			$this->assertMatchesRegularExpression(
+				'/^signed-agreement-photo-[A-Za-z0-9]{16}-scaled\.jpg$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertMatchesRegularExpression(
+				'/^signed-agreement-photo-[A-Za-z0-9]{16}\.jpg$/',
+				$metadata['original_image']
+			);
+
+			foreach ( $metadata['sizes'] as $size => $details ) {
+				$this->assertMatchesRegularExpression(
+					'/^signed-agreement-photo-[A-Za-z0-9]{16}-\d+x\d+\.jpg$/',
+					$details['file'],
+					"Size {$size} kept the name it had."
+				);
+				$this->assertFileExists( $directory . $details['file'] );
+			}
+
+			$this->assertFileExists( wp_get_original_image_path( $agreement_id ) );
+
+			// Nothing is left behind under a name that was handed out.
+			foreach ( array_merge( $sizes, array( 'signed-agreement-photo.jpg', 'signed-agreement-photo-scaled.jpg' ) ) as $old_name ) {
+				$this->assertFileDoesNotExist( $directory . $old_name );
+			}
+		} finally {
+			$this->delete_files_on_disk( $directory, 'signed-agreement-photo*' );
+		}
+	}
+
+	/**
+	 * Two registered sizes can name the same file, and the second one has to follow the first.
+	 */
+	public function test_sizes_that_share_a_file_stay_in_step() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'shared-size.jpg', 'image/jpeg' );
+
+		$directory = $this->create_files_on_disk(
+			$agreement_id,
+			'shared-size.jpg',
+			array( 'shared-size-300x300.jpg', 'shared-size-300x300.jpg' )
+		);
+
+		try {
+			// The file behind both sizes is moved once, and counted once.
+			$this->assertSame(
+				array(
+					'renamed'     => 2,
+					'left_behind' => 0,
+				),
+				rename_agreement_file( $agreement_id )
+			);
+
+			$sizes = wp_list_pluck( wp_get_attachment_metadata( $agreement_id )['sizes'], 'file' );
+
+			$this->assertCount( 1, array_unique( $sizes ) );
+			$this->assertFileExists( $directory . reset( $sizes ) );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'shared-size*' );
+		}
+	}
+
+	/**
+	 * A file that can't be moved is reported, rather than counted as done.
+	 */
+	public function test_a_size_left_behind_is_reported() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'stubborn.jpg', 'image/jpeg' );
+
+		$directory = $this->create_files_on_disk( $agreement_id, 'stubborn.jpg', array( 'stubborn-150x150.jpg' ) );
+
+		// A size Core would never have named this way, standing in for one that can't be derived.
+		$metadata                            = wp_get_attachment_metadata( $agreement_id );
+		$metadata['sizes']['size-0']['file'] = 'unrelated-150x150.jpg';
+		wp_update_attachment_metadata( $agreement_id, $metadata );
+		file_put_contents( $directory . 'unrelated-150x150.jpg', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		try {
+			$this->assertSame(
+				array(
+					'renamed'     => 1,
+					'left_behind' => 1,
+				),
+				rename_agreement_file( $agreement_id )
+			);
+
+			// What could move still moved, and the metadata names each file by what it's actually called.
+			$this->assertMatchesRegularExpression(
+				'/^stubborn-[A-Za-z0-9]{16}\.jpg$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertSame(
+				'unrelated-150x150.jpg',
+				wp_get_attachment_metadata( $agreement_id )['sizes']['size-0']['file']
+			);
+			$this->assertFileExists( $directory . 'unrelated-150x150.jpg' );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'stubborn*' );
+			$this->delete_files_on_disk( $directory, 'unrelated-*' );
+		}
+	}
+
+	/**
+	 * What the report says about each of those outcomes.
+	 *
+	 * @dataProvider data_rename_descriptions
+	 *
+	 * @param array  $outcome
+	 * @param bool   $dry_run
+	 * @param bool   $skip_rename
+	 * @param string $expected
+	 */
+	public function test_describe_rename( $outcome, $dry_run, $skip_rename, $expected ) {
+		$this->assertSame( $expected, describe_rename( $outcome, $dry_run, $skip_rename ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function data_rename_descriptions() {
+		$moved   = array(
+			'renamed'     => 9,
+			'left_behind' => 0,
+		);
+		$partial = array(
+			'renamed'     => 1,
+			'left_behind' => 8,
+		);
+		$nothing = array(
+			'renamed'     => 0,
+			'left_behind' => 0,
+		);
+
+		return array(
+			'every file moved'  => array( $moved, false, false, '9 files' ),
+			'a single file'     => array(
+				array(
+					'renamed'     => 1,
+					'left_behind' => 0,
+				),
+				false,
+				false,
+				'1 file',
+			),
+			'some left behind'  => array( $partial, false, false, '1 moved, 8 left' ),
+			'file already gone' => array( $nothing, false, false, 'file missing' ),
+			'no outcome given'  => array( array(), false, false, 'file missing' ),
+			'dry run'           => array( $nothing, true, false, 'pending' ),
+			'renaming skipped'  => array( array(), false, true, 'skipped' ),
+		);
+	}
+
+	/**
+	 * An empty `original_image` falls back to the attached file, the way the metadata read below assumes.
+	 */
+	public function test_an_empty_original_image_falls_back_to_the_attached_file() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'blank-original.jpg', 'image/jpeg' );
+
+		$directory = $this->create_files_on_disk( $agreement_id, 'blank-original.jpg', array( 'blank-original-150x150.jpg' ) );
+
+		$metadata                   = wp_get_attachment_metadata( $agreement_id );
+		$metadata['original_image'] = '';
+		wp_update_attachment_metadata( $agreement_id, $metadata );
+
+		try {
+			$this->assertSame( 2, rename_agreement_file( $agreement_id )['renamed'] );
+
+			$this->assertMatchesRegularExpression(
+				'/^blank-original-[A-Za-z0-9]{16}\.jpg$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertMatchesRegularExpression(
+				'/^blank-original-[A-Za-z0-9]{16}-150x150\.jpg$/',
+				wp_get_attachment_metadata( $agreement_id )['sizes']['size-0']['file']
+			);
+		} finally {
+			$this->delete_files_on_disk( $directory, 'blank-original*' );
+		}
+	}
+
+	/**
+	 * Two sizes naming one file that can't be moved report one file left behind, not two.
+	 */
+	public function test_a_shared_file_left_behind_is_counted_once() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'counted-once.jpg', 'image/jpeg' );
+
+		$directory = $this->create_files_on_disk( $agreement_id, 'counted-once.jpg', array( 'a.jpg', 'a.jpg' ) );
+
+		// Neither size can be derived from the attached file's base, so neither moves.
+		try {
+			$this->assertSame(
+				array(
+					'renamed'     => 1,
+					'left_behind' => 1,
+				),
+				rename_agreement_file( $agreement_id )
+			);
+		} finally {
+			$this->delete_files_on_disk( $directory, 'counted-once*' );
+			$this->delete_files_on_disk( $directory, 'a.jpg' );
+		}
+	}
+
+	/**
+	 * A file that won't move doesn't stop the ones named after it, and all of them are counted.
+	 *
+	 * The derivatives take their name from `original_image`, not from the attached file, so a stuck
+	 * attached file leaves them movable -- and the count is what tells the operator how much is left.
+	 */
+	public function test_a_stuck_attached_file_still_reports_every_other_one() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'unrelated-scaled.jpg', 'image/jpeg' );
+
+		$directory = $this->create_files_on_disk(
+			$agreement_id,
+			'unrelated-scaled.jpg',
+			array( 'photo-150x150.jpg', 'photo-300x300.jpg' ),
+			'photo.jpg'
+		);
+
+		try {
+			// The original and its two sizes move; the attached file, named from another base, doesn't.
+			$this->assertSame(
+				array(
+					'renamed'     => 3,
+					'left_behind' => 1,
+				),
+				rename_agreement_file( $agreement_id )
+			);
+
+			$metadata = wp_get_attachment_metadata( $agreement_id );
+
+			$this->assertSame( 'unrelated-scaled.jpg', wp_basename( get_attached_file( $agreement_id ) ) );
+			$this->assertFileExists( $directory . 'unrelated-scaled.jpg' );
+
+			foreach ( $metadata['sizes'] as $details ) {
+				$this->assertMatchesRegularExpression( '/^photo-[A-Za-z0-9]{16}-\d+x\d+\.jpg$/', $details['file'] );
+				$this->assertFileExists( $directory . $details['file'] );
+			}
+
+			$this->assertMatchesRegularExpression( '/^photo-[A-Za-z0-9]{16}\.jpg$/', $metadata['original_image'] );
+			$this->assertFileDoesNotExist( $directory . 'photo.jpg' );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'photo*' );
+			$this->delete_files_on_disk( $directory, 'unrelated-scaled*' );
+		}
+	}
+
+	/**
+	 * A name that merely starts with the base isn't one of this attachment's files.
+	 *
+	 * Core's derivatives are `<base>-<width>x<height>.<ext>` and `<base>-scaled.<ext>`, so the separator
+	 * is the test. Without it `photobooth-150x150.jpg` would be spliced rather than rebased.
+	 */
+	public function test_a_name_that_only_shares_a_prefix_is_left_alone() {
+		list( , $agreement_id ) = $this->create_legacy_agreement( 'photo.jpg', 'image/jpeg' );
+
+		$directory = $this->create_files_on_disk(
+			$agreement_id,
+			'photo.jpg',
+			array( 'photo-150x150.jpg', 'photobooth-150x150.jpg' )
+		);
+
+		try {
+			// The attached file and its real size move; the neighbour is counted, not renamed.
+			$this->assertSame(
+				array(
+					'renamed'     => 2,
+					'left_behind' => 1,
+				),
+				rename_agreement_file( $agreement_id )
+			);
+
+			$sizes = wp_list_pluck( wp_get_attachment_metadata( $agreement_id )['sizes'], 'file' );
+
+			$this->assertContains( 'photobooth-150x150.jpg', $sizes );
+			$this->assertFileExists( $directory . 'photobooth-150x150.jpg' );
+
+			foreach ( array_map( 'wp_basename', glob( $directory . 'photo*' ) ) as $name ) {
+				$this->assertDoesNotMatchRegularExpression(
+					'/^photo-[A-Za-z0-9]{16}booth/',
+					$name,
+					'The neighbour was spliced instead of left alone.'
+				);
+			}
+		} finally {
+			$this->delete_files_on_disk( $directory, 'photo*' );
+		}
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
@@ -9,6 +9,7 @@ use function WordCamp\Sponsor_Agreements\is_agreement;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
 
 use const WordCamp\Sponsor_Agreements\AGREEMENT_MARKER_META_KEY;
+use const WordCamp\Sponsor_Agreements\Backfill\BACKFILLED_META_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -137,5 +138,42 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 		$this->assertSame( array(), get_public_agreement_ids() );
 		$this->assertFalse( make_agreement_private( $agreement_id ), 'A second pass reported a change it did not make.' );
 		$this->assertSame( 'private', get_post_status( $agreement_id ) );
+	}
+
+	/**
+	 * The migration records which attachments it acted on.
+	 *
+	 * Those are the ones uploaded before `obscure_sponsor_file_names()` existed, and nothing else says so
+	 * once they are no longer `inherit`.
+	 */
+	public function test_the_migration_records_what_it_acted_on() {
+		list( , $legacy_id ) = $this->create_legacy_agreement();
+
+		$sponsor_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+		) );
+		$recent_id  = self::factory()->attachment->create_object( array(
+			'file'           => 'agreement-aBcDeFgHiJkLmNoP.pdf',
+			'post_parent'    => $sponsor_id,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+
+		// The hook covers this one as it's attached, so the migration never sees it.
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $recent_id );
+
+		$this->assertContains( $legacy_id, get_public_agreement_ids() );
+		$this->assertNotContains( $recent_id, get_public_agreement_ids() );
+
+		// What `Command::backfill()` does for each ID the query returns.
+		make_agreement_private( $legacy_id );
+		update_post_meta( $legacy_id, BACKFILLED_META_KEY, 1 );
+
+		$this->assertTrue( is_agreement( $legacy_id ) );
+		$this->assertTrue( is_agreement( $recent_id ) );
+
+		$this->assertSame( '1', get_post_meta( $legacy_id, BACKFILLED_META_KEY, true ) );
+		$this->assertSame( '', get_post_meta( $recent_id, BACKFILLED_META_KEY, true ) );
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace WordCamp\Sponsor_Agreements\Backfill\Tests;
+
+use WP_UnitTestCase;
+
+use function WordCamp\Sponsor_Agreements\Backfill\get_public_agreement_ids;
+use function WordCamp\Sponsor_Agreements\Backfill\rename_agreement_file;
+use function WordCamp\Sponsor_Agreements\is_agreement;
+use function WordCamp\Sponsor_Agreements\make_agreement_private;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * The one-time migration behind `wp wc-sponsor-agreements`.
+ *
+ * Goes when `wp-cli-commands/backfill-sponsor-agreements.php` does. `Test_Sponsor_Agreements` covers what
+ * stays.
+ *
+ * @group mu-plugins
+ * @group sponsor-agreements
+ */
+class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
+	/**
+	 * The command file only loads under WP-CLI, so pull in the part of it that isn't the command.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once dirname( __DIR__ ) . '/wp-cli-commands/backfill-sponsor-agreements.php';
+	}
+
+	/**
+	 * Register the sponsor post type, which lives in a plugin this suite doesn't load.
+	 *
+	 * No matching `tear_down()`: `WP_UnitTestCase` resets the registered post types itself before each
+	 * test, and unregistering by hand here takes rewrite rules and registered meta with it.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type( 'wcb_sponsor', array( 'public' => true ) );
+	}
+
+	/**
+	 * Attach a file to a sponsor and name it as the agreement, without the meta hook seeing it.
+	 *
+	 * This is the shape of a row written before `sponsor-agreements.php` existed, and the only shape the
+	 * migration has to deal with.
+	 *
+	 * @param string $filename
+	 *
+	 * @return array The sponsor ID and the attachment ID.
+	 */
+	protected function create_legacy_agreement( $filename = 'sponsorship-agreement-acme-signed.pdf' ) {
+		$sponsor_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+		) );
+
+		$agreement_id = self::factory()->attachment->create_object( array(
+			'file'           => $filename,
+			'post_parent'    => $sponsor_id,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+
+		add_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+		wp_update_post( array(
+			'ID'          => $agreement_id,
+			'post_status' => 'inherit',
+		) );
+
+		return array( $sponsor_id, $agreement_id );
+	}
+
+	/**
+	 * The migration finds the files it's for, and nothing else.
+	 */
+	public function test_legacy_agreements_are_reported_and_migrated() {
+		list( $sponsor_id, $agreement_id ) = $this->create_legacy_agreement();
+
+		$logo_id = self::factory()->attachment->create_object( array(
+			'file'           => 'acme-logo.png',
+			'post_parent'    => $sponsor_id,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image/png',
+		) );
+
+		$public = get_public_agreement_ids();
+
+		$this->assertContains( $agreement_id, $public );
+		$this->assertNotContains( $logo_id, $public, 'A sponsor logo is meant to be public.' );
+
+		$this->assertTrue( make_agreement_private( $agreement_id ) );
+		$this->assertSame( 'private', get_post_status( $agreement_id ) );
+		$this->assertTrue( is_agreement( $agreement_id ) );
+		$this->assertNotContains( $agreement_id, get_public_agreement_ids() );
+	}
+
+	/**
+	 * Naming a site explicitly is what lets `scan` ask this of a whole network from one process.
+	 */
+	public function test_the_query_can_be_asked_of_a_named_site() {
+		list( , $agreement_id ) = $this->create_legacy_agreement();
+
+		$this->assertContains( $agreement_id, get_public_agreement_ids( get_current_blog_id() ) );
+	}
+
+	/**
+	 * A file already on disk gets the name new uploads are given.
+	 */
+	public function test_an_existing_agreement_is_renamed() {
+		$uploads  = wp_upload_dir();
+		$old_path = trailingslashit( $uploads['path'] ) . 'sponsorship-agreement-acme-signed.pdf';
+
+		file_put_contents( $old_path, '%PDF-1.4' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		list( , $agreement_id ) = $this->create_legacy_agreement( $old_path );
+
+		try {
+			$this->assertTrue( rename_agreement_file( $agreement_id ) );
+
+			$new_path = get_attached_file( $agreement_id );
+
+			$this->assertFileDoesNotExist( $old_path );
+			$this->assertFileExists( $new_path );
+			$this->assertMatchesRegularExpression(
+				'/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( $new_path )
+			);
+
+			// The metabox resolves the file through the attachment, so the link follows the rename.
+			$this->assertStringEndsWith( wp_basename( $new_path ), wp_get_attachment_url( $agreement_id ) );
+		} finally {
+			foreach ( array( $old_path, get_attached_file( $agreement_id ) ) as $path ) {
+				if ( $path && is_file( $path ) ) {
+					wp_delete_file( $path );
+				}
+			}
+		}
+	}
+
+	/**
+	 * An attachment whose file has already gone is reported rather than treated as renamed.
+	 */
+	public function test_renaming_a_missing_file_reports_failure() {
+		list( , $agreement_id ) = $this->create_legacy_agreement();
+
+		$this->assertFalse( rename_agreement_file( $agreement_id ) );
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-backfill-sponsor-agreements.php
@@ -9,7 +9,7 @@ use function WordCamp\Sponsor_Agreements\is_agreement;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
 
 use const WordCamp\Sponsor_Agreements\AGREEMENT_MARKER_META_KEY;
-use const WordCamp\Sponsor_Agreements\Backfill\BACKFILLED_META_KEY;
+use const WordCamp\Sponsor_Agreements\NEEDS_RENAME_META_KEY;
 
 defined( 'WPINC' ) || die();
 
@@ -141,12 +141,11 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The migration records which attachments it acted on.
+	 * The migration records that the files it acted on still need renaming.
 	 *
-	 * Those are the ones uploaded before `obscure_sponsor_file_names()` existed, and nothing else says so
-	 * once they are no longer `inherit`.
+	 * Nothing else says so once they are no longer `inherit`, and it is what a later rename pass reads.
 	 */
-	public function test_the_migration_records_what_it_acted_on() {
+	public function test_the_migration_records_what_still_needs_renaming() {
 		list( , $legacy_id ) = $this->create_legacy_agreement();
 
 		$sponsor_id = self::factory()->post->create( array(
@@ -168,12 +167,12 @@ class Test_Backfill_Sponsor_Agreements extends WP_UnitTestCase {
 
 		// What `Command::backfill()` does for each ID the query returns.
 		make_agreement_private( $legacy_id );
-		update_post_meta( $legacy_id, BACKFILLED_META_KEY, 1 );
+		update_post_meta( $legacy_id, NEEDS_RENAME_META_KEY, 1 );
 
 		$this->assertTrue( is_agreement( $legacy_id ) );
 		$this->assertTrue( is_agreement( $recent_id ) );
 
-		$this->assertSame( '1', get_post_meta( $legacy_id, BACKFILLED_META_KEY, true ) );
-		$this->assertSame( '', get_post_meta( $recent_id, BACKFILLED_META_KEY, true ) );
+		$this->assertSame( '1', get_post_meta( $legacy_id, NEEDS_RENAME_META_KEY, true ) );
+		$this->assertSame( '', get_post_meta( $recent_id, NEEDS_RENAME_META_KEY, true ) );
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
@@ -6,7 +6,8 @@ use WP_UnitTestCase, WP_UnitTest_Factory, WP_REST_Request, WP_REST_Server;
 
 use function WordCamp\Sponsor_Agreements\is_agreement;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
-use function WordCamp\Sponsor_Agreements\obscure_sponsor_file_names;
+use function WordCamp\Sponsor_Agreements\add_csprn_to_filename;
+use function WordCamp\Sponsor_Agreements\rename_agreement_file;
 
 defined( 'WPINC' ) || die();
 
@@ -265,30 +266,6 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Uploads to a sponsor get a random suffix in the file name.
-	 */
-	public function test_sponsor_uploads_get_a_random_suffix() {
-		$_REQUEST['post_id'] = $this->create_sponsor();
-
-		$filename = obscure_sponsor_file_names( 'sponsorship-agreement-acme-signed.pdf', '.pdf' );
-
-		$this->assertMatchesRegularExpression( '/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/', $filename );
-	}
-
-	/**
-	 * Every other upload on the site keeps the name it was given.
-	 */
-	public function test_other_uploads_keep_their_name() {
-		$_REQUEST['post_id'] = self::factory()->post->create();
-
-		$this->assertSame( 'header.png', obscure_sponsor_file_names( 'header.png', '.png' ) );
-
-		unset( $_REQUEST['post_id'] );
-
-		$this->assertSame( 'header.png', obscure_sponsor_file_names( 'header.png', '.png' ) );
-	}
-
-	/**
 	 * `mes_sponsor_agreement` isn't protected meta, so the Custom Fields box will write it to any post that
 	 * supports them. Only a sponsor names its own agreement.
 	 */
@@ -393,28 +370,230 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The block editor posts to the REST media route, which names the parent `post` rather than `post_id`.
+	 * Attach a real file to a sponsor and record it as the agreement.
+	 *
+	 * @param string   $filename
+	 * @param string[] $size_names
+	 * @param string   $original_name The full-size original, when Core scaled the upload down.
+	 *
+	 * @return array The attachment ID and the directory its files are in.
 	 */
-	public function test_rest_uploads_to_a_sponsor_are_named_the_same_way() {
-		$_REQUEST['post'] = $this->create_sponsor();
+	protected function attach_agreement_on_disk( $filename, $size_names = array(), $original_name = '' ) {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+		$metadata   = array( 'file' => _wp_relative_upload_path( $directory . $filename ) );
 
-		$filename = obscure_sponsor_file_names( 'sponsorship-agreement-acme-signed.pdf', '.pdf' );
+		foreach ( array_merge( array( $filename ), $size_names, array_filter( array( $original_name ) ) ) as $name ) {
+			file_put_contents( $directory . $name, 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- fixtures on the local disk.
+		}
 
-		unset( $_REQUEST['post'] );
+		foreach ( $size_names as $index => $name ) {
+			$metadata['sizes'][ 'size-' . $index ] = array( 'file' => $name );
+		}
 
-		$this->assertMatchesRegularExpression( '/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/', $filename );
+		if ( $original_name ) {
+			$metadata['original_image'] = $original_name;
+		}
+
+		$agreement_id = self::factory()->attachment->create_object( array(
+			'file'           => $directory . $filename,
+			'post_parent'    => $sponsor_id,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+
+		update_attached_file( $agreement_id, $directory . $filename );
+		wp_update_attachment_metadata( $agreement_id, $metadata );
+
+		// The hook runs here, so the file is named as it's recorded.
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+
+		return array( $agreement_id, $directory );
+	}
+
+	/**
+	 * Remove whatever an attachment's files are called now.
+	 *
+	 * @param string $directory
+	 * @param string $pattern
+	 */
+	protected function delete_files_on_disk( $directory, $pattern ) {
+		foreach ( glob( $directory . $pattern ) as $path ) {
+			wp_delete_file( $path );
+		}
+	}
+
+	/**
+	 * Recording a file as an agreement gives it a name it wasn't uploaded under.
+	 */
+	public function test_an_agreement_is_renamed_when_it_is_recorded() {
+		list( $agreement_id, $directory ) = $this->attach_agreement_on_disk( 'sponsorship-agreement-acme-signed.pdf' );
+
+		try {
+			$this->assertMatchesRegularExpression(
+				'/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertFileDoesNotExist( $directory . 'sponsorship-agreement-acme-signed.pdf' );
+
+			// The metabox resolves the file through the attachment, so the link follows the rename.
+			$this->assertStringEndsWith(
+				wp_basename( get_attached_file( $agreement_id ) ),
+				wp_get_attachment_url( $agreement_id )
+			);
+		} finally {
+			$this->delete_files_on_disk( $directory, 'sponsorship-agreement-acme-signed*' );
+		}
+	}
+
+	/**
+	 * A file uploaded elsewhere and then picked from the Media Library is covered too.
+	 */
+	public function test_an_agreement_picked_from_the_library_is_renamed() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		file_put_contents( $directory . 'library-agreement.pdf', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		// Uploaded through Media > Add New, so it has no parent and no suffix.
+		$agreement_id = self::factory()->attachment->create_object( array(
+			'file'           => $directory . 'library-agreement.pdf',
+			'post_parent'    => 0,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+		update_attached_file( $agreement_id, $directory . 'library-agreement.pdf' );
+
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+
+		try {
+			$this->assertSame( 'private', get_post_status( $agreement_id ) );
+			$this->assertMatchesRegularExpression(
+				'/^library-agreement-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+		} finally {
+			$this->delete_files_on_disk( $directory, 'library-agreement*' );
+		}
+	}
+
+	/**
+	 * A scaled photo of a signed page moves every file Core derived from it.
+	 */
+	public function test_a_scaled_image_moves_every_file_it_generated() {
+		$sizes = array(
+			'signed-photo-150x150.jpg',
+			'signed-photo-1024x1024.jpg',
+			'signed-photo-2048x2048.jpg',
+		);
+
+		list( $agreement_id, $directory ) = $this->attach_agreement_on_disk(
+			'signed-photo-scaled.jpg',
+			$sizes,
+			'signed-photo.jpg'
+		);
+
+		try {
+			$metadata = wp_get_attachment_metadata( $agreement_id );
+
+			$this->assertMatchesRegularExpression(
+				'/^signed-photo-[A-Za-z0-9]{16}-scaled\.jpg$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertMatchesRegularExpression( '/^signed-photo-[A-Za-z0-9]{16}\.jpg$/', $metadata['original_image'] );
+
+			foreach ( $metadata['sizes'] as $size => $details ) {
+				$this->assertMatchesRegularExpression(
+					'/^signed-photo-[A-Za-z0-9]{16}-\d+x\d+\.jpg$/',
+					$details['file'],
+					"Size {$size} kept the name it had."
+				);
+				$this->assertFileExists( $directory . $details['file'] );
+			}
+
+			foreach ( array_merge( $sizes, array( 'signed-photo.jpg', 'signed-photo-scaled.jpg' ) ) as $old_name ) {
+				$this->assertFileDoesNotExist( $directory . $old_name );
+			}
+		} finally {
+			$this->delete_files_on_disk( $directory, 'signed-photo*' );
+		}
+	}
+
+	/**
+	 * A name that merely starts with the base isn't one of this attachment's files.
+	 */
+	public function test_a_name_that_only_shares_a_prefix_is_left_alone() {
+		list( $agreement_id, $directory ) = $this->attach_agreement_on_disk(
+			'photo.jpg',
+			array( 'photo-150x150.jpg', 'photobooth-150x150.jpg' )
+		);
+
+		try {
+			$sizes = wp_list_pluck( wp_get_attachment_metadata( $agreement_id )['sizes'], 'file' );
+
+			$this->assertContains( 'photobooth-150x150.jpg', $sizes );
+			$this->assertFileExists( $directory . 'photobooth-150x150.jpg' );
+
+			foreach ( array_map( 'wp_basename', glob( $directory . 'photo*' ) ) as $name ) {
+				$this->assertDoesNotMatchRegularExpression( '/^photo-[A-Za-z0-9]{16}booth/', $name );
+			}
+		} finally {
+			$this->delete_files_on_disk( $directory, 'photo*' );
+		}
+	}
+
+	/**
+	 * A sponsor's other uploads keep the names they were given.
+	 */
+	public function test_a_sponsor_logo_is_not_renamed() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		file_put_contents( $directory . 'acme-logo.png', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		$logo_id = self::factory()->attachment->create_object( array(
+			'file'           => $directory . 'acme-logo.png',
+			'post_parent'    => $sponsor_id,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image/png',
+		) );
+		update_attached_file( $logo_id, $directory . 'acme-logo.png' );
+
+		try {
+			$this->assertSame( 'acme-logo.png', wp_basename( get_attached_file( $logo_id ) ) );
+			$this->assertFileExists( $directory . 'acme-logo.png' );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'acme-logo*' );
+		}
+	}
+
+	/**
+	 * Naming the same file on a second sponsor doesn't suffix it twice.
+	 */
+	public function test_an_agreement_is_only_renamed_once() {
+		list( $agreement_id, $directory ) = $this->attach_agreement_on_disk( 'shared-agreement.pdf' );
+
+		try {
+			$renamed = wp_basename( get_attached_file( $agreement_id ) );
+
+			update_post_meta( $this->create_sponsor(), '_wcpt_sponsor_agreement', $agreement_id );
+
+			$this->assertSame( $renamed, wp_basename( get_attached_file( $agreement_id ) ) );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'shared-agreement*' );
+		}
 	}
 
 	/**
 	 * The extension is trimmed off the end, not wherever it happens to appear.
 	 */
 	public function test_a_name_that_repeats_its_extension_keeps_both_copies() {
-		$_REQUEST['post_id'] = $this->create_sponsor();
-
-		$filename = obscure_sponsor_file_names( 'agreement.pdf.pdf', '.pdf' );
-
-		unset( $_REQUEST['post_id'] );
-
-		$this->assertMatchesRegularExpression( '/^agreement\.pdf-[A-Za-z0-9]{16}\.pdf$/', $filename );
+		$this->assertMatchesRegularExpression(
+			'/^agreement\.pdf-[A-Za-z0-9]{16}\.pdf$/',
+			add_csprn_to_filename( 'agreement.pdf.pdf', '.pdf' )
+		);
 	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
@@ -1,0 +1,420 @@
+<?php
+
+namespace WordCamp\Sponsor_Agreements\Tests;
+
+use WP_UnitTestCase, WP_UnitTest_Factory, WP_REST_Request, WP_REST_Server;
+
+use function WordCamp\Sponsor_Agreements\is_agreement;
+use function WordCamp\Sponsor_Agreements\make_agreement_private;
+use function WordCamp\Sponsor_Agreements\obscure_sponsor_file_names;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Who can reach a sponsorship agreement.
+ *
+ * Organizers attach the agreement from the Sponsor screen, and the Media modal stores it as an ordinary
+ * attachment on a sponsor. These pin who it stays readable for once it's there.
+ *
+ * @group mu-plugins
+ * @group sponsor-agreements
+ */
+class Test_Sponsor_Agreements extends WP_UnitTestCase {
+	/** @var int An organizer, who is an Editor on a WordCamp site. */
+	protected static $organizer;
+
+	/** @var int A volunteer who can write posts but isn't trusted with anyone else's. */
+	protected static $volunteer;
+
+	/**
+	 * Register the sponsor post type with the arguments `wc-post-types` gives it in production.
+	 *
+	 * No matching `tear_down()`: `WP_UnitTestCase` resets the registered post types itself before each
+	 * test, and unregistering by hand here takes rewrite rules and registered meta with it.
+	 *
+	 * That plugin isn't loaded for this suite, and these two are what the behaviour under test follows
+	 * from. `Test_WC_Post_Types` covers the registration itself.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type(
+			'wcb_sponsor',
+			array(
+				'public'       => true,
+				'show_in_rest' => true,
+				'rest_base'    => 'sponsors',
+			)
+		);
+	}
+
+	/**
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$organizer = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$volunteer = $factory->user->create( array( 'role' => 'author' ) );
+	}
+
+	/**
+	 * Create a published sponsor.
+	 *
+	 * @return int
+	 */
+	protected function create_sponsor() {
+		return self::factory()->post->create( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'publish',
+		) );
+	}
+
+	/**
+	 * Attach a file to a sponsor, the way the Media modal does: `inherit`, parented to the sponsor.
+	 *
+	 * @param string $filename
+	 * @param int    $sponsor_id
+	 *
+	 * @return int
+	 */
+	protected function create_file( $filename, $sponsor_id ) {
+		return self::factory()->attachment->create_object( array(
+			'file'           => $filename,
+			'post_parent'    => $sponsor_id,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+	}
+
+	/**
+	 * Attach a file to a sponsor and record it as that sponsor's agreement.
+	 *
+	 * @param int    $sponsor_id
+	 * @param string $meta_key
+	 *
+	 * @return int The attachment ID.
+	 */
+	protected function attach_agreement( $sponsor_id, $meta_key = '_wcpt_sponsor_agreement' ) {
+		$agreement_id = $this->create_file( 'sponsorship-agreement-acme-signed.pdf', $sponsor_id );
+
+		update_post_meta( $sponsor_id, $meta_key, $agreement_id );
+
+		return $agreement_id;
+	}
+
+	/**
+	 * Ask the Media REST route for one attachment, as the current user.
+	 *
+	 * @param int $attachment_id
+	 *
+	 * @return int The HTTP status code.
+	 */
+	protected function request_media_item( $attachment_id ) {
+		$server = rest_get_server();
+
+		$response = $server->dispatch( new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id ) );
+
+		return $response->get_status();
+	}
+
+	/**
+	 * The IDs the Media collection route hands the current user.
+	 *
+	 * @return int[]
+	 */
+	protected function request_media_collection() {
+		$server = rest_get_server();
+
+		$response = $server->dispatch( new WP_REST_Request( 'GET', '/wp/v2/media' ) );
+
+		return array_map( 'intval', wp_list_pluck( $response->get_data(), 'id' ) );
+	}
+
+	/**
+	 * Attaching an agreement gives it the `private` status.
+	 *
+	 * @dataProvider data_agreement_meta_keys
+	 *
+	 * @param string $meta_key
+	 */
+	public function test_attaching_an_agreement_makes_it_private( $meta_key ) {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor(), $meta_key );
+
+		$this->assertSame( 'private', get_post_status( $agreement_id ) );
+	}
+
+	/**
+	 * The two meta keys an agreement is stored under, on an event site and on central.
+	 *
+	 * @return array
+	 */
+	public function data_agreement_meta_keys() {
+		return array(
+			'event site' => array( '_wcpt_sponsor_agreement' ),
+			'central'    => array( 'mes_sponsor_agreement' ),
+		);
+	}
+
+	/**
+	 * Replacing one agreement with another covers the new file too.
+	 */
+	public function test_replacing_an_agreement_makes_the_new_file_private() {
+		$sponsor_id = $this->create_sponsor();
+
+		$this->attach_agreement( $sponsor_id );
+
+		$replacement_id = $this->create_file( 'sponsorship-agreement-acme-countersigned.pdf', $sponsor_id );
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $replacement_id );
+
+		$this->assertSame( 'private', get_post_status( $replacement_id ) );
+	}
+
+	/**
+	 * The single Media route resolves by ID and runs no query, so the status is what answers it.
+	 */
+	public function test_anonymous_rest_read_is_denied() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 401, $this->request_media_item( $agreement_id ) );
+	}
+
+	/**
+	 * The Media collection route, which is the other way in.
+	 */
+	public function test_anonymous_rest_collection_omits_the_agreement() {
+		$sponsor_id   = $this->create_sponsor();
+		$agreement_id = $this->attach_agreement( $sponsor_id );
+		$logo_id      = $this->create_file( 'acme-logo.png', $sponsor_id );
+
+		wp_set_current_user( 0 );
+
+		$visible = $this->request_media_collection();
+
+		$this->assertNotContains( $agreement_id, $visible );
+		$this->assertContains( $logo_id, $visible, 'A sponsor logo is meant to be public.' );
+	}
+
+	/**
+	 * Attachments are searchable, and a front-end search names no post type.
+	 */
+	public function test_anonymous_search_omits_the_agreement() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_set_current_user( 0 );
+
+		$found = get_posts( array(
+			's'              => 'sponsorship-agreement-acme-signed',
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		) );
+
+		$this->assertNotContains( $agreement_id, array_map( 'intval', $found ) );
+	}
+
+	/**
+	 * Organizers keep the access the workflow needs.
+	 */
+	public function test_organizer_can_still_read_the_agreement() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_set_current_user( self::$organizer );
+
+		$this->assertSame( 200, $this->request_media_item( $agreement_id ) );
+	}
+
+	/**
+	 * Someone who can write on the site but isn't an organizer doesn't have it.
+	 */
+	public function test_volunteer_cannot_read_the_agreement() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_set_current_user( self::$volunteer );
+
+		$this->assertSame( 403, $this->request_media_item( $agreement_id ) );
+	}
+
+	/**
+	 * The Sponsor Agreement metabox links straight to the file, so the link has to survive the status.
+	 */
+	public function test_the_agreement_url_still_resolves() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		$this->assertNotEmpty( wp_get_attachment_url( $agreement_id ) );
+	}
+
+	/**
+	 * The sponsor itself is meant to be public, and stays that way.
+	 */
+	public function test_the_sponsor_remains_public() {
+		$sponsor_id = $this->create_sponsor();
+
+		$this->attach_agreement( $sponsor_id );
+
+		$this->assertSame( 'publish', get_post_status( $sponsor_id ) );
+	}
+
+	/**
+	 * A file that's already private reports that it needed no change.
+	 */
+	public function test_securing_an_agreement_twice_is_a_no_op() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		$this->assertFalse( make_agreement_private( $agreement_id ) );
+	}
+
+	/**
+	 * Uploads to a sponsor get a random suffix in the file name.
+	 */
+	public function test_sponsor_uploads_get_a_random_suffix() {
+		$_REQUEST['post_id'] = $this->create_sponsor();
+
+		$filename = obscure_sponsor_file_names( 'sponsorship-agreement-acme-signed.pdf', '.pdf' );
+
+		$this->assertMatchesRegularExpression( '/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/', $filename );
+	}
+
+	/**
+	 * Every other upload on the site keeps the name it was given.
+	 */
+	public function test_other_uploads_keep_their_name() {
+		$_REQUEST['post_id'] = self::factory()->post->create();
+
+		$this->assertSame( 'header.png', obscure_sponsor_file_names( 'header.png', '.png' ) );
+
+		unset( $_REQUEST['post_id'] );
+
+		$this->assertSame( 'header.png', obscure_sponsor_file_names( 'header.png', '.png' ) );
+	}
+
+	/**
+	 * `mes_sponsor_agreement` isn't protected meta, so the Custom Fields box will write it to any post that
+	 * supports them. Only a sponsor names its own agreement.
+	 */
+	public function test_meta_on_an_ordinary_post_leaves_the_attachment_alone() {
+		$post_id       = self::factory()->post->create();
+		$attachment_id = $this->create_file( 'header.png', $post_id );
+
+		update_post_meta( $post_id, 'mes_sponsor_agreement', $attachment_id );
+
+		$this->assertSame( 'inherit', get_post( $attachment_id )->post_status );
+		$this->assertFalse( is_agreement( $attachment_id ) );
+	}
+
+	/**
+	 * `absint()` reads an array as `1`, which is another attachment entirely.
+	 */
+	public function test_a_non_scalar_meta_value_is_ignored() {
+		$sponsor_id    = $this->create_sponsor();
+		$attachment_id = $this->create_file( 'header.png', $sponsor_id );
+
+		update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', array( $attachment_id ) );
+
+		$this->assertSame( 'inherit', get_post( $attachment_id )->post_status );
+	}
+
+	/**
+	 * The mark and the status stay with the file when it's detached.
+	 */
+	public function test_the_agreement_stays_marked_when_it_is_detached() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_update_post( array(
+			'ID'          => $agreement_id,
+			'post_parent' => 0,
+		) );
+
+		$this->assertTrue( is_agreement( $agreement_id ) );
+		$this->assertSame( 'private', get_post_status( $agreement_id ) );
+	}
+
+	/**
+	 * `wp.getMediaItem` takes an ID and runs no query, so the status doesn't reach it.
+	 */
+	public function test_xmlrpc_redacts_the_agreement_from_a_volunteer() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_set_current_user( self::$volunteer );
+
+		$this->assertEmpty( $this->prepare_media_item( $agreement_id )['link'] ?? '' );
+
+		wp_set_current_user( self::$organizer );
+
+		$this->assertNotEmpty( $this->prepare_media_item( $agreement_id )['link'] ?? '' );
+	}
+
+	/**
+	 * Run an attachment through the XML-RPC media struct filter.
+	 *
+	 * @param int $attachment_id
+	 *
+	 * @return array
+	 */
+	protected function prepare_media_item( $attachment_id ) {
+		$attachment = get_post( $attachment_id );
+
+		return apply_filters(
+			'xmlrpc_prepare_media_item',
+			array(
+				'attachment_id' => (string) $attachment->ID,
+				'link'          => wp_get_attachment_url( $attachment->ID ),
+			),
+			$attachment,
+			'thumbnail'
+		);
+	}
+
+	/**
+	 * `wp_ajax_get_attachment()` takes an ID and runs no query either.
+	 */
+	public function test_the_admin_js_details_are_redacted_for_a_volunteer() {
+		$agreement_id = $this->attach_agreement( $this->create_sponsor() );
+
+		wp_set_current_user( self::$volunteer );
+
+		$this->assertEmpty( wp_prepare_attachment_for_js( $agreement_id ) );
+
+		wp_set_current_user( self::$organizer );
+
+		$this->assertNotEmpty( wp_prepare_attachment_for_js( $agreement_id ) );
+	}
+
+	/**
+	 * Ordinary media keeps working for everyone, on the routes that resolve by ID.
+	 */
+	public function test_ordinary_media_is_left_alone_on_the_id_routes() {
+		$logo_id = $this->create_file( 'acme-logo.png', $this->create_sponsor() );
+
+		wp_set_current_user( self::$volunteer );
+
+		$this->assertNotEmpty( $this->prepare_media_item( $logo_id )['link'] ?? '' );
+		$this->assertNotEmpty( wp_prepare_attachment_for_js( $logo_id ) );
+	}
+
+	/**
+	 * The block editor posts to the REST media route, which names the parent `post` rather than `post_id`.
+	 */
+	public function test_rest_uploads_to_a_sponsor_are_named_the_same_way() {
+		$_REQUEST['post'] = $this->create_sponsor();
+
+		$filename = obscure_sponsor_file_names( 'sponsorship-agreement-acme-signed.pdf', '.pdf' );
+
+		unset( $_REQUEST['post'] );
+
+		$this->assertMatchesRegularExpression( '/^sponsorship-agreement-acme-signed-[A-Za-z0-9]{16}\.pdf$/', $filename );
+	}
+
+	/**
+	 * The extension is trimmed off the end, not wherever it happens to appear.
+	 */
+	public function test_a_name_that_repeats_its_extension_keeps_both_copies() {
+		$_REQUEST['post_id'] = $this->create_sponsor();
+
+		$filename = obscure_sponsor_file_names( 'agreement.pdf.pdf', '.pdf' );
+
+		unset( $_REQUEST['post_id'] );
+
+		$this->assertMatchesRegularExpression( '/^agreement\.pdf-[A-Za-z0-9]{16}\.pdf$/', $filename );
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
@@ -961,4 +961,81 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 			'cannot edit the sponsor' => array( 'upload-attachment', 'wcb_sponsor', 'volunteer' ),
 		);
 	}
+
+	/**
+	 * A rename that leaves a file behind says so, since the name it kept may already be out there.
+	 */
+	public function test_a_rename_that_leaves_a_file_behind_is_logged() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		file_put_contents( $directory . 'stubborn.pdf', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+		file_put_contents( $directory . 'unrelated-150x150.jpg', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		$agreement_id = self::factory()->attachment->create_object( array(
+			'file'           => $directory . 'stubborn.pdf',
+			'post_parent'    => 0,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+
+		update_attached_file( $agreement_id, $directory . 'stubborn.pdf' );
+
+		// A size Core would never have named this way, standing in for one that can't be derived.
+		$metadata = array(
+			'file'  => _wp_relative_upload_path( $directory . 'stubborn.pdf' ),
+			'sizes' => array( 'thumbnail' => array( 'file' => 'unrelated-150x150.jpg' ) ),
+		);
+
+		wp_update_attachment_metadata( $agreement_id, $metadata );
+
+		$logged = $this->capture_log( function () use ( $sponsor_id, $agreement_id ) {
+			update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+		} );
+
+		try {
+			$this->assertStringContainsString( 'sponsor_agreement_files_not_renamed', $logged );
+
+			// What could move still moved.
+			$this->assertMatchesRegularExpression(
+				'/^stubborn-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertFileExists( $directory . 'unrelated-150x150.jpg' );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'stubborn*' );
+			$this->delete_files_on_disk( $directory, 'unrelated-*' );
+		}
+	}
+
+	/**
+	 * A rename that moves everything says nothing.
+	 */
+	public function test_a_clean_rename_is_not_logged() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		file_put_contents( $directory . 'quiet.pdf', 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		$agreement_id = self::factory()->attachment->create_object( array(
+			'file'           => $directory . 'quiet.pdf',
+			'post_parent'    => 0,
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+
+		update_attached_file( $agreement_id, $directory . 'quiet.pdf' );
+
+		$logged = $this->capture_log( function () use ( $sponsor_id, $agreement_id ) {
+			update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+		} );
+
+		try {
+			$this->assertStringNotContainsString( 'sponsor_agreement_files_not_renamed', $logged );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'quiet*' );
+		}
+	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
@@ -10,6 +10,7 @@ use function WordCamp\Sponsor_Agreements\add_csprn_to_filename;
 use function WordCamp\Sponsor_Agreements\rename_agreement_file;
 use function WordCamp\Sponsor_Agreements\secure_agreement;
 
+use const WordCamp\Sponsor_Agreements\NEEDS_RENAME_META_KEY;
 use const WordCamp\Sponsor_Agreements\UPLOAD_PARAM;
 
 defined( 'WPINC' ) || die();
@@ -997,6 +998,12 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 		try {
 			$this->assertStringContainsString( 'sponsor_agreement_files_not_renamed', $logged );
 
+			/*
+			 * The migration can't see this one -- it is already `private`, which is the only thing that
+			 * query looks for -- so joining the rename work list is what keeps it findable.
+			 */
+			$this->assertSame( '1', get_post_meta( $agreement_id, NEEDS_RENAME_META_KEY, true ) );
+
 			// What could move still moved.
 			$this->assertMatchesRegularExpression(
 				'/^stubborn-[A-Za-z0-9]{16}\.pdf$/',
@@ -1034,6 +1041,7 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 
 		try {
 			$this->assertStringNotContainsString( 'sponsor_agreement_files_not_renamed', $logged );
+			$this->assertSame( '', get_post_meta( $agreement_id, NEEDS_RENAME_META_KEY, true ) );
 		} finally {
 			$this->delete_files_on_disk( $directory, 'quiet*' );
 		}

--- a/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/tests/test-sponsor-agreements.php
@@ -8,6 +8,9 @@ use function WordCamp\Sponsor_Agreements\is_agreement;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
 use function WordCamp\Sponsor_Agreements\add_csprn_to_filename;
 use function WordCamp\Sponsor_Agreements\rename_agreement_file;
+use function WordCamp\Sponsor_Agreements\secure_agreement;
+
+use const WordCamp\Sponsor_Agreements\UPLOAD_PARAM;
 
 defined( 'WPINC' ) || die();
 
@@ -100,6 +103,64 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 		update_post_meta( $sponsor_id, $meta_key, $agreement_id );
 
 		return $agreement_id;
+	}
+
+	/**
+	 * Run something with the error log pointed at a file this test can read.
+	 *
+	 * Written into the uploads directory the test environment already owns, rather than the system's
+	 * temporary directory.
+	 *
+	 * @param callable $callback
+	 *
+	 * @return string Whatever was logged.
+	 */
+	protected function capture_log( $callback ) {
+		$uploads = wp_upload_dir();
+		wp_mkdir_p( $uploads['basedir'] );
+		$log      = trailingslashit( $uploads['basedir'] ) . 'agreement-log-' . wp_generate_password( 8, false, false ) . '.log';
+		$previous = ini_set( 'error_log', $log ); // phpcs:ignore WordPress.PHP.IniSet.Risky -- scoped to this test.
+
+		try {
+			$callback();
+		} finally {
+			ini_set( 'error_log', $previous ); // phpcs:ignore WordPress.PHP.IniSet.Risky -- restoring what was there.
+		}
+
+		// Nothing logged means the file was never created.
+		if ( ! is_file( $log ) ) {
+			return '';
+		}
+
+		$contents = (string) file_get_contents( $log ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- a local file this test wrote.
+
+		wp_delete_file( $log );
+
+		return $contents;
+	}
+
+	/**
+	 * Put a file on disk and attach it to a sponsor, as an upload from that sponsor's screen.
+	 *
+	 * @param string   $filename
+	 * @param string   $directory
+	 * @param int|null $sponsor_id Defaults to a new sponsor, for the tests that don't need to name it.
+	 *
+	 * @return int The attachment ID.
+	 */
+	protected function create_upload_on_disk( $filename, $directory, $sponsor_id = null ) {
+		file_put_contents( $directory . $filename, 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		$attachment_id = self::factory()->attachment->create_object( array(
+			'file'           => $directory . $filename,
+			'post_parent'    => $sponsor_id ?? $this->create_sponsor(),
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+		) );
+
+		update_attached_file( $attachment_id, $directory . $filename );
+
+		return $attachment_id;
 	}
 
 	/**
@@ -594,6 +655,310 @@ class Test_Sponsor_Agreements extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression(
 			'/^agreement\.pdf-[A-Za-z0-9]{16}\.pdf$/',
 			add_csprn_to_filename( 'agreement.pdf.pdf', '.pdf' )
+		);
+	}
+
+	/**
+	 * An upload marked before the sponsor is saved is covered from the moment it lands.
+	 *
+	 * The Sponsor Agreement modal marks its own uploads, so a file that is uploaded and then abandoned --
+	 * the organizer removes it again, or never presses Update -- doesn't sit on a published sponsor as an
+	 * ordinary attachment.
+	 */
+	public function test_an_upload_is_secured_before_the_sponsor_is_saved() {
+		$uploads      = wp_upload_dir();
+		$directory    = trailingslashit( $uploads['path'] );
+		$agreement_id = $this->create_upload_on_disk( 'just-uploaded.pdf', $directory );
+
+		try {
+			// No sponsor meta is written: this is the upload being marked, not the sponsor being saved.
+			secure_agreement( $agreement_id );
+
+			$this->assertSame( 'private', get_post_status( $agreement_id ) );
+			$this->assertTrue( is_agreement( $agreement_id ) );
+			$this->assertMatchesRegularExpression(
+				'/^just-uploaded-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+
+			wp_set_current_user( 0 );
+
+			$this->assertSame( 401, $this->request_media_item( $agreement_id ) );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'just-uploaded*' );
+		}
+	}
+
+	/**
+	 * Saving the sponsor afterwards doesn't suffix the file a second time.
+	 */
+	public function test_saving_the_sponsor_after_an_upload_changes_nothing() {
+		$sponsor_id   = $this->create_sponsor();
+		$uploads      = wp_upload_dir();
+		$directory    = trailingslashit( $uploads['path'] );
+		$agreement_id = $this->create_upload_on_disk( 'marked-first.pdf', $directory, $sponsor_id );
+
+		try {
+			secure_agreement( $agreement_id );
+
+			$marked = wp_basename( get_attached_file( $agreement_id ) );
+
+			update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+
+			$this->assertSame( $marked, wp_basename( get_attached_file( $agreement_id ) ) );
+		} finally {
+			$this->delete_files_on_disk( $directory, 'marked-first*' );
+		}
+	}
+
+	/**
+	 * An upload the modal never marked is noted, because saving the sponsor otherwise hides that.
+	 */
+	public function test_an_unmarked_upload_is_logged() {
+		$sponsor_id   = $this->create_sponsor();
+		$agreement_id = $this->create_file( 'unmarked.pdf', $sponsor_id );
+
+		$logged = $this->capture_log( function () use ( $sponsor_id, $agreement_id ) {
+			update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+		} );
+
+		$this->assertStringContainsString( 'sponsor_agreement_upload_not_marked', $logged );
+		$this->assertSame( 'private', get_post_status( $agreement_id ), 'The file was left unsecured.' );
+	}
+
+	/**
+	 * A file chosen from the Media Library had no upload to mark, so it says nothing.
+	 */
+	public function test_a_library_choice_is_not_logged() {
+		$sponsor_id   = $this->create_sponsor();
+		$agreement_id = $this->create_file( 'from-the-library.pdf', 0 );
+
+		$logged = $this->capture_log( function () use ( $sponsor_id, $agreement_id ) {
+			update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+		} );
+
+		$this->assertStringNotContainsString( 'sponsor_agreement_upload_not_marked', $logged );
+	}
+
+	/**
+	 * An upload the modal did mark is already an agreement, so saving the sponsor says nothing either.
+	 */
+	public function test_a_marked_upload_is_not_logged() {
+		$sponsor_id   = $this->create_sponsor();
+		$agreement_id = $this->create_file( 'marked.pdf', $sponsor_id );
+
+		secure_agreement( $agreement_id );
+
+		$logged = $this->capture_log( function () use ( $sponsor_id, $agreement_id ) {
+			update_post_meta( $sponsor_id, '_wcpt_sponsor_agreement', $agreement_id );
+		} );
+
+		$this->assertStringNotContainsString( 'sponsor_agreement_upload_not_marked', $logged );
+	}
+
+	/**
+	 * Put the request into the shape `wp_ajax_upload_attachment()` gives it.
+	 *
+	 * @param int  $sponsor_id The parent the upload names.
+	 * @param bool $marked     Whether the modal marked this upload as an agreement.
+	 */
+	protected function start_upload_request( $sponsor_id, $marked = true ) {
+		$_REQUEST['action']  = 'upload-attachment';
+		$_REQUEST['post_id'] = $sponsor_id;
+
+		if ( $marked ) {
+			$_POST[ UPLOAD_PARAM ] = 1;
+		}
+	}
+
+	/**
+	 * Leave the superglobals as they were found.
+	 */
+	protected function end_upload_request() {
+		unset( $_REQUEST['action'], $_REQUEST['post_id'], $_POST[ UPLOAD_PARAM ] );
+	}
+
+	/**
+	 * Create an attachment the way `media_handle_upload()` does, so the upload hooks really run.
+	 *
+	 * @param string $filename
+	 * @param int    $sponsor_id
+	 * @param string $mime_type
+	 *
+	 * @return int
+	 */
+	protected function upload_attachment( $filename, $sponsor_id, $mime_type = 'application/pdf' ) {
+		$uploads   = wp_upload_dir();
+		$directory = trailingslashit( $uploads['path'] );
+		$name      = wp_unique_filename( $directory, $filename );
+
+		file_put_contents( $directory . $name, 'x' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- a fixture on the local disk.
+
+		return wp_insert_attachment(
+			array(
+				'post_title'     => $filename,
+				'post_parent'    => $sponsor_id,
+				'post_mime_type' => $mime_type,
+				'post_status'    => 'inherit',
+			),
+			$directory . $name,
+			$sponsor_id
+		);
+	}
+
+	/**
+	 * A marked upload is named, hidden and marked without anything having to move afterwards.
+	 */
+	public function test_a_marked_upload_is_secured_as_it_arrives() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		wp_set_current_user( self::$organizer );
+		$this->start_upload_request( $sponsor_id );
+
+		try {
+			$agreement_id = $this->upload_attachment( 'signed-agreement.pdf', $sponsor_id );
+
+			$this->assertMatchesRegularExpression(
+				'/^signed-agreement-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+			$this->assertSame( 'private', get_post( $agreement_id )->post_status );
+			$this->assertTrue( is_agreement( $agreement_id ) );
+
+			// It was never written under the name it arrived with.
+			$this->assertFileDoesNotExist( $directory . 'signed-agreement.pdf' );
+		} finally {
+			$this->end_upload_request();
+			$this->delete_files_on_disk( $directory, 'signed-agreement*' );
+		}
+	}
+
+	/**
+	 * A PDF is an agreement whether or not the modal marked it.
+	 *
+	 * This is what stands between an organizer and an exposed contract when the marking fails, which is
+	 * otherwise silent for an upload that is then abandoned.
+	 */
+	public function test_an_unmarked_pdf_on_a_sponsor_is_still_an_agreement() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		wp_set_current_user( self::$organizer );
+		$this->start_upload_request( $sponsor_id, false );
+
+		try {
+			$agreement_id = $this->upload_attachment( 'unmarked-contract.pdf', $sponsor_id );
+
+			$this->assertSame( 'private', get_post( $agreement_id )->post_status );
+			$this->assertTrue( is_agreement( $agreement_id ) );
+			$this->assertMatchesRegularExpression(
+				'/^unmarked-contract-[A-Za-z0-9]{16}\.pdf$/',
+				wp_basename( get_attached_file( $agreement_id ) )
+			);
+		} finally {
+			$this->end_upload_request();
+			$this->delete_files_on_disk( $directory, 'unmarked-contract*' );
+		}
+	}
+
+	/**
+	 * An unmarked image is a logo, and is left as one.
+	 *
+	 * The gap this leaves -- an image agreement whose marking failed -- is what
+	 * `report_unmarked_upload()` is for.
+	 */
+	public function test_an_unmarked_image_on_a_sponsor_is_left_alone() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		wp_set_current_user( self::$organizer );
+		$this->start_upload_request( $sponsor_id, false );
+
+		try {
+			$logo_id = $this->upload_attachment( 'acme-logo.png', $sponsor_id, 'image/png' );
+
+			$this->assertSame( 'inherit', get_post( $logo_id )->post_status );
+			$this->assertFalse( is_agreement( $logo_id ) );
+			$this->assertSame( 'acme-logo.png', wp_basename( get_attached_file( $logo_id ) ) );
+		} finally {
+			$this->end_upload_request();
+			$this->delete_files_on_disk( $directory, 'acme-logo*' );
+		}
+	}
+
+	/**
+	 * A marked image is an agreement, which is the whole of what the field is for.
+	 */
+	public function test_a_marked_image_on_a_sponsor_is_an_agreement() {
+		$sponsor_id = $this->create_sponsor();
+		$uploads    = wp_upload_dir();
+		$directory  = trailingslashit( $uploads['path'] );
+
+		wp_set_current_user( self::$organizer );
+		$this->start_upload_request( $sponsor_id );
+
+		try {
+			$agreement_id = $this->upload_attachment( 'signed-page.jpg', $sponsor_id, 'image/jpeg' );
+
+			$this->assertSame( 'private', get_post( $agreement_id )->post_status );
+			$this->assertTrue( is_agreement( $agreement_id ) );
+		} finally {
+			$this->end_upload_request();
+			$this->delete_files_on_disk( $directory, 'signed-page*' );
+		}
+	}
+
+	/**
+	 * The requests this has to stay out of, and why each one is here.
+	 *
+	 * @dataProvider data_requests_the_upload_hooks_decline
+	 *
+	 * @param string $action      The action Core dispatched on.
+	 * @param string $parent_type The post type the upload names as its parent.
+	 * @param string $role        The role of the user uploading.
+	 */
+	public function test_the_upload_hooks_decline_other_requests( $action, $parent_type, $role ) {
+		$parent_id = 'wcb_sponsor' === $parent_type
+			? $this->create_sponsor()
+			: self::factory()->post->create();
+
+		$uploads   = wp_upload_dir();
+		$directory = trailingslashit( $uploads['path'] );
+
+		wp_set_current_user( 'editor' === $role ? self::$organizer : self::$volunteer );
+
+		$this->start_upload_request( $parent_id );
+		$_REQUEST['action'] = $action;
+
+		try {
+			$attachment_id = $this->upload_attachment( 'untouched.pdf', $parent_id );
+
+			$this->assertSame( 'inherit', get_post( $attachment_id )->post_status );
+			$this->assertFalse( is_agreement( $attachment_id ) );
+			$this->assertSame( 'untouched.pdf', wp_basename( get_attached_file( $attachment_id ) ) );
+		} finally {
+			$this->end_upload_request();
+			$this->delete_files_on_disk( $directory, 'untouched*' );
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function data_requests_the_upload_hooks_decline() {
+		return array(
+			// The field only means anything in the request that creates the attachment.
+			'not an upload' => array( 'query-attachments', 'wcb_sponsor', 'editor' ),
+
+			// A PDF on anything else is somebody's ordinary media.
+			'not a sponsor' => array( 'upload-attachment', 'post', 'editor' ),
+
+			// `upload_files` is an Author capability; editing somebody else's sponsor is not.
+			'cannot edit the sponsor' => array( 'upload-attachment', 'wcb_sponsor', 'volunteer' ),
 		);
 	}
 }

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
@@ -15,7 +15,8 @@
 namespace WordCamp\Sponsor_Agreements\Backfill;
 
 use WP_CLI, WP_CLI_Command;
-use cli\Table;
+
+use function WP_CLI\Utils\format_items;
 
 use function WordCamp\Sponsor_Agreements\add_csprn_to_filename;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
@@ -74,7 +75,13 @@ function get_public_agreement_ids( $blog_id = null ) {
  * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
  * `wp_get_attachment_url()` -- so the new name reaches every reader.
  *
- * The generated sizes move with it. They sit beside the original under names derived from it.
+ * Every file Core derives from the upload moves with it, under one new base name:
+ *
+ * - the generated sizes, which for a PDF are renderings of the first page and for an image are copies of
+ *   it at up to 2048px;
+ * - the full-size original, when Core scaled the upload down. `_wp_attached_file` then points at the
+ *   `-scaled` copy while `original_image` holds the name the sizes are derived from, so that -- not the
+ *   attached file -- is what the new base is built from.
  *
  * Only ever called for the site the process was started on, because `ms_upload_constants()` defines
  * `UPLOADS` for whichever site that was -- see `backfill()`.
@@ -84,59 +91,168 @@ function get_public_agreement_ids( $blog_id = null ) {
  *
  * @param int $attachment_id
  *
- * @return bool Whether the file was renamed.
+ * @return array {
+ *     What happened on disk. The metadata always names whatever each file ended up being called.
+ *
+ *     @type int $renamed     Files moved.
+ *     @type int $left_behind Files still under the name they had.
+ * }
  */
 function rename_agreement_file( $attachment_id ) {
-	$old_path = get_attached_file( $attachment_id );
+	$outcome       = array(
+		'renamed'     => 0,
+		'left_behind' => 0,
+	);
+	$attached_path = get_attached_file( $attachment_id );
 
-	if ( ! $old_path || ! is_file( $old_path ) ) {
-		return false;
+	if ( ! $attached_path || ! is_file( $attached_path ) ) {
+		return $outcome;
 	}
 
-	$directory = dirname( $old_path );
-	$old_name  = wp_basename( $old_path );
-	$extension = pathinfo( $old_name, PATHINFO_EXTENSION );
-	$extension = $extension ? '.' . $extension : '';
-	$new_name  = wp_unique_filename( $directory, add_csprn_to_filename( $old_name, $extension ) );
+	$directory = dirname( $attached_path );
+	$metadata  = wp_get_attachment_metadata( $attachment_id );
+	$metadata  = is_array( $metadata ) ? $metadata : array();
 
-	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- WP_Filesystem needs credentials this can't ask for, and a failure is reported rather than fatal.
-	if ( ! @rename( $old_path, $directory . '/' . $new_name ) ) {
-		return false;
+	$old_base     = empty( $metadata['original_image'] ) ? wp_basename( $attached_path ) : $metadata['original_image'];
+	$extension    = pathinfo( $old_base, PATHINFO_EXTENSION );
+	$extension    = $extension ? '.' . $extension : '';
+	$new_base     = wp_unique_filename( $directory, add_csprn_to_filename( $old_base, $extension ) );
+	$old_base     = substr( $old_base, 0, strlen( $old_base ) - strlen( $extension ) );
+	$new_base     = substr( $new_base, 0, strlen( $new_base ) - strlen( $extension ) );
+	$already_done = array();
+
+	/**
+	 * Move one of the attachment's files, and answer to what it's now called.
+	 *
+	 * Two sizes can name the same file -- a theme registering a size Core already generates -- so the
+	 * second time one comes round it has already been dealt with. The cache is what keeps its metadata in
+	 * step with the first one's, and what keeps one file from being counted twice.
+	 *
+	 * @param string $name
+	 *
+	 * @return string
+	 */
+	$move = function ( $name ) use ( $directory, $old_base, $new_base, $extension, &$already_done, &$outcome ) {
+		if ( isset( $already_done[ $name ] ) ) {
+			return $already_done[ $name ];
+		}
+
+		$source = $directory . '/' . $name;
+
+		/*
+		 * Core names a derivative `<base>-<width>x<height>.<ext>` or `<base>-scaled.<ext>`, so the
+		 * separator is what tells `photo-150x150.jpg` from `photobooth-150x150.jpg`. Without it the
+		 * second would be rebased into `photo-<random>booth-150x150.jpg`, splicing the name rather than
+		 * replacing what it starts with.
+		 */
+		$derived = $name === $old_base . $extension || str_starts_with( $name, $old_base . '-' );
+
+		if ( ! $derived ) {
+			// Not this attachment's to rename. Count it only if there's a file there to be concerned with.
+			$outcome['left_behind'] += is_file( $source ) ? 1 : 0;
+			$already_done[ $name ]   = $name;
+
+			return $name;
+		}
+
+		$new_name = $new_base . substr( $name, strlen( $old_base ) );
+
+		// A name in the metadata with no file behind it was already stale, and moves nothing either way.
+		if ( ! is_file( $source ) ) {
+			$already_done[ $name ] = $name;
+
+			return $name;
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- WP_Filesystem needs credentials this can't ask for, and a failure is reported rather than fatal.
+		if ( ! @rename( $source, $directory . '/' . $new_name ) ) {
+			++$outcome['left_behind'];
+			$already_done[ $name ] = $name;
+
+			return $name;
+		}
+
+		++$outcome['renamed'];
+		$already_done[ $name ] = $new_name;
+
+		return $new_name;
+	};
+
+	$attached_name = wp_basename( $attached_path );
+	$new_attached  = $move( $attached_name );
+
+	/*
+	 * Carry on when the attached file itself wouldn't move. Everything else is named from `$old_base`
+	 * rather than from it, so those can still go -- and whether they went or not is the whole of what the
+	 * count is for.
+	 */
+	if ( ! empty( $metadata['original_image'] ) ) {
+		$metadata['original_image'] = $move( $metadata['original_image'] );
 	}
 
-	$old_base = substr( $old_name, 0, strlen( $old_name ) - strlen( $extension ) );
-	$new_base = substr( $new_name, 0, strlen( $new_name ) - strlen( $extension ) );
-	$metadata = wp_get_attachment_metadata( $attachment_id );
-
-	if ( is_array( $metadata ) ) {
-		if ( ! empty( $metadata['file'] ) ) {
-			$metadata['file'] = dirname( $metadata['file'] ) . '/' . $new_name;
+	foreach ( $metadata['sizes'] ?? array() as $size => $details ) {
+		if ( empty( $details['file'] ) ) {
+			continue;
 		}
 
-		foreach ( $metadata['sizes'] ?? array() as $size => $details ) {
-			if ( empty( $details['file'] ) || ! str_starts_with( $details['file'], $old_base ) ) {
-				continue;
-			}
+		$metadata['sizes'][ $size ]['file'] = $move( $details['file'] );
+	}
 
-			$new_size_name = $new_base . substr( $details['file'], strlen( $old_base ) );
+	if ( ! empty( $metadata['file'] ) ) {
+		$path_prefix      = str_contains( $metadata['file'], '/' ) ? dirname( $metadata['file'] ) . '/' : '';
+		$metadata['file'] = $path_prefix . $new_attached;
+	}
 
-			if ( is_file( $directory . '/' . $details['file'] ) ) {
-				// A size that won't move is left where it is, so the metadata keeps naming the real file.
-				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- as above.
-				if ( ! @rename( $directory . '/' . $details['file'], $directory . '/' . $new_size_name ) ) {
-					continue;
-				}
-			}
-
-			$metadata['sizes'][ $size ]['file'] = $new_size_name;
-		}
-
+	if ( $metadata ) {
 		wp_update_attachment_metadata( $attachment_id, $metadata );
 	}
 
-	update_attached_file( $attachment_id, $directory . '/' . $new_name );
+	if ( $new_attached !== $attached_name ) {
+		update_attached_file( $attachment_id, $directory . '/' . $new_attached );
+	}
 
-	return true;
+	return $outcome;
+}
+
+
+/**
+ * Say how a rename went, for the report.
+ *
+ * An attachment is rarely one file: a scaled photo leaves the full-size original beside it, and every
+ * registered size is another copy. The count is what says whether they all moved, since the `File` column
+ * can only name one of them.
+ *
+ * @param array $outcome     As returned by `rename_agreement_file()`.
+ * @param bool  $dry_run
+ * @param bool  $skip_rename
+ *
+ * @return string
+ */
+function describe_rename( $outcome, $dry_run, $skip_rename ) {
+	$renamed     = $outcome['renamed'] ?? 0;
+	$left_behind = $outcome['left_behind'] ?? 0;
+
+	if ( $skip_rename ) {
+		return 'skipped';
+	}
+
+	if ( $dry_run ) {
+		return 'pending';
+	}
+
+	/*
+	 * Nothing either way means `rename_agreement_file()` returned before it started, which it only does
+	 * when `_wp_attached_file` names a file that isn't there.
+	 */
+	if ( ! $renamed && ! $left_behind ) {
+		return 'file missing';
+	}
+
+	if ( $left_behind ) {
+		return sprintf( '%d moved, %d left', $renamed, $left_behind );
+	}
+
+	return sprintf( '%d %s', $renamed, 1 === $renamed ? 'file' : 'files' );
 }
 
 
@@ -148,6 +264,13 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
  * WordCamp.org: bring existing sponsorship agreements into line with `sponsor-agreements.php`.
  */
 class Command extends WP_CLI_Command {
+	/**
+	 * The columns of the `backfill` report.
+	 *
+	 * Named in one place so that the rows, the rendered report and the empty-set report can't drift apart.
+	 */
+	const REPORT_COLUMNS = array( 'Attachment', 'File', 'Private', 'Renamed' );
+
 	/**
 	 * Report which sites have agreements left to migrate.
 	 *
@@ -236,6 +359,17 @@ class Command extends WP_CLI_Command {
 	 * [--skip-rename]
 	 * : Set the status, but leave the files under the names they have.
 	 *
+	 * [--format=<format>]
+	 * : Render the report in this format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp --url=seattle.wordcamp.org/2023 wc-sponsor-agreements backfill --dry-run
@@ -247,56 +381,108 @@ class Command extends WP_CLI_Command {
 	public function backfill( $args, $assoc_args ) {
 		$dry_run       = isset( $assoc_args['dry-run'] );
 		$skip_rename   = isset( $assoc_args['skip-rename'] );
+		$format        = $assoc_args['format'] ?? 'table';
 		$agreement_ids = get_public_agreement_ids();
 		$results       = array();
+		$unfinished    = array();
+		$untouched     = array(
+			'renamed'     => 0,
+			'left_behind' => 0,
+		);
 
 		foreach ( $agreement_ids as $agreement_id ) {
-			$file = wp_basename( (string) get_attached_file( $agreement_id ) );
-
 			if ( $dry_run ) {
 				$migrated = true;
-				$renamed  = ! $skip_rename;
+				$outcome  = $untouched;
 			} else {
 				$migrated = make_agreement_private( $agreement_id );
-				$renamed  = $skip_rename ? false : rename_agreement_file( $agreement_id );
+				$outcome  = $skip_rename ? $untouched : rename_agreement_file( $agreement_id );
+			}
+
+			/*
+			 * Anything short of "every file moved" needs saying, and that includes the attachment whose
+			 * file was already gone -- it moved nothing, but it also isn't finished.
+			 */
+			if ( ! $dry_run && ! $skip_rename && ( $outcome['left_behind'] || ! $outcome['renamed'] ) ) {
+				$unfinished[] = $agreement_id;
 			}
 
 			$results[] = array(
 				'Attachment' => $agreement_id,
-				'File'       => $file,
+
+				// Read after the fact, so that the column names the file as it now stands on disk.
+				'File'       => wp_basename( (string) get_attached_file( $agreement_id ) ),
 				'Private'    => $migrated ? 'yes' : 'no',
-				'Renamed'    => $renamed ? 'yes' : 'no',
+				'Renamed'    => describe_rename( $outcome, $dry_run, $skip_rename ),
 			);
 		}
 
 		if ( ! $results ) {
-			WP_CLI::success( 'No sponsor agreements left to migrate.' );
+			// A machine-readable run still has to answer with something its caller can parse.
+			if ( 'table' !== $format ) {
+				format_items( $format, array(), self::REPORT_COLUMNS );
+			}
+
+			$this->summarize( 'success', 'No sponsor agreements left to migrate.', $format );
 
 			return;
 		}
 
-		WP_CLI::line();
+		// Blank lines frame the table for a person, and corrupt every other format.
+		if ( 'table' === $format ) {
+			WP_CLI::line();
+		}
 
-		$table = new Table();
-		$table->setHeaders( array_keys( $results[0] ) );
-		$table->setRows( $results );
-		$table->display();
+		format_items( $format, $results, self::REPORT_COLUMNS );
 
-		WP_CLI::line();
-
-		$unfinished = wp_list_filter( $results, array( 'Renamed' => 'no' ) );
+		if ( 'table' === $format ) {
+			WP_CLI::line();
+		}
 
 		if ( $dry_run ) {
-			WP_CLI::success( sprintf( '%d agreements would be migrated. Run without --dry-run to apply.', count( $results ) ) );
-		} elseif ( $unfinished && ! $skip_rename ) {
-			WP_CLI::warning( sprintf(
-				'%d of %d agreements kept the file name they had.',
+			$this->summarize( 'success', sprintf( '%d agreements would be migrated. Run without --dry-run to apply.', count( $results ) ), $format );
+		} elseif ( $unfinished ) {
+			$message = sprintf(
+				'%d of %d agreements are unfinished; the Renamed column says what happened to each.',
 				count( $unfinished ),
 				count( $results )
-			) );
+			);
+
+			$this->summarize( 'warning', $message, $format );
 		} else {
-			WP_CLI::success( sprintf( '%d agreements processed.', count( $results ) ) );
+			$this->summarize( 'success', sprintf( '%d agreements processed.', count( $results ) ), $format );
 		}
+	}
+
+	/**
+	 * Report on the run as a whole, without writing over the report itself.
+	 *
+	 * `WP_CLI::success()` goes to STDOUT, which is where a machine-readable format has just been written,
+	 * so anything piped to `jq` would find a sentence after the array. Warnings are already on STDERR.
+	 *
+	 * @param string $level  `success` or `warning`.
+	 * @param string $message
+	 * @param string $format The format the report was rendered in.
+	 */
+	protected function summarize( $level, $message, $format ) {
+		if ( 'warning' === $level ) {
+			WP_CLI::warning( $message );
+
+			return;
+		}
+
+		if ( 'table' === $format ) {
+			WP_CLI::success( $message );
+
+			return;
+		}
+
+		// `WP_CLI::success()` would have gone through the logger, which is what `--quiet` silences.
+		if ( WP_CLI::get_config( 'quiet' ) ) {
+			return;
+		}
+
+		fwrite( STDERR, 'Success: ' . $message . "\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- writing to the process's own STDERR.
 	}
 }
 

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
@@ -21,6 +21,15 @@ use function WordCamp\Sponsor_Agreements\make_agreement_private;
 
 defined( 'WPINC' ) || die();
 
+/**
+ * Recorded on every attachment this migration gives the `private` status.
+ *
+ * `AGREEMENT_MARKER_META_KEY` says an attachment is an agreement; it doesn't say which ones were uploaded
+ * before `obscure_sponsor_file_names()` existed and so still carry the name they were given. Nothing else
+ * distinguishes them once the status is set, and this is the only moment the answer is known.
+ */
+const BACKFILLED_META_KEY = '_wcorg_sponsor_agreement_backfilled';
+
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO -- the command and the work it does are one unit here, so that removing the migration is removing one file.
 
 
@@ -215,6 +224,8 @@ class Command extends WP_CLI_Command {
 
 			if ( ! $migrated ) {
 				$unfinished[] = $agreement_id;
+			} elseif ( ! $dry_run ) {
+				update_post_meta( $agreement_id, BACKFILLED_META_KEY, 1 );
 			}
 
 			$results[] = array(

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
@@ -4,12 +4,11 @@
  * A one-time migration, to be deleted once it has been run across the network.
  *
  * `sponsor-agreements.php` handles agreements from the moment they're attached. Files attached before it
- * existed keep the status and the name they already had, because writing the same meta value back fires no
- * hook. This brings those into line, and then has no further purpose.
+ * existed keep the status they already had, because writing the same meta value back fires no hook. This
+ * gives them that status, and then has no further purpose.
  *
  * Self-contained on purpose: everything here goes when the file does, apart from the two lines that load it
- * in `bootstrap.php`. The pieces that outlive the migration -- `make_agreement_private()` and
- * `add_csprn_to_filename()` -- stay in `sponsor-agreements.php` and are called from here.
+ * in `bootstrap.php`. `make_agreement_private()` outlives it, in `sponsor-agreements.php`.
  */
 
 namespace WordCamp\Sponsor_Agreements\Backfill;
@@ -18,7 +17,6 @@ use WP_CLI, WP_CLI_Command;
 
 use function WP_CLI\Utils\format_items;
 
-use function WordCamp\Sponsor_Agreements\add_csprn_to_filename;
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
 
 defined( 'WPINC' ) || die();
@@ -69,193 +67,6 @@ function get_public_agreement_ids( $blog_id = null ) {
 	return array_map( 'absint', $agreement_ids );
 }
 
-/**
- * Rename an agreement that's already on disk, so that it matches what new uploads get.
- *
- * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
- * `wp_get_attachment_url()` -- so the new name reaches every reader.
- *
- * Every file Core derives from the upload moves with it, under one new base name:
- *
- * - the generated sizes, which for a PDF are renderings of the first page and for an image are copies of
- *   it at up to 2048px;
- * - the full-size original, when Core scaled the upload down. `_wp_attached_file` then points at the
- *   `-scaled` copy while `original_image` holds the name the sizes are derived from, so that -- not the
- *   attached file -- is what the new base is built from.
- *
- * Only ever called for the site the process was started on, because `ms_upload_constants()` defines
- * `UPLOADS` for whichever site that was -- see `backfill()`.
- *
- * The `guid` is deliberately left alone. It's an identifier rather than the URL anything is served from,
- * and Core's rule is that it doesn't change once a post has one.
- *
- * @param int $attachment_id
- *
- * @return array {
- *     What happened on disk. The metadata always names whatever each file ended up being called.
- *
- *     @type int $renamed     Files moved.
- *     @type int $left_behind Files still under the name they had.
- * }
- */
-function rename_agreement_file( $attachment_id ) {
-	$outcome       = array(
-		'renamed'     => 0,
-		'left_behind' => 0,
-	);
-	$attached_path = get_attached_file( $attachment_id );
-
-	if ( ! $attached_path || ! is_file( $attached_path ) ) {
-		return $outcome;
-	}
-
-	$directory = dirname( $attached_path );
-	$metadata  = wp_get_attachment_metadata( $attachment_id );
-	$metadata  = is_array( $metadata ) ? $metadata : array();
-
-	$old_base     = empty( $metadata['original_image'] ) ? wp_basename( $attached_path ) : $metadata['original_image'];
-	$extension    = pathinfo( $old_base, PATHINFO_EXTENSION );
-	$extension    = $extension ? '.' . $extension : '';
-	$new_base     = wp_unique_filename( $directory, add_csprn_to_filename( $old_base, $extension ) );
-	$old_base     = substr( $old_base, 0, strlen( $old_base ) - strlen( $extension ) );
-	$new_base     = substr( $new_base, 0, strlen( $new_base ) - strlen( $extension ) );
-	$already_done = array();
-
-	/**
-	 * Move one of the attachment's files, and answer to what it's now called.
-	 *
-	 * Two sizes can name the same file -- a theme registering a size Core already generates -- so the
-	 * second time one comes round it has already been dealt with. The cache is what keeps its metadata in
-	 * step with the first one's, and what keeps one file from being counted twice.
-	 *
-	 * @param string $name
-	 *
-	 * @return string
-	 */
-	$move = function ( $name ) use ( $directory, $old_base, $new_base, $extension, &$already_done, &$outcome ) {
-		if ( isset( $already_done[ $name ] ) ) {
-			return $already_done[ $name ];
-		}
-
-		$source = $directory . '/' . $name;
-
-		/*
-		 * Core names a derivative `<base>-<width>x<height>.<ext>` or `<base>-scaled.<ext>`, so the
-		 * separator is what tells `photo-150x150.jpg` from `photobooth-150x150.jpg`. Without it the
-		 * second would be rebased into `photo-<random>booth-150x150.jpg`, splicing the name rather than
-		 * replacing what it starts with.
-		 */
-		$derived = $name === $old_base . $extension || str_starts_with( $name, $old_base . '-' );
-
-		if ( ! $derived ) {
-			// Not this attachment's to rename. Count it only if there's a file there to be concerned with.
-			$outcome['left_behind'] += is_file( $source ) ? 1 : 0;
-			$already_done[ $name ]   = $name;
-
-			return $name;
-		}
-
-		$new_name = $new_base . substr( $name, strlen( $old_base ) );
-
-		// A name in the metadata with no file behind it was already stale, and moves nothing either way.
-		if ( ! is_file( $source ) ) {
-			$already_done[ $name ] = $name;
-
-			return $name;
-		}
-
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- WP_Filesystem needs credentials this can't ask for, and a failure is reported rather than fatal.
-		if ( ! @rename( $source, $directory . '/' . $new_name ) ) {
-			++$outcome['left_behind'];
-			$already_done[ $name ] = $name;
-
-			return $name;
-		}
-
-		++$outcome['renamed'];
-		$already_done[ $name ] = $new_name;
-
-		return $new_name;
-	};
-
-	$attached_name = wp_basename( $attached_path );
-	$new_attached  = $move( $attached_name );
-
-	/*
-	 * Carry on when the attached file itself wouldn't move. Everything else is named from `$old_base`
-	 * rather than from it, so those can still go -- and whether they went or not is the whole of what the
-	 * count is for.
-	 */
-	if ( ! empty( $metadata['original_image'] ) ) {
-		$metadata['original_image'] = $move( $metadata['original_image'] );
-	}
-
-	foreach ( $metadata['sizes'] ?? array() as $size => $details ) {
-		if ( empty( $details['file'] ) ) {
-			continue;
-		}
-
-		$metadata['sizes'][ $size ]['file'] = $move( $details['file'] );
-	}
-
-	if ( ! empty( $metadata['file'] ) ) {
-		$path_prefix      = str_contains( $metadata['file'], '/' ) ? dirname( $metadata['file'] ) . '/' : '';
-		$metadata['file'] = $path_prefix . $new_attached;
-	}
-
-	if ( $metadata ) {
-		wp_update_attachment_metadata( $attachment_id, $metadata );
-	}
-
-	if ( $new_attached !== $attached_name ) {
-		update_attached_file( $attachment_id, $directory . '/' . $new_attached );
-	}
-
-	return $outcome;
-}
-
-
-/**
- * Say how a rename went, for the report.
- *
- * An attachment is rarely one file: a scaled photo leaves the full-size original beside it, and every
- * registered size is another copy. The count is what says whether they all moved, since the `File` column
- * can only name one of them.
- *
- * @param array $outcome     As returned by `rename_agreement_file()`.
- * @param bool  $dry_run
- * @param bool  $skip_rename
- *
- * @return string
- */
-function describe_rename( $outcome, $dry_run, $skip_rename ) {
-	$renamed     = $outcome['renamed'] ?? 0;
-	$left_behind = $outcome['left_behind'] ?? 0;
-
-	if ( $skip_rename ) {
-		return 'skipped';
-	}
-
-	if ( $dry_run ) {
-		return 'pending';
-	}
-
-	/*
-	 * Nothing either way means `rename_agreement_file()` returned before it started, which it only does
-	 * when `_wp_attached_file` names a file that isn't there.
-	 */
-	if ( ! $renamed && ! $left_behind ) {
-		return 'file missing';
-	}
-
-	if ( $left_behind ) {
-		return sprintf( '%d moved, %d left', $renamed, $left_behind );
-	}
-
-	return sprintf( '%d %s', $renamed, 1 === $renamed ? 'file' : 'files' );
-}
-
-
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
@@ -269,7 +80,7 @@ class Command extends WP_CLI_Command {
 	 *
 	 * Named in one place so that the rows, the rendered report and the empty-set report can't drift apart.
 	 */
-	const REPORT_COLUMNS = array( 'Attachment', 'File', 'Private', 'Renamed' );
+	const REPORT_COLUMNS = array( 'Attachment', 'File', 'Private' );
 
 	/**
 	 * Report which sites have agreements left to migrate.
@@ -302,15 +113,27 @@ class Command extends WP_CLI_Command {
 	public function scan( $args, $assoc_args ) {
 		global $wpdb;
 
-		$verbose = isset( $assoc_args['verbose'] );
-		$sites   = $wpdb->get_results( "SELECT blog_id, domain, path FROM {$wpdb->blogs} ORDER BY blog_id" );
-		$found   = 0;
+		$verbose  = isset( $assoc_args['verbose'] );
+		$sites    = $wpdb->get_results( "SELECT blog_id, domain, path FROM {$wpdb->blogs} ORDER BY blog_id" );
+		$found    = 0;
+		$unusable = array();
 
 		// A site whose tables have gone is a broken row, not a reason to stop part-way through a network.
-		$wpdb->suppress_errors( true );
+		$was_suppressing = $wpdb->suppress_errors( true );
 
 		foreach ( $sites as $site ) {
 			$agreement_ids = get_public_agreement_ids( $site->blog_id );
+
+			/*
+			 * `get_col()` answers an empty array whether the site has nothing or the query failed, so a
+			 * site whose tables are missing would otherwise be counted as clean and never reach the pipe.
+			 */
+			if ( $wpdb->last_error ) {
+				$unusable[]       = $site->domain . $site->path;
+				$wpdb->last_error = '';
+
+				continue;
+			}
 
 			if ( ! $agreement_ids ) {
 				continue;
@@ -331,7 +154,15 @@ class Command extends WP_CLI_Command {
 			}
 		}
 
-		$wpdb->suppress_errors( false );
+		$wpdb->suppress_errors( $was_suppressing );
+
+		if ( $unusable ) {
+			WP_CLI::warning( sprintf(
+				'%d sites could not be read, and are not in the list above: %s.',
+				count( $unusable ),
+				implode( ', ', array_slice( $unusable, 0, 10 ) ) . ( count( $unusable ) > 10 ? ', ...' : '' )
+			) );
+		}
 
 		if ( $verbose ) {
 			WP_CLI::warning( sprintf( '%d of %d sites have agreements to migrate.', $found, count( $sites ) ) );
@@ -341,13 +172,9 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Migrate the agreements on one site.
 	 *
-	 * Gives them the `private` status and the file name that new agreements get as they're attached.
-	 * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
+	 * Gives them the `private` status that new agreements get as they're attached. Nothing links to an
+	 * agreement by URL -- both plugins hold an attachment ID and resolve it through
 	 * `wp_get_attachment_url()` -- so organizers keep the access they have.
-	 *
-	 * One site per run, and it has to be: `ms_upload_constants()` defines `UPLOADS` for whichever site was
-	 * current at bootstrap, so a `switch_to_blog()` loop would resolve every other site's files against
-	 * the wrong directory and silently rename nothing. Use `scan` to find the sites that need this.
 	 *
 	 * Safe to re-run: a site with nothing outstanding does one query and stops.
 	 *
@@ -355,9 +182,6 @@ class Command extends WP_CLI_Command {
 	 *
 	 * [--dry-run]
 	 * : Report what would change, without changing it.
-	 *
-	 * [--skip-rename]
-	 * : Set the status, but leave the files under the names they have.
 	 *
 	 * [--format=<format>]
 	 * : Render the report in this format.
@@ -380,40 +204,23 @@ class Command extends WP_CLI_Command {
 	 */
 	public function backfill( $args, $assoc_args ) {
 		$dry_run       = isset( $assoc_args['dry-run'] );
-		$skip_rename   = isset( $assoc_args['skip-rename'] );
 		$format        = $assoc_args['format'] ?? 'table';
 		$agreement_ids = get_public_agreement_ids();
 		$results       = array();
 		$unfinished    = array();
-		$untouched     = array(
-			'renamed'     => 0,
-			'left_behind' => 0,
-		);
 
 		foreach ( $agreement_ids as $agreement_id ) {
-			if ( $dry_run ) {
-				$migrated = true;
-				$outcome  = $untouched;
-			} else {
-				$migrated = make_agreement_private( $agreement_id );
-				$outcome  = $skip_rename ? $untouched : rename_agreement_file( $agreement_id );
-			}
+			// `get_public_agreement_ids()` only returns `inherit` rows, so a `false` here is a failed write.
+			$migrated = $dry_run ? true : make_agreement_private( $agreement_id );
 
-			/*
-			 * Anything short of "every file moved" needs saying, and that includes the attachment whose
-			 * file was already gone -- it moved nothing, but it also isn't finished.
-			 */
-			if ( ! $dry_run && ! $skip_rename && ( $outcome['left_behind'] || ! $outcome['renamed'] ) ) {
+			if ( ! $migrated ) {
 				$unfinished[] = $agreement_id;
 			}
 
 			$results[] = array(
 				'Attachment' => $agreement_id,
-
-				// Read after the fact, so that the column names the file as it now stands on disk.
 				'File'       => wp_basename( (string) get_attached_file( $agreement_id ) ),
 				'Private'    => $migrated ? 'yes' : 'no',
-				'Renamed'    => describe_rename( $outcome, $dry_run, $skip_rename ),
 			);
 		}
 
@@ -423,7 +230,7 @@ class Command extends WP_CLI_Command {
 				format_items( $format, array(), self::REPORT_COLUMNS );
 			}
 
-			$this->summarize( 'success', 'No sponsor agreements left to migrate.', $format );
+			$this->summarize( 'success', sprintf( 'No sponsor agreements left to migrate on %s.', home_url() ), $format );
 
 			return;
 		}
@@ -431,6 +238,7 @@ class Command extends WP_CLI_Command {
 		// Blank lines frame the table for a person, and corrupt every other format.
 		if ( 'table' === $format ) {
 			WP_CLI::line();
+			WP_CLI::line( home_url() );
 		}
 
 		format_items( $format, $results, self::REPORT_COLUMNS );
@@ -440,17 +248,20 @@ class Command extends WP_CLI_Command {
 		}
 
 		if ( $dry_run ) {
-			$this->summarize( 'success', sprintf( '%d agreements would be migrated. Run without --dry-run to apply.', count( $results ) ), $format );
+			$message = sprintf( '%d agreements would be migrated on %s. Run without --dry-run to apply.', count( $results ), home_url() );
+
+			$this->summarize( 'success', $message, $format );
 		} elseif ( $unfinished ) {
 			$message = sprintf(
-				'%d of %d agreements are unfinished; the Renamed column says what happened to each.',
+				'%d of %d agreements on %s could not be given the private status.',
 				count( $unfinished ),
-				count( $results )
+				count( $results ),
+				home_url()
 			);
 
 			$this->summarize( 'warning', $message, $format );
 		} else {
-			$this->summarize( 'success', sprintf( '%d agreements processed.', count( $results ) ), $format );
+			$this->summarize( 'success', sprintf( '%d agreements processed on %s.', count( $results ), home_url() ), $format );
 		}
 	}
 

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * A one-time migration, to be deleted once it has been run across the network.
+ *
+ * `sponsor-agreements.php` handles agreements from the moment they're attached. Files attached before it
+ * existed keep the status and the name they already had, because writing the same meta value back fires no
+ * hook. This brings those into line, and then has no further purpose.
+ *
+ * Self-contained on purpose: everything here goes when the file does, apart from the two lines that load it
+ * in `bootstrap.php`. The pieces that outlive the migration -- `make_agreement_private()` and
+ * `add_csprn_to_filename()` -- stay in `sponsor-agreements.php` and are called from here.
+ */
+
+namespace WordCamp\Sponsor_Agreements\Backfill;
+
+use WP_CLI, WP_CLI_Command;
+use cli\Table;
+
+use function WordCamp\Sponsor_Agreements\add_csprn_to_filename;
+use function WordCamp\Sponsor_Agreements\make_agreement_private;
+
+defined( 'WPINC' ) || die();
+
+// phpcs:disable Universal.Files.SeparateFunctionsFromOO -- the command and the work it does are one unit here, so that removing the migration is removing one file.
+
+
+/**
+ * The agreement attachments on one site that are still `inherit`.
+ *
+ * Found through the sponsor rather than through the marker meta, because the files this is for were
+ * attached before anything marked them.
+ *
+ * Takes a blog ID and builds the table names itself rather than switching, so that `scan()` can ask this of
+ * every site on the network from a single process. `get_blog_prefix()` is string handling -- it loads no
+ * site, runs no query, and fires no `switch_blog`.
+ *
+ * @param int|null $blog_id Defaults to the current site.
+ *
+ * @return int[]
+ */
+function get_public_agreement_ids( $blog_id = null ) {
+	global $wpdb;
+
+	$prefix            = $wpdb->get_blog_prefix( $blog_id );
+	$meta_keys         = \WordCamp\Sponsor_Agreements\get_agreement_meta_keys();
+	$post_types        = \WordCamp\Sponsor_Agreements\get_sponsor_post_types();
+	$key_placeholders  = implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) );
+	$type_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+
+	// The placeholders are generated runs of `%s`, and the prefix comes from `get_blog_prefix()`.
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	$agreement_ids = $wpdb->get_col( $wpdb->prepare(
+		"SELECT DISTINCT agreement.ID
+		FROM {$prefix}posts AS agreement
+		INNER JOIN {$prefix}postmeta AS sponsor_meta
+			ON CAST( sponsor_meta.meta_value AS UNSIGNED ) = agreement.ID
+		INNER JOIN {$prefix}posts AS sponsor
+			ON sponsor.ID = sponsor_meta.post_id
+		WHERE sponsor_meta.meta_key IN ( $key_placeholders )
+		AND sponsor.post_type IN ( $type_placeholders )
+		AND agreement.post_type = 'attachment'
+		AND agreement.post_status = 'inherit'",
+		array_merge( $meta_keys, $post_types )
+	) );
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+	return array_map( 'absint', $agreement_ids );
+}
+
+/**
+ * Rename an agreement that's already on disk, so that it matches what new uploads get.
+ *
+ * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
+ * `wp_get_attachment_url()` -- so the new name reaches every reader.
+ *
+ * The generated sizes move with it. They sit beside the original under names derived from it.
+ *
+ * Only ever called for the site the process was started on, because `ms_upload_constants()` defines
+ * `UPLOADS` for whichever site that was -- see `backfill()`.
+ *
+ * The `guid` is deliberately left alone. It's an identifier rather than the URL anything is served from,
+ * and Core's rule is that it doesn't change once a post has one.
+ *
+ * @param int $attachment_id
+ *
+ * @return bool Whether the file was renamed.
+ */
+function rename_agreement_file( $attachment_id ) {
+	$old_path = get_attached_file( $attachment_id );
+
+	if ( ! $old_path || ! is_file( $old_path ) ) {
+		return false;
+	}
+
+	$directory = dirname( $old_path );
+	$old_name  = wp_basename( $old_path );
+	$extension = pathinfo( $old_name, PATHINFO_EXTENSION );
+	$extension = $extension ? '.' . $extension : '';
+	$new_name  = wp_unique_filename( $directory, add_csprn_to_filename( $old_name, $extension ) );
+
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- WP_Filesystem needs credentials this can't ask for, and a failure is reported rather than fatal.
+	if ( ! @rename( $old_path, $directory . '/' . $new_name ) ) {
+		return false;
+	}
+
+	$old_base = substr( $old_name, 0, strlen( $old_name ) - strlen( $extension ) );
+	$new_base = substr( $new_name, 0, strlen( $new_name ) - strlen( $extension ) );
+	$metadata = wp_get_attachment_metadata( $attachment_id );
+
+	if ( is_array( $metadata ) ) {
+		if ( ! empty( $metadata['file'] ) ) {
+			$metadata['file'] = dirname( $metadata['file'] ) . '/' . $new_name;
+		}
+
+		foreach ( $metadata['sizes'] ?? array() as $size => $details ) {
+			if ( empty( $details['file'] ) || ! str_starts_with( $details['file'], $old_base ) ) {
+				continue;
+			}
+
+			$new_size_name = $new_base . substr( $details['file'], strlen( $old_base ) );
+
+			if ( is_file( $directory . '/' . $details['file'] ) ) {
+				// A size that won't move is left where it is, so the metadata keeps naming the real file.
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.rename_rename -- as above.
+				if ( ! @rename( $directory . '/' . $details['file'], $directory . '/' . $new_size_name ) ) {
+					continue;
+				}
+			}
+
+			$metadata['sizes'][ $size ]['file'] = $new_size_name;
+		}
+
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+	}
+
+	update_attached_file( $attachment_id, $directory . '/' . $new_name );
+
+	return true;
+}
+
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+/**
+ * WordCamp.org: bring existing sponsorship agreements into line with `sponsor-agreements.php`.
+ */
+class Command extends WP_CLI_Command {
+	/**
+	 * Report which sites have agreements left to migrate.
+	 *
+	 * Reads the network's tables directly, one site at a time, so it never loads a site, never calls
+	 * `switch_to_blog()`, and holds nothing between rows. That matters on the production network, where
+	 * enumerating sites the ordinary way runs the process out of memory -- and it means `backfill` has to
+	 * be run only on the handful of sites that turn out to need it, rather than on all of them.
+	 *
+	 * Prints one `<url>` per site with work outstanding, so the output can be piped straight into a loop.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--verbose]
+	 * : Also report the number of agreements found on each site, on STDERR.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # See which sites need attention.
+	 *     wp wc-sponsor-agreements scan --verbose
+	 *
+	 *     # Migrate only those sites, one process each.
+	 *     wp wc-sponsor-agreements scan | while read -r site; do
+	 *         wp --url="$site" wc-sponsor-agreements backfill
+	 *     done
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function scan( $args, $assoc_args ) {
+		global $wpdb;
+
+		$verbose = isset( $assoc_args['verbose'] );
+		$sites   = $wpdb->get_results( "SELECT blog_id, domain, path FROM {$wpdb->blogs} ORDER BY blog_id" );
+		$found   = 0;
+
+		// A site whose tables have gone is a broken row, not a reason to stop part-way through a network.
+		$wpdb->suppress_errors( true );
+
+		foreach ( $sites as $site ) {
+			$agreement_ids = get_public_agreement_ids( $site->blog_id );
+
+			if ( ! $agreement_ids ) {
+				continue;
+			}
+
+			++$found;
+
+			WP_CLI::line( $site->domain . $site->path );
+
+			if ( $verbose ) {
+				WP_CLI::warning( sprintf(
+					'%s%s (blog %d): %d agreements.',
+					$site->domain,
+					$site->path,
+					$site->blog_id,
+					count( $agreement_ids )
+				) );
+			}
+		}
+
+		$wpdb->suppress_errors( false );
+
+		if ( $verbose ) {
+			WP_CLI::warning( sprintf( '%d of %d sites have agreements to migrate.', $found, count( $sites ) ) );
+		}
+	}
+
+	/**
+	 * Migrate the agreements on one site.
+	 *
+	 * Gives them the `private` status and the file name that new agreements get as they're attached.
+	 * Nothing links to an agreement by URL -- both plugins hold an attachment ID and resolve it through
+	 * `wp_get_attachment_url()` -- so organizers keep the access they have.
+	 *
+	 * One site per run, and it has to be: `ms_upload_constants()` defines `UPLOADS` for whichever site was
+	 * current at bootstrap, so a `switch_to_blog()` loop would resolve every other site's files against
+	 * the wrong directory and silently rename nothing. Use `scan` to find the sites that need this.
+	 *
+	 * Safe to re-run: a site with nothing outstanding does one query and stops.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Report what would change, without changing it.
+	 *
+	 * [--skip-rename]
+	 * : Set the status, but leave the files under the names they have.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp --url=seattle.wordcamp.org/2023 wc-sponsor-agreements backfill --dry-run
+	 *     wp --url=seattle.wordcamp.org/2023 wc-sponsor-agreements backfill
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function backfill( $args, $assoc_args ) {
+		$dry_run       = isset( $assoc_args['dry-run'] );
+		$skip_rename   = isset( $assoc_args['skip-rename'] );
+		$agreement_ids = get_public_agreement_ids();
+		$results       = array();
+
+		foreach ( $agreement_ids as $agreement_id ) {
+			$file = wp_basename( (string) get_attached_file( $agreement_id ) );
+
+			if ( $dry_run ) {
+				$migrated = true;
+				$renamed  = ! $skip_rename;
+			} else {
+				$migrated = make_agreement_private( $agreement_id );
+				$renamed  = $skip_rename ? false : rename_agreement_file( $agreement_id );
+			}
+
+			$results[] = array(
+				'Attachment' => $agreement_id,
+				'File'       => $file,
+				'Private'    => $migrated ? 'yes' : 'no',
+				'Renamed'    => $renamed ? 'yes' : 'no',
+			);
+		}
+
+		if ( ! $results ) {
+			WP_CLI::success( 'No sponsor agreements left to migrate.' );
+
+			return;
+		}
+
+		WP_CLI::line();
+
+		$table = new Table();
+		$table->setHeaders( array_keys( $results[0] ) );
+		$table->setRows( $results );
+		$table->display();
+
+		WP_CLI::line();
+
+		$unfinished = wp_list_filter( $results, array( 'Renamed' => 'no' ) );
+
+		if ( $dry_run ) {
+			WP_CLI::success( sprintf( '%d agreements would be migrated. Run without --dry-run to apply.', count( $results ) ) );
+		} elseif ( $unfinished && ! $skip_rename ) {
+			WP_CLI::warning( sprintf(
+				'%d of %d agreements kept the file name they had.',
+				count( $unfinished ),
+				count( $results )
+			) );
+		} else {
+			WP_CLI::success( sprintf( '%d agreements processed.', count( $results ) ) );
+		}
+	}
+}
+
+WP_CLI::add_command( 'wc-sponsor-agreements', __NAMESPACE__ . '\Command' );

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/backfill-sponsor-agreements.php
@@ -5,7 +5,7 @@
  *
  * `sponsor-agreements.php` handles agreements from the moment they're attached. Files attached before it
  * existed keep the status they already had, because writing the same meta value back fires no hook. This
- * gives them that status, and then has no further purpose.
+ * gives them that status, marks each one with `NEEDS_RENAME_META_KEY`, and then has no further purpose.
  *
  * Self-contained on purpose: everything here goes when the file does, apart from the two lines that load it
  * in `bootstrap.php`. `make_agreement_private()` outlives it, in `sponsor-agreements.php`.
@@ -19,16 +19,9 @@ use function WP_CLI\Utils\format_items;
 
 use function WordCamp\Sponsor_Agreements\make_agreement_private;
 
-defined( 'WPINC' ) || die();
+use const WordCamp\Sponsor_Agreements\NEEDS_RENAME_META_KEY;
 
-/**
- * Recorded on every attachment this migration gives the `private` status.
- *
- * `AGREEMENT_MARKER_META_KEY` says an attachment is an agreement; it doesn't say which ones were uploaded
- * before `obscure_sponsor_file_names()` existed and so still carry the name they were given. Nothing else
- * distinguishes them once the status is set, and this is the only moment the answer is known.
- */
-const BACKFILLED_META_KEY = '_wcorg_sponsor_agreement_backfilled';
+defined( 'WPINC' ) || die();
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO -- the command and the work it does are one unit here, so that removing the migration is removing one file.
 
@@ -225,7 +218,8 @@ class Command extends WP_CLI_Command {
 			if ( ! $migrated ) {
 				$unfinished[] = $agreement_id;
 			} elseif ( ! $dry_run ) {
-				update_post_meta( $agreement_id, BACKFILLED_META_KEY, 1 );
+				// This sets the status only; the file keeps its name until a later pass renames it.
+				update_post_meta( $agreement_id, NEEDS_RENAME_META_KEY, 1 );
 			}
 
 			$results[] = array(

--- a/public_html/wp-content/mu-plugins/wp-cli-commands/bootstrap.php
+++ b/public_html/wp-content/mu-plugins/wp-cli-commands/bootstrap.php
@@ -9,6 +9,9 @@ require_once( __DIR__ . '/rest-api.php'      );
 require_once( __DIR__ . '/rewrite-rules.php' );
 require_once( __DIR__ . '/users.php'         );
 
+// A one-time migration; remove this line and the file once it has been run across the network.
+require_once __DIR__ . '/backfill-sponsor-agreements.php';
+
 WP_CLI::add_command( 'wc-misc',    'WordCamp_CLI_Miscellaneous' );
 WP_CLI::add_command( 'wc-rewrite', 'WordCamp_CLI_Rewrite_Rules' );
 WP_CLI::add_command( 'wc-rest',    'WordCamp_CLI_REST_API'      );

--- a/public_html/wp-content/plugins/wc-post-types/js/wcb-spon.js
+++ b/public_html/wp-content/plugins/wc-post-types/js/wcb-spon.js
@@ -42,7 +42,40 @@
 				self.toggleElements();
 			} );
 
+			this.markOwnUploads();
 			this.toggleElements();
+
+			return this;
+		},
+
+		/**
+		 * Mark this modal's uploads as agreements while they are on their way to the server.
+		 *
+		 * A file uploaded here is an agreement whether or not the organizer goes on to select it and save
+		 * the sponsor, and until something says so it is an ordinary attachment on a public post. Sending
+		 * the answer with the file means it never has to be chased afterwards.
+		 *
+		 * The uploader is built when the modal first opens, so the field can only be set from here. A PDF
+		 * is taken as an agreement without it, so this failing quietly costs the images only.
+		 *
+		 * @returns {wcbSponsors.view.Agreement}
+		 */
+		markOwnUploads: function() {
+			var self = this;
+
+			if ( 'undefined' === typeof wcbSponsorAgreement ) {
+				return this;
+			}
+
+			this.frame.on( 'open', function() {
+				// Core leaves the frame without an uploader when uploading is unavailable, and there is
+				// then nothing arriving to mark.
+				var uploader = self.frame.uploader && self.frame.uploader.uploader;
+
+				if ( uploader && 'function' === typeof uploader.param ) {
+					uploader.param( wcbSponsorAgreement.param, 1 );
+				}
+			} );
 
 			return this;
 		},

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -301,7 +301,7 @@ class WordCamp_Post_Types_Plugin {
 			'wcb-spon', // Avoid "sponsor" since that's a trigger word for ad blockers.
 			plugins_url( 'js/wcb-spon.js', __FILE__ ),
 			array( 'jquery', 'backbone', 'media-views' ),
-			1,
+			'20260909',
 			true
 		);
 		wp_localize_script(


### PR DESCRIPTION
Makes sponsor agreement attachments private, rather than letting them inherit their sponsor's status, and gives them a random suffix in the name as `wordcamp-payments` does for its own files. A sponsor's other uploads — its logo, images in its content — are left alone.

An agreement uploaded from the Sponsor screen is named and made private in the request that creates it, so nothing has to be moved afterwards. One chosen from the existing Media Library is handled when the sponsor is saved, which does rename the file it already had.

Adds a one-time `wp wc-sponsor-agreements` migration for agreements attached before this, to be removed once it has been run. It sets the status and records that the file still needs renaming; renaming is being handled separately.

## Testing

On an event site, e.g. `https://seattle.wordcamp.test/2023/`, as an admin.

1. **Sponsors → Add New**, use **Attach Signed Agreement** to upload a PDF. Publish.
2. Reload. **View Agreement** opens the file, and its name has a 16-character suffix.
3. `wp --url=<site> eval 'echo get_post( <ATTACHMENT_ID> )->post_status;'` → `private`.
4. Repeat with a **JPG or PNG** as the agreement. Same result — this is the path that depends on the browser sending the field, so it's the one worth checking after any change to `wcb-spon.js`.
5. On the same sponsor, set a **featured image** and add an image to the content. Both stay `inherit` under the names they were uploaded with.
6. Upload a PDF through **Media → Add New**, then attach it with **Attach Signed Agreement** and press Update. It becomes `private` and is renamed on save.
7. The sponsor is unchanged: it renders on the front end, and `/wp-json/wp/v2/sponsors/<SPONSOR_ID>` still reports `"status":"publish"`.
8. **Media → Library** still lists and opens every agreement above for an admin or editor.

The migration, for agreements attached before this:

9. `wp wc-sponsor-agreements scan --verbose` reports which sites have any.
10. `wp --url=<site> wc-sponsor-agreements backfill --dry-run`, then without `--dry-run`. Each is reported `Private: yes`, a second `scan` reports none left, and **View Agreement** still opens the file. The files keep their names — they are recorded for the separate rename pass with `_wcorg_sponsor_agreement_needs_rename`.

    One site per process, so across the network:
    ```
    wp wc-sponsor-agreements scan | while read -r site; do
        wp --url="$site" wc-sponsor-agreements backfill
    done
    ```

Automated: `phpunit --testsuite "WordCamp MU Plugins" --group sponsor-agreements` (45 tests). The full `WordCamp MU Plugins`, `WordCamp Post Types` and `WordCamp Payments` suites pass, apart from failures that also occur on `production` — which ones varies by environment.

