### PR TITLE
Groups: show an error when publishing a stale event draft

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/event-form.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/event-form.js
@@ -95,6 +95,9 @@ function EventForm(
 	const [ saving, setSaving ] = useState( false );
 	const [ error, setError ] = useState( '' );
 
+	// The browser-side minimum date only applies to a brand-new event; the server validates a loaded post's date.
+	const [ isExistingPost, setIsExistingPost ] = useState( false );
+
 	/**
 	 * Description is intentionally NOT in form state - the inline block editor
 	 * owns it. We grab the current value via `descriptionRef` only at
@@ -148,6 +151,7 @@ function EventForm(
 					return;
 				}
 				setVenues( res.venues || [] );
+				setIsExistingPost( !! res.is_editing );
 				setInitialDescription( res.fields.description || '' );
 				setFeaturedImage( {
 					id: res.fields.featured_image_id || 0,
@@ -280,7 +284,7 @@ function EventForm(
 					label={ __( 'Date', 'wporg-groups-frontend' ) }
 					type="date"
 					value={ form.date }
-					min={ isEdit ? undefined : MINIMUM_EVENT_DATE }
+					min={ isExistingPost ? undefined : MINIMUM_EVENT_DATE }
 					onChange={ ( v ) => updateField( 'date', v ) }
 					required
 					__nextHasNoMarginBottom

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -280,6 +280,29 @@ class Test_Groups_REST extends Groups_TestCase {
 	}
 
 	/**
+	 * A draft whose date has passed cannot be published, and stays a draft
+	 * so the organiser can correct the date and try again.
+	 */
+	public function test_publish_draft_rejects_past_date() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$save = new WP_REST_Request( 'POST', '/wporg-groups/v1/draft' );
+		$save->set_param( 'title', 'Stale draft' );
+		$draft_id = save_draft( $save )->get_data()['id'];
+
+		$params         = $this->base_event_params();
+		$params['id']   = $draft_id;
+		$params['date'] = current_datetime()->modify( '-1 day' )->format( 'Y-m-d' );
+
+		$response = publish_draft( $this->event_request( $params ) );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'wporg_groups_past_event_date', $response->get_error_code() );
+		$this->assertSame( 'draft', get_post_status( $draft_id ) );
+	}
+
+	/**
 	 * An event whose end time equals its start time is rejected.
 	 */
 	public function test_zero_length_event_rejected() {

--- a/tests/e2e/event-form.spec.js
+++ b/tests/e2e/event-form.spec.js
@@ -41,17 +41,21 @@ test.describe( 'event form surfaces', () => {
 	 *
 	 * @param {import('@playwright/test').Page} page
 	 * @param {string}                          title
+	 * @return {Promise<Object>} The published event as the REST API reports it.
 	 */
 	async function expectPublishedWithDatetimes( page, title ) {
 		await page.waitForURL( /\/event\//, { timeout: 30000 } );
 		await expect( page.getByRole( 'heading', { name: title } ) ).toBeVisible();
 
 		const slug = new URL( page.url() ).pathname.split( '/' ).filter( Boolean ).pop();
-		const response = await page.request.get( `wp-json/wp/v2/gatherpress_events?slug=${ slug }&_fields=meta` );
+		const response = await page.request.get(
+			`wp-json/wp/v2/gatherpress_events?slug=${ slug }&_fields=id,meta`
+		);
 		expect( response.ok() ).toBe( true );
 		const [ event ] = await response.json();
 		expect( event.meta.gatherpress_datetime_start ).toBe( `${ DATE } ${ START }:00` );
 		expect( event.meta.gatherpress_datetime_end ).toBe( `${ DATE } 13:00:00` );
+		return event;
 	}
 
 	/**
@@ -89,6 +93,11 @@ test.describe( 'event form surfaces', () => {
 	 * The modal autosaves a draft, and reopening it lists that draft in the
 	 * picker. Publishing from there goes through `/draft/{id}/publish` with
 	 * the recurrence the form-data endpoint handed back.
+	 *
+	 * The draft is saved with a past date. A fresh form blocks that through
+	 * the browser's minimum-date check, but a loaded draft must not (#1978):
+	 * the request reaches the server, its "Event date cannot be in the past."
+	 * error shows in the form, and correcting the date publishes the same draft.
 	 */
 	test( 'publishes a draft continued from the modal picker', async ( { page } ) => {
 		test.slow();
@@ -96,13 +105,22 @@ test.describe( 'event form surfaces', () => {
 		await login( page, 'organiser3', 'password' );
 
 		const title = `Event form draft E2E ${ Date.now() }`;
+		const pastDate = '2020-01-01';
 		await page.goto( '' );
 		await page.getByRole( 'button', { name: '+ Create event', exact: true } ).click();
 		const modal = page.locator( '.wporg-groups-event-modal' );
+		const date = modal.getByLabel( 'Date', { exact: true } );
 		await modal.getByLabel( 'Event title' ).fill( title );
-		await modal.getByLabel( 'Date', { exact: true } ).fill( DATE );
+		await date.fill( pastDate );
 		await modal.getByLabel( 'Start time' ).fill( START );
 		await modal.getByLabel( 'Duration' ).selectOption( { label: '1 hour' } );
+
+		// A fresh form keeps the minimum date. Checked through the constraint
+		// state rather than the attribute: a broken localisation still renders
+		// `min=""`, which would pass an attribute check while enforcing nothing.
+		expect( await date.evaluate( ( input ) => input.validity.rangeUnderflow ) ).toBe( true );
+
+		// `fill()` bypasses that check, so the past date autosaves.
 		await expect( modal ).toContainText( 'Draft saved at', { timeout: 15000 } );
 
 		// Closing a modal with a draft asks for confirmation.
@@ -111,11 +129,22 @@ test.describe( 'event form surfaces', () => {
 		await expect( modal ).toBeHidden();
 
 		await page.getByRole( 'button', { name: '+ Create event', exact: true } ).click();
-		await modal.getByLabel( 'Continue from a draft' ).selectOption( { label: `${ title } — ${ DATE }` } );
+		const picker = modal.getByLabel( 'Continue from a draft' );
+		await picker.selectOption( { label: `${ title } — ${ pastDate }` } );
+		const draftId = Number( await picker.inputValue() );
 		await expect( modal.getByLabel( 'Event title' ) ).toHaveValue( title );
-		await modal.getByRole( 'button', { name: 'Create event' } ).click();
+		await expect( date ).toHaveValue( pastDate );
+		await expect( date ).not.toHaveAttribute( 'min' );
 
-		await expectPublishedWithDatetimes( page, title );
+		await modal.getByRole( 'button', { name: 'Create event' } ).click();
+		const notice = modal.locator( '.components-notice' );
+		await expect( notice ).toBeVisible();
+		await expect( notice ).toContainText( 'Event date cannot be in the past.' );
+
+		await date.fill( DATE );
+		await modal.getByRole( 'button', { name: 'Create event' } ).click();
+		const event = await expectPublishedWithDatetimes( page, title );
+		expect( event.id ).toBe( draftId );
 	} );
 
 	/**


### PR DESCRIPTION
The Create event modal blocked a continued draft with a past date and gave no feedback. The Date input carries `min` set to today, so the browser refused the submit before any request left the page.

New events still can't be given a past date. When a loaded draft already has one, the publish request now reaches the server and the modal shows its "Event date cannot be in the past." error. The organiser fixes the date and submits again.

Fixes #1978

Props vanyukov

### How to test the changes in this Pull Request:

1. Open "+ Create event", fill in a title, start time and duration, and type a date before today into the Date field. Wait for "Draft saved at", then close the modal.
2. Open "+ Create event" again and pick the draft under "Continue from a draft".
3. Click "Create event". The modal should show "Event date cannot be in the past." and the draft should stay a draft.
4. Change the date to a future date and submit again.
5. The existing draft is published, with no duplicate event.
6. Start a new event and confirm the Date field still refuses a date before today.