### PR TITLE
Groups: e2e for event-form edit mode and the settings-tab Speakers field

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -817,4 +817,21 @@ class Test_Groups_REST extends Groups_TestCase {
 
 		$this->assertSame( $stored_before, (string) get_post_field( 'post_title', $event_id, 'raw' ) );
 	}
+
+	/**
+	 * The form marks a published event's recurrence as locked. The frontend relies on this flag to leave
+	 * recurrence out of the edit payload.
+	 */
+	public function test_event_form_locks_recurrence_for_published_event(): void {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$event_id = create_event( $this->event_request( $this->base_event_params() ) )->get_data()['id'];
+
+		$load = new WP_REST_Request( 'GET', '/wporg-groups/v1/event-form-data' );
+		$load->set_param( 'event_id', $event_id );
+		$recurrence = get_event_form_data( $load )->get_data()['fields']['recurrence'];
+
+		$this->assertTrue( $recurrence['locked'] );
+	}
 }

--- a/tests/e2e/event-form-edit.spec.js
+++ b/tests/e2e/event-form-edit.spec.js
@@ -1,0 +1,94 @@
+const { test, expect } = require( '@playwright/test' );
+const { login } = require( './utils/login' );
+
+/**
+ * Edit mode of the shared event form, through the group-settings Events tab.
+ * The tab is the only surface with the Speakers field, and the only edit
+ * surface an editor-tier user sees: the group page's modal edit button is
+ * rendered for users who cannot manage group settings, so it needs its own
+ * author-tier account and event and is not covered here.
+ *
+ * Requires the `organiser2` (`password`) editor-tier test user, and
+ * `organiser1` to exist as a group member to pick as the speaker.
+ */
+test.describe( 'event form edit mode', () => {
+	// See event-form.spec.js for why the date sits this far out.
+	const DATE = '2099-03-04';
+	const START = '12:00';
+	const SPEAKER = 'organiser1';
+
+	/**
+	 * Reads the event's meta through REST rather than the rendered page.
+	 *
+	 * @param {import('@playwright/test').Page} page
+	 * @param {string}                          slug
+	 * @return {Promise<Object>} The event's `meta`.
+	 */
+	async function fetchMeta( page, slug ) {
+		const response = await page.request.get( `wp-json/wp/v2/gatherpress_events?slug=${ slug }&_fields=meta` );
+		expect( response.ok() ).toBe( true );
+		const [ event ] = await response.json();
+		return event.meta;
+	}
+
+	test( 'keeps the speakers and drops the create-only date minimum when editing', async ( { page } ) => {
+		test.slow(); // Two cold boots of the inline block editor.
+
+		await login( page, 'organiser2', 'password' );
+
+		const title = `Event form edit E2E ${ Date.now() }`;
+		await page.goto( '' );
+		await page.locator( '[data-wporg-settings-open]' ).click();
+		const dialog = page.getByRole( 'dialog' );
+		await dialog.getByRole( 'button', { name: '+ Create event', exact: true } ).click();
+		const form = page.locator( 'form.wporg-event-form' );
+
+		// The minimum only applies when creating; the edit assertion below
+		// would pass vacuously if it went missing here too.
+		await expect( form.getByLabel( 'Date', { exact: true } ) ).toHaveAttribute( 'min', /^\d{4}-\d{2}-\d{2}$/ );
+
+		await form.getByLabel( 'Event title' ).fill( title );
+		await form.getByLabel( 'Date', { exact: true } ).fill( DATE );
+		await form.getByLabel( 'Start time' ).fill( START );
+		await form.getByLabel( 'Duration' ).selectOption( { label: '1 hour' } );
+
+		// The suggestions arrive from a separate members request; a token
+		// that matches no member is dropped silently.
+		const speakers = form.getByLabel( 'Speakers' );
+		await speakers.pressSequentially( SPEAKER );
+		const option = form.getByRole( 'option', { name: SPEAKER, exact: true } );
+		await expect( option ).toBeVisible();
+		await option.click();
+		await expect(
+			form.locator( '.components-form-token-field__token-text', { hasText: SPEAKER } )
+		).toBeVisible();
+
+		await form.getByRole( 'button', { name: 'Create event' } ).click();
+		await page.waitForURL( /\/event\//, { timeout: 30000 } );
+		await expect( page.getByRole( 'heading', { name: title } ) ).toBeVisible();
+
+		const slug = new URL( page.url() ).pathname.split( '/' ).filter( Boolean ).pop();
+		const created = await fetchMeta( page, slug );
+		expect( created._event_speakers ).toHaveLength( 1 );
+
+		// The single-event page renders the settings block's edit button,
+		// which opens the Events tab straight into this event.
+		await page.getByRole( 'button', { name: 'Edit this event' } ).click();
+		await expect( form.getByLabel( 'Event title' ) ).toHaveValue( title );
+		await expect( form.getByLabel( 'Date', { exact: true } ) ).not.toHaveAttribute( 'min' );
+		await expect(
+			form.locator( '.components-form-token-field__token-text', { hasText: SPEAKER } )
+		).toBeVisible();
+
+		const editedTitle = `${ title } edited`;
+		await form.getByLabel( 'Event title' ).fill( editedTitle );
+		await form.getByRole( 'button', { name: 'Save changes' } ).click();
+		// The save redirects back to the same event URL; the new heading is
+		// the signal that the reload landed.
+		await expect( page.getByRole( 'heading', { name: editedTitle } ) ).toBeVisible( { timeout: 30000 } );
+
+		const edited = await fetchMeta( page, slug );
+		expect( edited._event_speakers ).toEqual( created._event_speakers );
+		expect( edited.gatherpress_datetime_start ).toBe( created.gatherpress_datetime_start );
+	} );
+} );


### PR DESCRIPTION
#1935 consolidated the modal and the settings Events tab into a shared `EventForm`, and its e2e only covered create and publish. This adds the settings-tab test suggested in #2005: select a speaker, publish, reopen the event with "Edit this event", save, and check that `_event_speakers` and the start datetime persist.

The spec also checks that the date input carries the minimum on the create form and not in edit mode, so the create-only date constraint has an assertion on each side. A REST unit test covers the other regression named in review, that a published event's recurrence comes back as `locked`. Only the unlocked cases had a test before.

The modal's edit mode is not covered here. Its edit button only renders for users who cannot manage group settings, so it needs an author-tier account and an event that account owns. The date `min`, the recurrence gate and the locked notice all live in the shared `EventForm`, so the settings-tab test exercises them for both surfaces

Fixes #2005, See #1935

Props gedex

### Screenshots

Test-only change.

### How to test the changes in this Pull Request:

1. The e2e workflow for this PR runs `tests/e2e/event-form-edit.spec.js` and passes.
2. The unit-test workflow passes `test_event_form_locks_recurrence_for_published_event` in the WordCamp MU Plugins suite.
3. To see the spec fail, make `event-form.js` always pass `MINIMUM_EVENT_DATE` as the date input's `min`, or make the settings tab save an empty `_event_speakers` list. Either turns the e2e run red.