### PR TITLE
Groups: generate venue static maps in the background

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -548,3 +548,26 @@ add_filter(
 		return $endpoints;
 	}
 );
+
+/**
+ * Generate venue static maps in the background instead of during the save.
+ *
+ * GatherPress renders a venue's static map from `wp_after_insert_post`, so
+ * every venue create/update pays for the OSM tile fetches and the GD
+ * composite inline — once for the 1x image and again for the 2x retina one.
+ * Each render is bounded by its own multi-second wall-clock budget, so a
+ * single save can sit there for a long time when the tile host is slow.
+ * Our front-end event form creates and updates venues over REST
+ * (`wporg-groups-frontend/inc/rest.php`), and bulk imports create many in a
+ * row, so that cost lands squarely on the organizer waiting for the form.
+ *
+ * Opting in here moves the render to a WP-Cron job a moment later and lets
+ * the save return immediately. The trade-off is that the map appears on the
+ * next cron tick rather than the instant the venue is saved, which is fine
+ * for an image nobody is looking at yet when the address is first entered.
+ *
+ * Needs GatherPress 0.36.0 or newer; on older versions the filter is simply
+ * never applied and generation stays synchronous. See
+ * https://github.com/WordPress/wordcamp.org/issues/1823.
+ */
+add_filter( 'gatherpress_static_map_generate_async', '__return_true' );


### PR DESCRIPTION
Fixes #1823.

GatherPress renders a venue's static map from `wp_after_insert_post`, so every venue create/update pays for the OSM tile fetches and the GD composite inline — once for the 1x image, again for the 2x retina one. Each render carries its own multi-second wall-clock budget, so a single save can block for a long time when the tile host is slow. Our front-end event form creates and updates venues over REST (`wporg-groups-frontend/inc/rest.php`), and bulk imports create many in a row, so that cost lands on the organizer waiting for the form.

This opts in to `gatherpress_static_map_generate_async`, the filter added upstream in [GatherPress#2048](https://github.com/GatherPress/gatherpress/pull/2048). The render moves to a WP-Cron job and the save returns immediately; the map appears on the next cron tick instead of the instant the venue is saved.

**Inert until the plugin is bumped.** The filter ships in GatherPress 0.36.0, which isn't released yet — we're pinned to 0.35.2, where the filter is simply never applied and generation stays synchronous. This can merge now and takes effect with no further code change once the pin moves.

## Testing

Nothing in our code reads the `gatherpress_static_map` meta, so there's no behaviour to check on 0.35.2 beyond "nothing changed". To verify the actual fix, run against GatherPress `develop` (or 0.36.0 once tagged):

1. On a group site, create or update a venue with a real, geocodable address — via the front-end event form or `POST`/`PUT` to `/wp/v2/gatherpress_venues/{id}`.
2. Time the request. It should return immediately rather than scaling with tile-fetch latency.
3. Confirm a `gatherpress_static_map_generate_run` event is queued (`wp cron event list --url=<group site>`), and that the map renders after it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYC5Kd2VGXpWmCMtjJULDC
