### PR TITLE
Speaker Feedback: display submitted answers as plain text

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/includes/view.php
@@ -19,7 +19,8 @@ defined( 'WPINC' ) || die();
 
 const SPEAKER_VIEWED_KEY = 'sft-speaker-viewed-feedback';
 
-add_filter( 'the_content', __NAMESPACE__ . '\render' );
+// The appended view is not post content, so it runs after core's shortcode pass at 11.
+add_filter( 'the_content', __NAMESPACE__ . '\render', 12 );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'sft_speaker_viewed_feedback', __NAMESPACE__ . '\mark_speaker_as_viewed', 10, 2 );
 
@@ -200,6 +201,24 @@ function render_feedback_view() {
 }
 
 /**
+ * Prepare an attendee-submitted answer for display.
+ *
+ * Answers are free-form text, so the syntax that later filters would act on is encoded along
+ * with the tags that `wp_kses_data()` handles.
+ *
+ * @param string $answer
+ *
+ * @return string
+ */
+function sanitize_answer_for_display( $answer ) {
+	return str_replace(
+		array( '[', ']' ),
+		array( '&#91;', '&#93;' ),
+		wp_kses_data( $answer )
+	);
+}
+
+/**
  * Render a single feedback comment to a human-readable HTML string.
  *
  * @param WP_Comment|Feedback|string|int $comment A comment/feedback object or a comment ID.
@@ -223,7 +242,7 @@ function render_feedback_comment( $comment, $echo = true ) {
 			$output .= sprintf(
 				'<p class="speaker-feedback__question">%s</p><p class="speaker-feedback__answer">%s</p>',
 				wp_kses_data( $question ),
-				wp_kses_data( $answer )
+				sanitize_answer_for_display( $answer )
 			);
 		}
 	}

--- a/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-view.php
+++ b/public_html/wp-content/plugins/wordcamp-speaker-feedback/tests/test-view.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace WordCamp\SpeakerFeedback\Tests;
+
+use WP_Post;
+use WP_UnitTestCase, WP_UnitTest_Factory;
+use const WordCamp\SpeakerFeedback\Comment\COMMENT_TYPE;
+use function WordCamp\SpeakerFeedback\View\{ render_feedback_comment, sanitize_answer_for_display };
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Class Test_SpeakerFeedback_View
+ *
+ * @group wordcamp-speaker-feedback
+ */
+class Test_SpeakerFeedback_View extends WP_UnitTestCase {
+	/**
+	 * @var WP_Post
+	 */
+	protected static $session_post;
+
+	/**
+	 * Set up shared fixtures for these tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$session_post = $factory->post->create_and_get( array(
+			'post_type' => 'wcb_session',
+		) );
+	}
+
+	/**
+	 * Reset after each test.
+	 */
+	protected function tearDown(): void {
+		global $wpdb;
+
+		$ids = $wpdb->get_col( "SELECT comment_ID FROM {$wpdb->prefix}comments" );
+
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}comments" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}commentmeta" );
+		clean_comment_cache( $ids );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\View\sanitize_answer_for_display()
+	 */
+	public function test_sanitize_answer_for_display_keeps_the_text_readable() {
+		$this->assertSame(
+			'It was great! I liked the &#91;demo&#93; part.',
+			sanitize_answer_for_display( 'It was great! I liked the [demo] part.' )
+		);
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\View\sanitize_answer_for_display()
+	 */
+	public function test_sanitize_answer_for_display_encodes_delimiters() {
+		$answer = '[caption width=1 caption=\x3ca\x20id=x\x3eY\x3c/a\x3e]Z[/caption]';
+
+		$sanitized = sanitize_answer_for_display( $answer );
+
+		$this->assertStringNotContainsString( '[', $sanitized );
+		$this->assertStringNotContainsString( ']', $sanitized );
+		$this->assertSame( $sanitized, do_shortcode( $sanitized ) );
+	}
+
+	/**
+	 * @covers \WordCamp\SpeakerFeedback\View\render_feedback_comment()
+	 */
+	public function test_rendered_answers_survive_a_later_shortcode_pass() {
+		$comment_id = self::factory()->comment->create( array(
+			'comment_post_ID' => self::$session_post->ID,
+			'comment_type'    => COMMENT_TYPE,
+			'comment_meta'    => array(
+				'version' => 1,
+				'rating'  => 5,
+				'q1'      => '[caption width=1 caption=\x3ca\x20id=x\x3eY\x3c/a\x3e]Z[/caption]',
+			),
+		) );
+
+		$output = render_feedback_comment( $comment_id, false );
+
+		$this->assertStringContainsString( 'speaker-feedback__answer', $output );
+		$this->assertSame( $output, do_shortcode( $output ) );
+		$this->assertStringNotContainsString( '<a ', do_shortcode( $output ) );
+	}
+
+	/**
+	 * The rendered view is appended to `the_content`, so it must land after core's shortcode pass.
+	 *
+	 * @covers \WordCamp\SpeakerFeedback\View\render()
+	 */
+	public function test_render_runs_after_do_shortcode() {
+		$this->assertGreaterThan(
+			has_filter( 'the_content', 'do_shortcode' ),
+			has_filter( 'the_content', 'WordCamp\SpeakerFeedback\View\render' )
+		);
+	}
+}


### PR DESCRIPTION
Feedback answers are attendee-submitted free-form text, so they are now displayed as such, and the feedback
view is appended after core's shortcode pass instead of before it.

## Testing steps

1. On a camp site, open a session that is inside its feedback window and submit feedback containing bracketed
   text, e.g. `It was great, I liked the [demo] part.`
2. Approve it under *Tickets → Feedback*. The moderation list shows the answer unchanged.
3. As the speaker or an organizer, open the session's `/feedback/` page. The answer renders as literal text,
   brackets included, and the feedback form and rating stars are unaffected.
4. `./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist --testsuite "WordCamp Speaker Feedback"`
   → 68 tests, 189 assertions, all passing.
