### PR TITLE
MES: add a sponsor group model alongside sponsor regions

### DIFF
--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -118,6 +118,7 @@ require_once SUT_WPMU_PLUGIN_DIR . '/groups/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-coming-soon-page/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/wordcamp-forms-to-drafts/tests/bootstrap.php';
 require_once WP_PLUGIN_DIR . '/campt-indian-payment-gateway/tests/bootstrap.php';
+require_once WP_PLUGIN_DIR . '/multi-event-sponsors/tests/bootstrap.php';
 
 /*
  * GatherPress hooks `send_headers` to set a novelty HTTP header ("Go

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,6 +32,12 @@
 			</directory>
 		</testsuite>
 
+		<testsuite name="Multi-Event Sponsors">
+			<directory prefix="test-" suffix=".php">
+				./public_html/wp-content/plugins/multi-event-sponsors/tests/
+			</directory>
+		</testsuite>
+
 		<testsuite name="WordCamp Organizer Reminders">
 			<directory prefix="test-" suffix=".php">
 				./public_html/wp-content/plugins/wordcamp-organizer-reminders/tests/

--- a/public_html/wp-content/plugins/multi-event-sponsors/bootstrap.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/bootstrap.php
@@ -14,12 +14,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once( __DIR__ . '/classes/multi-event-sponsors.php' );
 require_once( __DIR__ . '/classes/mes-region.php' );
 require_once( __DIR__ . '/classes/mes-sponsor.php' );
+require_once __DIR__ . '/classes/mes-sponsor-group.php';
 require_once( __DIR__ . '/classes/mes-sponsorship-level.php' );
 require_once( __DIR__ . '/classes/mes-privacy.php' );
 
 $GLOBALS['multi_event_sponsors']  = new Multi_Event_Sponsors();
 $GLOBALS['mes_sponsor']           = new MES_Region();
 $GLOBALS['mes_sponsor']           = new MES_Sponsor();
+$GLOBALS['mes_sponsor_group']     = new MES_Sponsor_Group();
 $GLOBALS['mes_sponsorship_level'] = new MES_Sponsorship_Level();
 $GLOBALS['mes_privacy']           = new MES_Privacy();
 

--- a/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor-group.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor-group.php
@@ -1,0 +1,168 @@
+<?php
+/*
+ * Register the Sponsor Groups taxonomy and manage camp-side group membership.
+ *
+ * A group is a curated set of WordCamps a sponsor can target — e.g. a region,
+ * "Flagships", or "Top 5 WPCC". Generalizes the legacy single-region model:
+ * a camp can belong to multiple groups, and a sponsor maps each group to a
+ * sponsorship level (see MES_Sponsor::get_group_sponsorships()).
+ *
+ * Camp-side membership is stored as post meta on the WordCamp post (like the
+ * legacy region), NOT as assigned terms — the WordCamp post lives on the
+ * central site while the taxonomy belongs to the mes post type.
+ */
+
+class MES_Sponsor_Group {
+	public const TAXONOMY_SLUG = 'mes_sponsor_group';
+	public const CAMP_META_KEY = 'mes_sponsor_groups';
+	public const WCPT_FIELD    = 'Multi-Event Sponsor Groups';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'init',               array( $this, 'create_taxonomy' ) );
+		add_action( 'wcpt_metabox_value', array( $this, 'render_group_picker' ), 10, 3 );
+		add_action( 'wcpt_metabox_save',  array( $this, 'save_group_picker' ),   10, 3 );
+		add_filter( 'wcpt_admin_meta_keys', array( $this, 'register_wcpt_field' ), 10, 2 );
+	}
+
+	/**
+	 * Whether the camp-side group UI is switched on.
+	 *
+	 * Off by default, so merging the group model changes nothing an organizer or
+	 * deputy can see: the field is not offered on the WordCamp screen, saves are
+	 * ignored, and the taxonomy has no admin menu. Flip it with
+	 *
+	 *     add_filter( 'mes_sponsor_groups_enabled', '__return_true' );
+	 *
+	 * once the read path is deployed and the migration has been dry-run.
+	 *
+	 * Deliberately checked inside each callback rather than around the
+	 * `add_action()` calls, so the answer doesn't depend on whether a filter was
+	 * registered before this plugin loaded.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return (bool) apply_filters( 'mes_sponsor_groups_enabled', false );
+	}
+
+	/**
+	 * Offer the camp-side group field on the WordCamp admin screen.
+	 *
+	 * Registered from here rather than hardcoded into wcpt's own list so the
+	 * field appears and disappears with `is_enabled()`. wcpt renders and saves
+	 * unrecognised field types through the `wcpt_metabox_value` and
+	 * `wcpt_metabox_save` actions, which this class already handles, so no
+	 * change to wcpt is needed for the field itself.
+	 *
+	 * @param array  $keys       Field name => field type.
+	 * @param string $meta_group Which group of fields wcpt is asking for.
+	 *
+	 * @return array
+	 */
+	public function register_wcpt_field( $keys, $meta_group ) {
+		if ( ! self::is_enabled() ) {
+			return $keys;
+		}
+
+		if ( ! in_array( $meta_group, array( 'wordcamp', 'all' ), true ) ) {
+			return $keys;
+		}
+
+		$keys[ self::WCPT_FIELD ] = 'mes-groups';
+
+		return $keys;
+	}
+
+	/**
+	 * Registers the sponsor groups taxonomy
+	 */
+	public function create_taxonomy() {
+		$params = array(
+			'label'        => __( 'Sponsor Group', 'wordcamporg' ),
+			'labels'       => array(
+				'name'          => __( 'Sponsor Groups', 'wordcamporg' ),
+				'singular_name' => __( 'Sponsor Group', 'wordcamporg' ),
+			),
+			'hierarchical' => false,
+			'rewrite'      => array( 'slug' => self::TAXONOMY_SLUG ),
+
+			/*
+			 * Always registered so the data model and queries are stable, but
+			 * it stays out of the menu until the group UI is switched on.
+			 */
+			'show_ui'      => self::is_enabled(),
+			'show_in_menu' => self::is_enabled(),
+		);
+
+		if ( ! taxonomy_exists( self::TAXONOMY_SLUG ) ) {
+			register_taxonomy( self::TAXONOMY_SLUG, MES_Sponsor::POST_TYPE_SLUG, $params );
+		}
+	}
+
+	/**
+	 * Get the group term IDs a WordCamp belongs to.
+	 *
+	 * @param int $wordcamp_id WordCamp post ID (on central).
+	 *
+	 * @return int[] Unique, non-zero group term IDs.
+	 */
+	public static function get_camp_groups( $wordcamp_id ) {
+		$raw = get_post_meta( $wordcamp_id, self::CAMP_META_KEY, true );
+
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		return array_values( array_unique( array_filter( array_map( 'absint', $raw ) ) ) );
+	}
+
+	/**
+	 * Render the group multi-select for the WordCamp Post Type plugin
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @param string $field_name
+	 */
+	public function render_group_picker( $key, $value, $field_name ) {
+		if ( self::WCPT_FIELD !== $key || ! self::is_enabled() ) {
+			return;
+		}
+
+		global $post;
+
+		$groups    = get_terms( array(
+			'taxonomy'   => self::TAXONOMY_SLUG,
+			'hide_empty' => false,
+		) );
+		$selected  = self::get_camp_groups( $post->ID );
+		$protected = WordCamp_Admin::is_protected_field( $key );
+
+		require dirname( __DIR__ ) . '/views/template-group-picker.php';
+	}
+
+	/**
+	 * Save the group multi-select for the WordCamp Post Type plugin
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @param int    $post_id
+	 */
+	public function save_group_picker( $key, $value, $post_id ) {
+		if ( self::WCPT_FIELD !== $key || ! self::is_enabled() ) {
+			return;
+		}
+
+		if ( WordCamp_Admin::is_protected_field( $key ) ) {
+			return;
+		}
+
+		$post_key = wcpt_key_to_str( $key, 'wcpt_' );
+		$selected = isset( $_POST[ $post_key ] ) ? (array) $_POST[ $post_key ] : array();
+		$selected = array_values( array_unique( array_filter( array_map( 'absint', $selected ) ) ) );
+
+		update_post_meta( $post_id, self::CAMP_META_KEY, $selected );
+	}
+} // end MES_Sponsor_Group

