### PR TITLE
Meetup: tie the OAuth callback to the request that started it

### DIFF
--- a/public_html/wp-content/mu-plugins/tests/test-meetup-oauth-state.php
+++ b/public_html/wp-content/mu-plugins/tests/test-meetup-oauth-state.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace WordCamp\Tests;
+
+use WP_UnitTestCase;
+
+use function WordCamp\Meetup_OAuth\{ create_oauth_state, delete_oauth_state, filter_authorize_url, get_page_url,
+	maybe_exchange_code_for_token, verify_oauth_state };
+use const WordCamp\Meetup_OAuth\STATE_META_KEY;
+
+defined( 'WPINC' ) || die();
+
+require_once dirname( __DIR__ ) . '/wcorg-meetup-oauth.php';
+
+/**
+ * Tests for the `state` value that ties a Meetup OAuth callback to the authorization request that started it.
+ *
+ * @group mu-plugins
+ * @group meetup
+ *
+ * @package WordCamp\Tests
+ */
+class Test_Meetup_OAuth_State extends WP_UnitTestCase {
+	/**
+	 * A network admin, who is the only kind of user that can run the OAuth process.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * A user with no network privileges.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * Create the shared fixtures.
+	 *
+	 * @param \WP_UnitTest_Factory $factory
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Start each test as the network admin who initiates the process.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set directly rather than through `site_admins`, which the object cache holds onto between tests.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restored in `tear_down()`.
+		$GLOBALS['super_admins'] = array( get_userdata( self::$admin_id )->user_login );
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Clear out the callback parameters and the super admin override that the tests set.
+	 */
+	public function tear_down() {
+		$_GET = array();
+
+		unset( $GLOBALS['super_admins'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Whatever `state` is stored for a user, or an empty string if there isn't any.
+	 *
+	 * @param int $user_id
+	 *
+	 * @return array|string
+	 */
+	protected function stored_state( $user_id ) {
+		return get_user_meta( $user_id, STATE_META_KEY, true );
+	}
+
+	/**
+	 * Play back a callback from Meetup.
+	 *
+	 * @param array $query The query parameters Meetup redirected with.
+	 *
+	 * @return void
+	 */
+	protected function handle_callback( array $query ) {
+		$_GET = $query;
+
+		maybe_exchange_code_for_token();
+	}
+
+	/**
+	 * The value sent to Meetup is remembered for the user who started the process.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\create_oauth_state
+	 */
+	public function test_created_state_is_stored_for_the_current_user() {
+		$state = create_oauth_state();
+		$meta  = $this->stored_state( self::$admin_id );
+
+		$this->assertSame( 32, strlen( $state ) );
+		$this->assertSame( $state, $meta['state'] );
+		$this->assertGreaterThan( time(), $meta['expires'] );
+	}
+
+	/**
+	 * A callback carrying the value we sent is accepted.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_matching_state_is_verified() {
+		$state = create_oauth_state();
+
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * The literal the callback used to accept is no longer good for anything.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_former_hardcoded_state_is_not_verified() {
+		create_oauth_state();
+
+		$this->assertFalse( verify_oauth_state( 'meetup-oauth' ) );
+	}
+
+	/**
+	 * A callback that can't be matched leaves a pending authorization alone, so the genuine one that follows
+	 * can still complete.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_unmatched_callback_leaves_a_pending_state_alone() {
+		$state = create_oauth_state();
+
+		$this->assertFalse( verify_oauth_state( 'AJd83ndKSl92mfkeAJd83ndKSl92mfke' ) );
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * A callback that doesn't carry the value we sent is turned away.
+	 *
+	 * @dataProvider data_unverified_states
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 *
+	 * @param mixed $state
+	 */
+	public function test_other_states_are_not_verified( $state ) {
+		create_oauth_state();
+
+		$this->assertFalse( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * Data provider for `test_other_states_are_not_verified`.
+	 *
+	 * @return array
+	 */
+	public function data_unverified_states() {
+		return array(
+			'empty'        => array( '' ),
+			'mismatched'   => array( 'AJd83ndKSl92mfkeAJd83ndKSl92mfke' ),
+			'not a string' => array( array( 'nope' ) ),
+		);
+	}
+
+	/**
+	 * A callback that arrives long after the process started is turned away.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_expired_state_is_not_verified() {
+		$state = create_oauth_state();
+
+		update_user_meta(
+			self::$admin_id,
+			STATE_META_KEY,
+			array(
+				'state'   => $state,
+				'expires' => time() - 1,
+			)
+		);
+
+		$this->assertFalse( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * A stored value that isn't a string is turned away rather than handed to `hash_equals()`, which would
+	 * throw a TypeError.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_non_string_stored_state_is_not_verified() {
+		update_user_meta(
+			self::$admin_id,
+			STATE_META_KEY,
+			array(
+				'state'   => array( 'nope' ),
+				'expires' => time() + MINUTE_IN_SECONDS,
+			)
+		);
+
+		$this->assertFalse( verify_oauth_state( 'AJd83ndKSl92mfkeAJd83ndKSl92mfke' ) );
+	}
+
+	/**
+	 * The value only counts for the user it was created for.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_state_is_not_verified_for_another_user() {
+		$state = create_oauth_state();
+
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertFalse( verify_oauth_state( $state ) );
+
+		// The original user's value is untouched, so their own callback can still complete.
+		wp_set_current_user( self::$admin_id );
+
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * A callback from a logged-out request is turned away.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\verify_oauth_state
+	 */
+	public function test_state_is_not_verified_without_a_user() {
+		$state = create_oauth_state();
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * Once spent, the value can't be replayed.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\delete_oauth_state
+	 */
+	public function test_deleted_state_is_not_verified() {
+		$state = create_oauth_state();
+
+		delete_oauth_state();
+
+		$this->assertSame( '', $this->stored_state( self::$admin_id ) );
+		$this->assertFalse( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * A request that isn't a callback at all leaves any pending authorization alone.
+	 *
+	 * @dataProvider data_non_callback_requests
+	 * @covers \WordCamp\Meetup_OAuth\maybe_exchange_code_for_token
+	 *
+	 * @param array $query
+	 */
+	public function test_non_callback_requests_are_ignored( array $query ) {
+		$state = create_oauth_state();
+
+		$this->handle_callback( $query );
+
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * Data provider for `test_non_callback_requests_are_ignored`.
+	 *
+	 * @return array
+	 */
+	public function data_non_callback_requests() {
+		return array(
+			'nothing'      => array( array() ),
+			'code only'    => array( array( 'code' => 'ANYTHING' ) ),
+			'state only'   => array( array( 'state' => 'meetup-oauth' ) ),
+			'array code'   => array(
+				array(
+					'code' => array( 'ANYTHING' ), 'state' => 'meetup-oauth',
+				),
+			),
+		);
+	}
+
+	/**
+	 * A callback carrying the value that used to be accepted no longer is.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\maybe_exchange_code_for_token
+	 */
+	public function test_exchange_is_refused_with_the_former_hardcoded_state() {
+		$state = create_oauth_state();
+
+		$this->handle_callback(
+			array(
+				'code'  => 'ANYTHING',
+				'state' => 'meetup-oauth',
+			)
+		);
+
+		// The authorization that's actually in flight is untouched, so its callback can still complete.
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * A user without network privileges can't drive the process, even carrying their own value.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\maybe_exchange_code_for_token
+	 */
+	public function test_exchange_is_refused_without_the_capability() {
+		wp_set_current_user( self::$editor_id );
+
+		$state = create_oauth_state();
+
+		$this->assertFalse( current_user_can( 'manage_network' ) );
+
+		$this->handle_callback(
+			array(
+				'code'  => 'ANYTHING',
+				'state' => $state,
+			)
+		);
+
+		// Nothing was spent, because nothing was attempted.
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * A callback that gets past the checks but can't reach Meetup can be retried, because the value that
+	 * vouched for it is only discarded once a token comes back.
+	 *
+	 * There are no credentials in the test environment, so the exchange stops before the client loads.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\maybe_exchange_code_for_token
+	 */
+	public function test_exchange_keeps_the_state_when_the_token_request_fails() {
+		$state = create_oauth_state();
+
+		$this->assertFalse( defined( 'MEETUP_OAUTH_CONSUMER_KEY' ) );
+
+		$this->handle_callback(
+			array(
+				'code'  => 'ANYTHING',
+				'state' => $state,
+			)
+		);
+
+		$this->assertTrue( verify_oauth_state( $state ) );
+	}
+
+	/**
+	 * The client's reconnection notice points at the screen that mints a value, rather than at Meetup directly.
+	 *
+	 * @covers \WordCamp\Meetup_OAuth\filter_authorize_url
+	 */
+	public function test_authorize_url_points_at_the_settings_page() {
+		$this->assertSame( get_page_url(), filter_authorize_url() );
+		$this->assertStringContainsString( 'page=wcorg-meetup', filter_authorize_url() );
+		$this->assertStringNotContainsString( 'secure.meetup.com', filter_authorize_url() );
+	}
+}

--- a/public_html/wp-content/mu-plugins/tests/test-meetup-oauth-state.php
+++ b/public_html/wp-content/mu-plugins/tests/test-meetup-oauth-state.php
@@ -6,7 +6,7 @@ use WP_UnitTestCase;
 
 use function WordCamp\Meetup_OAuth\{ create_oauth_state, delete_oauth_state, filter_authorize_url, get_page_url,
 	maybe_exchange_code_for_token, verify_oauth_state };
-use const WordCamp\Meetup_OAuth\STATE_META_KEY;
+use const WordCamp\Meetup_OAuth\{ AUTHORIZATION_SITE_OPTION, STATE_META_KEY };
 
 defined( 'WPINC' ) || die();
 
@@ -66,9 +66,20 @@ class Test_Meetup_OAuth_State extends WP_UnitTestCase {
 	public function tear_down() {
 		$_GET = array();
 
+		delete_site_option( AUTHORIZATION_SITE_OPTION );
+
 		unset( $GLOBALS['super_admins'] );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * The code currently queued for the client, or `false` if there isn't one.
+	 *
+	 * @return string|bool
+	 */
+	protected function stored_auth_code() {
+		return get_site_option( AUTHORIZATION_SITE_OPTION, false );
 	}
 
 	/**
@@ -269,6 +280,7 @@ class Test_Meetup_OAuth_State extends WP_UnitTestCase {
 		$this->handle_callback( $query );
 
 		$this->assertTrue( verify_oauth_state( $state ) );
+		$this->assertFalse( $this->stored_auth_code() );
 	}
 
 	/**
@@ -306,6 +318,7 @@ class Test_Meetup_OAuth_State extends WP_UnitTestCase {
 
 		// The authorization that's actually in flight is untouched, so its callback can still complete.
 		$this->assertTrue( verify_oauth_state( $state ) );
+		$this->assertFalse( $this->stored_auth_code() );
 	}
 
 	/**
@@ -329,6 +342,7 @@ class Test_Meetup_OAuth_State extends WP_UnitTestCase {
 
 		// Nothing was spent, because nothing was attempted.
 		$this->assertTrue( verify_oauth_state( $state ) );
+		$this->assertFalse( $this->stored_auth_code() );
 	}
 
 	/**
@@ -352,6 +366,7 @@ class Test_Meetup_OAuth_State extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue( verify_oauth_state( $state ) );
+		$this->assertFalse( $this->stored_auth_code() );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
+++ b/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
@@ -1,13 +1,301 @@
 <?php
+/**
+ * Connect the network's Meetup integration to a Meetup account.
+ *
+ * Meetup hands the authorization code back through a redirect rather than a request we make ourselves, so the
+ * callback that receives it can't carry a nonce of its own. Both ends of that trip live here: a network admin
+ * starts the process from Settings, and the `state` minted for them at that point is what the callback matches
+ * against when Meetup sends them back.
+ */
 
-if ( empty( $_GET['code'] ) || empty( $_GET['state'] ) || 'meetup-oauth' !== $_GET['state'] ) {
-	return;
+namespace WordCamp\Meetup_OAuth;
+
+use WordPressdotorg\MU_Plugins\Utilities\Meetup_OAuth2_Client;
+
+defined( 'WPINC' ) || die();
+
+const OAUTH_CAP      = 'manage_network';
+const OAUTH_ACTION   = 'wcorg-meetup-oauth';
+const PAGE_SLUG      = 'wcorg-meetup';
+const STATE_META_KEY = 'wcorg_meetup_oauth_state';
+const STATE_LIFETIME = 15 * MINUTE_IN_SECONDS;
+const AUTHORIZE_URL  = 'https://secure.meetup.com/oauth2/authorize';
+
+/**
+ * The site option the Meetup client keeps its token in.
+ *
+ * Mirrors `Meetup_OAuth2_Client::SITE_OPTION_KEY_OAUTH`. It's repeated rather than referenced so that reading
+ * the connection status doesn't have to load a class whose constants require the Meetup credentials to be
+ * defined, and whose constructor pre-caches a token as a side effect.
+ */
+const TOKEN_SITE_OPTION = 'meetup_access_token';
+
+add_action( 'network_admin_menu', __NAMESPACE__ . '\add_page' );
+add_action( 'admin_post_' . OAUTH_ACTION, __NAMESPACE__ . '\handle_authorize_request' );
+add_action( 'admin_init', __NAMESPACE__ . '\maybe_exchange_code_for_token' );
+add_filter( 'meetup_oauth2_authorize_url', __NAMESPACE__ . '\filter_authorize_url' );
+
+/**
+ * Add a settings page.
+ *
+ * @return void
+ */
+function add_page() {
+	add_submenu_page(
+		'settings.php',
+		'Meetup',
+		'Meetup',
+		OAUTH_CAP,
+		PAGE_SLUG,
+		__NAMESPACE__ . '\render_page'
+	);
 }
 
-add_action(
-	'admin_init',
-	function () {
-		// Store the new meetup oauth tokens.
-		( new WordPressdotorg\MU_Plugins\Utilities\Meetup_OAuth2_Client() )->get_oauth_token();
+/**
+ * The screen that starts the connection process.
+ *
+ * @return string
+ */
+function get_page_url() {
+	return add_query_arg( 'page', PAGE_SLUG, network_admin_url( 'settings.php' ) );
+}
+
+/**
+ * Point the client's reconnection notice at the screen that starts the process.
+ *
+ * The client can't build a usable link itself, because the `state` on it has to be minted and remembered by
+ * whoever handles the callback.
+ *
+ * @return string
+ */
+function filter_authorize_url() {
+	return get_page_url();
+}
+
+/**
+ * Whether this environment has the credentials needed to talk to Meetup.
+ *
+ * @return bool
+ */
+function has_credentials() {
+	return defined( 'MEETUP_OAUTH_CONSUMER_KEY' ) && MEETUP_OAUTH_CONSUMER_KEY
+		&& defined( 'MEETUP_OAUTH_CONSUMER_REDIRECT_URI' ) && MEETUP_OAUTH_CONSUMER_REDIRECT_URI;
+}
+
+/**
+ * Render the settings page.
+ *
+ * @return void
+ */
+function render_page() {
+	$token     = get_site_option( TOKEN_SITE_OPTION, array() );
+	$connected = is_array( $token ) && ! empty( $token['access_token'] );
+	$expires   = ( $connected && isset( $token['timestamp'], $token['expires_in'] ) )
+		? (int) $token['timestamp'] + (int) $token['expires_in']
+		: 0;
+
+	?>
+	<div class="wrap">
+		<h1>Meetup</h1>
+
+		<h2>Connection</h2>
+
+		<p>
+			This connection lets the network read group and event data from Meetup, which feeds chapter and
+			meetup vetting as well as the events importer.
+		</p>
+
+		<?php if ( $connected ) : ?>
+			<p>
+				<span class="dashicons dashicons-yes" aria-hidden="true"></span>
+				<?php
+				if ( $expires ) {
+					printf(
+						'Connected. The access token %1$s on <strong>%2$s</strong>.',
+						esc_html( $expires > time() ? 'expires' : 'expired' ),
+						esc_html( gmdate( 'd M Y H:i', $expires ) . ' UTC' )
+					);
+				} else {
+					echo 'Connected.';
+				}
+				?>
+			</p>
+			<p>Reconnecting replaces the stored token for every site on the network.</p>
+		<?php else : ?>
+			<p>
+				<span class="dashicons dashicons-no" aria-hidden="true"></span>
+				Not connected.
+			</p>
+		<?php endif; ?>
+
+		<?php if ( has_credentials() ) : ?>
+			<p>
+				You will be asked to log in to meetup.com to complete the connection. Use the
+				<strong>WordCamp Central</strong> Meetup account for this login &mdash; the network's Meetup
+				requests all run as whichever account authorizes here.
+			</p>
+
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<?php wp_nonce_field( OAUTH_ACTION ); ?>
+
+				<input type="hidden" name="action" value="<?php echo esc_attr( OAUTH_ACTION ); ?>" />
+
+				<?php submit_button( $connected ? 'Reconnect' : 'Connect', 'primary', 'submit', false ); ?>
+			</form>
+		<?php else : ?>
+			<p><em>The Meetup credentials are not configured in this environment.</em></p>
+		<?php endif; ?>
+	</div>
+	<?php
+}
+
+/**
+ * Send the user to Meetup to authorize the connection.
+ *
+ * @return void
+ */
+function handle_authorize_request() {
+	if ( ! current_user_can( OAUTH_CAP ) ) {
+		wp_die( 'You do not have permission to perform this action.', 403 );
 	}
-);
+
+	check_admin_referer( OAUTH_ACTION );
+
+	if ( ! has_credentials() ) {
+		wp_die( 'The Meetup credentials are not configured in this environment.' );
+	}
+
+	$url = AUTHORIZE_URL . '?' . http_build_query(
+		array(
+			'client_id'     => MEETUP_OAUTH_CONSUMER_KEY,
+			'response_type' => 'code',
+			'redirect_uri'  => MEETUP_OAUTH_CONSUMER_REDIRECT_URI,
+			'state'         => create_oauth_state(),
+		),
+		'',
+		'&',
+		PHP_QUERY_RFC3986
+	);
+
+	// Added right before the redirect, so that meetup.com isn't considered "safe" for the rest of the request.
+	add_filter( 'allowed_redirect_hosts', __NAMESPACE__ . '\allow_meetup_redirect', 10, 2 );
+
+	wp_safe_redirect( $url );
+	exit;
+}
+
+/**
+ * Add meetup.com to the safe redirect list so we can go start the authorization.
+ *
+ * @param array  $allowed_domains
+ * @param string $domain
+ *
+ * @return array
+ */
+function allow_meetup_redirect( $allowed_domains, $domain ) {
+	if ( 'secure.meetup.com' === $domain ) {
+		$allowed_domains[] = $domain;
+	}
+
+	return array_unique( $allowed_domains );
+}
+
+/**
+ * Turn an authorization code from Meetup into a stored token.
+ *
+ * Meetup redirects to the network's admin root, so this runs on every wp-admin request and has to decide for
+ * itself whether the one it's looking at is a callback that this user started.
+ *
+ * @return void
+ */
+function maybe_exchange_code_for_token() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Meetup redirects the browser here, so
+	// it can't send a nonce. The `state` checked below is what stands in for one.
+	$code  = isset( $_GET['code'] ) && is_string( $_GET['code'] ) ? sanitize_text_field( wp_unslash( $_GET['code'] ) ) : '';
+	$state = isset( $_GET['state'] ) && is_string( $_GET['state'] ) ? sanitize_text_field( wp_unslash( $_GET['state'] ) ) : '';
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( ! $code || ! $state ) {
+		return;
+	}
+
+	// The token is shared by every site on the network, so binding it is a network administrator's call.
+	if ( ! current_user_can( OAUTH_CAP ) ) {
+		return;
+	}
+
+	if ( ! verify_oauth_state( $state ) ) {
+		return;
+	}
+
+	if ( ! has_credentials() || ! class_exists( Meetup_OAuth2_Client::class ) ) {
+		return;
+	}
+
+	if ( ( new Meetup_OAuth2_Client() )->get_oauth_token( $code ) ) {
+		// The code has been spent, so the value that vouched for it is done too.
+		delete_oauth_state();
+	}
+}
+
+/**
+ * Generate a `state` for an authorization request, and remember it for the callback.
+ *
+ * User meta is used rather than an option or a transient because it's shared across every site and network in
+ * the install, while the redirect URI always points at one of them.
+ *
+ * @return string
+ */
+function create_oauth_state() {
+	$state = wp_generate_password( 32, false );
+
+	update_user_meta(
+		get_current_user_id(),
+		STATE_META_KEY,
+		array(
+			'state'   => $state,
+			'expires' => time() + STATE_LIFETIME,
+		)
+	);
+
+	return $state;
+}
+
+/**
+ * Check that a callback's `state` matches the authorization request that this user started.
+ *
+ * This only reads the stored value; discarding it is left to `maybe_exchange_code_for_token()`. That way a
+ * stray request to the callback URL -- a reloaded tab, an old one out of history -- can't throw away an
+ * authorization that's still in flight.
+ *
+ * @param string $state
+ *
+ * @return bool
+ */
+function verify_oauth_state( $state ) {
+	$stored = get_user_meta( get_current_user_id(), STATE_META_KEY, true );
+
+	if ( ! is_string( $state ) || ! $state || ! is_array( $stored ) ) {
+		return false;
+	}
+
+	// `hash_equals()` throws a TypeError on anything but strings, so check the stored side too.
+	if ( empty( $stored['state'] ) || ! is_string( $stored['state'] ) ) {
+		return false;
+	}
+
+	if ( empty( $stored['expires'] ) || time() > $stored['expires'] ) {
+		return false;
+	}
+
+	return hash_equals( $stored['state'], $state );
+}
+
+/**
+ * Discard the `state` stored for the current user, once it can't be of any more use.
+ *
+ * @return bool
+ */
+function delete_oauth_state() {
+	return delete_user_meta( get_current_user_id(), STATE_META_KEY );
+}

--- a/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
+++ b/public_html/wp-content/mu-plugins/wcorg-meetup-oauth.php
@@ -30,6 +30,14 @@ const AUTHORIZE_URL  = 'https://secure.meetup.com/oauth2/authorize';
  */
 const TOKEN_SITE_OPTION = 'meetup_access_token';
 
+/**
+ * The site option the Meetup client reads a pending authorization code from.
+ *
+ * Mirrors `Meetup_OAuth2_Client::SITE_OPTION_KEY_AUTHORIZATION`, repeated for the same reason as
+ * `TOKEN_SITE_OPTION`.
+ */
+const AUTHORIZATION_SITE_OPTION = 'meetup_oauth_authorization';
+
 add_action( 'network_admin_menu', __NAMESPACE__ . '\add_page' );
 add_action( 'admin_post_' . OAUTH_ACTION, __NAMESPACE__ . '\handle_authorize_request' );
 add_action( 'admin_init', __NAMESPACE__ . '\maybe_exchange_code_for_token' );
@@ -79,6 +87,7 @@ function filter_authorize_url() {
  */
 function has_credentials() {
 	return defined( 'MEETUP_OAUTH_CONSUMER_KEY' ) && MEETUP_OAUTH_CONSUMER_KEY
+		&& defined( 'MEETUP_OAUTH_CONSUMER_SECRET' ) && MEETUP_OAUTH_CONSUMER_SECRET
 		&& defined( 'MEETUP_OAUTH_CONSUMER_REDIRECT_URI' ) && MEETUP_OAUTH_CONSUMER_REDIRECT_URI;
 }
 
@@ -231,6 +240,14 @@ function maybe_exchange_code_for_token() {
 	if ( ! has_credentials() || ! class_exists( Meetup_OAuth2_Client::class ) ) {
 		return;
 	}
+
+	/*
+	 * The client pre-caches a token in its constructor, which runs before the argument below can reach it,
+	 * and that pre-cache falls back to whatever code is sitting in the site option. Putting the validated
+	 * code there first means the constructor spends this one rather than a leftover from an earlier attempt.
+	 * The client clears the option itself once the exchange succeeds.
+	 */
+	update_site_option( AUTHORIZATION_SITE_OPTION, $code );
 
 	if ( ( new Meetup_OAuth2_Client() )->get_oauth_token( $code ) ) {
 		// The code has been spent, so the value that vouched for it is done too.


### PR DESCRIPTION
## Summary

- Mints a per-user `state` when a connection starts, keeps it in user meta for 15 minutes, and matches it with `hash_equals()` on the callback. The callback previously matched a fixed string.
- Adds Network Admin → Settings → Meetup with a nonce'd Connect button, gated on `manage_network`. There was no screen on our side to start the flow from, and the notice the client prints now points here.
- Queues the validated code in `meetup_oauth_authorization` and also hands it to `get_oauth_token()` explicitly.

Follows the pattern already used by `mu-plugins/quickbooks/`.

Pairs with WordPress/wporg-mu-plugins#769. Either order is fine to deploy — see below.

## Why the code is queued in the option

`Meetup_OAuth2_Client::__construct()` calls `get_oauth_token()` to pre-cache, which runs *before* the argument in the second call can reach it, and that pre-cache falls back to whatever is in `meetup_oauth_authorization`. Without queuing, a reconnect spends a leftover code from an earlier attempt rather than the one the operator just authorized — and binds the network to whichever account that leftover belonged to. Production currently has an unspent code sitting in that option, so this isn't hypothetical.

Queuing also makes the change order-independent: the option is read the same way by the client before and after #769, so neither PR has to land first.

## Test plan

- [x] phpunit — 370 tests, 20 of them new
- [x] phpcs clean
- [x] CI green — PHP 8.3 / 8.4 / 8.5, JavaScript, lint
- [x] Manual pass (below)

`Test_QuickBooks_OAuth_State::test_authorize_url_carries_the_stored_state` fails in my local environment, but it fails identically on `production` with this branch stashed, so it isn't from these changes. CI is green on it — I have an untracked `composer.lock` locally while CI installs fresh, which is the likeliest difference, though I didn't chase it down.

### Manual test steps

1. **Super admin** — Settings → Meetup renders with connection status and the credentials notice. ✅
2. **Super admin** — `admin-post.php?action=wcorg-meetup-oauth` with no nonce → "The link you followed has expired." ✅
3. **Editor** — `manage_network` is false; a callback carrying the old fixed string writes nothing; a callback carrying their own minted value is refused and that value stays pending for a later legitimate callback. ✅
4. **Super admin** — a callback carrying the old fixed string is no longer accepted. ✅

Steps 3 and 4 were driven through wp-cli against the running site rather than the browser: switching actors in the browser hit the known per-user session-limit quirk in this stack, and I stopped rather than keep retrying.

Unit tests also cover the invariant that a code which hasn't been vouched for never reaches `meetup_oauth_authorization`, across every refusal path.

Not exercised: the real Meetup round trip. The dev environment has no Meetup credentials, so the Connect button is hidden and the authorize redirect can't be driven locally. Unit tests cover everything up to that boundary.
