### PR TITLE
Groups: bucket recurring occurrences by their own date in event archives

### DIFF
--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-query.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/includes/class-query.php
@@ -42,11 +42,16 @@ final class Query {
 			);
 		}
 
-		$start_expression   = "COALESCE(gpre_occ_query.datetime_start_gmt, {$core_table}.datetime_start_gmt)";
-		$end_expression     = "COALESCE(gpre_occ_query.datetime_end_gmt, {$core_table}.datetime_end_gmt)";
-		$clauses['where']   = str_replace( "{$core_table}.datetime_start_gmt", $start_expression, $clauses['where'] );
-		$clauses['where']   = str_replace( "{$core_table}.datetime_end_gmt", $end_expression, $clauses['where'] );
-		$clauses['orderby'] = str_replace( "{$core_table}.datetime_start_gmt", $start_expression, $clauses['orderby'] );
+		/**
+		 * GatherPress writes the WHERE comparison through `$wpdb->prepare( '%i.%i' )`, which backtick-quotes both
+		 * identifiers, but builds ORDER BY by plain concatenation. Accept either form so both clauses get the
+		 * occurrence date.
+		 */
+		$pattern = '/(?<!\w)`?' . preg_quote( $core_table, '/' ) . '`?\.`?(datetime_(?:start|end)_gmt)`?(?!\w)/';
+		$replace = static fn( array $matches ): string => "COALESCE(gpre_occ_query.{$matches[1]}, {$core_table}.{$matches[1]})";
+
+		$clauses['where']   = preg_replace_callback( $pattern, $replace, $clauses['where'] );
+		$clauses['orderby'] = preg_replace_callback( $pattern, $replace, $clauses['orderby'] );
 
 		$query->set( 'gpre_occurrence_query', $type );
 		return $clauses;

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -28,6 +28,13 @@ defined( 'WPINC' ) || die();
  */
 final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 
