### PR TITLE
Forms to Drafts, Blocks, Post Types: keep submitted titles as plain text

### DIFF
--- a/public_html/wp-content/mu-plugins/3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/3-helpers-misc.php
@@ -430,6 +430,34 @@ function wcorg_json_encode_attr_i18n( $raw_value ) {
 }
 
 /**
+ * Encode the shortcode delimiters in submitted text.
+ *
+ * Submitted free-text is stored and later rendered inside post content, where core parses shortcodes.
+ * Encoding the `[` and `]` delimiters keeps that text as literal characters, so a submission is shown
+ * as written rather than run. The result reads as `[` and `]` to a human.
+ *
+ * Applying this twice is a no-op: `&#91;` and `&#93;` contain no delimiter of their own. The result is
+ * HTML-encoded, so decode it for a plain-text medium the same way `wcorg_sanitize_plain_text()` output
+ * is decoded.
+ *
+ * @param mixed $value Arrays are handled recursively, with keys left alone. Anything neither array nor
+ *                     scalar becomes `''`.
+ *
+ * @return string|array A string, or an array of strings when `$value` is an array.
+ */
+function wcorg_escape_shortcodes( $value ) {
+	if ( is_array( $value ) ) {
+		return array_map( 'wcorg_escape_shortcodes', $value );
+	}
+
+	if ( ! is_scalar( $value ) ) {
+		return '';
+	}
+
+	return str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), (string) $value );
+}
+
+/**
  * Reduce a submitted value to text that stays text once WordPress saves it.
  *
  * `strip_tags()` wants a letter, `/`, `!` or `?` after a `<` before it counts as a tag, but `wp_kses()`

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/session-speakers/controller.php
@@ -82,9 +82,13 @@ function render( $attributes, $content, $block ) {
 	foreach ( $speakers as $speaker ) {
 		$content .= '<span class="wp-block-wordcamp-session-speakers__name">';
 		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-			$content .= sprintf( '<a href="%1$s">%2$s</a>', get_the_permalink( $speaker->ID ), get_the_title( $speaker->ID ) );
+			$content .= sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( get_the_permalink( $speaker->ID ) ),
+				wcorg_escape_shortcodes( get_the_title( $speaker->ID ) )
+			);
 		} else {
-			$content .= get_the_title( $speaker->ID );
+			$content .= wcorg_escape_shortcodes( get_the_title( $speaker->ID ) );
 		}
 		$content .= '</span>';
 	}

--- a/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/blocks/speaker-sessions/controller.php
@@ -100,9 +100,13 @@ function render( $attributes, $content, $block ) {
 	foreach ( $sessions as $session ) {
 		$session_li = '<li><p>';
 		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-			$session_li .= sprintf( '<a href="%1$s">%2$s</a>', get_the_permalink( $session->ID ), get_the_title( $session->ID ) );
+			$session_li .= sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( get_the_permalink( $session->ID ) ),
+				wcorg_escape_shortcodes( get_the_title( $session->ID ) )
+			);
 		} else {
-			$session_li .= get_the_title( $session->ID );
+			$session_li .= wcorg_escape_shortcodes( get_the_title( $session->ID ) );
 		}
 		$session_li .= '</p>';
 

--- a/public_html/wp-content/mu-plugins/blocks/source/components/item/controller.php
+++ b/public_html/wp-content/mu-plugins/blocks/source/components/item/controller.php
@@ -8,6 +8,10 @@ defined( 'WPINC' ) || die();
 /**
  * Render HTML for a title with specified heading level and optionally a link.
  *
+ * The title is concatenated into post content, which core parses for shortcodes, so its
+ * delimiters are encoded. `esc_html()` would double-encode the entities a stored title
+ * already carries, see `wcorg_sanitize_plain_text()`.
+ *
  * @param string $title
  * @param string $link
  * @param int    $heading_level
@@ -45,7 +49,7 @@ function render_item_title( $title, $link = '', $heading_level = 3, array $class
 	if ( $link ) {
 		$output .= '<a href="' . esc_url( $link ) . '">';
 	}
-	$output .= $title;
+	$output .= wcorg_escape_shortcodes( $title );
 	if ( $link ) {
 		$output .= '</a>';
 	}

--- a/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
+++ b/public_html/wp-content/mu-plugins/tests/test-3-helpers-misc.php
@@ -175,4 +175,97 @@ class Test_Helpers_Misc extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<code>', wp_filter_kses( sanitize_text_field( self::SPACED_TAG ) ) );
 		$this->assertStringNotContainsString( '<code>', wp_filter_kses( wcorg_sanitize_plain_text( self::SPACED_TAG ) ) );
 	}
+
+	/**
+	 * @covers ::wcorg_escape_shortcodes
+	 *
+	 * @dataProvider data_wcorg_escape_shortcodes
+	 */
+	public function test_wcorg_escape_shortcodes( $value, $expected ) {
+		$this->assertSame( $expected, wcorg_escape_shortcodes( $value ) );
+	}
+
+	/**
+	 * Data provider for `test_wcorg_escape_shortcodes()`.
+	 *
+	 * @return array
+	 */
+	public function data_wcorg_escape_shortcodes() {
+		return array(
+			'text without delimiters is untouched' => array(
+				'Portland, Oregon',
+				'Portland, Oregon',
+			),
+			'both delimiters are encoded'          => array(
+				'[camptix_private]hello[/camptix_private]',
+				'&#91;camptix_private&#93;hello&#91;/camptix_private&#93;',
+			),
+			'an unpaired delimiter still counts'   => array(
+				'Rated [A best',
+				'Rated &#91;A best',
+			),
+			'arrays are handled recursively'       => array(
+				array(
+					'a' => '[x]',
+					'b' => 'y',
+				),
+				array(
+					'a' => '&#91;x&#93;',
+					'b' => 'y',
+				),
+			),
+			'non-scalars become an empty string'   => array(
+				new \stdClass(),
+				'',
+			),
+			'integers keep their digits'           => array(
+				42,
+				'42',
+			),
+		);
+	}
+
+	/**
+	 * Escaping an already-escaped value must not change it again.
+	 *
+	 * The write paths apply this on top of `wcorg_sanitize_plain_text()`, and some of them run
+	 * twice over the same value, so a second pass has to be a no-op.
+	 *
+	 * @covers ::wcorg_escape_shortcodes
+	 */
+	public function test_wcorg_escape_shortcodes_is_idempotent() {
+		$once = wcorg_escape_shortcodes( '[camptix_private]hello[/camptix_private]' );
+
+		$this->assertSame( $once, wcorg_escape_shortcodes( $once ) );
+	}
+
+	/**
+	 * The point of the helper: what comes out is not parsed as a shortcode.
+	 *
+	 * `wp_kses_post()` rewrites `&#91;` to the equivalent `&#091;`, so the assertion is that no
+	 * delimiter survives rather than that a particular entity does.
+	 *
+	 * @covers ::wcorg_escape_shortcodes
+	 */
+	public function test_wcorg_escape_shortcodes_survives_the_kses_pass() {
+		$escaped = wp_kses_post( wcorg_escape_shortcodes( '[caption width=1 caption=x]y[/caption]' ) );
+
+		$this->assertStringNotContainsString( '[', $escaped );
+		$this->assertStringNotContainsString( ']', $escaped );
+		$this->assertSame( $escaped, do_shortcode( $escaped ) );
+	}
+
+	/**
+	 * The stored form decodes back to what the submitter typed.
+	 *
+	 * The read sites that pre-fill a text input decode with `html_entity_decode()`, so the
+	 * round trip has to hold for the delimiters too.
+	 *
+	 * @covers ::wcorg_escape_shortcodes
+	 */
+	public function test_wcorg_escape_shortcodes_round_trips() {
+		$value = 'Rated [A best';
+
+		$this->assertSame( $value, html_entity_decode( wcorg_escape_shortcodes( $value ) ) );
+	}
 }

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-item.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-item.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+use function WordCamp\Blocks\Components\render_item_title;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/blocks/source/components/item/controller.php';
+
+/**
+ * Tests for the title the listing blocks render.
+ *
+ * `render_item_title()` is the one component the Sponsors, Speakers, Sessions and
+ * Organizers blocks all route their title through, and those blocks are rendered
+ * inside post content, which core parses for shortcodes at `the_content` priority 11.
+ *
+ * @group blocks
+ */
+class Test_Blocks_Item extends WP_UnitTestCase {
+	/**
+	 * A title that would run as a shortcode if it were emitted verbatim.
+	 *
+	 * @var string
+	 */
+	const SHORTCODE_TITLE = 'Acme [caption width=1 caption=x]y[/caption] Co';
+
+	/**
+	 * The rendered title is not parsed as a shortcode.
+	 *
+	 * @covers \WordCamp\Blocks\Components\render_item_title
+	 */
+	public function test_title_is_rendered_as_text() {
+		$output = render_item_title( self::SHORTCODE_TITLE );
+
+		$this->assertStringContainsString( 'Acme', $output );
+		$this->assertStringContainsString( 'Co', $output );
+		$this->assertStringNotContainsString( '[', $output );
+		$this->assertStringNotContainsString( ']', $output );
+		$this->assertSame( $output, do_shortcode( $output ) );
+	}
+
+	/**
+	 * The encoding holds through the `wp_kses_post()` pass the block views apply.
+	 *
+	 * @covers \WordCamp\Blocks\Components\render_item_title
+	 */
+	public function test_title_survives_the_kses_pass() {
+		$output = wp_kses_post( render_item_title( self::SHORTCODE_TITLE, 'https://example.org/acme/' ) );
+
+		$this->assertStringNotContainsString( '[', $output );
+		$this->assertSame( $output, do_shortcode( $output ) );
+		$this->assertStringContainsString( 'https://example.org/acme/', $output );
+	}
+
+	/**
+	 * A title that a store-time sanitiser already encoded is not encoded a second time.
+	 *
+	 * Stored titles carry `&lt;` for a `<` the submitter typed, see `wcorg_sanitize_plain_text()`.
+	 * `esc_html()` here would turn that into `&amp;lt;` and show the entity on the page.
+	 *
+	 * @covers \WordCamp\Blocks\Components\render_item_title
+	 */
+	public function test_existing_entities_are_not_double_encoded() {
+		$output = render_item_title( 'Hall &lt; 100 &gt; seats' );
+
+		$this->assertStringContainsString( 'Hall &lt; 100 &gt; seats', $output );
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-session-speakers.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-session-speakers.php
@@ -121,6 +121,24 @@ class Test_Session_Speakers_Block extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A speaker title is listed as text, not run through the shortcode parser.
+	 *
+	 * The block's output is concatenated into post content, which core parses at
+	 * `the_content` priority 11.
+	 */
+	public function test_speaker_title_is_listed_as_text() {
+		wp_set_current_user( 0 );
+
+		$this->attach_speaker( 'Escaped [caption width=1]x[/caption] speaker', 'publish', 0 );
+
+		$output = $this->render_block();
+
+		$this->assertStringContainsString( 'Escaped', $output );
+		$this->assertStringNotContainsString( '[caption', $output );
+		$this->assertSame( $output, do_shortcode( $output ) );
+	}
+
+	/**
 	 * Test that draft speakers are not listed for a logged out visitor.
 	 */
 	public function test_logged_out_does_not_see_draft_speaker() {

--- a/public_html/wp-content/mu-plugins/tests/test-blocks-speaker-sessions.php
+++ b/public_html/wp-content/mu-plugins/tests/test-blocks-speaker-sessions.php
@@ -106,6 +106,24 @@ class Test_Speaker_Sessions_Block extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A session title is listed as text, not run through the shortcode parser.
+	 *
+	 * The block's output is concatenated into post content, which core parses at
+	 * `the_content` priority 11.
+	 */
+	public function test_session_title_is_listed_as_text() {
+		wp_set_current_user( 0 );
+
+		$this->add_session( 'Escaped [caption width=1]x[/caption] session', 'publish', 0 );
+
+		$output = $this->render_block();
+
+		$this->assertStringContainsString( 'Escaped', $output );
+		$this->assertStringNotContainsString( '[caption', $output );
+		$this->assertSame( $output, do_shortcode( $output ) );
+	}
+
+	/**
 	 * Test that a logged out visitor is only asked about published sessions.
 	 */
 	public function test_logged_out_gets_published_status_only() {

--- a/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/inc/favorite-schedule-shortcode.php
@@ -371,7 +371,8 @@ function generate_plaintext_fav_sessions( $sessions_rev, $fav_sessions_lookup ) 
 
 			$speakers_names = array();
 			foreach ( $speakers as $speaker ) {
-				$speaker_name     = apply_filters( 'the_title', $speaker->post_title );
+				// Decoded for the same reason the session title above is: this is a plain-text mail.
+				$speaker_name     = html_entity_decode( apply_filters( 'the_title', $speaker->post_title ) );
 				$speakers_names[] = $speaker_name;
 			}
 

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-content-appenders.php
@@ -155,6 +155,29 @@ class Test_Content_Appenders extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The spliced speaker name is appended as text, not run through the shortcode parser.
+	 *
+	 * These callbacks are registered on `the_content` at priority 10 and core parses
+	 * shortcodes at 11, so whatever they append is handed to the parser afterwards.
+	 */
+	public function test_appended_speaker_name_is_text() {
+		$session_id = $this->go_to_session();
+
+		$speaker_id = self::factory()->post->create( array(
+			'post_type'   => 'wcb_speaker',
+			'post_status' => 'publish',
+			'post_title'  => 'Escaped [caption width=1 caption=x]y[/caption] Speaker',
+		) );
+		add_post_meta( $session_id, '_wcpt_speaker_id', $speaker_id );
+
+		$output = $this->apply_session_appenders( $session_id, 'Session body.' );
+
+		$this->assertStringContainsString( 'Escaped', $output );
+		$this->assertStringNotContainsString( '[caption', $output );
+		$this->assertSame( $output, do_shortcode( $output ) );
+	}
+
+	/**
 	 * A protected session keeps the password form on its own. Core has already
 	 * replaced the body by the time these run, so appending would put the
 	 * session's own material back beneath the form.

--- a/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
+++ b/public_html/wp-content/plugins/wc-post-types/tests/test-schedule-shortcode.php
@@ -96,6 +96,40 @@ class Test_Schedule_Shortcode extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The favourites email is `text/plain`, so entity-encoded titles are decoded
+	 * for it -- the speaker name the same way the session title beside it is.
+	 *
+	 * Submitted titles are stored entity-encoded, so `Ada &#91;Lovelace&#93;` in the
+	 * database has to read as `Ada [Lovelace]` in the mail rather than as its entities.
+	 *
+	 * @covers ::generate_email_body
+	 */
+	public function test_email_body_decodes_entities_in_titles(): void {
+		$speaker_id = self::factory()->post->create( array(
+			'post_type'  => 'wcb_speaker',
+			'post_title' => 'Ada &#91;Lovelace&#93;',
+		) );
+
+		$session_id = self::factory()->post->create( array(
+			'post_type'  => 'wcb_session',
+			'post_title' => 'Closing &#91;Remarks&#93;',
+			'meta_input' => array(
+				'_wcpt_session_time' => 1786791600,
+				'_wcpt_session_type' => 'session',
+				'_wcpt_speaker_id'   => $speaker_id,
+			),
+		) );
+
+		wp_set_object_terms( $session_id, array( self::$track_id ), 'wcb_track' );
+
+		$body = generate_email_body( 'WordCamp Test', array( $session_id => 1 ), 'https://example.org/schedule/' );
+
+		$this->assertStringContainsString( 'Closing [Remarks]', $body );
+		$this->assertStringContainsString( 'Ada [Lovelace]', $body );
+		$this->assertStringNotContainsString( '&#91;', $body );
+	}
+
+	/**
 	 * The track name lands in the `data-track-title` attribute, so a double
 	 * quote in it has to be encoded rather than closing the attribute early.
 	 *

--- a/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
+++ b/public_html/wp-content/plugins/wc-post-types/wc-post-types.php
@@ -914,7 +914,11 @@ class WordCamp_Post_Types_Plugin {
 		$speakers_html .= '<ul id="session-speaker-names">';
 		while ( $speakers->have_posts() ) {
 			$speakers->the_post();
-			$speakers_html .= sprintf( '<li><a href="%s">%s</a></li>', get_the_permalink(), get_the_title() );
+			$speakers_html .= sprintf(
+				'<li><a href="%s">%s</a></li>',
+				esc_url( get_the_permalink() ),
+				wcorg_escape_shortcodes( get_the_title() )
+			);
 		}
 		$speakers_html .= '</ul>';
 
@@ -1137,7 +1141,11 @@ class WordCamp_Post_Types_Plugin {
 		$sessions_html .= '<ul id="speaker-session-names">';
 		while ( $sessions->have_posts() ) {
 			$sessions->the_post();
-			$sessions_html .= sprintf( '<li><a href="%s">%s</a></li>', get_the_permalink(), get_the_title() );
+			$sessions_html .= sprintf(
+				'<li><a href="%s">%s</a></li>',
+				esc_url( get_the_permalink() ),
+				wcorg_escape_shortcodes( get_the_title() )
+			);
 		}
 		$sessions_html .= '</ul>';
 

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/tests/test-draft-content.php
@@ -282,6 +282,92 @@ class Test_Draft_Content extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A submitted Company Name is neutralized in the generated draft Sponsor.
+	 */
+	public function test_sponsor_title_shortcodes_are_escaped() {
+		$this->plugin->call_for_sponsors(
+			$this->make_submission( 'call-for-sponsors' ),
+			array(
+				'Company Name'        => self::SHORTCODE_INPUT,
+				'Company Description' => 'A description.',
+				'Website'             => 'https://example.org',
+			),
+			array()
+		);
+
+		$sponsor = get_posts( array(
+			'post_type'   => 'wcb_sponsor',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $sponsor );
+		$this->assertShortcodeNeutralized( $sponsor[0]->post_title );
+	}
+
+	/**
+	 * A submitted volunteer Name is neutralized in the generated draft Volunteer.
+	 */
+	public function test_volunteer_title_shortcodes_are_escaped() {
+		$this->plugin->call_for_volunteers(
+			$this->make_submission( 'call-for-volunteers' ),
+			array(
+				'Name'                   => self::SHORTCODE_INPUT,
+				'Email'                  => 'volunteer@example.org',
+				'WordPress.org Username' => 'nonexistent-user-for-tests',
+			),
+			array()
+		);
+
+		$volunteer = get_posts( array(
+			'post_type'   => 'wcb_volunteer',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $volunteer );
+		$this->assertShortcodeNeutralized( $volunteer[0]->post_title );
+	}
+
+	/**
+	 * A submitted speaker Name and Topic Title are neutralized in the generated drafts.
+	 *
+	 * The session's `_wcb_session_speakers` meta is a copy of the speaker title, so it is
+	 * covered by the same write.
+	 */
+	public function test_speaker_and_session_title_shortcodes_are_escaped() {
+		$this->plugin->call_for_speakers(
+			$this->make_submission( 'call-for-speakers' ),
+			array(
+				'Name'                   => self::SHORTCODE_INPUT,
+				'Email Address'          => 'speaker@example.org',
+				'WordPress.org Username' => 'nonexistent-user-for-tests',
+				'Your Bio'               => 'A bio.',
+				'Topic Title'            => self::SHORTCODE_INPUT,
+				'Topic Description'      => 'A description.',
+			),
+			array()
+		);
+
+		$speaker = get_posts( array(
+			'post_type'   => 'wcb_speaker',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $speaker );
+		$this->assertShortcodeNeutralized( $speaker[0]->post_title );
+
+		$session = get_posts( array(
+			'post_type'   => 'wcb_session',
+			'post_status' => 'draft',
+			'numberposts' => 1,
+		) );
+		$this->assertNotEmpty( $session );
+		$this->assertShortcodeNeutralized( $session[0]->post_title );
+		$this->assertShortcodeNeutralized(
+			get_post_meta( $session[0]->ID, '_wcb_session_speakers', true )
+		);
+	}
+
+	/**
 	 * Formatting and percent-encoded URLs a submitter typed still reach the draft body.
 	 *
 	 * Jetpack runs `wp_kses_post()` over these values before the handler sees them, so the

--- a/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
+++ b/public_html/wp-content/plugins/wordcamp-forms-to-drafts/wordcamp-forms-to-drafts.php
@@ -443,7 +443,7 @@ class WordCamp_Forms_To_Drafts {
 		// Create the post.
 		$draft_id = wp_insert_post( array(
 			'post_type'    => 'wcb_sponsor',
-			'post_title'   => wcorg_sanitize_plain_text( $all_values['Company Name'] ?? '' ),
+			'post_title'   => $this->escape_shortcodes( wcorg_sanitize_plain_text( $all_values['Company Name'] ?? '' ) ),
 			'post_content' => $this->escape_shortcodes( $all_values['Company Description'] ?? '' ),
 			'post_status'  => 'draft',
 			'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
@@ -525,7 +525,7 @@ class WordCamp_Forms_To_Drafts {
 
 		$draft_id = wp_insert_post( array(
 			'post_type'    => 'wcb_volunteer',
-			'post_title'   => wcorg_sanitize_plain_text( $all_values['Name'] ?? '' ),
+			'post_title'   => $this->escape_shortcodes( wcorg_sanitize_plain_text( $all_values['Name'] ?? '' ) ),
 			'post_status'  => 'draft',
 			'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
 		) );
@@ -660,20 +660,21 @@ class WordCamp_Forms_To_Drafts {
 	/**
 	 * Escape shortcode delimiters in submitted content.
 	 *
-	 * Submitted free-text is placed into draft post content that organizers later
-	 * render (e.g. when previewing the draft). Encoding the `[` and `]` delimiters
-	 * keeps that text as literal characters instead of letting it run as shortcodes,
-	 * so a submission is shown as written rather than executed.
+	 * Submitted free-text is placed into draft posts that organizers later publish and
+	 * render. Encoding the `[` and `]` delimiters keeps that text as literal characters
+	 * instead of letting it run as shortcodes, so a submission is shown as written rather
+	 * than executed. Titles need this as much as bodies do -- the WordCamp blocks and
+	 * `wc-post-types` both concatenate a title into post content.
 	 *
 	 * Tags are not a concern here: Jetpack has already run these values through `wp_kses_post()`,
 	 * and `content_save_pre` runs them through it again on the way into the database.
 	 *
-	 * @param string $content Submitted content.
+	 * @param string $content Submitted title or body.
 	 *
 	 * @return string Content with shortcode delimiters encoded.
 	 */
 	protected function escape_shortcodes( $content ) {
-		return str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), (string) $content );
+		return wcorg_escape_shortcodes( $content );
 	}
 
 	/**
@@ -699,7 +700,7 @@ class WordCamp_Forms_To_Drafts {
 		$speaker_id = wp_insert_post(
 			array(
 				'post_type'    => 'wcb_speaker',
-				'post_title'   => wcorg_sanitize_plain_text( $speaker['Name'] ?? 'Untitled' ),
+				'post_title'   => $this->escape_shortcodes( wcorg_sanitize_plain_text( $speaker['Name'] ?? 'Untitled' ) ),
 				'post_content' => $content,
 				'post_status'  => 'draft',
 				'post_author'  => $this->get_user_id_from_username( 'wordcamp' ),
@@ -749,7 +750,7 @@ class WordCamp_Forms_To_Drafts {
 		$session_id = wp_insert_post(
 			array(
 				'post_type'    => 'wcb_session',
-				'post_title'   => wcorg_sanitize_plain_text( $session['Topic Title'] ?? '' ),
+				'post_title'   => $this->escape_shortcodes( wcorg_sanitize_plain_text( $session['Topic Title'] ?? '' ) ),
 				'post_content' => $content,
 				'post_status'  => 'draft',
 				'post_author'  => $this->get_user_id_from_username( $session['WordPress.org Username'] ?? '' ),


### PR DESCRIPTION
Titles submitted through the public forms are free-form text, so they are now stored and rendered as such,
the way the submitted bodies already were. The listing blocks and the `wc-post-types` content appenders
render a title as text too, which also covers titles already in the database.

## Testing steps

1. On a camp site, submit the Call for Sponsors form with a Company Name containing bracketed text, e.g.
   `Acme [demo] Co`, then publish the drafted sponsor.
2. Add the Sponsors block to a page and list that sponsor. The name reads `Acme [demo] Co`, and the
   permalink still works.
3. Repeat through Call for Speakers (`Name`, `Topic Title`) and Call for Volunteers (`Name`) — the
   Speakers and Sessions blocks, and a classic-theme camp's session/speaker pages, all read the same.
4. `./public_html/wp-content/mu-plugins/vendor/bin/phpunit -c phpunit.xml.dist`
   → 1382 tests, 3550 assertions. The three `Test_Groups_Blocks` password-protected-page failures are
   present on `production` too and are unrelated to this branch.