--- a/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/classes/mes-sponsor.php
@@ -15,6 +15,19 @@ class MES_Sponsor {
 	public const POST_TYPE_SLUG = 'mes';
 
 	/**
+	 * Get a sponsor's group → sponsorship-level map.
+	 *
+	 * @param int $sponsor_id
+	 *
+	 * @return array { group_term_id (int) => sponsorship_level_post_id (int) }
+	 */
+	public static function get_group_sponsorships( $sponsor_id ) {
+		$map = get_post_meta( $sponsor_id, 'mes_group_sponsorships', true );
+
+		return is_array( $map ) ? $map : array();
+	}
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -203,6 +216,21 @@ class MES_Sponsor {
 			'default'
 		);
 
+		/*
+		 * Offered only once the group UI is switched on, so merging the model
+		 * adds nothing to this screen. See MES_Sponsor_Group::is_enabled().
+		 */
+		if ( MES_Sponsor_Group::is_enabled() ) {
+			add_meta_box(
+				'mes_group_sponsorships',
+				__( 'Group Sponsorships', 'wordcamporg' ),
+				array( $this, 'markup_meta_boxes' ),
+				self::POST_TYPE_SLUG,
+				'normal',
+				'default'
+			);
+		}
+
 		add_meta_box(
 			'mes_contact_information',
 			__( 'Contact Information', 'wordcamporg' ),
@@ -239,6 +267,21 @@ class MES_Sponsor {
 				) );
 				$regional_sponsorships = $this->populate_default_regional_sponsorships( get_post_meta( $post->ID, 'mes_regional_sponsorships', true ), $regions );
 				$view                  = 'metabox-regional-sponsorships.php';
+				break;
+
+			case 'mes_group_sponsorships':
+				$groups             = get_terms(
+					array(
+						'taxonomy'   => MES_Sponsor_Group::TAXONOMY_SLUG,
+						'hide_empty' => false,
+					)
+				);
+				$sponsorship_levels = get_posts( array(
+					'post_type'   => MES_Sponsorship_Level::POST_TYPE_SLUG,
+					'numberposts' => - 1,
+				) );
+				$group_sponsorships = self::get_group_sponsorships( $post->ID );
+				$view               = 'metabox-group-sponsorships.php';
 				break;
 
 			case 'mes_contact_information':
@@ -383,6 +426,21 @@ class MES_Sponsor {
 		if ( isset( $new_values['mes_regional_sponsorships'] ) ) {
 			array_walk( $new_values['mes_regional_sponsorships'], 'absint' );
 			update_post_meta( $post_id, 'mes_regional_sponsorships', $new_values['mes_regional_sponsorships'] );
+		}
+
+		if ( isset( $new_values['mes_group_sponsorships'] ) && is_array( $new_values['mes_group_sponsorships'] ) ) {
+			$clean = array();
+
+			foreach ( $new_values['mes_group_sponsorships'] as $group_id => $level_id ) {
+				$group_id = absint( $group_id );
+				$level_id = absint( $level_id );
+
+				if ( $group_id && $level_id ) {
+					$clean[ $group_id ] = $level_id;
+				}
+			}
+
+			update_post_meta( $post_id, 'mes_group_sponsorships', $clean );
 		}
 
 		if ( isset( $new_values['mes_email_address'] ) ) {

--- a/public_html/wp-content/plugins/multi-event-sponsors/tests/bootstrap.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/tests/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Integrated-harness bootstrap for the Multi-Event Sponsors test suite.
+ *
+ * Loaded by the repo-wide phpunit-bootstrap.php. For isolated local runs, use
+ * phpunit-standalone.xml.dist instead (see tests/standalone-bootstrap.php).
+ */
+
+tests_add_filter(
+	'muplugins_loaded',
+	function () {
+		require_once dirname( __DIR__ ) . '/bootstrap.php';
+	}
+);

--- a/public_html/wp-content/plugins/multi-event-sponsors/tests/test-sponsor-group.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/tests/test-sponsor-group.php
@@ -1,0 +1,322 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Tests for the mes_sponsor_group taxonomy, camp-side membership, and the
+ * sponsor-side group → level map.
+ *
+ * @group multi-event-sponsors
+ * @group sponsor-groups
+ */
+class Test_MES_Sponsor_Group extends WP_UnitTestCase {
+	/**
+	 * Switch the camp-side group UI on for one test.
+	 *
+	 * WP_UnitTestCase backs up and restores hooks per test, so this does not
+	 * leak into the rest of the suite.
+	 */
+	protected function enable_groups() {
+		add_filter( 'mes_sponsor_groups_enabled', '__return_true' );
+	}
+
+	/**
+	 * Invoke a protected/private method for testing.
+	 *
+	 * @param object $object The object to invoke the method on.
+	 * @param string $method The method name.
+	 * @param array  $args   Arguments to pass to the method.
+	 *
+	 * @return mixed
+	 */
+	protected function invoke( $object, $method, array $args = array() ) {
+		// No `setAccessible()` call -- it's been a no-op since PHP 8.1, and deprecated since 8.5.
+		$ref = new ReflectionMethod( $object, $method );
+
+		return $ref->invokeArgs( $object, $args );
+	}
+
+	/**
+	 * Taxonomy is registered.
+	 */
+	public function test_taxonomy_is_registered() {
+		$this->assertTrue( taxonomy_exists( MES_Sponsor_Group::TAXONOMY_SLUG ) );
+	}
+
+	/**
+	 * Taxonomy is attached to mes post type.
+	 */
+	public function test_taxonomy_is_attached_to_mes_post_type() {
+		$taxonomies = get_object_taxonomies( MES_Sponsor::POST_TYPE_SLUG );
+
+		$this->assertContains( MES_Sponsor_Group::TAXONOMY_SLUG, $taxonomies );
+	}
+
+	/**
+	 * Group sponsorships save and read.
+	 */
+	public function test_group_sponsorships_save_and_read() {
+		$sponsor_id = self::factory()->post->create( array( 'post_type' => MES_Sponsor::POST_TYPE_SLUG ) );
+		$mes        = new MES_Sponsor();
+
+		$submitted = array(
+			'mes_group_sponsorships' => array(
+				11 => 501,
+				12 => 'null',
+				13 => 502,
+			),
+		);
+
+		$this->invoke( $mes, 'save_post_meta', array( $sponsor_id, $submitted ) );
+
+		$map = MES_Sponsor::get_group_sponsorships( $sponsor_id );
+
+		// 'null'/non-numeric dropped.
+		$expected = array(
+			11 => 501,
+			13 => 502,
+		);
+
+		$this->assertSame( $expected, $map );
+	}
+
+	/**
+	 * Group sponsorships read defaults to empty array.
+	 */
+	public function test_group_sponsorships_read_defaults_to_empty_array() {
+		$sponsor_id = self::factory()->post->create( array( 'post_type' => MES_Sponsor::POST_TYPE_SLUG ) );
+
+		$this->assertSame( array(), MES_Sponsor::get_group_sponsorships( $sponsor_id ) );
+	}
+
+	/**
+	 * Camp groups save and read.
+	 */
+	public function test_camp_groups_save_and_read() {
+		$wordcamp_id = self::factory()->post->create( array( 'post_type' => 'wordcamp' ) );
+
+		update_post_meta( $wordcamp_id, 'mes_sponsor_groups', array( 11, 13, 0, '13' ) );
+
+		$groups = MES_Sponsor_Group::get_camp_groups( $wordcamp_id );
+
+		$this->assertSame( array( 11, 13 ), $groups ); // Ints, deduped, zero dropped.
+	}
+
+	/**
+	 * Camp groups read defaults to empty array.
+	 */
+	public function test_camp_groups_read_defaults_to_empty_array() {
+		$wordcamp_id = self::factory()->post->create( array( 'post_type' => 'wordcamp' ) );
+
+		$this->assertSame( array(), MES_Sponsor_Group::get_camp_groups( $wordcamp_id ) );
+	}
+
+	/**
+	 * Log in as a user who may edit wrangler-protected wcpt fields.
+	 *
+	 * The capability is granted explicitly rather than relying on a super admin's
+	 * blanket caps, so the test states exactly what the save path requires.
+	 *
+	 * @return int User ID.
+	 */
+	protected function set_current_user_as_wrangler() {
+		global $wcorg_subroles;
+
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		// The capability comes from a subrole, not from add_cap(): wcorg-subroles
+		// deliberately filters ad-hoc grants of it back out.
+		$wcorg_subroles = array( $user_id => array( 'wordcamp_wrangler' ) );
+
+		wp_set_current_user( $user_id );
+
+		return $user_id;
+	}
+
+	/**
+	 * Clear any subrole assignment so it can't leak into another test.
+	 */
+	public function tear_down() {
+		$GLOBALS['wcorg_subroles'] = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * `save_group_picker` writes sanitized selection.
+	 */
+	public function test_save_group_picker_writes_sanitized_selection() {
+		$this->enable_groups();
+
+		$this->set_current_user_as_wrangler();
+
+		$wordcamp_id = self::factory()->post->create( array( 'post_type' => 'wordcamp' ) );
+		$post_key    = wcpt_key_to_str( MES_Sponsor_Group::WCPT_FIELD, 'wcpt_' );
+
+		$_POST[ $post_key ] = array( '7', '7', '0', 9 );
+
+		$group = new MES_Sponsor_Group();
+		$group->save_group_picker( MES_Sponsor_Group::WCPT_FIELD, '', $wordcamp_id );
+
+		unset( $_POST[ $post_key ] );
+
+		$this->assertSame( array( 7, 9 ), MES_Sponsor_Group::get_camp_groups( $wordcamp_id ) );
+	}
+
+	/**
+	 * Group sponsorships metabox renders selection.
+	 */
+	public function test_group_sponsorships_metabox_renders_selection() {
+		$this->enable_groups();
+
+		$group_id = self::factory()->term->create( array(
+			'taxonomy' => MES_Sponsor_Group::TAXONOMY_SLUG, 'name' => 'Flagships',
+		) );
+		$level_id = self::factory()->post->create( array(
+			'post_type' => MES_Sponsorship_Level::POST_TYPE_SLUG, 'post_title' => 'Champion',
+		) );
+
+		$sponsor_id = self::factory()->post->create( array( 'post_type' => MES_Sponsor::POST_TYPE_SLUG ) );
+		update_post_meta( $sponsor_id, 'mes_group_sponsorships', array( $group_id => $level_id ) );
+
+		ob_start();
+		( new MES_Sponsor() )->markup_meta_boxes( get_post( $sponsor_id ), array( 'id' => 'mes_group_sponsorships' ) );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'Flagships', $html );
+		$this->assertStringContainsString( 'name="mes_group_sponsorships[' . $group_id . ']"', $html );
+		$this->assertMatchesRegularExpression( '/value="' . $level_id . '"\s+selected/', $html );
+	}
+
+	/**
+	 * `save_group_picker` respects protected field.
+	 */
+	public function test_save_group_picker_respects_protected_field() {
+		$this->enable_groups();
+
+		$wordcamp_id = self::factory()->post->create( array( 'post_type' => 'wordcamp' ) );
+		$post_key    = wcpt_key_to_str( MES_Sponsor_Group::WCPT_FIELD, 'wcpt_' );
+
+		update_post_meta( $wordcamp_id, 'mes_sponsor_groups', array( 5 ) );
+
+		// No wrangler capability, so wcpt treats the field as locked.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$_POST[ $post_key ] = array( '7' );
+
+		$group = new MES_Sponsor_Group();
+		$group->save_group_picker( MES_Sponsor_Group::WCPT_FIELD, '', $wordcamp_id );
+
+		unset( $_POST[ $post_key ] );
+
+		$this->assertSame( array( 5 ), MES_Sponsor_Group::get_camp_groups( $wordcamp_id ) );
+	}
+
+	/**
+	 * The camp-side group UI is off unless something switches it on.
+	 *
+	 * This is what makes merging the group model a no-op for organizers and
+	 * deputies: no field on the WordCamp screen, no taxonomy menu, no saves.
+	 */
+	public function test_group_ui_is_disabled_by_default() {
+		$this->assertFalse( MES_Sponsor_Group::is_enabled() );
+	}
+
+	/**
+	 * The taxonomy is registered but stays out of the admin menu while disabled.
+	 */
+	public function test_taxonomy_has_no_admin_menu_while_disabled() {
+		$taxonomy = get_taxonomy( MES_Sponsor_Group::TAXONOMY_SLUG );
+
+		$this->assertNotFalse( $taxonomy );
+		$this->assertFalse( $taxonomy->show_ui );
+	}
+
+	/**
+	 * While disabled, wcpt is not offered the field at all.
+	 */
+	public function test_wcpt_field_is_not_offered_while_disabled() {
+		$group = new MES_Sponsor_Group();
+
+		$this->assertSame( array(), $group->register_wcpt_field( array(), 'wordcamp' ) );
+		$this->assertSame( array(), $group->register_wcpt_field( array(), 'all' ) );
+	}
+
+	/**
+	 * Once enabled, the field is offered to the WordCamp field groups.
+	 */
+	public function test_wcpt_field_is_offered_when_enabled() {
+		$this->enable_groups();
+
+		$group = new MES_Sponsor_Group();
+
+		foreach ( array( 'wordcamp', 'all' ) as $meta_group ) {
+			$keys = $group->register_wcpt_field( array(), $meta_group );
+
+			$this->assertSame( array( MES_Sponsor_Group::WCPT_FIELD => 'mes-groups' ), $keys );
+		}
+	}
+
+	/**
+	 * The field is not added to unrelated field groups.
+	 */
+	public function test_wcpt_field_is_not_offered_to_other_meta_groups() {
+		$this->enable_groups();
+
+		$group = new MES_Sponsor_Group();
+
+		$this->assertSame( array(), $group->register_wcpt_field( array(), 'venue' ) );
+		$this->assertSame( array(), $group->register_wcpt_field( array(), 'organizer' ) );
+	}
+
+	/**
+	 * While disabled, the picker renders nothing even if wcpt asks for it.
+	 */
+	public function test_render_outputs_nothing_while_disabled() {
+		$group = new MES_Sponsor_Group();
+
+		ob_start();
+		$group->render_group_picker( MES_Sponsor_Group::WCPT_FIELD, '', MES_Sponsor_Group::WCPT_FIELD );
+		$html = ob_get_clean();
+
+		$this->assertSame( '', $html );
+	}
+
+	/**
+	 * While disabled, a posted selection is ignored.
+	 */
+	public function test_save_is_ignored_while_disabled() {
+		$wordcamp_id = self::factory()->post->create( array( 'post_type' => 'wordcamp' ) );
+		$post_key    = wcpt_key_to_str( MES_Sponsor_Group::WCPT_FIELD, 'wcpt_' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$_POST[ $post_key ] = array( '7', '9' );
+
+		$group = new MES_Sponsor_Group();
+		$group->save_group_picker( MES_Sponsor_Group::WCPT_FIELD, '', $wordcamp_id );
+
+		unset( $_POST[ $post_key ] );
+
+		$this->assertSame( array(), MES_Sponsor_Group::get_camp_groups( $wordcamp_id ) );
+	}
+
+	/**
+	 * The sponsor screen gains no metabox while the group UI is disabled.
+	 */
+	public function test_sponsor_metabox_is_not_added_while_disabled() {
+		global $wp_meta_boxes;
+
+		$wp_meta_boxes = array();
+
+		set_current_screen( MES_Sponsor::POST_TYPE_SLUG );
+
+		$sponsor = new MES_Sponsor();
+		$sponsor->add_meta_boxes();
+
+		$registered = $wp_meta_boxes[ MES_Sponsor::POST_TYPE_SLUG ]['normal']['default'] ?? array();
+
+		$this->assertArrayNotHasKey( 'mes_group_sponsorships', $registered );
+		$this->assertArrayHasKey( 'mes_regional_sponsorships', $registered );
+	}
+}

--- a/public_html/wp-content/plugins/multi-event-sponsors/views/metabox-group-sponsorships.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/views/metabox-group-sponsorships.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Sponsor-side table mapping each sponsor group to a sponsorship level.
+ *
+ * @var array $groups             Available mes_sponsor_group terms.
+ * @var array $sponsorship_levels Available level posts.
+ * @var array $group_sponsorships Stored { group term ID => level post ID } map.
+ */
+
+?>
+<?php if ( empty( $groups ) ) : ?>
+
+	<p>
+		No sponsor groups exist yet. Create them under
+		<a href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=' . MES_Sponsor_Group::TAXONOMY_SLUG . '&post_type=' . MES_Sponsor::POST_TYPE_SLUG ) ); ?>">Sponsor Groups</a>.
+	</p>
+
+<?php else : ?>
+
+	<table>
+		<thead>
+			<tr>
+				<th>Group</th>
+				<th>Sponsorship Level</th>
+			</tr>
+		</thead>
+
+		<tbody>
+			<?php foreach ( $groups as $group ) : ?>
+
+				<tr>
+					<td>
+						<label for="mes_group_sponsorships-<?php echo esc_attr( $group->term_id ); ?>">
+							<?php echo esc_html( $group->name ); ?>
+						</label>
+					</td>
+
+					<td>
+						<select id="mes_group_sponsorships-<?php echo esc_attr( $group->term_id ); ?>" name="mes_group_sponsorships[<?php echo esc_attr( $group->term_id ); ?>]">
+							<option value="">None</option>
+
+							<?php foreach ( $sponsorship_levels as $level ) : ?>
+								<option value="<?php echo esc_attr( $level->ID ); ?>" <?php selected( $group_sponsorships[ $group->term_id ] ?? 0, $level->ID ); ?>>
+									<?php echo esc_html( $level->post_title ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+					</td>
+				</tr>
+
+			<?php endforeach; ?>
+		</tbody>
+	</table>
+
+	<p class="description">
+		A sponsor is placed on every camp that belongs to a group with a level selected here.
+		Groups take precedence over the legacy region mapping.
+	</p>
+
+<?php endif; ?>

--- a/public_html/wp-content/plugins/multi-event-sponsors/views/template-group-picker.php
+++ b/public_html/wp-content/plugins/multi-event-sponsors/views/template-group-picker.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Multi-select of the sponsor groups a WordCamp belongs to.
+ *
+ * @var string $field_name Name attribute for the field.
+ * @var array  $groups     Available mes_sponsor_group terms.
+ * @var array  $selected   Term IDs currently assigned to the camp.
+ * @var bool   $protected  Whether the field is locked for this user.
+ */
+
+?>
+<select
+	id="<?php echo esc_attr( $field_name ); ?>"
+	name="<?php echo esc_attr( $field_name ); ?>[]"
+	multiple
+	size="<?php echo esc_attr( min( 8, max( 3, count( $groups ) ) ) ); ?>"
+	<?php disabled( $protected ); ?>
+>
+	<?php foreach ( $groups as $group ) : ?>
+		<option value="<?php echo esc_attr( $group->term_id ); ?>" <?php selected( in_array( $group->term_id, $selected, true ) ); ?>>
+			<?php echo esc_html( $group->name ); ?>
+		</option>
+	<?php endforeach; ?>
+</select>
+
+<br />
+<em>A camp can belong to multiple groups. Sponsors targeting any of them are placed on this camp.</em>

--- a/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
+++ b/public_html/wp-content/plugins/wcpt/wcpt-wordcamp/wordcamp-admin.php
@@ -1255,6 +1255,7 @@ if ( ! class_exists( 'WordCamp_Admin' ) ) :
 					$protected_fields,
 					array(
 						'Multi-Event Sponsor Region',
+						'Multi-Event Sponsor Groups',
 						'Series Event',
 					)
 				);


### PR DESCRIPTION
Part of #2003.

First of five stacked PRs adding flexible sponsor groups. This one adds the model and its admin
surfaces **behind an off-by-default flag, so merging it changes nothing anyone can see.**

A WordCamp currently belongs to exactly one `Multi-Event Sponsor Region`, and each `mes` sponsor
maps one level per region. Region is therefore both the geography and the only way to say "this
sponsor applies to these camps." Sponsor groups add a many-to-many grouping alongside regions,
without changing what regions do.

### What this adds

- **`MES_Sponsor_Group`** — a `mes_sponsor_group` taxonomy on the `mes` post type, the
  `mes_sponsor_groups` post meta on `wordcamp` posts, and `get_camp_groups()` /
  group-sponsorship accessors.
- **Group-aware level resolution on `MES_Sponsor`**, plus a *Group Sponsorships* metabox on the
  Multi-Event Sponsor screen mirroring the existing regional-sponsorships one.
- **A camp-side group picker** on the WordCamp screen, registered through wcpt's existing
  `wcpt_admin_meta_keys` filter.

### Merging this is a no-op

Everything an organizer or deputy could see sits behind `MES_Sponsor_Group::is_enabled()`, a filter
defaulting to `false`. With it off:

- the `Multi-Event Sponsor Groups` field is **not offered** on the WordCamp screen
- the **Group Sponsorships** metabox is **not added** to the Multi-Event Sponsor screen
- the taxonomy is registered — so the data model and queries are stable — but has **no admin menu**
- a posted group selection is **ignored**

```php
add_filter( 'mes_sponsor_groups_enabled', '__return_true' );
```

…switches it on, once the read path is deployed and the migration has been dry-run. The flag is
checked inside each callback rather than around the `add_action()` calls, so the answer doesn't
depend on whether a filter was registered before this plugin loaded. Seven tests assert the
disabled state directly.

`multi-event-sponsors` is active in production, which is why the flag is here rather than left as
a follow-up.

### Why this touches wcpt, and why only one line

The field is registered from this plugin through wcpt's own `wcpt_admin_meta_keys` filter rather
than hardcoded into `WordCamp_Admin::meta_keys()`, so it appears and disappears with the flag.
wcpt already routes unrecognised field types to the `wcpt_metabox_value` and `wcpt_metabox_save`
actions this class handles, so it needs no `case` for `mes-groups` — the same way
`Multi-Event Sponsor Region` / `mes-dropdown` already works.

That leaves **one** line in wcpt: the `Multi-Event Sponsor Groups` entry in
`get_protected_fields()`, which has no filter to go through. It is deliberately **unconditional** —
the field is guarded whether or not it is currently offered, so enabling the flag cannot open a
window where it is editable but unprotected.

### What it deliberately does not do

- Nothing reads `mes_sponsor_groups` yet. Sponsor resolution is untouched — that is PR 2.
- No migration, no propagation, no CLI commands. Those are PRs 3 and 4.
- The legacy `Multi-Event Sponsor Region` path is not modified.

### Also in this PR: the test suite had no registration

`multi-event-sponsors` has a `tests/` directory but no entry in `phpunit-bootstrap.php` or
`phpunit.xml.dist`, so the integrated harness collected **none** of its tests. Without those two
lines CI reports green while running nothing, so they are here rather than in a follow-up. The
same registration then serves PRs 2–5.

### Screenshots

**To follow.** The picker and the Group Sponsorships metabox both have a visual component and I
have not done a browser pass yet — I'll add shots of both screens with the flag enabled. Flagging
it rather than leaving the section empty.

### How to test the changes in this Pull Request:

**With the flag off (the state this merges in):**

1. Edit a `wordcamp` post on Central. Confirm there is **no** Multi-Event Sponsor Groups field.
2. Edit a Multi-Event Sponsor (`edit.php?post_type=mes`). Confirm there is **no** Group
   Sponsorships metabox, and no Sponsor Groups item in the menu.
3. Confirm a camp with a region still lists exactly the same Multi-Event Sponsors as before.

**Then enable it** — `add_filter( 'mes_sponsor_groups_enabled', '__return_true' );` in an
mu-plugin — and repeat:

4. On the Multi-Event Sponsor screen, confirm a **Group Sponsorships** metabox appears listing
   sponsorship levels. Create a sponsor group term, map a level to it, save, reload, confirm it
   persists.
5. On a `wordcamp` post, as a user with `wordcamp_wrangle_wordcamps`, confirm a **Multi-Event
   Sponsor Groups** picker appears. Select a group, save, reload, confirm it persists.
6. As a user **without** that capability, confirm the field is locked and that posting a different
   value does not change the stored groups.
7. Confirm sponsor resolution is *still* unchanged — nothing reads groups until PR 2.

### Verification

Against `upstream/production` at `981bedf0`:

| Gate | Result |
|---|---|
| PHPUnit, integrated harness (`--testsuite "Multi-Event Sponsors"`) | **OK — 17 tests, 24 assertions** |
| Warnings / deprecations in test output | **0** |
| phpcs, added files (`phpcs -snq`) | **0 errors** |
| phpcs, changed lines on modified files (`phpcs-changed`) | **0 errors** |

Local harness is PHP 8.4.25; CI runs 8.5, so version-specific behaviour is unproven locally.

`Test_MES_Sponsor_Group` covers taxonomy registration and attachment, group-sponsorship and
camp-group round trips, both empty-default cases, sanitised save, metabox rendering, and
`test_save_group_picker_respects_protected_field` — a user without the capability cannot overwrite
a camp's groups. Seven further tests pin the disabled state: the flag defaults off, the taxonomy
has no menu, the field is not offered to any wcpt field group, the picker renders nothing, a posted
selection is ignored, and the sponsor metabox is not added.

### Notes for reviewers

- **Read the stack in order.** PR 2 turns on resolution, PR 3 adds the opt-in migration, PR 4 adds
  propagation and flagship seeding, PR 5 adds a read-only dry-run screen. Each is green on its own.
- **`mes_sponsor_groups` is post meta holding term IDs**, matching how `Multi-Event Sponsor Region`
  already works. A real taxonomy relation on `wordcamp` posts would query better; I followed the
  existing convention rather than introducing a second pattern, but I'll change it if you prefer.
- **How should the flag eventually be flipped?** A one-line default change in a follow-up, or a
  network option someone can toggle without a deploy — happy either way.
- **New `require_once` lines drop the parentheses** the surrounding file uses. The phpcs
  changed-lines gate holds new lines to the current standard, so matching the neighbours fails.
