### PR TITLE
CampTix: keep a refunded attendee refunded when a later payment result arrives

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6749,6 +6749,16 @@ class CampTix_Plugin {
 
 			$old_post_status = $attendee->post_status;
 
+			// A refund reverses the charge, so a later completed, pending or failed result for
+			// the same order leaves the attendee and its transaction record untouched. Gateways
+			// keep reporting the session as paid after a refund (Stripe records the refund on the
+			// charge, not the session), and a gateway error on a repeated return would otherwise
+			// drop the refund marker.
+			if ( 'refund' === $attendee->post_status && in_array( $result, array( self::PAYMENT_STATUS_COMPLETED, self::PAYMENT_STATUS_PENDING, self::PAYMENT_STATUS_FAILED ), true ) ) {
+				$this->log( 'Refusing to change a refunded attendee; a later payment result does not undo a refund.', $attendee->ID, $data );
+				continue;
+			}
+
 			update_post_meta( $attendee->ID, 'tix_transaction_id', $transaction_id );
 			update_post_meta( $attendee->ID, 'tix_transaction_details', $transaction_details );
 
@@ -6771,19 +6781,17 @@ class CampTix_Plugin {
 				}
 			}
 
-			// A refund reverses the charge, so a later completed, pending or failed result for
-			// the same order leaves the attendee refunded. Gateways keep reporting the session as
-			// paid after a refund (Stripe records the refund on the charge, not the session), and a
-			// gateway error on a repeated return would otherwise drop the refund marker.
-			if ( 'refund' === $attendee->post_status && in_array( $result, array( self::PAYMENT_STATUS_COMPLETED, self::PAYMENT_STATUS_PENDING, self::PAYMENT_STATUS_FAILED ), true ) ) {
-				$this->log( 'Refusing to change a refunded attendee; a later payment result does not undo a refund.', $attendee->ID, $data );
-			} elseif ( self::PAYMENT_STATUS_FAILED == $result ) {
+			if ( self::PAYMENT_STATUS_FAILED == $result ) {
 				$attendee->post_status = 'failed';
 				wp_update_post( $attendee );
-			} elseif ( self::PAYMENT_STATUS_COMPLETED == $result ) {
+			}
+
+			if ( self::PAYMENT_STATUS_COMPLETED == $result ) {
 				$attendee->post_status = 'publish';
 				wp_update_post( $attendee );
-			} elseif ( self::PAYMENT_STATUS_PENDING == $result ) {
+			}
+
+			if ( self::PAYMENT_STATUS_PENDING == $result ) {
 				$attendee->post_status = 'pending';
 				wp_update_post( $attendee );
 			}

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -6776,12 +6776,15 @@ class CampTix_Plugin {
 				wp_update_post( $attendee );
 			}
 
-			if ( self::PAYMENT_STATUS_COMPLETED == $result ) {
+			// A refund reverses the charge, so a later completed or pending result for the
+			// same order must not re-seat the attendee. Gateways keep reporting the session
+			// as paid after a refund (Stripe records the refund on the charge, not the session).
+			if ( 'refund' === $attendee->post_status && in_array( $result, array( self::PAYMENT_STATUS_COMPLETED, self::PAYMENT_STATUS_PENDING ), true ) ) {
+				$this->log( 'Refusing to re-seat a refunded attendee; a later payment result does not undo a refund.', $attendee->ID, $data );
+			} elseif ( self::PAYMENT_STATUS_COMPLETED == $result ) {
 				$attendee->post_status = 'publish';
 				wp_update_post( $attendee );
-			}
-
-			if ( self::PAYMENT_STATUS_PENDING == $result ) {
+			} elseif ( self::PAYMENT_STATUS_PENDING == $result ) {
 				$attendee->post_status = 'pending';
 				wp_update_post( $attendee );
 			}

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -2846,8 +2846,8 @@ class CampTix_Plugin {
 							delete_post_meta( $rel_attendee->ID, 'tix_pending_refund' );
 							$rel_attendee->post_status = 'refund';
 							wp_update_post( $rel_attendee );
-							update_post_meta( $attendee->ID, 'tix_refund_transaction_id', $result['refund_transaction_id'] );
-							update_post_meta( $attendee->ID, 'tix_refund_transaction_details', $result['refund_transaction_details'] );
+							update_post_meta( $rel_attendee->ID, 'tix_refund_transaction_id', $result['refund_transaction_id'] );
+							update_post_meta( $rel_attendee->ID, 'tix_refund_transaction_details', $result['refund_transaction_details'] );
 							clean_post_cache( $rel_attendee->ID );
 						}
 					}
@@ -6771,16 +6771,15 @@ class CampTix_Plugin {
 				}
 			}
 
