### PR TITLE
Require Login: carry the ticket selection through the WordPress.org round trip

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/require-login.php
+++ b/public_html/wp-content/plugins/camptix/addons/require-login.php
@@ -216,22 +216,34 @@ class CampTix_Require_Login extends CampTix_Addon {
 	/**
 	 * Get the URL to return to after logging in or creating an account.
 	 *
+	 * The buyer's ticket selection only exists in the current request, so it has to be carried
+	 * across the round trip to WordPress.org. Leaving it behind returns them to an empty form
+	 * with a total of 0, and they have to start the order again.
+	 *
 	 * @return string
 	 */
 	public function get_redirect_return_url() {
 		/** @var $camptix CampTix_Plugin */
 		global $camptix;
 
-		$camptix_url = $camptix->get_tickets_url();
-		$url_params  = array( 'tix_coupon', 'tix_reservation_id', 'tix_reservation_token' );
+		/*
+		 * Only what describes the order the buyer was in the middle of. Error states and the
+		 * attendee-editing tokens deliberately stay behind.
+		 */
+		$carried_parameters = array(
+			'tix_action',
+			'tix_tickets_selected',
+			'tix_coupon',
+			'tix_reservation_id',
+			'tix_reservation_token',
+		);
 
-		foreach ( $url_params as $param ) {
-			if ( isset( $_REQUEST[ $param ] ) ) {
-				$camptix_url = add_query_arg( $param, $_REQUEST[ $param ], $camptix_url );
-			}
-		}
+		$args = array_intersect_key(
+			$this->get_sanitized_tix_parameters( $_REQUEST ),
+			array_flip( $carried_parameters )
+		);
 
-		return $camptix_url;
+		return add_query_arg( urlencode_deep( $args ), $camptix->get_tickets_url() );
 	}
 
 	/**


### PR DESCRIPTION
`get_redirect_return_url()` built the return URL from a fixed list of three parameters, leaving out `tix_action` and `tix_tickets_selected`. Any link built on it sent the buyer back to an empty ticket form showing 0, including both links in the "Before purchasing your tickets" notice.

`block_unauthenticated_actions()` a few lines up already does this properly with `get_sanitized_tix_parameters()`. This reuses it and keeps only the parameters that describe the order in progress, so error states and the attendee-editing tokens stay behind. The three parameters carried before are still carried.

This does not fix every case. A buyer who clicks Register on login.wordpress.org still loses the selection, because that link drops the `redirect_to` it was handed. That is outside this repo and is covered in https://meta.trac.wordpress.org/ticket/8428.

Fixes #2014
Props arunshenoy99

### Screenshots

None. This only changes the query string of a link.

### How to test the changes in this Pull Request:

1. Logged out, select 2 of any ticket on a Tickets page, then click Apply Coupon with any code.
2. Check the `href` of "log in with your WordPress.org account" in the notice. Before, `redirect_to` carries `tix_coupon` only. After, it also carries `tix_action=attendee_info` and `tix_tickets_selected%5B<ticket_id>%5D=2`.
3. Log in and confirm you come back with 2 still selected.
4. Check the ordinary path still works: select tickets, Register, log in.
5. Check a plain GET of the Tickets page while logged out still gives a bare return URL.

PHPCS passes on the changed lines. I could not run PHPUnit against this one: Require Login is inactive by default and only switched on through the `camptix_default_addons` filter, which runs before `init`. If you can point me at the right way to load it in the suite, I will add a test.
