### PR TITLE
CampTix Badge Generator: Fix bugs and add QR code support for Gravatar and WordPress.org profiles

### DIFF
--- a/public_html/wp-content/plugins/camptix-badge-generator/bootstrap.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/bootstrap.php
@@ -14,9 +14,11 @@ defined( 'WPINC' ) || die();
 
 const REQUIRED_CAPABILITY = 'manage_options';
 
-require_once( __DIR__ . '/includes/common.php'      );
-require_once( __DIR__ . '/includes/html-badges.php' );
+require_once( __DIR__ . '/includes/class-qr-code.php' );
+require_once( __DIR__ . '/includes/common.php'        );
+require_once( __DIR__ . '/includes/html-badges.php'   );
 
 if ( is_admin() ) {
 	require_once( __DIR__ . '/includes/indesign-badges.php' );
 }
+

--- a/public_html/wp-content/plugins/camptix-badge-generator/css/html-badges-default-styles.css
+++ b/public_html/wp-content/plugins/camptix-badge-generator/css/html-badges-default-styles.css
@@ -72,3 +72,30 @@ html, body {
 	margin: .5em 0 0 0;
 	font-size: 2.4em;
 }
+
+.attendee-qrcode {
+	margin: .5em auto 0;
+	width: 1.25in;
+	height: 1.25in;
+	max-width: 50%;
+}
+
+.attendee-qrcode svg {
+	width: 100%;
+	height: 100%;
+	display: block;
+}
+
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}
+

