### PR TITLE
Groups: elevate sidebar stacking context when RSVP modal is open

### DIFF
--- a/public_html/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/responsive.css
@@ -167,4 +167,15 @@
 		z-index: 1;
 		align-self: flex-start;
 	}
+
+	/*
+	 * When the RSVP modal inside the sidebar opens, elevate the sidebar's
+	 * stacking context so the full-screen modal and backdrop appear above all
+	 * page content and sibling elements (such as the event-date navigation
+	 * arrows in the main content column and the sticky navigation bar).
+	 */
+
+	.groups-site-event-sidebar:has(.wporg-event-rsvp__modal.is-open) {
+		z-index: 100000;
+	}
 }


### PR DESCRIPTION
Fixes #1997

### Description
On desktop (>= 1024px), `.groups-site-event-sidebar` is `position: sticky` and has `z-index: 1` to prevent Leaflet map controls from rendering over the page header.

Because the RSVP attendees modal (`.wporg-event-rsvp__modal`, `position: fixed; z-index: 100000;`) is rendered inside the event info card within this sidebar, its entire stacking context was constrained to `z-index: 1`.

Consequently, sibling elements in the main content column (`.groups-site-event-content`) with `z-index >= 1` - such as the circular date navigation arrows in the recurring-events occurrence selector (`.gpre-occurrence-selector__control`, `z-index: 1`) - rendered on top of the open modal dialog and its backdrop.

This PR elevates `.groups-site-event-sidebar` to `z-index: 100000` whenever `.wporg-event-rsvp__modal.is-open` is present inside it, ensuring the modal dialog properly sits above all page content and controls.

### How to test the changes in this Pull Request:

1. Visit an event page with recurring occurrences (e.g. on the Internal Testing Group) on desktop (>= 1024px viewport width).
2. Click the attendee summary or avatars below the RSVP button to open the attendees modal.
3. Verify that the recurring-events navigation arrow (`>`) does not overlap or poke through the modal dialog or backdrop.
4. Close the modal and confirm that the sticky sidebar behavior and header/nav stacking remain intact.

Props @wppoland, @nikvalani96