### PR TITLE
Post Types: list published posts only in the legacy shortcodes and widgets

### DIFF
--- a/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/back-compat.php
@@ -82,6 +82,8 @@ class WordCamp_Post_Types_Plugin_Back_Compat {
 
 		$speakers = new WP_Query( array(
 			'post_type'      => 'wcb_speaker',
+			'post_status'    => 'publish',
+			'has_password'   => false,
 			'orderby'        => 'title',
 			'order'          => 'ASC',
 			'posts_per_page' => -1,
@@ -159,6 +161,8 @@ class WordCamp_Post_Types_Plugin_Back_Compat {
 
 		$sessions = new WP_Query( array(
 			'post_type'      => 'wcb_session',
+			'post_status'    => 'publish',
+			'has_password'   => false,
 			'orberby'        => 'title',
 			'order'          => 'DESC',
 			'posts_per_page' => -1,
@@ -267,6 +271,8 @@ class WordCamp_Post_Types_Plugin_Back_Compat {
 
 				$sponsors = new WP_Query( array(
 					'post_type'      => 'wcb_sponsor',
+					'post_status'    => 'publish',
+					'has_password'   => false,
 					'order'          => 'ASC',
 					'posts_per_page' => - 1,
 					'taxonomy'       => $term->taxonomy,

--- a/public_html/wp-content/plugins/wc-post-types/inc/deprecated.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/deprecated.php
@@ -53,6 +53,8 @@ function shortcode_speakers( $attr, $content ) {
 	$session_args = array(
 		'post_type'      => 'wcb_session',
 		'posts_per_page' => -1,
+		'post_status'    => 'publish',
+		'has_password'   => false,
 	);
 
 	if ( ! empty( $attr['track'] ) ) {
@@ -92,10 +94,17 @@ function shortcode_speakers( $attr, $content ) {
 		$speakers_tracks[ $speaker_id ] = array_unique( $tracks );
 	}
 
+	// An empty `post__in` is ignored by `WP_Query`, which would list every speaker.
+	if ( ! empty( $attr['track'] ) && empty( $speaker_ids ) ) {
+		return '';
+	}
+
 	// Fetch all specified speakers.
 	$speaker_args = array(
 		'post_type'      => 'wcb_speaker',
 		'posts_per_page' => intval( $attr['posts_per_page'] ),
+		'post_status'    => 'publish',
+		'has_password'   => false,
 		'orderby'        => $attr['orderby'],
 		'order'          => $attr['order'],
 	);
@@ -196,6 +205,8 @@ function shortcode_organizers( $attr, $content ) {
 	$query_args = array(
 		'post_type'      => 'wcb_organizer',
 		'posts_per_page' => intval( $attr['posts_per_page'] ),
+		'post_status'    => 'publish',
+		'has_password'   => false,
 		'orderby'        => $attr['orderby'],
 		'order'          => $attr['order'],
 	);
@@ -289,6 +300,8 @@ function shortcode_sessions( $attr, $content ) {
 	$args = array(
 		'post_type'      => 'wcb_session',
 		'posts_per_page' => intval( $attr['posts_per_page'] ),
+		'post_status'    => 'publish',
+		'has_password'   => false,
 		'tax_query'      => array(),
 		'orderby'        => $attr['orderby'],
 		'order'          => $attr['order'],
@@ -369,6 +382,8 @@ function shortcode_sessions( $attr, $content ) {
 				$speakers = get_posts( array(
 					'post_type'      => 'wcb_speaker',
 					'posts_per_page' => -1,
+					'post_status'    => 'publish',
+					'has_password'   => false,
 					'post__in'       => $speakers_ids,
 				) );
 			}
@@ -510,6 +525,8 @@ function shortcode_sponsors( $attr, $content ) {
 		<?php foreach ( $terms as $term ) :
 			$sponsors = new WP_Query( array(
 				'post_type'      => 'wcb_sponsor',
+				'post_status'    => 'publish',
+				'has_password'   => false,
 				'order'          => 'ASC',
 				'posts_per_page' => -1,
 				'taxonomy'       => $term->taxonomy,

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -190,6 +190,8 @@ function get_schedule_sessions( $schedule_date, $tracks_explicitly_specified, $t
 	$query_args = array(
 		'post_type'      => 'wcb_session',
 		'posts_per_page' => - 1,
+		'post_status'    => 'publish',
+		'has_password'   => false,
 		'meta_query'     => array(
 			'relation' => 'AND',
 			array(

--- a/public_html/wp-content/plugins/wc-post-types/inc/widgets.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/widgets.php
@@ -56,6 +56,8 @@ class WCB_Widget_Sponsors extends WP_Widget {
 
 			$sponsors = new WP_Query( array(
 				'post_type'      => 'wcb_sponsor',
+				'post_status'    => 'publish',
+				'has_password'   => false,
 				'posts_per_page' => -1,
 				'order'          => 'ASC',
 				'taxonomy'       => $term->taxonomy,

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
@@ -271,4 +271,48 @@ class Test_Content_Appenders extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'speaker-avatar', $output );
 		$this->assertStringContainsString( 'Unannounced Session', $output );
 	}
+
+	/**
+	 * The speakers named under a session are the published ones, whoever is
+	 * looking. The callback reads `global $post`, which a sidebar widget's loop
+	 * also sets, and the widgets cache what they render for every visitor.
+	 */
+	public function test_session_names_published_speakers_only_for_an_administrator() {
+		$session_id = $this->go_to_session();
+
+		$private_speaker_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_speaker',
+			'post_status' => 'private',
+			'post_title'  => 'Private Speaker Name',
+		) );
+		add_post_meta( $session_id, '_wcpt_speaker_id', $private_speaker_id );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$output = $this->apply_session_appenders( $session_id, 'Session body.' );
+
+		$this->assertStringContainsString( 'Speaker Name', $output );
+		$this->assertStringNotContainsString( 'Private Speaker Name', $output );
+	}
+
+	/**
+	 * Same rule for the sessions listed under a speaker.
+	 */
+	public function test_speaker_lists_published_sessions_only_for_an_administrator() {
+		$speaker_id = $this->go_to_speaker();
+
+		$private_session_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'private',
+			'post_title'  => 'Private Session',
+		) );
+		add_post_meta( $private_session_id, '_wcpt_speaker_id', $speaker_id );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$output = $this->apply_speaker_appenders( 'Speaker bio.' );
+
+		$this->assertStringContainsString( 'Unannounced Session', $output );
+		$this->assertStringNotContainsString( 'Private Session', $output );
+	}
 }

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-listing-visibility.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-listing-visibility.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace WordCamp\WC_Post_Types\Tests;
+
+use WP_UnitTestCase;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests that the listing shortcodes and widgets show published posts only.
+ *
+ * The three sidebar widgets store their rendered markup in a transient and
+ * serve it to every visitor, so the listings must not depend on who runs the
+ * query.
+ *
+ * @group wc-post-types
+ */
+class Test_Listing_Visibility extends WP_UnitTestCase {
+	/**
+	 * The statuses each listing is checked against, keyed by title prefix.
+	 *
+	 * @var array
+	 */
+	const STATUSES = array(
+		'Published' => array( 'post_status' => 'publish' ),
+		'Private'   => array( 'post_status' => 'private' ),
+		'Draft'     => array( 'post_status' => 'draft' ),
+		'Locked'    => array(
+			'post_status'   => 'publish',
+			'post_password' => 'hunter2',
+		),
+	);
+
+	/**
+	 * An administrator, who can read private posts of these types.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Post IDs by "{$prefix} {$label}" title.
+	 *
+	 * @var array
+	 */
+	protected static $posts = array();
+
+	/**
+	 * Create one post per status for each of the four listed post types.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		$level = $factory->term->create( array( 'taxonomy' => 'wcb_sponsor_level' ) );
+
+		$types = array(
+			'wcb_speaker'   => 'Speaker',
+			'wcb_session'   => 'Session',
+			'wcb_organizer' => 'Organizer',
+			'wcb_sponsor'   => 'Sponsor',
+		);
+
+		foreach ( $types as $type => $label ) {
+			foreach ( self::STATUSES as $prefix => $args ) {
+				$title = "$prefix $label";
+
+				$post_args = array(
+					'post_type'    => $type,
+					'post_title'   => $title,
+					'post_content' => "Body of the $title.",
+				);
+
+				$id = $factory->post->create( array_merge( $args, $post_args ) );
+
+				if ( 'wcb_sponsor' === $type ) {
+					wp_set_object_terms( $id, $level, 'wcb_sponsor_level' );
+				}
+
+				self::$posts[ $title ] = $id;
+			}
+		}
+
+		// Every speaker presents the published session, so its meta names them.
+		foreach ( self::STATUSES as $prefix => $args ) {
+			add_post_meta( self::$posts['Published Session'], '_wcpt_speaker_id', self::$posts[ "$prefix Speaker" ] );
+		}
+	}
+
+	/**
+	 * Remove the fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$posts as $id ) {
+			wp_delete_post( $id, true );
+		}
+	}
+
+	/**
+	 * Register the widgets and act as the administrator.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! class_exists( 'WCPT_Widget_Speakers' ) ) {
+			$GLOBALS['wcpt_plugin']->register_widgets();
+		}
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Drop the widget caches the tests fill.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+
+		foreach ( array( 'wcpt_speakers', 'wcpt_sessions', 'wcpt_organizers' ) as $id_base ) {
+			delete_transient( 'wcpt-' . md5( "$id_base-2" ) );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Assert that only the published, password-free post of a type is listed.
+	 *
+	 * @param string $markup Rendered listing.
+	 * @param string $label  Post type label used in the fixture titles.
+	 */
+	protected function assert_published_only( $markup, $label ) {
+		$this->assertStringContainsString( "Published $label", $markup );
+
+		foreach ( array( 'Private', 'Draft', 'Locked' ) as $prefix ) {
+			$this->assertStringNotContainsString( "$prefix $label", $markup );
+		}
+	}
+
+	/**
+	 * @dataProvider data_shortcodes
+	 */
+	public function test_shortcode_lists_published_posts_only( $shortcode, $label ) {
+		$this->assert_published_only( do_shortcode( $shortcode ), $label );
+	}
+
+	/**
+	 * Shortcodes and the label of the post type they list.
+	 */
+	public function data_shortcodes() {
+		return array(
+			array( '[speakers]', 'Speaker' ),
+			array( '[sessions]', 'Session' ),
+			array( '[organizers]', 'Organizer' ),
+			array( '[sponsors]', 'Sponsor' ),
+		);
+	}
+
+	/**
+	 * The session meta names the speakers, so it is subject to the same rule.
+	 */
+	public function test_session_meta_names_published_speakers_only() {
+		$this->assert_published_only( do_shortcode( '[sessions show_meta="true"]' ), 'Speaker' );
+	}
+
+	/**
+	 * A track with no sessions has no speakers, rather than all of them.
+	 */
+	public function test_speakers_shortcode_with_empty_track_lists_nobody() {
+		self::factory()->term->create( array(
+			'taxonomy' => 'wcb_track',
+			'slug'     => 'empty-track',
+		) );
+
+		$this->assertSame( '', do_shortcode( '[speakers track="empty-track"]' ) );
+	}
+
+	/**
+	 * A widget primed by an administrator serves the same markup to a visitor.
+	 *
+	 * @dataProvider data_widgets
+	 */
+	public function test_widget_cached_by_admin_lists_published_posts_only( $widget, $id_base, $label ) {
+		$instance = array(
+			'title'  => '',
+			'count'  => 10,
+			'random' => false,
+		);
+		$args     = array(
+			'widget_id'     => "$id_base-2",
+			'before_widget' => '',
+			'after_widget'  => '',
+			'before_title'  => '',
+			'after_title'   => '',
+		);
+
+		ob_start();
+		the_widget( $widget, $instance, $args );
+		$this->assert_published_only( ob_get_clean(), $label );
+
+		wp_set_current_user( 0 );
+
+		ob_start();
+		the_widget( $widget, $instance, $args );
+		$this->assert_published_only( ob_get_clean(), $label );
+	}
+
+	/**
+	 * Widget classes, their id bases and the label of the post type they list.
+	 */
+	public function data_widgets() {
+		return array(
+			array( 'WCPT_Widget_Speakers', 'wcpt_speakers', 'Speaker' ),
+			array( 'WCPT_Widget_Sessions', 'wcpt_sessions', 'Session' ),
+			array( 'WCPT_Widget_Organizers', 'wcpt_organizers', 'Organizer' ),
+		);
+	}
+}

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-listing-visibility.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-listing-visibility.php
@@ -198,6 +198,9 @@ class Test_Listing_Visibility extends WP_UnitTestCase {
 		the_widget( $widget, $instance, $args );
 		$this->assert_published_only( ob_get_clean(), $label );
 
+		// Confirm the admin render filled the transient the anonymous one reads, so the second assertion cannot pass for the wrong reason.
+		$this->assertNotFalse( get_transient( 'wcpt-' . md5( "$id_base-2" ) ) );
+
 		wp_set_current_user( 0 );
 
 		ob_start();

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
@@ -186,4 +186,34 @@ class Test_Schedule_Shortcode extends WP_UnitTestCase {
 			'unlinked names' => array( 'none' ),
 		);
 	}
+
+	/**
+	 * A private session is left out of the grid whoever renders it. `[schedule]`
+	 * is not cached itself, but authored into a widgetised bio it renders into a
+	 * fragment the listing widgets serve to every visitor.
+	 *
+	 * @covers WordCamp_Post_Types_Plugin::shortcode_schedule
+	 */
+	public function test_private_session_is_omitted_for_an_administrator(): void {
+		$private_id = self::factory()->post->create( array(
+			'post_type'  => 'wcb_session',
+			'post_status' => 'private',
+			'post_title' => 'Unannounced Keynote',
+			'meta_input' => array(
+				'_wcpt_session_time' => 1786788000,
+				'_wcpt_session_type' => 'session',
+			),
+		) );
+		wp_set_object_terms( $private_id, array( self::$track_id ), 'wcb_track' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$html = $this->render_schedule();
+
+		$this->assertStringContainsString( 'Opening', $html );
+		$this->assertStringNotContainsString( 'Unannounced Keynote', $html );
+
+		wp_set_current_user( 0 );
+		wp_delete_post( $private_id, true );
+	}
 }

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -544,6 +544,8 @@ class WordCamp_Post_Types_Plugin {
 					$speakers = get_posts( array(
 						'post_type'      => 'wcb_speaker',
 						'posts_per_page' => -1,
+						'post_status'    => 'publish',
+						'has_password'   => false,
 						'post__in'       => $speakers_ids,
 					) );
 				}
@@ -814,7 +816,13 @@ class WordCamp_Post_Types_Plugin {
 	 * @return bool
 	 */
 	protected function should_add_to_content( $post_type ) {
+		/*
+		 * The main query being a single CPT post is not enough: `the_content` also
+		 * runs for the entries a listing widget renders on that page, and those
+		 * widgets cache their markup. Add only to the post being viewed.
+		 */
 		return $this->is_single_cpt_post( $post_type )
+			&& get_the_ID() === get_queried_object_id()
 			&& ! site_supports_block_templates()
 			&& ! post_password_required( get_post() );
 	}

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -890,6 +890,8 @@ class WordCamp_Post_Types_Plugin {
 		$speaker_args = array(
 			'post_type'      => 'wcb_speaker',
 			'posts_per_page' => -1,
+			'post_status'    => 'publish',
+			'has_password'   => false,
 			'post__in'       => $speaker_ids,
 			'orderby'        => 'title',
 			'order'          => 'asc',
@@ -1112,6 +1114,8 @@ class WordCamp_Post_Types_Plugin {
 		$session_args = array(
 			'post_type'      => 'wcb_session',
 			'posts_per_page' => -1,
+			'post_status'    => 'publish',
+			'has_password'   => false,
 			'meta_key'       => '_wcpt_speaker_id',
 			'meta_value'     => $post->ID,
 			'orderby'        => 'title',

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -103,6 +103,11 @@ function render( $content ) {
 		return $content;
 	}
 
+	// Only the post being viewed gets the form, not every post whose content renders on the page.
+	if ( get_queried_object_id() !== $post->ID ) {
+		return $content;
+	}
+
 	$now = date_create( 'now', wp_timezone() );
 	$form_content = '';
 

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/views/form-select-sessions.php
@@ -7,6 +7,8 @@ use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
 $session_args = array(
 	'post_type'      => 'wcb_session',
 	'posts_per_page' => -1,
+	'post_status'    => 'publish',
+	'has_password'   => false,
 	'orderby'        => 'meta_value_num',
 	'order'          => 'asc',
 	'meta_key'       => '_wcpt_session_time',


### PR DESCRIPTION
## Why

`[speakers track="x"]` lists every speaker when the track has no sessions. The shortcode collects speaker ids from the track's sessions and passes them as `post__in`, and `WP_Query` ignores an empty `post__in`, so the filter drops out instead of matching nothing.

Separately, the `[speakers]`, `[sessions]`, `[organizers]` and `[sponsors]` shortcodes, their back-compat copies for the `wordcamp-base` themes, and the Sponsors widget query their post type without a `post_status`, so core decides per viewer which statuses to include. The Speakers, Sessions and Organizers widgets keep that rendered output in a transient for an hour and serve it to every visitor, so the cached copy depends on whoever happened to fill it. The single session and speaker views also append a speaker list and a session list to the content; those callbacks gate on the main query but read `global $post`, so they run for each entry a listing widget renders on the page, again without a status. The blocks that replaced these shortcodes already query `publish` only (`mu-plugins/blocks/source/blocks/*/controller.php`).

## What changed

- Every legacy listing queries published, password-free posts: the four shortcodes, their back-compat copies, the Sponsors widget, the `[schedule]` grid, the speakers named in a session's meta line, the two single-view content appenders, and the session dropdown on the feedback page. Password-protected entries no longer appear in these listings; the blocks still show them with the password form.
- `[speakers track="..."]` returns nothing when the track has no sessions.
- The single-view content appenders and the speaker feedback form add markup to the post being viewed only, not to every entry a listing widget renders on the same page.
- Tests for the four shortcodes, the cached widgets, the empty track, the schedule grid, and the two content appenders.

## Testing

- New `Test_Listing_Visibility` (9), two new `Test_Content_Appenders` cases and a schedule visibility test fail on `production` and pass on the branch. The `WordCamp Post Types` (70) and `WordCamp Speaker Feedback` (64) suites pass.
- Verified on a local multisite camp on a classic theme with all four widgets in the sidebar and one published and one non-public post of each type. An administrator's page view followed by an anonymous one lists only the published posts, all four widgets still render, and the empty-track shortcode renders nothing; the same holds on the single session, single speaker and feedback pages.
- phpcs clean on the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
