### PR TITLE
Coming Soon: Stop feeds from serving posts while active

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -13,6 +13,7 @@ class WordCamp_Coming_Soon_Page {
 		add_action( 'wp_head',                    array( $this, 'render_dynamic_styles'           )        );
 		add_filter( 'template_include',           array( $this, 'override_theme_template'         )        );
 		add_action( 'template_redirect',          array( $this, 'disable_jetpacks_open_graph'     )        );
+		add_action( 'template_redirect',          array( $this, 'disable_feeds' ) );
 		add_filter( 'rest_request_before_callbacks', array( $this, 'disable_rest_endpoints'       ), 99, 3 );
 		// Again after the callbacks, since `before_callbacks` only sets a response and a
 		// later filter on the same request can replace it. `PHP_INT_MAX` so nothing runs after it.
@@ -130,6 +131,34 @@ class WordCamp_Coming_Soon_Page {
 		if ( $this->override_theme_template ) {
 			add_filter( 'jetpack_enable_open_graph', '__return_false' );
 		}
+	}
+
+	/**
+	 * Prevent feeds from leaking content while the Coming Soon page is active.
+	 *
+	 * Core dispatches feed requests in `wp-includes/template-loader.php` and returns before the
+	 * `template_include` filter runs, so `override_theme_template()` never fires for them and posts
+	 * stay readable at `/feed/`, `/comments/feed/`, etc. `template_redirect` does fire for feeds, so
+	 * refuse them here, and strip the feed discovery links from the Coming Soon page so the blocked
+	 * feeds aren't advertised. Gated like the page and REST locks, so logged-in editors keep access.
+	 *
+	 * @see https://github.com/WordPress/wordcamp.org/issues/600
+	 */
+	public function disable_feeds() {
+		if ( ! $this->override_theme_template ) {
+			return;
+		}
+
+		if ( is_feed() ) {
+			wp_die(
+				esc_html__( 'Feeds are not available while the site is in Coming Soon mode.', 'wordcamporg' ),
+				'',
+				array( 'response' => 403 )
+			);
+		}
+
+		remove_action( 'wp_head', 'feed_links', 2 );
+		remove_action( 'wp_head', 'feed_links_extra', 3 );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-feed-lockdown.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-feed-lockdown.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace WordCamp\Coming_Soon_Page\Tests;
+
+use WordCamp_Coming_Soon_Page;
+use WP_UnitTestCase;
+use WPDieException;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group coming-soon-page
+ *
+ * @covers WordCamp_Coming_Soon_Page::disable_feeds
+ */
+class Test_Feed_Lockdown extends WP_UnitTestCase {
+	/**
+	 * Start each test anonymous, the way a public feed request arrives.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Build the plugin with Coming Soon in the given state and its state initialized.
+	 *
+	 * @param string $enabled `on` or `off`.
+	 * @return WordCamp_Coming_Soon_Page
+	 */
+	protected function plugin_with_coming_soon( $enabled ) {
+		update_option( 'wccsp_settings', array( 'enabled' => $enabled ) );
+
+		$plugin = new WordCamp_Coming_Soon_Page();
+		$plugin->init();
+
+		return $plugin;
+	}
+
+	/**
+	 * A feed request is refused while Coming Soon is active.
+	 */
+	public function test_feed_request_is_refused() {
+		$plugin = $this->plugin_with_coming_soon( 'on' );
+
+		$this->go_to( '/?feed=rss2' );
+		$this->assertTrue( is_feed(), 'The request should be a feed request.' );
+
+		// `wp_die()` in a feed request routes through the XML handler; point it at the test
+		// case's throwing handler so the refusal surfaces as an exception we can assert on.
+		add_filter( 'wp_die_xml_handler', array( $this, 'get_wp_die_handler' ) );
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionCode( 403 );
+		$this->expectExceptionMessage( 'Feeds are not available while the site is in Coming Soon mode.' );
+
+		$plugin->disable_feeds();
+	}
+
+	/**
+	 * The Coming Soon page stops advertising the now-blocked feeds.
+	 */
+	public function test_feed_discovery_links_are_removed() {
+		$plugin = $this->plugin_with_coming_soon( 'on' );
+
+		$this->go_to( '/' );
+		$plugin->disable_feeds();
+
+		$this->assertFalse( has_action( 'wp_head', 'feed_links' ) );
+		$this->assertFalse( has_action( 'wp_head', 'feed_links_extra' ) );
+	}
+
+	/**
+	 * With the site launched, a feed request is left alone and the discovery links stay.
+	 */
+	public function test_launched_site_feed_is_not_refused() {
+		$plugin = $this->plugin_with_coming_soon( 'off' );
+
+		$this->go_to( '/?feed=rss2' );
+		$plugin->disable_feeds();
+
+		$this->assertSame( 2, has_action( 'wp_head', 'feed_links' ) );
+		$this->assertSame( 3, has_action( 'wp_head', 'feed_links_extra' ) );
+	}
+
+	/**
+	 * A logged-in editor keeps feed access while Coming Soon is active.
+	 *
+	 * The gate matches the page and REST locks: it applies to anonymous visitors, not to the
+	 * organizers working on the site. Set the editor before init() so `override_theme_template`
+	 * is computed for a user who can `edit_posts`.
+	 */
+	public function test_logged_in_editor_feed_is_not_refused() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$plugin = $this->plugin_with_coming_soon( 'on' );
+
+		$this->go_to( '/?feed=rss2' );
+		$this->assertTrue( is_feed(), 'The request should be a feed request.' );
+
+		// Reaching the assertions at all proves the request was not refused: a refusal would
+		// `wp_die()` and throw before we get here. The discovery links are left in place too.
+		$plugin->disable_feeds();
+
+		$this->assertSame( 2, has_action( 'wp_head', 'feed_links' ) );
+		$this->assertSame( 3, has_action( 'wp_head', 'feed_links_extra' ) );
+	}
+}

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-feed-lockdown.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-feed-lockdown.php
@@ -20,6 +20,15 @@ class Test_Feed_Lockdown extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		/*
+		 * `go_to()` runs `WP->main()`, which fires the `wp` action after the query. There
+		 * `maybe_add_latest_site_hints()` switches to a central blog this test environment does
+		 * not provision, which writes DB errors to the log and trips the suite's error-log guard.
+		 * These tests exercise `disable_feeds()` directly and need nothing off `wp`, so drop that
+		 * callback. `WP_UnitTestCase` restores the hook registry after each test.
+		 */
+		remove_action( 'wp', 'WordCamp\Latest_Site_Hints\maybe_add_latest_site_hints' );
+
 		wp_set_current_user( 0 );
 	}
 