--- a/public_html/wp-content/plugins/camptix-badge-generator/css/html-badges-default-styles.css
+++ b/public_html/wp-content/plugins/camptix-badge-generator/css/html-badges-default-styles.css
@@ -19,6 +19,7 @@ html, body {
 
 .attendee:nth-of-type( even ) {
 	float: right;
+	break-after: page;
 	page-break-after: always;
 }
 
@@ -33,6 +34,8 @@ html, body {
 	box-sizing: border-box;
 	height: 50%;
 	position: relative;
+	break-inside: avoid;
+	page-break-inside: avoid;
 }
 
 .badge-back {

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/class-qr-code.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/class-qr-code.php
@@ -1,0 +1,598 @@
+<?php
+
+namespace CampTix\Badge_Generator;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Standalone, dependency-free QR Code generator for badge printing and InDesign merge.
+ *
+ * Implements ISO/IEC 18004:2006 QR Code standard in Byte Mode (UTF-8 / 8-bit).
+ */
+class QR_Code {
+
+	public const ECC_L = 0; // 7% error correction
+	public const ECC_M = 1; // 15% error correction
+	public const ECC_Q = 2; // 25% error correction
+	public const ECC_H = 3; // 30% error correction
+
+	/**
+	 * Capacity table for Byte mode (Version 1 to 10) [L, M, Q, H].
+	 */
+	private static array $capacity = array(
+		1  => array( 17, 14, 11, 7 ),
+		2  => array( 32, 26, 20, 14 ),
+		3  => array( 53, 42, 32, 24 ),
+		4  => array( 78, 62, 46, 34 ),
+		5  => array( 106, 84, 60, 44 ),
+		6  => array( 134, 106, 74, 58 ),
+		7  => array( 154, 122, 86, 64 ),
+		8  => array( 192, 152, 108, 84 ),
+		9  => array( 230, 180, 130, 98 ),
+		10 => array( 271, 213, 151, 119 ),
+	);
+
+	/**
+	 * Total data codewords per version & ECC level [total_codewords, ec_codewords_per_block, num_blocks_g1, data_cw_g1, num_blocks_g2, data_cw_g2].
+	 */
+	private static array $ecc_table = array(
+		1  => array(
+			self::ECC_L => array( 26, 7, 1, 19, 0, 0 ),
+			self::ECC_M => array( 26, 10, 1, 16, 0, 0 ),
+			self::ECC_Q => array( 26, 13, 1, 13, 0, 0 ),
+			self::ECC_H => array( 26, 17, 1, 9, 0, 0 ),
+		),
+		2  => array(
+			self::ECC_L => array( 44, 10, 1, 34, 0, 0 ),
+			self::ECC_M => array( 44, 16, 1, 28, 0, 0 ),
+			self::ECC_Q => array( 44, 22, 1, 22, 0, 0 ),
+			self::ECC_H => array( 44, 28, 1, 16, 0, 0 ),
+		),
+		3  => array(
+			self::ECC_L => array( 70, 15, 1, 55, 0, 0 ),
+			self::ECC_M => array( 70, 26, 1, 44, 0, 0 ),
+			self::ECC_Q => array( 70, 18, 2, 17, 0, 0 ),
+			self::ECC_H => array( 70, 22, 2, 13, 0, 0 ),
+		),
+		4  => array(
+			self::ECC_L => array( 100, 20, 1, 80, 0, 0 ),
+			self::ECC_M => array( 100, 18, 2, 32, 0, 0 ),
+			self::ECC_Q => array( 100, 26, 2, 24, 0, 0 ),
+			self::ECC_H => array( 100, 16, 4, 9, 0, 0 ),
+		),
+		5  => array(
+			self::ECC_L => array( 134, 26, 1, 108, 0, 0 ),
+			self::ECC_M => array( 134, 24, 2, 43, 0, 0 ),
+			self::ECC_Q => array( 134, 18, 2, 15, 2, 16 ),
+			self::ECC_H => array( 134, 22, 2, 11, 2, 12 ),
+		),
+		6  => array(
+			self::ECC_L => array( 172, 18, 2, 68, 0, 0 ),
+			self::ECC_M => array( 172, 16, 4, 27, 0, 0 ),
+			self::ECC_Q => array( 172, 24, 4, 19, 0, 0 ),
+			self::ECC_H => array( 172, 28, 4, 15, 0, 0 ),
+		),
+		7  => array(
+			self::ECC_L => array( 196, 20, 2, 78, 0, 0 ),
+			self::ECC_M => array( 196, 18, 4, 31, 0, 0 ),
+			self::ECC_Q => array( 196, 18, 2, 14, 4, 15 ),
+			self::ECC_H => array( 196, 26, 4, 13, 1, 14 ),
+		),
+		8  => array(
+			self::ECC_L => array( 242, 24, 2, 97, 0, 0 ),
+			self::ECC_M => array( 242, 22, 2, 38, 2, 39 ),
+			self::ECC_Q => array( 242, 22, 4, 18, 2, 19 ),
+			self::ECC_H => array( 242, 26, 4, 14, 2, 15 ),
+		),
+		9  => array(
+			self::ECC_L => array( 292, 30, 2, 116, 0, 0 ),
+			self::ECC_M => array( 292, 22, 3, 36, 2, 37 ),
+			self::ECC_Q => array( 292, 20, 4, 16, 4, 17 ),
+			self::ECC_H => array( 292, 24, 4, 12, 4, 13 ),
+		),
+		10 => array(
+			self::ECC_L => array( 346, 18, 2, 68, 2, 69 ),
+			self::ECC_M => array( 346, 26, 4, 43, 1, 44 ),
+			self::ECC_Q => array( 346, 24, 6, 19, 2, 20 ),
+			self::ECC_H => array( 346, 28, 6, 15, 2, 16 ),
+		),
+	);
+
+	/**
+	 * Alignment pattern center coordinates.
+	 */
+	private static array $alignment_patterns = array(
+		1  => array(),
+		2  => array( 6, 18 ),
+		3  => array( 6, 22 ),
+		4  => array( 6, 26 ),
+		5  => array( 6, 30 ),
+		6  => array( 6, 34 ),
+		7  => array( 6, 22, 38 ),
+		8  => array( 6, 24, 42 ),
+		9  => array( 6, 26, 46 ),
+		10 => array( 6, 28, 50 ),
+	);
+
+	/**
+	 * Galois Field 256 tables for Reed-Solomon coding.
+	 */
+	private static array $gf_exp = array();
+	private static array $gf_log = array();
+
+	/**
+	 * Initialize GF(256) tables.
+	 */
+	private static function init_gf(): void {
+		if ( ! empty( self::$gf_exp ) ) {
+			return;
+		}
+
+		self::$gf_exp = array_fill( 0, 512, 0 );
+		self::$gf_log = array_fill( 0, 256, 0 );
+
+		$x = 1;
+		for ( $i = 0; $i < 255; $i++ ) {
+			self::$gf_exp[ $i ] = $x;
+			self::$gf_log[ $x ] = $i;
+			$x <<= 1;
+			if ( $x & 0x100 ) {
+				$x ^= 0x11d; // Primitive polynomial x^8 + x^4 + x^3 + x^2 + 1
+			}
+		}
+		for ( $i = 255; $i < 512; $i++ ) {
+			self::$gf_exp[ $i ] = self::$gf_exp[ $i - 255 ];
+		}
+	}
+
+	/**
+	 * Generate SVG string for given text.
+	 *
+	 * @param string $text      The URL or text to encode.
+	 * @param int    $ecc_level Error correction level (default ECC_M).
+	 * @param int    $margin    Quiet zone margin in modules (default 4).
+	 *
+	 * @return string SVG element markup.
+	 */
+	public static function get_svg( string $text, int $ecc_level = self::ECC_M, int $margin = 4 ): string {
+		$matrix = self::get_matrix( $text, $ecc_level );
+		if ( empty( $matrix ) ) {
+			return '';
+		}
+
+		$size       = count( $matrix );
+		$total_size = $size + ( $margin * 2 );
+		$path_data  = '';
+
+		for ( $r = 0; $r < $size; $r++ ) {
+			for ( $c = 0; $c < $size; $c++ ) {
+				if ( $matrix[ $r ][ $c ] ) {
+					$x          = $c + $margin;
+					$y          = $r + $margin;
+					$path_data .= "M{$x},{$y}h1v1h-1z ";
+				}
+			}
+		}
+
+		return sprintf(
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %1$d %1$d" width="100%%" height="100%%" role="img" aria-hidden="true" shape-rendering="crispEdges"><path fill="currentColor" d="%2$s"/></svg>',
+			$total_size,
+			trim( $path_data )
+		);
+	}
+
+	/**
+	 * Generate 2D boolean matrix for the QR Code.
+	 *
+	 * @param string $text
+	 * @param int    $ecc_level
+	 *
+	 * @return array<int, array<int, bool>>
+	 */
+	public static function get_matrix( string $text, int $ecc_level = self::ECC_M ): array {
+		self::init_gf();
+
+		$data_len = strlen( $text );
+		$version  = self::get_best_version( $data_len, $ecc_level );
+		if ( 0 === $version ) {
+			return array();
+		}
+
+		$data_codewords = self::encode_data( $text, $version, $ecc_level );
+		$final_bits     = self::interleave_blocks( $data_codewords, $version, $ecc_level );
+
+		$size   = 17 + 4 * $version;
+		$matrix = array_fill( 0, $size, array_fill( 0, $size, null ) );
+
+		// Place function patterns
+		self::place_finder_pattern( $matrix, 0, 0 );
+		self::place_finder_pattern( $matrix, $size - 7, 0 );
+		self::place_finder_pattern( $matrix, 0, $size - 7 );
+
+		self::place_separators( $matrix, $size );
+		self::place_timing_patterns( $matrix, $size );
+		self::place_alignment_patterns( $matrix, $version );
+		self::place_dark_module( $matrix, $version );
+		self::reserve_format_information( $matrix, $size );
+
+		// Place data modules and choose best mask
+		$best_mask   = 0;
+		$best_penalty = PHP_INT_MAX;
+		$best_matrix = array();
+
+		for ( $mask = 0; $mask < 8; $mask++ ) {
+			$test_matrix = $matrix;
+			self::place_data_bits( $test_matrix, $final_bits, $mask, $size );
+			self::place_format_information( $test_matrix, $ecc_level, $mask, $size );
+
+			$penalty = self::calculate_penalty( $test_matrix, $size );
+			if ( $penalty < $best_penalty ) {
+				$best_penalty = $penalty;
+				$best_mask    = $mask;
+				$best_matrix  = $test_matrix;
+			}
+		}
+
+		return array_map( function( $row ) {
+			return array_map( function( $val ) {
+				return (bool) $val;
+			}, $row );
+		}, $best_matrix );
+	}
+
+	private static function get_best_version( int $data_len, int $ecc_level ): int {
+		foreach ( self::$capacity as $version => $limits ) {
+			if ( $data_len <= $limits[ $ecc_level ] ) {
+				return $version;
+			}
+		}
+		return 0;
+	}
+
+	private static function encode_data( string $text, int $version, int $ecc_level ): array {
+		$bit_buffer = '';
+
+		// Mode Indicator: Byte Mode (0100)
+		$bit_buffer .= '0100';
+
+		// Character Count Indicator (8 bits for v1-9, 16 bits for v10+)
+		$count_bits  = ( $version <= 9 ) ? 8 : 16;
+		$bit_buffer .= str_pad( decbin( strlen( $text ) ), $count_bits, '0', STR_PAD_LEFT );
+
+		// Data bits
+		$len = strlen( $text );
+		for ( $i = 0; $i < $len; $i++ ) {
+			$bit_buffer .= str_pad( decbin( ord( $text[ $i ] ) ), 8, '0', STR_PAD_LEFT );
+		}
+
+		$ecc_info        = self::$ecc_table[ $version ][ $ecc_level ];
+		$total_data_bytes = ( $ecc_info[2] * $ecc_info[3] ) + ( $ecc_info[4] * $ecc_info[5] );
+		$total_data_bits  = $total_data_bytes * 8;
+
+		// Terminator
+		$bit_buffer .= str_repeat( '0', min( 4, $total_data_bits - strlen( $bit_buffer ) ) );
+
+		// Pad to byte
+		if ( 0 !== strlen( $bit_buffer ) % 8 ) {
+			$bit_buffer .= str_repeat( '0', 8 - ( strlen( $bit_buffer ) % 8 ) );
+		}
+
+		// Pad bytes (0xEC, 0x11)
+		$pad_bytes = array( '11101100', '00010001' );
+		$p         = 0;
+		while ( strlen( $bit_buffer ) < $total_data_bits ) {
+			$bit_buffer .= $pad_bytes[ $p % 2 ];
+			$p++;
+		}
+
+		$codewords = array();
+		for ( $i = 0; $i < strlen( $bit_buffer ); $i += 8 ) {
+			$codewords[] = bindec( substr( $bit_buffer, $i, 8 ) );
+		}
+
+		return $codewords;
+	}
+
+	private static function interleave_blocks( array $data_codewords, int $version, int $ecc_level ): string {
+		$info            = self::$ecc_table[ $version ][ $ecc_level ];
+		$ec_cw_per_block = $info[1];
+		$num_b1          = $info[2];
+		$cw_b1           = $info[3];
+		$num_b2          = $info[4];
+		$cw_b2           = $info[5];
+
+		$blocks    = array();
+		$ec_blocks = array();
+		$offset    = 0;
+
+		for ( $i = 0; $i < $num_b1; $i++ ) {
+			$block       = array_slice( $data_codewords, $offset, $cw_b1 );
+			$offset     += $cw_b1;
+			$blocks[]    = $block;
+			$ec_blocks[] = self::generate_ec_codewords( $block, $ec_cw_per_block );
+		}
+
+		for ( $i = 0; $i < $num_b2; $i++ ) {
+			$block       = array_slice( $data_codewords, $offset, $cw_b2 );
+			$offset     += $cw_b2;
+			$blocks[]    = $block;
+			$ec_blocks[] = self::generate_ec_codewords( $block, $ec_cw_per_block );
+		}
+
+		$interleaved = '';
+		$max_data_cw = max( $cw_b1, $cw_b2 );
+
+		// Interleave data codewords
+		for ( $i = 0; $i < $max_data_cw; $i++ ) {
+			foreach ( $blocks as $b ) {
+				if ( isset( $b[ $i ] ) ) {
+					$interleaved .= str_pad( decbin( $b[ $i ] ), 8, '0', STR_PAD_LEFT );
+				}
+			}
+		}
+
+		// Interleave EC codewords
+		for ( $i = 0; $i < $ec_cw_per_block; $i++ ) {
+			foreach ( $ec_blocks as $eb ) {
+				if ( isset( $eb[ $i ] ) ) {
+					$interleaved .= str_pad( decbin( $eb[ $i ] ), 8, '0', STR_PAD_LEFT );
+				}
+			}
+		}
+
+		return $interleaved;
+	}
+
+	private static function generate_ec_codewords( array $data, int $num_ec ): array {
+		$generator = self::get_generator_poly( $num_ec );
+		$msg       = array_merge( $data, array_fill( 0, $num_ec, 0 ) );
+
+		for ( $i = 0; $i < count( $data ); $i++ ) {
+			$lead = $msg[ $i ];
+			if ( 0 !== $lead ) {
+				$lead_log = self::$gf_log[ $lead ];
+				for ( $j = 0; $j < count( $generator ); $j++ ) {
+					$msg[ $i + $j ] ^= self::$gf_exp[ $lead_log + $generator[ $j ] ];
+				}
+			}
+		}
+
+		return array_slice( $msg, count( $data ), $num_ec );
+	}
+
+	private static function get_generator_poly( int $degree ): array {
+		$poly = array( 0 ); // (x - a^0)
+		for ( $i = 1; $i < $degree; $i++ ) {
+			$next = array_fill( 0, count( $poly ) + 1, 0 );
+			for ( $j = 0; $j < count( $poly ); $j++ ) {
+				$next[ $j ]     ^= self::$gf_exp[ $poly[ $j ] + $i ];
+				$next[ $j + 1 ] ^= self::$gf_exp[ $poly[ $j ] ];
+			}
+			$poly = array_map( function( $val ) {
+				return self::$gf_log[ $val ];
+			}, $next );
+		}
+		return $poly;
+	}
+
+	private static function place_finder_pattern( array &$matrix, int $x, int $y ): void {
+		for ( $r = 0; $r < 7; $r++ ) {
+			for ( $c = 0; $c < 7; $c++ ) {
+				if ( 0 === $r || 6 === $r || 0 === $c || 6 === $c || ( $r >= 2 && $r <= 4 && $c >= 2 && $c <= 4 ) ) {
+					$matrix[ $y + $r ][ $x + $c ] = 1;
+				} else {
+					$matrix[ $y + $r ][ $x + $c ] = 0;
+				}
+			}
+		}
+	}
+
+	private static function place_separators( array &$matrix, int $size ): void {
+		for ( $i = 0; $i < 8; $i++ ) {
+			$matrix[7][ $i ]        = 0;
+			$matrix[ $i ][7]        = 0;
+			$matrix[ $size - 8 ][ $i ] = 0;
+			$matrix[ $size - 1 - $i ][7] = 0;
+			$matrix[7][ $size - 1 - $i ] = 0;
+			$matrix[ $i ][ $size - 8 ] = 0;
+		}
+	}
+
+	private static function place_timing_patterns( array &$matrix, int $size ): void {
+		for ( $i = 8; $i < $size - 8; $i++ ) {
+			if ( null === $matrix[6][ $i ] ) {
+				$matrix[6][ $i ] = ( 0 === $i % 2 ) ? 1 : 0;
+			}
+			if ( null === $matrix[ $i ][6] ) {
+				$matrix[ $i ][6] = ( 0 === $i % 2 ) ? 1 : 0;
+			}
+		}
+	}
+
+	private static function place_alignment_patterns( array &$matrix, int $version ): void {
+		$positions = self::$alignment_patterns[ $version ];
+		$count     = count( $positions );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			for ( $j = 0; $j < $count; $j++ ) {
+				$r = $positions[ $i ];
+				$c = $positions[ $j ];
+
+				// Skip if overlapping with finder patterns
+				if ( ( 6 === $r && 6 === $c ) ||
+					 ( 6 === $r && $positions[ $count - 1 ] === $c && 0 === $i ) ||
+					 ( $positions[ $count - 1 ] === $r && 6 === $c && 0 === $j ) ) {
+					continue;
+				}
+
+				for ( $dy = -2; $dy <= 2; $dy++ ) {
+					for ( $dx = -2; $dx <= 2; $dx++ ) {
+						if ( abs( $dy ) === 2 || abs( $dx ) === 2 || ( 0 === $dy && 0 === $dx ) ) {
+							$matrix[ $r + $dy ][ $c + $dx ] = 1;
+						} else {
+							$matrix[ $r + $dy ][ $c + $dx ] = 0;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static function place_dark_module( array &$matrix, int $version ): void {
+		$matrix[ 4 * $version + 9 ][8] = 1;
+	}
+
+	private static function reserve_format_information( array &$matrix, int $size ): void {
+		for ( $i = 0; $i < 9; $i++ ) {
+			if ( null === $matrix[8][ $i ] ) {
+				$matrix[8][ $i ] = 0;
+			}
+			if ( null === $matrix[ $i ][8] ) {
+				$matrix[ $i ][8] = 0;
+			}
+		}
+		for ( $i = $size - 8; $i < $size; $i++ ) {
+			if ( null === $matrix[8][ $i ] ) {
+				$matrix[8][ $i ] = 0;
+			}
+			if ( null === $matrix[ $i ][8] ) {
+				$matrix[ $i ][8] = 0;
+			}
+		}
+	}
+
+	private static function place_data_bits( array &$matrix, string $bits, int $mask, int $size ): void {
+		$bit_idx = 0;
+		$bit_len = strlen( $bits );
+
+		$x   = $size - 1;
+		$dir = -1; // Moving upwards
+
+		while ( $x > 0 ) {
+			if ( 6 === $x ) {
+				$x--; // Skip vertical timing pattern
+			}
+
+			$y = ( -1 === $dir ) ? $size - 1 : 0;
+
+			while ( $y >= 0 && $y < $size ) {
+				for ( $c = 0; $c < 2; $c++ ) {
+					$col = $x - $c;
+					if ( null === $matrix[ $y ][ $col ] ) {
+						$bit = ( $bit_idx < $bit_len ) ? (int) $bits[ $bit_idx ] : 0;
+						$bit_idx++;
+
+						if ( self::apply_mask( $mask, $y, $col ) ) {
+							$bit ^= 1;
+						}
+
+						$matrix[ $y ][ $col ] = $bit;
+					}
+				}
+				$y += $dir;
+			}
+
+			$dir = -$dir;
+			$x  -= 2;
+		}
+	}
+
+	private static function apply_mask( int $mask, int $r, int $c ): bool {
+		return match ( $mask ) {
+			0 => ( ( $r + $c ) % 2 === 0 ),
+			1 => ( $r % 2 === 0 ),
+			2 => ( $c % 3 === 0 ),
+			3 => ( ( $r + $c ) % 3 === 0 ),
+			4 => ( ( intdiv( $r, 2 ) + intdiv( $c, 3 ) ) % 2 === 0 ),
+			5 => ( ( ( $r * $c ) % 2 ) + ( ( $r * $c ) % 3 ) === 0 ),
+			6 => ( ( ( ( $r * $c ) % 2 ) + ( ( $r * $c ) % 3 ) ) % 2 === 0 ),
+			7 => ( ( ( ( $r + $c ) % 2 ) + ( ( $r * $c ) % 3 ) ) % 2 === 0 ),
+			default => false,
+		};
+	}
+
+	private static function place_format_information( array &$matrix, int $ecc_level, int $mask, int $size ): void {
+		// Format string: ECC (2 bits) + Mask (3 bits) + 10 BCH error correction bits, XORed with 0x5412
+		$format_bits = array(
+			self::ECC_L => array( 0x77c4, 0x72f3, 0x7daa, 0x789d, 0x662f, 0x6318, 0x6c41, 0x6976 ),
+			self::ECC_M => array( 0x5412, 0x5125, 0x5e7c, 0x5b4b, 0x45f9, 0x40ce, 0x4f97, 0x4aa0 ),
+			self::ECC_Q => array( 0x355f, 0x3068, 0x3f31, 0x3a06, 0x24b4, 0x2183, 0x2eda, 0x2bed ),
+			self::ECC_H => array( 0x1689, 0x13be, 0x1ce7, 0x19d0, 0x0762, 0x0255, 0x0d0c, 0x083b ),
+		);
+
+		$val = $format_bits[ $ecc_level ][ $mask ];
+
+		for ( $i = 0; $i < 15; $i++ ) {
+			$bit = ( $val >> ( 14 - $i ) ) & 1;
+
+			// Top-left
+			if ( $i < 6 ) {
+				$matrix[ $i ][8] = $bit;
+			} elseif ( $i < 8 ) {
+				$matrix[ $i + 1 ][8] = $bit;
+			} else {
+				$matrix[8][ 14 - $i ] = $bit;
+			}
+
+			// Top-right and bottom-left
+			if ( $i < 8 ) {
+				$matrix[8][ $size - 1 - $i ] = $bit;
+			} else {
+				$matrix[ $size - 15 + $i ][8] = $bit;
+			}
+		}
+	}
+
+	private static function calculate_penalty( array $matrix, int $size ): int {
+		$penalty = 0;
+
+		// Condition 1: Runs of same color >= 5
+		for ( $r = 0; $r < $size; $r++ ) {
+			$run_len = 1;
+			for ( $c = 1; $c < $size; $c++ ) {
+				if ( $matrix[ $r ][ $c ] === $matrix[ $r ][ $c - 1 ] ) {
+					$run_len++;
+				} else {
+					if ( $run_len >= 5 ) {
+						$penalty += 3 + ( $run_len - 5 );
+					}
+					$run_len = 1;
+				}
+			}
+			if ( $run_len >= 5 ) {
+				$penalty += 3 + ( $run_len - 5 );
+			}
+		}
+
+		for ( $c = 0; $c < $size; $c++ ) {
+			$run_len = 1;
+			for ( $r = 1; $r < $size; $r++ ) {
+				if ( $matrix[ $r ][ $c ] === $matrix[ $r - 1 ][ $c ] ) {
+					$run_len++;
+				} else {
+					if ( $run_len >= 5 ) {
+						$penalty += 3 + ( $run_len - 5 );
+					}
+					$run_len = 1;
+				}
+			}
+			if ( $run_len >= 5 ) {
+				$penalty += 3 + ( $run_len - 5 );
+			}
+		}
+
+		// Condition 2: 2x2 blocks
+		for ( $r = 0; $r < $size - 1; $r++ ) {
+			for ( $c = 0; $c < $size - 1; $c++ ) {
+				$val = $matrix[ $r ][ $c ];
+				if ( $val === $matrix[ $r + 1 ][ $c ] &&
+					 $val === $matrix[ $r ][ $c + 1 ] &&
+					 $val === $matrix[ $r + 1 ][ $c + 1 ] ) {
+					$penalty += 3;
+				}
+			}
+		}
+
+		return $penalty;
+	}
+}

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/common.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/common.php
@@ -192,6 +192,34 @@ function add_dynamic_post_meta( $value, $post_id, $meta_key ) {
 			);
 			break;
 
+		case 'gravatar_profile_url':
+			$email = strtolower( trim( (string) $attendee->tix_email ) );
+			$value = ! empty( $email ) ? 'https://gravatar.com/' . md5( $email ) : '';
+			break;
+
+		case 'wporg_username':
+			$value = get_wporg_username( $attendee );
+			break;
+
+		case 'wporg_profile_url':
+			$username = get_wporg_username( $attendee );
+			$value    = ! empty( $username ) ? 'https://w.org/@' . rawurlencode( $username ) : '';
+			break;
+
+		case 'qr_code_target_url':
+			$type = get_option( 'cbg_qr_code_type', 'none' );
+			if ( 'gravatar' === $type ) {
+				$value = $attendee->gravatar_profile_url;
+			} elseif ( 'wporg' === $type ) {
+				$value = $attendee->wporg_profile_url;
+			}
+			break;
+
+		case 'qr_code_svg':
+			$target_url = $attendee->qr_code_target_url;
+			$value      = ! empty( $target_url ) ? QR_Code::get_svg( $target_url ) : '';
+			break;
+
 		case 'ticket':
 			$ticket = get_post( $attendee->tix_ticket_id );
 			$value  = $ticket->post_name ?? '';
@@ -199,6 +227,37 @@ function add_dynamic_post_meta( $value, $post_id, $meta_key ) {
 	}
 
 	return $value;
+}
+
+/**
+ * Get an attendee's WordPress.org username
+ *
+ * @param \WP_Post $attendee
+ *
+ * @return string
+ */
+function get_wporg_username( $attendee ) {
+	/** @global CampTix_Plugin $camptix */
+	global $camptix;
+
+	$username = get_post_meta( $attendee->ID, 'tix_username', true );
+
+	if ( ! empty( $username ) && '[[ unconfirmed ]]' !== $username ) {
+		return trim( $username );
+	}
+
+	if ( isset( $camptix ) && is_object( $camptix ) && method_exists( $camptix, 'get_all_questions' ) ) {
+		foreach ( $camptix->get_all_questions() as $question ) {
+			if ( false !== stripos( $question->post_title, 'username' ) || false !== stripos( $question->post_title, 'WordPress.org' ) ) {
+				$answers = (array) $attendee->tix_questions;
+				if ( ! empty( $answers[ $question->ID ] ) ) {
+					return trim( (string) $answers[ $question->ID ] );
+				}
+			}
+		}
+	}
+
+	return '';
 }
 
 /**

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/common.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/common.php
@@ -106,6 +106,19 @@ function get_attendees( $ticket_ids = 'all', $registered_after = '', $admin_flag
 
 	$attendees = get_posts( $params );
 
+	// Exclude placeholder and unconfirmed attendee records.
+	$attendees = array_filter( $attendees, function( $attendee ) {
+		if ( 'unknown.attendee@example.org' === $attendee->tix_email ) {
+			return false;
+		}
+
+		if ( '[[ unconfirmed ]]' === $attendee->tix_username ) {
+			return false;
+		}
+
+		return true;
+	} );
+
 	if ( '' !== $admin_flag ) {
 		$attendees = array_filter( $attendees, function( $attendee ) use ( $admin_flag ) {
 			$flags = get_post_meta( $attendee->ID, 'camptix-admin-flag' );
@@ -114,7 +127,7 @@ function get_attendees( $ticket_ids = 'all', $registered_after = '', $admin_flag
 		} );
 	}
 
-	return $attendees;
+	return array_values( $attendees );
 }
 
 /**

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/html-badges.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/html-badges.php
@@ -69,6 +69,33 @@ function register_customizer_components( $wp_customize ) {
 	);
 
 	$wp_customize->add_setting(
+		'cbg_qr_code_type',
+		array(
+			'default'           => 'none',
+			'type'              => 'option',
+			'capability'        => Badge_Generator\REQUIRED_CAPABILITY,
+			'transport'         => 'refresh',
+			'sanitize_callback' => __NAMESPACE__ . '\sanitize_qr_code_type',
+		)
+	);
+
+	$wp_customize->add_control(
+		'cbg_qr_code_type',
+		array(
+			'section'     => 'camptix_html_badges',
+			'type'        => 'select',
+			'priority'    => 2,
+			'label'       => __( 'QR Code Destination', 'wordcamporg' ),
+			'description' => __( 'Optionally include a QR code on each badge linking to the attendee profile.', 'wordcamporg' ),
+			'choices'     => array(
+				'none'     => __( 'None', 'wordcamporg' ),
+				'gravatar' => __( 'Gravatar Profile (gravatar.com/...)', 'wordcamporg' ),
+				'wporg'    => __( 'WordPress.org Profile (w.org/@username)', 'wordcamporg' ),
+			),
+		)
+	);
+
+	$wp_customize->add_setting(
 		'cbg_badge_css',
 		array(
 			'default'           => file_get_contents( dirname( __DIR__ ) . '/css/html-badges-default-styles.css' ),
@@ -84,10 +111,23 @@ function register_customizer_components( $wp_customize ) {
 		array(
 			'section'  => 'camptix_html_badges',
 			'type'     => 'textarea',
-			'priority' => 2,
+			'priority' => 3,
 			'label'    => __( 'Customize Badge CSS', 'wordcamporg' ),
 		)
 	);
+}
+
+/**
+ * Sanitize QR code type setting
+ *
+ * @param string $value
+ *
+ * @return string
+ */
+function sanitize_qr_code_type( $value ) {
+	$valid_types = array( 'none', 'gravatar', 'wporg' );
+
+	return in_array( $value, $valid_types, true ) ? $value : 'none';
 }
 
 /**

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/html-badges.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/html-badges.php
@@ -126,22 +126,26 @@ function enqueue_customizer_scripts() {
 		return;
 	}
 
+	// Enqueue code editor for CSS syntax highlighting.
+	$editor_settings = wp_enqueue_code_editor( array( 'type' => 'text/css' ) );
+
 	// Enqueue our scripts.
 	wp_enqueue_script(
 		'camptix-html-badges-customizer',
 		plugins_url( 'javascript/html-badges-customizer.js', __DIR__ ),
-		array( 'jquery', 'jetpack-codemirror' ),
+		array( 'jquery', 'customize-controls' ),
 		1,
 		true
 	);
-
-	wp_enqueue_style( 'jetpack-codemirror' );
 
 	wp_localize_script(
 		'camptix-html-badges-customizer',
 		'cbgHtmlCustomizerData',
 		array(
-			'defaultCSS' => file_get_contents( dirname( __DIR__ ) . '/css/html-badges-default-styles.css' ),
+			'defaultCSS'     => file_get_contents( dirname( __DIR__ ) . '/css/html-badges-default-styles.css' ),
+			'siteURL'        => site_url(),
+			'badgesPageURL'  => add_query_arg( 'camptix-badges', '', site_url() ),
+			'editorSettings' => $editor_settings,
 		)
 	);
 }

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/indesign-badges.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/indesign-badges.php
@@ -38,6 +38,7 @@ function build_assets( $options ) {
 			'ticket_ids'       => 'all',
 			'registered_after' => '',
 			'admin_flag'       => '',
+			'qr_code_type'     => get_option( 'cbg_qr_code_type', 'none' ),
 		),
 		$options
 	);
@@ -46,6 +47,7 @@ function build_assets( $options ) {
 		// Security: assets are intentionally saved to a folder outside the web root. See serve_zip_file() for details.
 		$assets_folder    = sprintf( '%scamptix-badges-%d-%d', get_temp_dir(), get_current_blog_id(), time() );
 		$gravatar_folder  = $assets_folder . '/gravatars';
+		$qr_folder        = $assets_folder . '/qrcodes';
 		$csv_filename     = $assets_folder . '/attendees.csv';
 		$zip_filename     = get_zip_filename( $assets_folder );
 		$zip_local_folder = pathinfo( $zip_filename, PATHINFO_FILENAME );
@@ -53,13 +55,23 @@ function build_assets( $options ) {
 
 		wp_mkdir_p( $gravatar_folder );
 		download_gravatars( $attendees, $gravatar_folder );
-		generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_folder );
-		create_zip_file( $zip_filename, $zip_local_folder, $csv_filename, $gravatar_folder );
+
+		if ( 'none' !== $options['qr_code_type'] ) {
+			wp_mkdir_p( $qr_folder );
+			generate_qr_codes( $attendees, $qr_folder, $options['qr_code_type'] );
+		}
+
+		generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_folder, $qr_folder, $options['qr_code_type'] );
+		create_zip_file( $zip_filename, $zip_local_folder, $csv_filename, $gravatar_folder, $qr_folder );
 	} finally {
 		if ( isset( $assets_folder ) && is_dir( $assets_folder ) ) {
 			if ( is_dir( $gravatar_folder ) ) {
 				array_map( 'unlink', glob( "$gravatar_folder/*" ) ?: array() );
 				@rmdir( $gravatar_folder );
+			}
+			if ( is_dir( $qr_folder ) ) {
+				array_map( 'unlink', glob( "$qr_folder/*" ) ?: array() );
+				@rmdir( $qr_folder );
 			}
 			if ( is_file( $csv_filename ) ) {
 				@unlink( $csv_filename );
@@ -185,6 +197,63 @@ function get_gravatar_filename( $attendee ) {
  *
  * @return string
  */
+/**
+ * Generate QR code images for attendees
+ *
+ * @param array  $attendees
+ * @param string $qr_folder
+ * @param string $qr_code_type
+ */
+function generate_qr_codes( $attendees, $qr_folder, $qr_code_type = 'none' ) {
+	if ( 'none' === $qr_code_type ) {
+		return;
+	}
+
+	foreach ( $attendees as $attendee ) {
+		$target_url = '';
+		if ( 'gravatar' === $qr_code_type ) {
+			$target_url = $attendee->gravatar_profile_url;
+		} elseif ( 'wporg' === $qr_code_type ) {
+			$target_url = $attendee->wporg_profile_url;
+		}
+
+		if ( empty( $target_url ) ) {
+			continue;
+		}
+
+		$svg = Badge_Generator\QR_Code::get_svg( $target_url );
+		if ( empty( $svg ) ) {
+			continue;
+		}
+
+		$filename = get_qr_code_filename( $attendee );
+		file_put_contents( $qr_folder . '/' . $filename, $svg );
+	}
+}
+
+/**
+ * Get the filename of the saved QR code for the given attendee
+ *
+ * @param \WP_Post $attendee
+ *
+ * @return string
+ */
+function get_qr_code_filename( $attendee ) {
+	return sanitize_file_name( strtolower( sprintf(
+		'%d-%s-%s-qr.svg',
+		$attendee->ID,
+		remove_accents( $attendee->tix_first_name ),
+		remove_accents( $attendee->tix_last_name )
+	) ) );
+}
+
+/**
+ * Get the filename for the Zip file
+ *
+ * @param string $assets_folder
+ *
+ * @return string
+ */
 function get_zip_filename( $assets_folder ) {
 	return sprintf(
 		'%s/%s-badges.zip',
@@ -207,10 +276,12 @@ function get_zip_filename( $assets_folder ) {
  * @param string $zip_local_folder
  * @param array  $attendees
  * @param string $gravatar_folder
+ * @param string $qr_folder
+ * @param string $qr_code_type
  *
  * @throws Exception
  */
-function generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_folder ) {
+function generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_folder, $qr_folder = '', $qr_code_type = 'none' ) {
 	/** @var CampTix_Plugin $camptix */
 	global $camptix;
 
@@ -225,10 +296,10 @@ function generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_f
 		throw new Exception( __( "Couldn't open CSV file.", 'wordcamporg' ) );
 	}
 
-	fputcsv( $csv_handle, Utilities\Export_CSV::esc_csv( get_header_row( $admin_flags, $questions ) ), ',', '"', '', "\n" );
+	fputcsv( $csv_handle, Utilities\Export_CSV::esc_csv( get_header_row( $admin_flags, $questions, $qr_code_type ) ), ',', '"', '', "\n" );
 
 	foreach ( $attendees as $attendee ) {
-		$row = get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directory, $empty_twitter, $admin_flags, $questions );
+		$row = get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directory, $empty_twitter, $admin_flags, $questions, $qr_folder, $qr_code_type );
 
 		if ( empty( $row ) ) {
 			continue;
@@ -262,15 +333,21 @@ function get_admin_flags() {
 /**
  * Get the header row for the CSV
  *
- * @param array $admin_flags
- * @param array $questions
+ * @param array  $admin_flags
+ * @param array  $questions
+ * @param string $qr_code_type
  *
  * @return array
  */
-function get_header_row( $admin_flags, $questions ) {
+function get_header_row( $admin_flags, $questions, $qr_code_type = 'none' ) {
 	$header_row   = array( 'First Name', 'Last Name', 'Email Address', 'Ticket', 'Coupon', 'Twitter' );
 	$header_row   = array_merge( $header_row, array_values( $admin_flags ) );
 	$header_row   = array_merge( $header_row, wp_list_pluck( $questions, 'post_title' ) );
+
+	if ( 'none' !== $qr_code_type ) {
+		$header_row[] = '@QRCode';
+	}
+
 	$header_row[] = '@Gravatar'; // Prefixed with an @ to let InDesign know that it contains an image. Last because InDesign complains if it's not.
 
 	return $header_row;
@@ -285,10 +362,12 @@ function get_header_row( $admin_flags, $questions ) {
  * @param string   $empty_twitter
  * @param array    $admin_flags
  * @param array    $questions
+ * @param string   $qr_folder
+ * @param string   $qr_code_type
  *
  * @return array
  */
-function get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directory, $empty_twitter, $admin_flags, $questions ) {
+function get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directory, $empty_twitter, $admin_flags, $questions, $qr_folder = '', $qr_code_type = 'none' ) {
 	$row = array();
 
 	if ( 'unknown.attendee@example.org' === $attendee->tix_email ) {
@@ -296,13 +375,20 @@ function get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directo
 	}
 
 	$gravatar_path     = '';
+	$qr_code_path      = '';
 	$first_name        = ucwords( $attendee->tix_first_name );
 	$gravatar_filename = get_gravatar_filename( $attendee );
+	$qr_filename       = get_qr_code_filename( $attendee );
 	$attendee_flags    = (array) get_post_meta( $attendee->ID, 'camptix-admin-flag' );
 	$answers           = (array) $attendee->tix_questions;
 
 	if ( file_exists( $gravatar_folder .'/'. $gravatar_filename ) ) {
 		$gravatar_path = $destination_directory . $gravatar_filename;
+	}
+
+	if ( ! empty( $qr_folder ) && file_exists( $qr_folder . '/' . $qr_filename ) ) {
+		$qr_destination_dir = str_replace( ':gravatars:', ':qrcodes:', $destination_directory );
+		$qr_code_path       = $qr_destination_dir . $qr_filename;
 	}
 
 	$row = array(
@@ -320,6 +406,10 @@ function get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directo
 
 	foreach ( $questions as $question ) {
 		$row[ "question-{$question->ID}" ] = get_answer( $question, $answers );
+	}
+
+	if ( 'none' !== $qr_code_type ) {
+		$row['qr-code-path'] = $qr_code_path;
 	}
 
 	$row['gravatar-path'] = $gravatar_path;
@@ -421,7 +511,7 @@ function get_answer( $question, $answers ) {
  *
  * @throws Exception
  */
-function create_zip_file( $zip_filename, $zip_local_folder, $csv_filename, $gravatar_folder ) {
+function create_zip_file( $zip_filename, $zip_local_folder, $csv_filename, $gravatar_folder, $qr_folder = '' ) {
 	if ( ! class_exists( 'ZipArchive') ) {
 		Logger\log( 'zip_ext_not_installed' );
 		throw new Exception( __( 'The Zip extension for PHP is not installed.', 'wordcamporg' ) );
@@ -448,6 +538,17 @@ function create_zip_file( $zip_filename, $zip_local_folder, $csv_filename, $grav
 			'remove_all_path' => true,
 		)
 	);
+
+	if ( ! empty( $qr_folder ) && is_dir( $qr_folder ) ) {
+		$zip_file->addGlob(
+			$qr_folder . '/*',
+			0,
+			array(
+				'add_path'        => $zip_local_folder . '/qrcodes/',
+				'remove_all_path' => true,
+			)
+		);
+	}
 
 	$zip_file->close();
 }

--- a/public_html/wp-content/plugins/camptix-badge-generator/includes/indesign-badges.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/includes/indesign-badges.php
@@ -56,7 +56,15 @@ function build_assets( $options ) {
 		generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_folder );
 		create_zip_file( $zip_filename, $zip_local_folder, $csv_filename, $gravatar_folder );
 	} finally {
-		// todo Delete contents of $assets_folder, then rmdir( $assets_folder );.
+		if ( isset( $assets_folder ) && is_dir( $assets_folder ) ) {
+			if ( is_dir( $gravatar_folder ) ) {
+				array_map( 'unlink', glob( "$gravatar_folder/*" ) ?: array() );
+				@rmdir( $gravatar_folder );
+			}
+			if ( is_file( $csv_filename ) ) {
+				@unlink( $csv_filename );
+			}
+		}
 	}
 }
 
@@ -178,7 +186,7 @@ function get_gravatar_filename( $attendee ) {
  * @return string
  */
 function get_zip_filename( $assets_folder ) {
-	return $zip_filename = sprintf(
+	return sprintf(
 		'%s/%s-badges.zip',
 		$assets_folder,
 		sanitize_file_name( sanitize_title( get_wordcamp_name() ) )
@@ -217,7 +225,7 @@ function generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_f
 		throw new Exception( __( "Couldn't open CSV file.", 'wordcamporg' ) );
 	}
 
-	fputcsv( $csv_handle, Utilities\Export_CSV::esc_csv( get_header_row( $admin_flags, $questions ) ), ',', '"', '\\', "\n" );
+	fputcsv( $csv_handle, Utilities\Export_CSV::esc_csv( get_header_row( $admin_flags, $questions ) ), ',', '"', '', "\n" );
 
 	foreach ( $attendees as $attendee ) {
 		$row = get_attendee_csv_row( $attendee, $gravatar_folder, $destination_directory, $empty_twitter, $admin_flags, $questions );
@@ -226,7 +234,7 @@ function generate_csv( $csv_filename, $zip_local_folder, $attendees, $gravatar_f
 			continue;
 		}
 
-		fputcsv( $csv_handle, Utilities\Export_CSV::esc_csv( $row ), ',', '"', '\\', "\n" );
+		fputcsv( $csv_handle, Utilities\Export_CSV::esc_csv( $row ), ',', '"', '', "\n" );
 	}
 
 	fclose( $csv_handle );

--- a/public_html/wp-content/plugins/camptix-badge-generator/javascript/html-badges-customizer.js
+++ b/public_html/wp-content/plugins/camptix-badge-generator/javascript/html-badges-customizer.js
@@ -2,16 +2,24 @@ wp.customize.CampTixHtmlBadgesCustomizer = ( function( $, api ) {
 	'use strict';
 
 	var self = {
-		sectionID    : 'camptix_html_badges',
-		cssSettingID : 'cbg_badge_css',
-		siteURL      : window.location.protocol + '//' + window.location.hostname,
-		cmEditor     : null
+		sectionID      : 'camptix_html_badges',
+		cssSettingID   : 'cbg_badge_css',
+		siteURL        : '',
+		badgesPageURL  : '',
+		editorSettings : null,
+		cmEditor       : null
 	};
-
-	self.badgesPageURL = self.siteURL + '?camptix-badges';
 
 	$.extend( self, cbgHtmlCustomizerData );
 	window.cbgHtmlCustomizerData = null;
+
+	if ( ! self.siteURL ) {
+		self.siteURL = window.location.protocol + '//' + window.location.host;
+	}
+
+	if ( ! self.badgesPageURL ) {
+		self.badgesPageURL = self.siteURL + '?camptix-badges';
+	}
 
 	/**
 	 * Initialize
@@ -58,20 +66,31 @@ wp.customize.CampTixHtmlBadgesCustomizer = ( function( $, api ) {
 			return;
 		}
 
-		self.cmEditor = CodeMirror.fromTextArea(
-			$( '#customize-control-cbg_badge_css' ).find( 'textarea' ).get(0),
-			{
-				tabSize        : 2,
-				indentWithTabs : true,
-				lineWrapping   : true
-			}
-		);
+		var $textarea = $( '#customize-control-cbg_badge_css' ).find( 'textarea' );
+		if ( ! $textarea.length ) {
+			return;
+		}
 
-		self.cmEditor.setSize( null, 'auto' );
+		if ( wp.codeEditor && self.editorSettings ) {
+			var editor = wp.codeEditor.initialize( $textarea, self.editorSettings );
+			self.cmEditor = editor.codemirror;
+		} else if ( typeof CodeMirror !== 'undefined' ) {
+			self.cmEditor = CodeMirror.fromTextArea(
+				$textarea.get(0),
+				{
+					tabSize        : 2,
+					indentWithTabs : true,
+					lineWrapping   : true
+				}
+			);
+			self.cmEditor.setSize( null, 'auto' );
+		}
 
-		self.cmEditor.on( 'change', function() {
-			api( self.cssSettingID ).set( self.cmEditor.getValue() );
-		} );
+		if ( self.cmEditor ) {
+			self.cmEditor.on( 'change', function() {
+				api( self.cssSettingID ).set( self.cmEditor.getValue() );
+			} );
+		}
 	};
 
 	/**
@@ -92,7 +111,12 @@ wp.customize.CampTixHtmlBadgesCustomizer = ( function( $, api ) {
 	 * @param {object} event
 	 */
 	self.printBadges = function( event ) {
-		window.frames[0].print();
+		var previewFrame = api.previewer.container.find( 'iframe' )[0];
+		if ( previewFrame && previewFrame.contentWindow ) {
+			previewFrame.contentWindow.print();
+		} else if ( window.frames[0] ) {
+			window.frames[0].print();
+		}
 	};
 
 	/**
@@ -102,7 +126,11 @@ wp.customize.CampTixHtmlBadgesCustomizer = ( function( $, api ) {
 	 */
 	self.resetCSS = function( event ) {
 		api( self.cssSettingID ).set( self.defaultCSS );
-		self.cmEditor.setValue(       self.defaultCSS );
+		if ( self.cmEditor ) {
+			self.cmEditor.setValue( self.defaultCSS );
+		} else {
+			$( '#customize-control-cbg_badge_css' ).find( 'textarea' ).val( self.defaultCSS );
+		}
 	};
 
 	api.bind( 'ready', self.initialize );

--- a/public_html/wp-content/plugins/camptix-badge-generator/views/html-badges/template-part-badge-contents.php
+++ b/public_html/wp-content/plugins/camptix-badge-generator/views/html-badges/template-part-badge-contents.php
@@ -38,6 +38,15 @@ defined( 'WPINC' ) || die();
 	</figcaption>
 </figure>
 
+<?php if ( ! empty( $attendee->qr_code_svg ) ) : ?>
+	<figure class="attendee-qrcode">
+		<?php echo $attendee->qr_code_svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<figcaption class="screen-reader-text">
+			<?php echo esc_html( sprintf( __( 'QR code linking to %s', 'wordcamporg' ), $attendee->qr_code_target_url ) ); ?>
+		</figcaption>
+	</figure>
+<?php endif; ?>
+
 <!-- These are arbitrary elements that you can use for any purpose -->
 <div class="badge-design-element-1"></div>
 <div class="badge-design-element-2"></div>


### PR DESCRIPTION
## Description

This PR addresses several long-standing bugs and modernizes the `camptix-badge-generator` plugin, and introduces support for generating QR codes linking to either an attendee's Gravatar profile or their WordPress.org user profile (`w.org/@username`).

### Bugfixes & Modernization:
- **Customizer CSS Editor**: Replaced the legacy `'jetpack-codemirror'` dependency with WordPress core `wp_enqueue_code_editor()` and localized settings, fixing JS errors when expanding the Customizer section.
- **Customizer Preview & Print Frame**: Fixed URL handling to preserve host, port (e.g. `localhost:8888`), and subdirectories. Fixed the print button to reliably target the preview iframe rather than relying on `window.frames[0]`.
- **Placeholder Attendees**: Filtered out unconfirmed/placeholder attendee records (`'[[ unconfirmed ]]'` and `'unknown.attendee@example.org'`) in `get_attendees()` so blank badges are not generated.
- **PHP 8.4 Deprecation**: Fixed `fputcsv()` escape parameter deprecation in InDesign badges export (`$escape` passed as `""`).
- **Temporary File Cleanup**: Added automatic cleanup of temporary attendee/Gravatar directories in `build_assets()`.
- **Print Styles**: Modernized page-breaking CSS using `break-after: page;` and `break-inside: avoid;`.

### QR Code Feature:
- **Pure PHP QR Code Generator**: Implemented `QR_Code` class (`includes/class-qr-code.php`) to generate vector SVGs with zero external network requests or dependencies.
- **Customizer Setting**: Added `cbg_qr_code_type` option to the Customizer with options:
  - `None` (Default)
  - `Gravatar Profile` (`https://gravatar.com/{hash}`)
  - `WordPress.org Profile` (`https://w.org/@{username}`)
- **Badge Template Integration**: Rendered `<figure class="attendee-qrcode">` in badge contents with accessible screen-reader text and styling in default CSS.
- **InDesign Data Merge Support**: Added QR code asset generation (`/qrcodes`) and `@QRCode` column in the export CSV.

## Testing Instructions
1. Navigate to **Tickets > Tools > Generate Badges**.
2. Open **Create Badges with HTML and CSS** (Customizer).
3. Under **QR Code Destination**, select *Gravatar Profile* or *WordPress.org Profile*.
4. Verify that badges display crisp vector QR codes that scan correctly to the attendee's profile URL.
5. Verify that printing in browser formats each badge across pages cleanly.