+	/** Leave the screen global as we found it for whatever runs next. */
+	public function tear_down() {
+		unset( $GLOBALS['current_screen'] );
+
+		parent::tear_down();
+	}
+
 	/** Weekly expansion keeps local wall time across DST. */
 	public function test_weekly_recurrence_preserves_wall_time_across_dst(): void {
 		$start = new DateTimeImmutable( '2026-10-26 18:00:00', new DateTimeZone( 'America/Los_Angeles' ) );
@@ -478,6 +485,13 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 	 * occurrence was listed under Past.
 	 */
 	public function test_archive_queries_use_occurrence_dates(): void {
+		/*
+		 * `wordcamp-remote-css/tests/bootstrap.php` defines `WP_ADMIN` for the
+		 * whole run, so `is_admin()` is true unless a screen says otherwise, and
+		 * `Query::clauses()` exempts wp-admin. This is a front-end archive query.
+		 */
+		set_current_screen( 'front' );
+
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'gatherpress_event',

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -18,6 +18,7 @@ use WordPressdotorg\GatherPress_Recurring_Events\Occurrences;
 use WordPressdotorg\GatherPress_Recurring_Events\Plugin;
 use WordPressdotorg\GatherPress_Recurring_Events\Rule;
 use WP_Comment_Query;
+use WP_Query;
 use WP_UnitTestCase;
 
 defined( 'WPINC' ) || die();
@@ -465,6 +466,74 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 			'WE',
 			Rule::from_post( $post_id )['monthly_weekday']
 		);
+	}
+
+	/**
+	 * Archive queries bucket a series by each occurrence's date, not the master date.
+	 *
+	 * GatherPress builds the WHERE comparison with `$wpdb->prepare( '%i.%i' )`,
+	 * which backtick-quotes the identifiers. The extension's clause rewrite
+	 * used to match only the unquoted form, so once a series' first occurrence
+	 * had ended the whole series fell out of Upcoming and every future
+	 * occurrence was listed under Past.
+	 */
+	public function test_archive_queries_use_occurrence_dates(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'draft',
+			)
+		);
+
+		$start = ( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) )->modify( '-8 days' )->setTime( 10, 0 );
+
+		( new Event( $post_id ) )->save_datetimes(
+			array(
+				'post_id'        => $post_id,
+				'datetime_start' => $start->format( 'Y-m-d H:i:s' ),
+				'datetime_end'   => $start->modify( '+1 hour' )->format( 'Y-m-d H:i:s' ),
+				'timezone'       => 'UTC',
+			)
+		);
+
+		update_post_meta( $post_id, Rule::META_PREFIX . 'frequency', 'weekly' );
+		update_post_meta( $post_id, Rule::META_PREFIX . 'interval', 1 );
+		update_post_meta( $post_id, Rule::META_PREFIX . 'weekdays', array( strtoupper( substr( $start->format( 'D' ), 0, 2 ) ) ) );
+		update_post_meta( $post_id, Rule::META_PREFIX . 'end_type', 'count' );
+		update_post_meta( $post_id, Rule::META_PREFIX . 'count', 4 );
+
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Occurrences at -8d, -1d, +6d and +13d relative to now.
+		$upcoming = new WP_Query(
+			array(
+				'post_type'               => 'gatherpress_event',
+				'post__in'                => array( $post_id ),
+				'orderby'                 => 'datetime',
+				'order'                   => 'ASC',
+				'gatherpress_event_query' => 'upcoming',
+				'include_unfinished'      => 1,
+			)
+		);
+		$past     = new WP_Query(
+			array(
+				'post_type'               => 'gatherpress_event',
+				'post__in'                => array( $post_id ),
+				'orderby'                 => 'datetime',
+				'order'                   => 'DESC',
+				'gatherpress_event_query' => 'past',
+				'include_unfinished'      => 0,
+			)
+		);
+
+		$this->assertStringContainsString( 'COALESCE(gpre_occ_query.datetime_end_gmt', $upcoming->request );
+		$this->assertCount( 2, $upcoming->posts, 'Upcoming should list the two future occurrences.' );
+		$this->assertCount( 2, $past->posts, 'Past should list only the two finished occurrences.' );
 	}
 
 	/**

--- a/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
+++ b/public_html/wp-content/mu-plugins/gatherpress-recurring-events/tests/test-gatherpress-recurring-events.php
@@ -546,6 +546,7 @@ final class Test_GatherPress_Recurring_Events extends WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString( 'COALESCE(gpre_occ_query.datetime_end_gmt', $upcoming->request );
+		$this->assertStringContainsString( 'COALESCE(gpre_occ_query.datetime_start_gmt', $upcoming->request );
 		$this->assertCount( 2, $upcoming->posts, 'Upcoming should list the two future occurrences.' );
 		$this->assertCount( 2, $past->posts, 'Past should list only the two finished occurrences.' );
 	}


### PR DESCRIPTION
Rewrite GatherPress's archive date comparison so it accepts the backtick-quoted identifiers that `$wpdb->prepare( '%i.%i' )` emits, not only the unquoted form. Until now the extension's `str_replace()` matched `ORDER BY` but never `WHERE`, so archives filtered on the series master date. Root cause and symptoms are in the linked issue.

Also adds a PHPUnit test that publishes a series with two finished and two future occurrences and asserts each archive bucket returns exactly those two. It fails on `production` and passes with the fix.

Fixes #2011

Props vanyukov

### Screenshots

None, server-side query change only.

### How to test the changes in this Pull Request:

1. On a group site, publish a weekly recurring event whose first occurrence starts now and ends in a few minutes, with a count of four or more.
2. After the first occurrence ends, open the group's `/event/` archive. Upcoming should list the remaining occurrences in date order and `?event_time=past` only the finished one. On `production` the series is missing from Upcoming and Past lists every future occurrence.
3. Run `vendor/bin/phpunit -c phpunit.xml.dist --testsuite "GatherPress Recurring Events"`.