### PR DESCRIPTION
## Summary

Coming Soon mode hides a WordCamp site's page, REST API, Open Graph tags, subscriber email,
and Publicize. This change does the same thing for feeds (`/feed/`, `/comments/feed/`, and the
RSS/Atom/RDF variants). Refs #600, [Meta Trac Ticket 3309](https://meta.trac.wordpress.org/ticket/3309).

## Technical details

The Coming Soon plugin hides the site by swapping the page for the placeholder on the
`template_include` filter via `override_theme_template()`. But feeds never reach that filter.
For a feed request, core dispatches the feed in `wp-includes/template-loader.php` and returns
before `template_include` runs. The REST API had the same gap and got its own lock.

This change fixes it for feeds using the `template_redirect` hook, which *does* fire for feed
requests (it's where we already disable Open Graph). A new `disable_feeds()` method there:

- Runs all `is_feed()` requests through `wp_die( 403 )`, including RSS2, RSS, Atom, RDF, and the
  comments feed.
- Removes core `feed_links` / `feed_links_extra` discovery tags so the placeholder stops
  advertising the now-blocked feeds.
- It's gated on the plugin's existing `override_theme_template` flag, so it matches everything
  else. If you're working on the site as an organizer, you can see and test everything as though
  the site is launched. If you're signed out, you get the anonymous view and everything is
  hidden, including the feed advertisements.

## How to test the changes in this Pull Request:

1. On a WordCamp site with at least one published post, turn on Coming Soon mode.
2. As a logged-out visitor, open a feed in your browser: `https://<camp>.wordcamp.org/feed/`
   (also try `/comments/feed/`). **Before:** the published posts are there in full. **After:**
   a `403`, and the `<link rel="alternate">` feed tags are gone from the Coming Soon page's
   source (`view-source:` the front page).
3. Confirm organizers are unaffected: logged in as an editor, open the feed. It still loads
   normally.
4. Launch the site (Coming Soon off) and confirm feeds and their discovery tags behave normally
   again.

Automated coverage: `tests/test-feed-lockdown.php` (modeled on `test-rest-lockdown.php`) covers
the 403, the tag removal, the launched-site case, and a logged-in editor keeping feed access.
Full suite green on multisite (17 tests, 30 assertions). PHPCS clean on changed lines.