-			if ( self::PAYMENT_STATUS_FAILED == $result ) {
+			// A refund reverses the charge, so a later completed, pending or failed result for
+			// the same order leaves the attendee refunded. Gateways keep reporting the session as
+			// paid after a refund (Stripe records the refund on the charge, not the session), and a
+			// gateway error on a repeated return would otherwise drop the refund marker.
+			if ( 'refund' === $attendee->post_status && in_array( $result, array( self::PAYMENT_STATUS_COMPLETED, self::PAYMENT_STATUS_PENDING, self::PAYMENT_STATUS_FAILED ), true ) ) {
+				$this->log( 'Refusing to change a refunded attendee; a later payment result does not undo a refund.', $attendee->ID, $data );
+			} elseif ( self::PAYMENT_STATUS_FAILED == $result ) {
 				$attendee->post_status = 'failed';
 				wp_update_post( $attendee );
-			}
-
-			// A refund reverses the charge, so a later completed or pending result for the
-			// same order must not re-seat the attendee. Gateways keep reporting the session
-			// as paid after a refund (Stripe records the refund on the charge, not the session).
-			if ( 'refund' === $attendee->post_status && in_array( $result, array( self::PAYMENT_STATUS_COMPLETED, self::PAYMENT_STATUS_PENDING ), true ) ) {
-				$this->log( 'Refusing to re-seat a refunded attendee; a later payment result does not undo a refund.', $attendee->ID, $data );
 			} elseif ( self::PAYMENT_STATUS_COMPLETED == $result ) {
 				$attendee->post_status = 'publish';
 				wp_update_post( $attendee );

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -246,4 +246,67 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 
 		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
 	}
+
+	/**
+	 * A refund reverses the charge, so a later completed result for the same order
+	 * (a replayed return URL, a repeated webhook) must not re-seat the attendee.
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 * @testWith [2]
+	 *           [3]
+	 */
+	public function test_payment_result_does_not_reseat_refunded_attendee( $result ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_refunded_' . $result;
+		$attendee_id   = $this->create_attendee( $payment_token, 'refund' );
+		update_post_meta( $attendee_id, 'tix_refund_transaction_id', 're_test' );
+
+		$camptix->payment_result( $payment_token, $result, array( 'transaction_id' => 'ch_test' ), false );
+
+		$this->assertSame( 'refund', get_post_status( $attendee_id ) );
+		$this->assertSame( 're_test', get_post_meta( $attendee_id, 'tix_refund_transaction_id', true ) );
+	}
+
+	/**
+	 * Every attendee on the order is resolved together, so a refunded multi-seat
+	 * order stays refunded as a whole.
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 */
+	public function test_payment_result_does_not_reseat_refunded_order() {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_refunded_order';
+		$first         = $this->create_attendee( $payment_token, 'refund' );
+		$second        = $this->create_attendee( $payment_token, 'refund' );
+
+		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, array(), false );
+
+		$this->assertSame( 'refund', get_post_status( $first ) );
+		$this->assertSame( 'refund', get_post_status( $second ) );
+	}
+
+	/**
+	 * The late-webhook recovery paths still work: a pending or cancelled attendee
+	 * is published when the gateway confirms the payment.
+	 *
+	 * @covers CampTix_Plugin::payment_result
+	 * @testWith ["draft"]
+	 *           ["pending"]
+	 *           ["cancel"]
+	 */
+	public function test_payment_result_publishes_unpaid_attendee( $status ) {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$payment_token = 'tok_publish_' . $status;
+		$attendee_id   = $this->create_attendee( $payment_token, $status );
+
+		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, array(), false );
+
+		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
+	}
 }

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -264,11 +264,13 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		$payment_token = 'tok_refunded_' . $result;
 		$attendee_id   = $this->create_attendee( $payment_token, 'refund' );
 		update_post_meta( $attendee_id, 'tix_refund_transaction_id', 're_test' );
+		update_post_meta( $attendee_id, 'tix_transaction_id', 'ch_original' );
 
 		$camptix->payment_result( $payment_token, $result, array( 'transaction_id' => 'ch_test' ), false );
 
 		$this->assertSame( 'refund', get_post_status( $attendee_id ) );
 		$this->assertSame( 're_test', get_post_meta( $attendee_id, 'tix_refund_transaction_id', true ) );
