### PR TITLE
Base theme: guard header image against a null $post on singular views

### DIFF
--- a/public_html/wp-content/themes/wordcamp-base/lib/utils/header.php
+++ b/public_html/wp-content/themes/wordcamp-base/lib/utils/header.php
@@ -51,6 +51,7 @@ function wcb_header_image() {
 
 	// Check if this is a post or page, if it has a thumbnail, and if it's a big one
 	if ( is_singular()
+	&& $post
 	&& has_post_thumbnail( $post->ID )
 	&& ( /* $src, $width, $height */ $image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'post-thumbnail' ) )
 	&& $image[1] >= get_custom_header()->width ) :


### PR DESCRIPTION
## Why

The base theme's header image logic assumes that any singular-context request has a resolved post available:

```php
if ( is_singular()
&& has_post_thumbnail( $post->ID )
```

`is_singular()` reflects how the query vars were parsed (a `name`, `p`, `pagename`, or `attachment` var was present), not whether that query actually matched a post. A request for a slug that no longer exists (a stale link, a typo, a bot probing old URLs) can leave `is_singular()` true with zero results — `WP_Query` never populates `$post` in that case, so `$post` stays `null` and `wcb_header_image()` reads `->ID` off it, throwing:

```
PHP Warning: Attempt to read property "ID" on null in .../themes/wordcamp-base/lib/utils/header.php on line 54
```

This shows up in production error logs (e.g. `paris.wordcamp.org`, 2011 archive) on any singular-shaped URL that no longer resolves.

Reproduced locally by querying for a nonexistent post ID and calling `wcb_header_image()` directly: `is_singular()` true, `post_count` 0, `$post` null, same warning at the same line.

## What changed

- `wcb_header_image()` now also checks that `$post` is set before reading `$post->ID`, matching the same short-circuit style as the rest of the condition.

## Testing

- Reproduced the warning against a nonexistent post ID before the fix, confirmed it's gone after, using the same query setup.
- Confirmed the normal singular-with-a-real-post path (both with and without a header image) still runs without warnings or output changes.