+		$this->assertSame( 'ch_original', get_post_meta( $attendee_id, 'tix_transaction_id', true ) );
 	}
 
 	/**
@@ -310,5 +312,70 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 		$camptix->payment_result( $payment_token, CampTix_Plugin::PAYMENT_STATUS_COMPLETED, array(), false );
 
 		$this->assertSame( 'publish', get_post_status( $attendee_id ) );
+	}
+
+	/**
+	 * The refund-all batch refunds every attendee sharing a transaction and records
+	 * the refund transaction on each of them, not only on the first one.
+	 *
+	 * @covers CampTix_Plugin::process_refund_all
+	 */
+	public function test_process_refund_all_records_refund_on_related_attendees() {
+		/** @var CampTix_Plugin $camptix */
+		global $camptix;
+
+		$stub = new class() {
+			/**
+			 * Answer every refund request as refunded.
+			 *
+			 * @param string $payment_token Payment token.
+			 *
+			 * @return array
+			 */
+			public function send_refund_request( $payment_token ) {
+				return array(
+					'token'                      => $payment_token,
+					'status'                     => CampTix_Plugin::PAYMENT_STATUS_REFUNDED,
+					'refund_transaction_id'      => 're_batch',
+					'refund_transaction_details' => array( 'stub' => true ),
+				);
+			}
+		};
+
+		$resolve = function ( $method, $id ) use ( $stub ) {
+			return 'stub' === $id ? $stub : $method;
+		};
+		add_filter( 'camptix_get_payment_method_by_id', $resolve, 10, 2 );
+
+		$payment_token = 'tok_refund_all';
+		$attendees     = array(
+			$this->create_attendee( $payment_token, 'publish' ),
+			$this->create_attendee( $payment_token, 'publish' ),
+		);
+		foreach ( $attendees as $attendee_id ) {
+			update_post_meta( $attendee_id, 'tix_transaction_id', 'ch_batch' );
+			update_post_meta( $attendee_id, 'tix_payment_method', 'stub' );
+			update_post_meta( $attendee_id, 'tix_pending_refund', 1 );
+		}
+		update_option( 'camptix_doing_refunds', 1 );
+		update_option(
+			'camptix_refund_all_results',
+			array(
+				'status'    => 'running',
+				'succeeded' => 0,
+				'failed'    => 0,
+			)
+		);
+
+		$camptix->process_refund_all();
+
+		remove_filter( 'camptix_get_payment_method_by_id', $resolve, 10 );
+		delete_option( 'camptix_doing_refunds' );
+		delete_option( 'camptix_refund_all_results' );
+
+		foreach ( $attendees as $attendee_id ) {
+			$this->assertSame( 'refund', get_post_status( $attendee_id ) );
+			$this->assertSame( 're_batch', get_post_meta( $attendee_id, 'tix_refund_transaction_id', true ) );
+		}
 	}
 }

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix.php
@@ -248,12 +248,14 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A refund reverses the charge, so a later completed result for the same order
-	 * (a replayed return URL, a repeated webhook) must not re-seat the attendee.
+	 * A refund reverses the charge, so a later completed, pending or failed result
+	 * for the same order (a replayed return URL, a repeated webhook) leaves the
+	 * attendee refunded.
 	 *
 	 * @covers CampTix_Plugin::payment_result
 	 * @testWith [2]
 	 *           [3]
+	 *           [4]
 	 */
 	public function test_payment_result_does_not_reseat_refunded_attendee( $result ) {
 		/** @var CampTix_Plugin $camptix */


### PR DESCRIPTION
## Why

`payment_result()` sets every attendee on an order to whatever the gateway reports. The cancelled branch checks the attendee's current status first (#1717) and lists `refund` among the statuses it refuses to downgrade. The completed and pending branches don't check at all, so a repeated payment result for an order that was since refunded puts the attendees back to `publish`. Gateways keep reporting the session as paid after a refund (Stripe records the refund on the charge, not the session), so the Stripe return URL, the timed-out-order recovery and a repeated PayPal IPN all reach that branch with a completed result.

## What changed

- A completed, pending or failed result leaves an attendee in `refund` alone, transaction record included, and logs `Refusing to change a refunded attendee` against it. Draft, pending and cancelled attendees still publish on a completed result, so a late webhook still recovers a cancelled order as before.
- The refund-all batch wrote `tix_refund_transaction_id` and its details to the first attendee's row for every related attendee on the order. They now go on the related attendee.
- Loading the Stripe return URL again after a refund now renders the tickets page (status unchanged) instead of redirecting to the ticket.
- Tests: refunded attendee on a completed, pending and failed result, a two-seat refunded order, draft/pending/cancel → publish, and the refund-all batch on a two-seat order.

## Testing

- `Test_CampTix_Plugin`: 4 failures on `production`, all passing on the branch.
- Local camp with Stripe mocked at the HTTP layer, `curl` only, same session against `production` and the branch: pay, refund, load the return URL again. `production` republishes the attendee (and for a two-seat order both seats, on top of a second order that took them meanwhile: 4 published on a capacity of 2). The branch leaves them in `refund` (2 published, 2 refunded). Pay, force `cancel`, then return: publishes on both. Pay, refund, then a return that reports a canceled intent: `production` moves the row to `failed`, the branch leaves it `refund`. Refund-all on a two-seat order: both rows refunded on both, and on the branch the second row carries the refund transaction id too.
- phpcs is clean on the touched lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
