### PR TITLE
CampTix: count checkouts in progress against ticket, coupon and reservation quantities

### DIFF
--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -219,8 +219,9 @@ class CampTix_Plugin {
 
 		add_action( 'tix_scheduled_every_ten_minutes', array( $this, 'send_emails_batch' ) );
 		add_action( 'tix_scheduled_every_ten_minutes', array( $this, 'process_refund_all' ) );
+		// A draft attendee holds its seat until it times out, so sweep often enough that an abandoned checkout releases it at 24 hours, not up to 48.
+		add_action( 'tix_scheduled_every_ten_minutes', array( $this, 'review_timeout_payments' ) );
 
-		add_action( 'tix_scheduled_daily', array( $this, 'review_timeout_payments' ) );
 		add_action( 'tix_scheduled_daily', array( $this, 'cron_camptix_stats_ticket_validation' ) );
 
 		if ( ! wp_next_scheduled( 'tix_scheduled_every_ten_minutes' ) )
@@ -3189,12 +3190,12 @@ class CampTix_Plugin {
 	/**
 	 * Returns true, if a reservation is valid, and can be used to purchase a ticket.
 	 */
-	function is_reservation_valid_for_use( $token ) {
+	function is_reservation_valid_for_use( $token, $exclude_attendee_ids = array() ) {
 		$reservation = $this->get_reservation( $token );
 		if ( ! $reservation )
 			return false;
 
-		$count = $this->get_purchased_tickets_count( $reservation['ticket_id'], $reservation['token'] );
+		$count = $this->get_purchased_tickets_count( $reservation['ticket_id'], $reservation['token'], $exclude_attendee_ids );
 		if ( $count < $reservation['quantity'] )
 			return true;
 
@@ -5976,14 +5977,14 @@ class CampTix_Plugin {
 	}
 
 	/**
-	 * Returns the number of remaining tickets according to number of published attendees.
+	 * Returns the number of remaining tickets according to the number of sold and in-progress attendees.
 	 * @todo maybe cache values and bust in purchase process.
 	 */
-	function get_remaining_tickets( $post_id, $via_reservation = false ) {
+	function get_remaining_tickets( $post_id, $via_reservation = false, $exclude_attendee_ids = array() ) {
 		$remaining = 0;
 		if ( $this->is_ticket_valid_for_display( $post_id ) ) {
 			$quantity = intval( get_post_meta( $post_id, 'tix_quantity', true ) );
-			$remaining = $quantity - $this->get_purchased_tickets_count( $post_id );
+			$remaining = $quantity - $this->get_purchased_tickets_count( $post_id, false, $exclude_attendee_ids );
 		}
 
 		// Look for reservations
@@ -5995,14 +5996,14 @@ class CampTix_Plugin {
 				continue;
 
 			// Subtract ones already purchased
-			$reserved_tickets = $reservation['quantity'] - $this->get_purchased_tickets_count( $post_id, $reservation['token'] );
+			$reserved_tickets = $reservation['quantity'] - $this->get_purchased_tickets_count( $post_id, $reservation['token'], $exclude_attendee_ids );
 			$remaining -= $reserved_tickets;
 		}
 
 		return apply_filters( 'camptix_get_remaining_tickets', $remaining, $post_id, $via_reservation, $quantity, $reservations );
 	}
 
-	function get_purchased_tickets_count( $post_id, $via_reservation = false ) {
+	function get_purchased_tickets_count( $post_id, $via_reservation = false, $exclude_attendee_ids = array() ) {
 		$purchased = 0;
 
 		$meta_query = array( array(
@@ -6021,10 +6022,15 @@ class CampTix_Plugin {
 			);
 		}
 
+		// A draft is a checkout waiting on the payment gateway. It keeps its seat until it
+		// completes or review_timeout_payments() times it out, so it is not offered again.
+		// $exclude_attendee_ids lets an order in progress re-check availability without its
+		// own drafts counting against it (the gateway's final verify_order()).
 		$attendees = new WP_Query( array(
 			'post_type' => 'tix_attendee',
 			'posts_per_page' => 1,
-			'post_status' => array( 'publish', 'pending' ),
+			'post_status' => array( 'publish', 'pending', 'draft' ),
+			'post__not_in' => $exclude_attendee_ids,
 			'meta_query' => $meta_query,
 		) );
 
@@ -6058,11 +6064,11 @@ class CampTix_Plugin {
 	/**
 	 * Returns true if one con use a coupon.
 	 */
-	function is_coupon_valid_for_use( $coupon_id ) {
+	function is_coupon_valid_for_use( $coupon_id, $exclude_attendee_ids = array() ) {
 		$coupon = get_post( $coupon_id );
 		if ( $coupon->post_type != 'tix_coupon' ) return false;
 		if ( $coupon->post_status != 'publish' ) return false;
-		if ( $this->get_remaining_coupons( $coupon->ID ) < 1 ) return false;
+		if ( $this->get_remaining_coupons( $coupon->ID, $exclude_attendee_ids ) < 1 ) return false;
 
 		$start = get_post_meta( $coupon->ID, 'tix_coupon_start', true );
 		$end = get_post_meta( $coupon->ID, 'tix_coupon_end', true );
@@ -6104,27 +6110,29 @@ class CampTix_Plugin {
 	/**
 	 * Returns the number of available coupons by coupon_id
 	 */
-	function get_remaining_coupons( $coupon_id ) {
+	function get_remaining_coupons( $coupon_id, $exclude_attendee_ids = array() ) {
 		$remaining = 0;
 		$coupon = get_post( $coupon_id );
 		if ( $coupon && $coupon->post_type == 'tix_coupon' ) {
 			$quantity = intval( get_post_meta( $coupon->ID, 'tix_coupon_quantity', true ) );
 			$remaining = $quantity;
 
-			$used = $this->get_used_coupons_count( $coupon_id );
+			$used = $this->get_used_coupons_count( $coupon_id, $exclude_attendee_ids );
 			$remaining -= $used;
 		}
 		return $remaining;
 	}
 
-	function get_used_coupons_count( $coupon_id ) {
+	function get_used_coupons_count( $coupon_id, $exclude_attendee_ids = array() ) {
 		$used = 0;
 		$coupon = get_post( $coupon_id );
 		if ( $coupon && $coupon->post_type == 'tix_coupon' ) {
+			// Drafts count, as in get_purchased_tickets_count().
 			$attendees = new WP_Query( array(
 				'post_type' => 'tix_attendee',
 				'posts_per_page' => 1,
-				'post_status' => array( 'publish', 'pending' ),
+				'post_status' => array( 'publish', 'pending', 'draft' ),
+				'post__not_in' => $exclude_attendee_ids,
 				'meta_query' => array(
 					array(
 						'key' => 'tix_coupon_id',
@@ -6451,11 +6459,33 @@ class CampTix_Plugin {
 		$via_reservation = false;
 		$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order', 10 );
 
+		// An order already in progress owns draft attendees that hold its seats. When it
+		// re-checks availability (the gateway's final verify_order() before charging), don't
+		// count its own drafts against it, or buying the last remaining seat would fail.
+		$exclude_attendee_ids = array();
+		if ( ! empty( $order['attendee_id'] ) ) {
+			$payment_token = get_post_meta( $order['attendee_id'], 'tix_payment_token', true );
+			if ( $payment_token ) {
+				$exclude_attendee_ids = get_posts( array(
+					'fields'         => 'ids',
+					'post_type'      => 'tix_attendee',
+					'post_status'    => array( 'draft', 'pending', 'publish' ),
+					'posts_per_page' => -1,
+					'meta_query'     => array(
+						array(
+							'key'   => 'tix_payment_token',
+							'value' => $payment_token,
+						),
+					),
+				) );
+			}
+		}
+
 		// Let's check the coupon first.
 		if ( ! empty( $order['coupon'] ) ) {
 			$coupon = $this->get_coupon_by_code( $order['coupon'] );
-			if ( $coupon && $this->is_coupon_valid_for_use( $coupon->ID ) ) {
-				$coupon->tix_coupon_remaining = $this->get_remaining_coupons( $coupon->ID );
+			if ( $coupon && $this->is_coupon_valid_for_use( $coupon->ID, $exclude_attendee_ids ) ) {
+				$coupon->tix_coupon_remaining = $this->get_remaining_coupons( $coupon->ID, $exclude_attendee_ids );
 				$coupon->tix_discount_price = (float) get_post_meta( $coupon->ID, 'tix_discount_price', true );
 				$coupon->tix_discount_percent = (int) get_post_meta( $coupon->ID, 'tix_discount_percent', true );
 				$coupon->tix_applies_to = (array) get_post_meta( $coupon->ID, 'tix_applies_to' );
@@ -6478,7 +6508,7 @@ class CampTix_Plugin {
 		if ( isset( $order['reservation_id'], $order['reservation_token'] ) ) {
 			$reservation = $this->get_reservation( $order['reservation_token'] );
 
-			if ( $reservation && $reservation['id'] == strtolower( $order['reservation_id'] ) && $this->is_reservation_valid_for_use( $reservation['token'] ) ) {
+			if ( $reservation && $reservation['id'] == strtolower( $order['reservation_id'] ) && $this->is_reservation_valid_for_use( $reservation['token'], $exclude_attendee_ids ) ) {
 				$via_reservation = $reservation['token'];
 			} else {
 				$this->error_flags['invalid_reservation'] = true;
@@ -6490,7 +6520,7 @@ class CampTix_Plugin {
 		$tickets = array();
 		foreach ( $tickets_objects as $ticket ) {
 			$ticket->tix_price = (float) get_post_meta( $ticket->ID, 'tix_price', true );
-			$ticket->tix_remaining = $this->get_remaining_tickets( $ticket->ID, $via_reservation );
+			$ticket->tix_remaining = $this->get_remaining_tickets( $ticket->ID, $via_reservation, $exclude_attendee_ids );
 			$ticket->tix_coupon_applied = false;
 			$ticket->tix_discounted_price = $ticket->tix_price;
 

--- a/public_html/wp-content/plugins/camptix/camptix.php
+++ b/public_html/wp-content/plugins/camptix/camptix.php
@@ -51,6 +51,8 @@ class CampTix_Plugin {
 	protected $coupon;
 	protected $error_data;
 	protected $did_template_redirect;
+	protected $checkout_lock_open  = false;
+	protected $checkout_lock_names = array();
 	protected $did_checkout;
 	protected $shortcode_contents;
 	protected $shortcode_str;
@@ -4781,6 +4783,9 @@ class CampTix_Plugin {
 		if ( isset( $this->error_flags['invalid_payment_method'] ) )
 			$this->error( __( 'You have selected an invalid payment method. Please try again.', 'wordcamporg' ) );
 
+		if ( isset( $this->error_flags['checkout_busy'] ) )
+			$this->error( __( 'A lot of people are checking out at the same time. Please try again in a moment.', 'wordcamporg' ) );
+
 		if ( isset( $this->error_flags['invalid_coupon'] ) )
 			$this->notice( __( "Looks like you're trying to use an invalid or expired coupon.", 'wordcamporg' ) );
 
@@ -6032,6 +6037,9 @@ class CampTix_Plugin {
 			'post_status' => array( 'publish', 'pending', 'draft' ),
 			'post__not_in' => $exclude_attendee_ids,
 			'meta_query' => $meta_query,
+			// Live under the checkout lock: the order is counted before checkout and again under
+			// the lock, and a cached count can predate a competitor's insert. Cached everywhere else.
+			'cache_results' => ! $this->checkout_lock_open,
 		) );
 
 		if ( $attendees->found_posts > 0 )
@@ -6133,6 +6141,7 @@ class CampTix_Plugin {
 				'posts_per_page' => 1,
 				'post_status' => array( 'publish', 'pending', 'draft' ),
 				'post__not_in' => $exclude_attendee_ids,
+				'cache_results' => ! $this->checkout_lock_open, // Live under the lock, as in get_purchased_tickets_count().
 				'meta_query' => array(
 					array(
 						'key' => 'tix_coupon_id',
@@ -6338,72 +6347,45 @@ class CampTix_Plugin {
 			return $this->form_attendee_info();
 		}
 
-		$this->verify_order( $this->order );
-
-		$reservation_quantity = 0;
-		if ( isset( $this->reservation ) && $this->reservation )
-			$reservation_quantity = $this->reservation['quantity'];
-
-		$log_data = array(
-			'post' => $_POST,
-		);
-
-		$access_token = md5( 'tix-access-token' . print_r( $_POST, true ) . time() . rand( 1, 9999 ) );
-		$payment_token = md5( 'tix-payment-token' . $access_token . time() . rand( 1, 9999 ) );
-
-		foreach ( $attendees as $attendee ) {
-			$post_id = wp_insert_post( array(
-				'post_title' => $this->format_name_string( "%first% %last%", $attendee->first_name, $attendee->last_name ),
-				'post_type' => 'tix_attendee',
-				'post_status' => 'draft',
-			) );
-
-			if ( $post_id ) {
-				$this->log( 'Created attendee draft.', $post_id, $log_data );
-
-				$edit_token = md5( sprintf( 'tix-edit-token-%d-%s-%s', $post_id, $access_token, time() ) );
-
-				update_post_meta( $post_id, 'tix_access_token', $access_token );
-				update_post_meta( $post_id, 'tix_payment_token', $payment_token );
-				update_post_meta( $post_id, 'tix_edit_token', $edit_token );
-				update_post_meta( $post_id, 'tix_payment_method', $payment_method );
-				update_post_meta( $post_id, 'tix_order', $this->order );
-
-				update_post_meta( $post_id, 'tix_timestamp', time() );
-				update_post_meta( $post_id, 'tix_ticket_id', $attendee->ticket_id );
-				update_post_meta( $post_id, 'tix_first_name', $attendee->first_name );
-				update_post_meta( $post_id, 'tix_last_name', $attendee->last_name );
-				update_post_meta( $post_id, 'tix_email', $attendee->email );
-				update_post_meta( $post_id, 'tix_tickets_selected', $this->tickets_selected );
-				update_post_meta( $post_id, 'tix_receipt_email', wp_slash( $receipt_email ) );
-
-				do_action( 'camptix_checkout_update_post_meta', $post_id, $attendee );
-
-				// Cash
-				update_post_meta( $post_id, 'tix_order_total', (float) $this->order['total'] );
-				update_post_meta( $post_id, 'tix_ticket_price', (float) $this->tickets[ $attendee->ticket_id ]->tix_price );
-				update_post_meta( $post_id, 'tix_ticket_discounted_price', (float) $this->tickets[ $attendee->ticket_id ]->tix_discounted_price );
-
-				// @todo sanitize questions
-				update_post_meta( $post_id, 'tix_questions', wp_slash( $attendee->answers ) );
-
-				if ( $this->coupon && in_array( $attendee->ticket_id, $this->coupon->tix_applies_to ) ) {
-					update_post_meta( $post_id, 'tix_coupon_id', $this->coupon->ID );
-					update_post_meta( $post_id, 'tix_coupon', $this->coupon->post_title );
-				}
-
-				if ( isset( $this->reservation ) && $this->reservation && $this->reservation['ticket_id'] == $attendee->ticket_id ) {
-					if ( $reservation_quantity > 0 ) {
-						update_post_meta( $post_id, 'tix_reservation_id', $this->reservation['id'] );
-						update_post_meta( $post_id, 'tix_reservation_token', $this->reservation['token'] );
-						$reservation_quantity--;
-					}
-				}
-
-				// Write post content (triggers save_post).
-				wp_update_post( array( 'ID' => $post_id ) );
-				$attendee->post_id = $post_id;
+		// Hold a lock per ticket and coupon in the order while we count and insert, so two
+		// checkouts for the same seat run one after the other instead of both counting it free.
+		$lock_ids = wp_list_pluck( $this->order['items'], 'id' );
+		if ( ! empty( $this->order['coupon'] ) ) {
+			$lock_coupon = $this->get_coupon_by_code( $this->order['coupon'] );
+			if ( $lock_coupon ) {
+				$lock_ids[] = $lock_coupon->ID;
 			}
+		}
+		$this->lock_checkout_rows( $lock_ids );
+
+		if ( $this->error_flags ) {
+			return $this->form_attendee_info();
+		}
+
+		// Nothing renders in here, a render would hold the lock for everyone waiting on it.
+		$claimed = false;
+		try {
+			$this->verify_order( $this->order );
+
+			// This count, under the lock, is the one that decides; the earlier checks may be stale.
+			if ( ! $this->error_flags ) {
+				$access_token  = md5( 'tix-access-token' . print_r( $_POST, true ) . time() . rand( 1, 9999 ) );
+				$payment_token = md5( 'tix-payment-token' . $access_token . time() . rand( 1, 9999 ) );
+				$inserted      = $this->insert_attendee_drafts( $attendees, $payment_method, $receipt_email, $access_token, $payment_token );
+
+				if ( false === $inserted ) {
+					$this->error_flag( 'checkout_busy' );
+				} else {
+					$attendees = $inserted;
+					$claimed   = true;
+				}
+			}
+		} finally {
+			$this->release_checkout_rows();
+		}
+
+		if ( ! $claimed ) {
+			return $this->form_attendee_info();
 		}
 
 		$attendees_posts = array();
@@ -6442,6 +6424,167 @@ class CampTix_Plugin {
 		} else { // free beer for everyone!
 			$this->payment_result( $payment_token, self::PAYMENT_STATUS_COMPLETED );
 		}
+	}
+
+	/**
+	 * Insert the draft attendee posts for an order, inside the checkout lock. If one cannot be
+	 * written the ones already written are removed, so a partial order never holds seats.
+	 *
+	 * @param object[] $attendees      Attendee objects built by form_checkout().
+	 * @param string   $payment_method Selected payment method id.
+	 * @param string   $receipt_email  Receipt e-mail for the order.
+	 * @param string   $access_token   Access token shared by the order.
+	 * @param string   $payment_token  Payment token shared by the order.
+	 * @return object[]|false The same attendees, each with post_id set, or false if any draft could not be written.
+	 */
+	function insert_attendee_drafts( $attendees, $payment_method, $receipt_email, $access_token, $payment_token ) {
+		$reservation_quantity = 0;
+		if ( isset( $this->reservation ) && $this->reservation ) {
+			$reservation_quantity = $this->reservation['quantity'];
+		}
+
+		$log_data = array(
+			'post' => $_POST,
+		);
+
+		$created = array();
+
+		foreach ( $attendees as $attendee ) {
+			$post_id = wp_insert_post( array(
+				'post_title' => $this->format_name_string( "%first% %last%", $attendee->first_name, $attendee->last_name ),
+				'post_type' => 'tix_attendee',
+				'post_status' => 'draft',
+			) );
+
+			if ( ! $post_id || is_wp_error( $post_id ) ) {
+				$this->log( 'Could not create attendee draft; aborting checkout.', null, array( 'error' => is_wp_error( $post_id ) ? $post_id->get_error_message() : $post_id ) );
+				foreach ( $created as $created_id ) {
+					wp_delete_post( $created_id, true );
+				}
+				return false;
+			}
+
+			if ( $post_id ) {
+				$created[] = $post_id;
+				$this->log( 'Created attendee draft.', $post_id, $log_data );
+
+				$edit_token = md5( sprintf( 'tix-edit-token-%d-%s-%s', $post_id, $access_token, time() ) );
+
+				update_post_meta( $post_id, 'tix_access_token', $access_token );
+				update_post_meta( $post_id, 'tix_payment_token', $payment_token );
+				update_post_meta( $post_id, 'tix_edit_token', $edit_token );
+				update_post_meta( $post_id, 'tix_payment_method', $payment_method );
+				update_post_meta( $post_id, 'tix_order', $this->order );
+
+				update_post_meta( $post_id, 'tix_timestamp', time() );
+				update_post_meta( $post_id, 'tix_ticket_id', $attendee->ticket_id );
+				update_post_meta( $post_id, 'tix_first_name', $attendee->first_name );
+				update_post_meta( $post_id, 'tix_last_name', $attendee->last_name );
+				update_post_meta( $post_id, 'tix_email', $attendee->email );
+				update_post_meta( $post_id, 'tix_tickets_selected', $this->tickets_selected );
+				update_post_meta( $post_id, 'tix_receipt_email', wp_slash( $receipt_email ) );
+
+				do_action( 'camptix_checkout_update_post_meta', $post_id, $attendee );
+
+				// Cash
+				$ticket = $this->tickets[ $attendee->ticket_id ] ?? null;
+				update_post_meta( $post_id, 'tix_order_total', (float) ( $this->order['total'] ?? 0 ) );
+				update_post_meta( $post_id, 'tix_ticket_price', (float) ( $ticket->tix_price ?? 0 ) );
+				update_post_meta( $post_id, 'tix_ticket_discounted_price', (float) ( $ticket->tix_discounted_price ?? 0 ) );
+
+				// @todo sanitize questions
+				update_post_meta( $post_id, 'tix_questions', wp_slash( $attendee->answers ) );
+
+				if ( $this->coupon && in_array( $attendee->ticket_id, $this->coupon->tix_applies_to ) ) {
+					update_post_meta( $post_id, 'tix_coupon_id', $this->coupon->ID );
+					update_post_meta( $post_id, 'tix_coupon', $this->coupon->post_title );
+				}
+
+				if ( isset( $this->reservation ) && $this->reservation && $this->reservation['ticket_id'] == $attendee->ticket_id ) {
+					if ( $reservation_quantity > 0 ) {
+						update_post_meta( $post_id, 'tix_reservation_id', $this->reservation['id'] );
+						update_post_meta( $post_id, 'tix_reservation_token', $this->reservation['token'] );
+						$reservation_quantity--;
+					}
+				}
+
+				// Write post content (triggers save_post).
+				wp_update_post( array( 'ID' => $post_id ) );
+				$attendee->post_id = $post_id;
+			}
+		}
+
+		return $attendees;
+	}
+
+	/**
+	 * Take a named database lock per ticket and coupon a checkout is about to claim from, so
+	 * another checkout for the same rows waits until this one has counted and written its
+	 * drafts. A mutex, not a transaction: every statement stays autocommit, so the count taken
+	 * after the lock reads the latest rows. Acquired in ID order, so two orders sharing rows
+	 * cannot deadlock. A lock that cannot be taken within ten seconds sets checkout_busy.
+	 *
+	 * @param int[] $post_ids Ticket and coupon post IDs in the order.
+	 * @return bool Whether the locks are held.
+	 */
+	function lock_checkout_rows( $post_ids ) {
+		global $wpdb;
+
+		$post_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) $post_ids ) ) ) );
+		if ( ! $post_ids ) {
+			return false;
+		}
+		sort( $post_ids );
+
+		// GET_LOCK is a SELECT, which WordPress.org's HyperDB would send to a replica where nobody
+		// else is waiting on it; pin the request to the master. Plain wpdb has one connection.
+		if ( method_exists( $wpdb, 'send_reads_to_masters' ) ) {
+			$wpdb->send_reads_to_masters();
+		}
+
+		// Registered before acquiring: a fatal or wp_die() partway through the loop, or later in a
+		// hook, would otherwise leave the locks already taken held past the request on a reused
+		// connection. A no-op after a normal release.
+		register_shutdown_function( array( $this, 'release_checkout_rows' ) );
+
+		$blog_id = get_current_blog_id();
+		foreach ( $post_ids as $post_id ) {
+			$name = sprintf( 'camptix_checkout_%d_%d', $blog_id, $post_id );
+			$got  = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK( %s, %d )', $name, 10 ) );
+
+			if ( '1' !== (string) $got ) {
+				$this->log( 'Could not take a checkout lock.', null, array( 'lock' => $name, 'result' => $got, 'error' => $wpdb->last_error ) );
+				$this->release_checkout_rows();
+				$this->error_flag( 'checkout_busy' );
+				return false;
+			}
+
+			$this->checkout_lock_names[] = $name;
+		}
+
+		$this->checkout_lock_open = true;
+
+		return true;
+	}
+
+	/**
+	 * Release the locks taken by lock_checkout_rows(). Idempotent.
+	 */
+	function release_checkout_rows() {
+		global $wpdb;
+
+		foreach ( $this->checkout_lock_names as $name ) {
+			$released = $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK( %s )', $name ) );
+
+			// 0: held by another connection; NULL: not held at all. Either way this checkout's lock
+			// is not what we released, and a lock left held stalls every later checkout for that row.
+			if ( '1' !== (string) $released ) {
+				$this->log( 'Checkout lock was not released.', null, array( 'lock' => $name, 'result' => $released, 'error' => $wpdb->last_error ) );
+			}
+		}
+
+		$this->checkout_lock_names = array();
+		$this->checkout_lock_open  = false;
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -88,7 +88,10 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		self::$attendees = array();
 
 		remove_filter( 'camptix_options', array( $this, 'enable_reservations' ) );
+		remove_filter( 'query', array( $this, 'record_query' ) );
 		self::$camptix->load_options();
+		self::$camptix->release_checkout_rows();
+		$this->seen_queries = array();
 
 		unset(
 			$_GET['post_type'],
@@ -815,6 +818,196 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 
 		$this->assertFalse( self::$camptix->is_coupon_valid_for_use( $coupon_id ) );
 		$this->assertTrue( self::$camptix->is_coupon_valid_for_use( $coupon_id, array( $coupon_draft ) ) );
+	}
+
+	/**
+	 * SQL statements seen by the checkout-lock tests, in order.
+	 *
+	 * @var string[]
+	 */
+	protected $seen_queries = array();
+
+	/**
+	 * Record each statement. The named locks run for real on the test connection and are
+	 * released again, so nothing needs neutralising.
+	 *
+	 * @param string $query SQL about to run.
+	 * @return string
+	 */
+	public function record_query( $query ) {
+		$this->seen_queries[] = trim( $query );
+
+		return $query;
+	}
+
+	/**
+	 * Return the recorded statements that match a pattern.
+	 *
+	 * @param string $pattern Regex.
+	 * @return string[]
+	 */
+	protected function seen( $pattern ) {
+		return array_values( preg_grep( $pattern, $this->seen_queries ) );
+	}
+
+	/**
+	 * Locking a checkout takes one named lock per ticket and coupon, in ID order (so two
+	 * orders sharing rows cannot deadlock), and releasing lets them all go.
+	 */
+	public function test_lock_checkout_rows_locks_in_id_order_and_releases() {
+		$ticket_a = $this->create_ticket();
+		$ticket_b = $this->create_ticket();
+		$coupon   = $this->create_coupon();
+		$blog_id  = get_current_blog_id();
+
+		add_filter( 'query', array( $this, 'record_query' ) );
+		$locked = self::$camptix->lock_checkout_rows( array( $ticket_b, $coupon, $ticket_a, $ticket_a ) );
+		self::$camptix->release_checkout_rows();
+		self::$camptix->release_checkout_rows(); // A second release is a no-op.
+		remove_filter( 'query', array( $this, 'record_query' ) );
+
+		$this->assertTrue( $locked );
+
+		$expected_ids = array( $ticket_a, $ticket_b, $coupon );
+		sort( $expected_ids );
+		$expected_names = array();
+		foreach ( $expected_ids as $id ) {
+			$expected_names[] = "camptix_checkout_{$blog_id}_{$id}";
+		}
+
+		$locks = $this->seen( '/GET_LOCK/' );
+		$this->assertCount( 3, $locks );
+		foreach ( $expected_names as $i => $name ) {
+			$this->assertStringContainsString( "'{$name}'", $locks[ $i ] );
+		}
+
+		$this->assertCount( 3, $this->seen( '/RELEASE_LOCK/' ) );
+	}
+
+	/**
+	 * Nothing to lock means no lock statements at all.
+	 */
+	public function test_lock_checkout_rows_with_no_ids_does_nothing() {
+		add_filter( 'query', array( $this, 'record_query' ) );
+		$locked = self::$camptix->lock_checkout_rows( array( 0, '', null ) );
+		self::$camptix->release_checkout_rows();
+		remove_filter( 'query', array( $this, 'record_query' ) );
+
+		$this->assertFalse( $locked );
+		$this->assertCount( 0, $this->seen( '/GET_LOCK|RELEASE_LOCK/' ) );
+	}
+
+	/**
+	 * Under the checkout lock the count query must run every call, not be served from the
+	 * query cache: the order is counted before checkout and again under the lock, and the
+	 * second read has to be live. Outside the lock (ticket form, admin columns) the cached
+	 * count is fine. Asserting values would pass either way, because wp_insert_post()
+	 * invalidates the posts cache; assert how often the SQL runs instead.
+	 */
+	public function test_purchased_count_query_is_live_only_under_the_lock() {
+		$ticket_id = $this->create_ticket( array( 'quantity' => 5 ) );
+
+		add_filter( 'query', array( $this, 'record_query' ) );
+
+		self::$camptix->get_purchased_tickets_count( $ticket_id );
+		self::$camptix->get_purchased_tickets_count( $ticket_id );
+		$outside = count( $this->seen( '/FROM.+posts.+tix_ticket_id/is' ) );
+
+		self::$camptix->lock_checkout_rows( array( $ticket_id ) );
+		self::$camptix->get_purchased_tickets_count( $ticket_id );
+		self::$camptix->get_purchased_tickets_count( $ticket_id );
+		self::$camptix->release_checkout_rows();
+		$inside = count( $this->seen( '/FROM.+posts.+tix_ticket_id/is' ) ) - $outside;
+
+		remove_filter( 'query', array( $this, 'record_query' ) );
+
+		$this->assertSame( 1, $outside, 'outside the lock the second call is served from the query cache' );
+		$this->assertSame( 2, $inside, 'under the lock every call hits the database' );
+	}
+
+	/**
+	 * The same, for the coupon count.
+	 */
+	public function test_used_coupons_count_query_is_live_only_under_the_lock() {
+		$coupon_id = $this->create_coupon();
+
+		add_filter( 'query', array( $this, 'record_query' ) );
+
+		self::$camptix->get_used_coupons_count( $coupon_id );
+		self::$camptix->get_used_coupons_count( $coupon_id );
+		$outside = count( $this->seen( '/FROM.+posts.+tix_coupon_id/is' ) );
+
+		self::$camptix->lock_checkout_rows( array( $coupon_id ) );
+		self::$camptix->get_used_coupons_count( $coupon_id );
+		self::$camptix->get_used_coupons_count( $coupon_id );
+		self::$camptix->release_checkout_rows();
+		$inside = count( $this->seen( '/FROM.+posts.+tix_coupon_id/is' ) ) - $outside;
+
+		remove_filter( 'query', array( $this, 'record_query' ) );
+
+		$this->assertSame( 1, $outside );
+		$this->assertSame( 2, $inside );
+	}
+
+	/**
+	 * Fail the Nth wp_insert_post() call, to test a draft that cannot be written.
+	 *
+	 * @var int
+	 */
+	protected $fail_insert_at = 0;
+
+	/**
+	 * New-post inserts seen by fail_nth_insert() in the current test.
+	 *
+	 * @var int
+	 */
+	protected $inserts_seen = 0;
+
+	/**
+	 * Callback for wp_insert_post_empty_content: fail the Nth new-post insert. Counts only
+	 * inserts (empty ID), because wp_update_post() runs the same filter for existing posts.
+	 *
+	 * @param bool  $maybe_empty Whether the post is considered empty.
+	 * @param array $postarr     Post data.
+	 * @return bool
+	 */
+	public function fail_nth_insert( $maybe_empty, $postarr ) {
+		if ( ! empty( $postarr['ID'] ) ) {
+			return $maybe_empty;
+		}
+
+		$this->inserts_seen++;
+
+		return $this->inserts_seen === $this->fail_insert_at ? true : $maybe_empty;
+	}
+
+	/**
+	 * A draft that cannot be written aborts the order and removes the drafts already written,
+	 * so a partial order never holds seats and the buyer is not sent to the gateway with no
+	 * attendee rows behind the order.
+	 */
+	public function test_insert_attendee_drafts_aborts_and_cleans_up_when_a_draft_cannot_be_written() {
+		$ticket_id = $this->create_ticket();
+
+		$attendees = array();
+		foreach ( array( 'One', 'Two' ) as $name ) {
+			$attendee             = new stdClass();
+			$attendee->ticket_id  = $ticket_id;
+			$attendee->first_name = $name;
+			$attendee->last_name  = 'Row';
+			$attendee->email      = strtolower( $name ) . '@example.test';
+			$attendee->answers    = array();
+			$attendees[]          = $attendee;
+		}
+
+		// The first attendee's draft is written normally; the second insert fails.
+		$this->fail_insert_at = 2;
+		add_filter( 'wp_insert_post_empty_content', array( $this, 'fail_nth_insert' ), 10, 2 );
+		$result = self::$camptix->insert_attendee_drafts( $attendees, 'stripe', 'r@example.test', 'acc', 'pay' );
+		remove_filter( 'wp_insert_post_empty_content', array( $this, 'fail_nth_insert' ), 10 );
+
+		$this->assertFalse( $result );
+		$this->assertSame( 0, self::$camptix->get_purchased_tickets_count( $ticket_id ), 'the first draft was removed again' );
 	}
 
 	/**

--- a/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
+++ b/public_html/wp-content/plugins/camptix/tests/test-camptix-admin.php
@@ -87,6 +87,9 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		self::$coupons   = array();
 		self::$attendees = array();
 
+		remove_filter( 'camptix_options', array( $this, 'enable_reservations' ) );
+		self::$camptix->load_options();
+
 		unset(
 			$_GET['post_type'],
 			$_GET['s'],
@@ -186,6 +189,7 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 			'coupon_id'        => '',
 			'payment_method'   => '',
 			'reservation'      => '',
+			'timestamp'        => 0,
 		);
 		$args     = wp_parse_args( $args, $defaults );
 
@@ -216,6 +220,9 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 		}
 		if ( ! empty( $args['reservation'] ) ) {
 			update_post_meta( $post_id, 'tix_reservation_token', $args['reservation'] );
+		}
+		if ( ! empty( $args['timestamp'] ) ) {
+			update_post_meta( $post_id, 'tix_timestamp', $args['timestamp'] );
 		}
 
 		self::$attendees[] = $post_id;
@@ -299,13 +306,68 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify draft attendees do not count toward purchased tickets.
+	 * A draft attendee is a checkout waiting on the payment gateway. It holds its
+	 * seat, so the ticket cannot be sold again underneath it.
 	 */
-	public function test_remaining_tickets_ignores_draft_attendees() {
+	public function test_remaining_tickets_counts_draft_attendees() {
 		$ticket_id = $this->create_ticket( array( 'quantity' => 10 ) );
 		$this->create_attendee( $ticket_id, array( 'status' => 'draft' ) );
 
+		$this->assertSame( 9, self::$camptix->get_remaining_tickets( $ticket_id ) );
+	}
+
+	/**
+	 * A checkout that ended without a sale releases its seat.
+	 *
+	 * @testWith ["cancel"]
+	 *           ["failed"]
+	 *           ["timeout"]
+	 *           ["refund"]
+	 */
+	public function test_remaining_tickets_ignores_finished_checkouts( $status ) {
+		$ticket_id = $this->create_ticket( array( 'quantity' => 10 ) );
+		$this->create_attendee( $ticket_id, array( 'status' => $status ) );
+
 		$this->assertSame( 10, self::$camptix->get_remaining_tickets( $ticket_id ) );
+	}
+
+	/**
+	 * A checkout abandoned more than 24 hours ago is timed out by the sweep and
+	 * its seat goes back on sale. A younger one is left alone.
+	 */
+	public function test_timeout_sweep_releases_abandoned_checkout() {
+		$ticket_id   = $this->create_ticket( array( 'quantity' => 2 ) );
+		$abandoned   = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'    => 'draft',
+				'timestamp' => time() - 25 * HOUR_IN_SECONDS,
+			)
+		);
+		$in_progress = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'    => 'draft',
+				'timestamp' => time() - HOUR_IN_SECONDS,
+			)
+		);
+
+		$this->assertSame( 0, self::$camptix->get_remaining_tickets( $ticket_id ) );
+
+		self::$camptix->review_timeout_payments();
+
+		$this->assertSame( 'timeout', get_post_status( $abandoned ) );
+		$this->assertSame( 'draft', get_post_status( $in_progress ) );
+		$this->assertSame( 1, self::$camptix->get_remaining_tickets( $ticket_id ) );
+	}
+
+	/**
+	 * The sweep runs on the ten-minute schedule, so an abandoned checkout holds
+	 * its seat for about 24 hours rather than anywhere up to 48.
+	 */
+	public function test_timeout_sweep_runs_every_ten_minutes() {
+		$this->assertNotFalse( has_action( 'tix_scheduled_every_ten_minutes', array( self::$camptix, 'review_timeout_payments' ) ) );
+		$this->assertFalse( has_action( 'tix_scheduled_daily', array( self::$camptix, 'review_timeout_payments' ) ) );
 	}
 
 	/**
@@ -317,16 +379,65 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify only publish and pending attendees count as purchased.
+	 * Verify publish, pending and draft attendees count as purchased, and the
+	 * statuses a checkout ends in without a sale do not.
 	 */
 	public function test_purchased_tickets_count_with_mixed_statuses() {
 		$ticket_id = $this->create_ticket();
 		$this->create_attendee( $ticket_id, array( 'status' => 'publish' ) );
 		$this->create_attendee( $ticket_id, array( 'status' => 'pending' ) );
 		$this->create_attendee( $ticket_id, array( 'status' => 'draft' ) );
+		$this->create_attendee( $ticket_id, array( 'status' => 'cancel' ) );
+		$this->create_attendee( $ticket_id, array( 'status' => 'failed' ) );
+		$this->create_attendee( $ticket_id, array( 'status' => 'timeout' ) );
+		$this->create_attendee( $ticket_id, array( 'status' => 'refund' ) );
 
-		// Only publish + pending count as purchased.
-		$this->assertSame( 2, self::$camptix->get_purchased_tickets_count( $ticket_id ) );
+		$this->assertSame( 3, self::$camptix->get_purchased_tickets_count( $ticket_id ) );
+	}
+
+	/**
+	 * A checkout in progress against a reservation uses up one of its seats.
+	 */
+	public function test_reservation_counts_draft_attendees() {
+		add_filter( 'camptix_options', array( $this, 'enable_reservations' ) );
+		self::$camptix->load_options();
+
+		$ticket_id = $this->create_ticket( array( 'quantity' => 5 ) );
+		add_post_meta(
+			$ticket_id,
+			'tix_reservation',
+			array(
+				'id'        => 'speakers',
+				'token'     => 'speakertoken',
+				'quantity'  => 1,
+				'name'      => 'Speakers',
+				'ticket_id' => $ticket_id,
+			)
+		);
+
+		$this->assertTrue( self::$camptix->is_reservation_valid_for_use( 'speakertoken' ) );
+
+		$this->create_attendee(
+			$ticket_id,
+			array(
+				'status'      => 'draft',
+				'reservation' => 'speakertoken',
+			)
+		);
+
+		$this->assertFalse( self::$camptix->is_reservation_valid_for_use( 'speakertoken' ) );
+	}
+
+	/**
+	 * Filter callback for camptix_options: turn reservations on for a test.
+	 *
+	 * @param array $options CampTix options.
+	 * @return array
+	 */
+	public function enable_reservations( $options ) {
+		$options['reservations_enabled'] = true;
+
+		return $options;
 	}
 
 	/**
@@ -613,7 +724,8 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify used coupons count excludes draft attendees.
+	 * Verify used coupons count includes draft attendees (a checkout in progress)
+	 * and excludes ones whose checkout ended without a sale.
 	 */
 	public function test_used_coupons_count() {
 		$ticket_id = $this->create_ticket();
@@ -622,24 +734,125 @@ class Test_CampTix_Admin extends WP_UnitTestCase {
 			'discount_price' => 5.00,
 		) );
 
-		$this->create_attendee( $ticket_id, array( 'coupon_id' => $coupon_id ) );
-		$this->create_attendee(
+		foreach ( array( 'publish', 'pending', 'draft', 'cancel', 'failed', 'timeout', 'refund' ) as $status ) {
+			$this->create_attendee(
+				$ticket_id,
+				array(
+					'coupon_id' => $coupon_id,
+					'status'    => $status,
+				)
+			);
+		}
+
+		$this->assertSame( 3, self::$camptix->get_used_coupons_count( $coupon_id ) );
+	}
+
+	/**
+	 * An order re-checking its own availability (the gateway's final verify_order()
+	 * before charging) must not count its own in-progress drafts against it, or buying
+	 * the last remaining seat would fail.
+	 */
+	public function test_remaining_tickets_excludes_the_orders_own_drafts() {
+		$ticket_id = $this->create_ticket( array( 'quantity' => 1 ) );
+		$own       = $this->create_attendee(
 			$ticket_id,
 			array(
-				'coupon_id' => $coupon_id,
-				'status'    => 'pending',
-			)
-		);
-		// Draft attendee should not count.
-		$this->create_attendee(
-			$ticket_id,
-			array(
-				'coupon_id' => $coupon_id,
 				'status'    => 'draft',
+				'timestamp' => time(),
 			)
 		);
 
-		$this->assertSame( 2, self::$camptix->get_used_coupons_count( $coupon_id ) );
+		// The seat is taken for everyone else.
+		$this->assertSame( 0, self::$camptix->get_remaining_tickets( $ticket_id ) );
+
+		// But the order that owns that draft still sees its seat as available to it.
+		$this->assertSame( 1, self::$camptix->get_remaining_tickets( $ticket_id, false, array( $own ) ) );
+	}
+
+	/**
+	 * The same exclusion applies to the coupon and reservation checks.
+	 */
+	public function test_coupon_and_reservation_exclude_the_orders_own_drafts() {
+		add_filter( 'camptix_options', array( $this, 'enable_reservations' ) );
+		self::$camptix->load_options();
+
+		$ticket_id = $this->create_ticket( array( 'quantity' => 5 ) );
+		add_post_meta(
+			$ticket_id,
+			'tix_reservation',
+			array(
+				'id'        => 'speakers',
+				'token'     => 'speakertoken',
+				'quantity'  => 1,
+				'name'      => 'Speakers',
+				'ticket_id' => $ticket_id,
+			)
+		);
+		$coupon_id = $this->create_coupon(
+			array(
+				'quantity'     => 1,
+				'discount_pct' => 100,
+			)
+		);
+
+		$reservation_draft = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'      => 'draft',
+				'reservation' => 'speakertoken',
+			)
+		);
+		$coupon_draft = $this->create_attendee(
+			$ticket_id,
+			array(
+				'status'    => 'draft',
+				'coupon_id' => $coupon_id,
+			)
+		);
+
+		$this->assertFalse( self::$camptix->is_reservation_valid_for_use( 'speakertoken' ) );
+		$this->assertTrue( self::$camptix->is_reservation_valid_for_use( 'speakertoken', array( $reservation_draft ) ) );
+
+		$this->assertFalse( self::$camptix->is_coupon_valid_for_use( $coupon_id ) );
+		$this->assertTrue( self::$camptix->is_coupon_valid_for_use( $coupon_id, array( $coupon_draft ) ) );
+	}
+
+	/**
+	 * A checkout in progress against a single-use coupon uses it up, and a coupon
+	 * with redemptions to spare stays valid.
+	 */
+	public function test_coupon_valid_for_use_counts_draft_attendees() {
+		$ticket_id  = $this->create_ticket();
+		$single_use = $this->create_coupon(
+			array(
+				'code'         => 'ONCE',
+				'quantity'     => 1,
+				'discount_pct' => 100,
+			)
+		);
+		$two_uses   = $this->create_coupon(
+			array(
+				'code'         => 'TWICE',
+				'quantity'     => 2,
+				'discount_pct' => 100,
+			)
+		);
+
+		$this->assertTrue( self::$camptix->is_coupon_valid_for_use( $single_use ) );
+		$this->assertTrue( self::$camptix->is_coupon_valid_for_use( $two_uses ) );
+
+		foreach ( array( $single_use, $two_uses ) as $coupon_id ) {
+			$this->create_attendee(
+				$ticket_id,
+				array(
+					'coupon_id' => $coupon_id,
+					'status'    => 'draft',
+				)
+			);
+		}
+
+		$this->assertFalse( self::$camptix->is_coupon_valid_for_use( $single_use ) );
+		$this->assertTrue( self::$camptix->is_coupon_valid_for_use( $two_uses ) );
 	}
 
 	/**


### PR DESCRIPTION
### Why

A paid checkout creates the attendee as a draft and only publishes it once payment is confirmed. Every quantity check runs through `get_purchased_tickets_count()` and `get_used_coupons_count()`, and both counted `publish` and `pending` only, so the ticket count didn't drop while a purchase was in progress and the seat stayed on offer to everyone else. Two people buying the last ticket at the same time both finished, and it sold twice. That is #1301, and it is what happened at WordCamp Sylhet in April 2024 with ordinary buyers.

Two commits: the first counts checkouts in progress, the second makes the count-and-claim one step so simultaneous checkouts can't both take the last seat.

### What changed

**Count checkouts in progress**

- `get_purchased_tickets_count()` and `get_used_coupons_count()` count `draft` attendees. The "remaining" number on the ticket form, the Tickets and Coupons admin columns, and a reservation's "Used" column now include checkouts in progress. `cancel`, `failed`, `timeout` and `refund` still don't count.
- The gateway re-checks the order right before charging, and by then the buyer's own drafts exist. So the counting functions take an optional list of attendee IDs to exclude, and `verify_order()` passes the order's own attendees. Without it, buying the last seat would fail: the buyer's own draft would count against them and empty their order.
- An abandoned checkout keeps its seat until `review_timeout_payments()` moves it to `timeout` at 24 hours, matching the Stripe Checkout session lifetime. That sweep moves from the daily cron to the ten-minute one, so the seat comes back at 24 hours rather than anywhere up to 48.

**Sell the last seat once**

- `form_checkout()` takes a named database lock (`GET_LOCK`) per ticket and coupon in the order, in ID order, while it counts and writes its drafts, and releases them before any gateway call. A second checkout for the same rows waits until the first has claimed its seats. It's a mutex, not a transaction: statements stay autocommit, so the count after the lock is current and nothing needs rolling back.
- While the lock is held the counting queries read live rather than from the query cache, because the order is counted once before checkout and again under the lock. Everywhere else (ticket form, admin columns, reports) they stay cached as before.
- Nothing renders while the lock is held. A checkout that can't get the lock within ten seconds, or whose draft can't be written, is asked to try again; partially written drafts are removed so they never hold seats.
- On production's HyperDB a `GET_LOCK` is treated as a read and would land on a replica where no one else is waiting, so the request is pinned to the primary first. Local `wpdb` has no such method and uses one connection.

Visible effect for buyers: during a rush, checkouts for the same ticket are processed one behind another (tens of milliseconds each), and the odd buyer who loses the last seat is told to try again instead of being sold a ticket that isn't there.

Known follow-up, tracked separately and to land close behind: a buyer who abandons a paid checkout without using the gateway's cancel link has their own draft hold their single-use coupon or quantity-1 reservation until the 24-hour timeout, where before this change they could simply retry. There is no self-service way out in those 24 hours: the attendee status control on the edit screen needs `manage_sites`, so an organiser can't release a stuck draft either, and each case is a Central ticket until the follow-up lands.

### Testing

`Test_CampTix_Admin` and `Test_CampTix_Plugin`, the branch's test files against `production`'s `camptix.php` and against the branch:

| | `production` | branch |
|---|---|---|
| the counting and lock tests | fail | pass |

New tests cover a draft at each of the three checks, the four finished statuses, the 24-hour sweep and its schedule, an order not blocking its own re-check, the locks taken in ID order and released, the count reading live only under the lock, and a draft that can't be written aborting the order and removing the ones already written. Five revenue-report tests skip on both for lack of `intl`.

Parallel checkouts against a quantity-limited ticket, coupon and reservation, on a standalone install with the gateway mocked: `production` sells past the limit, the branch sells exactly the limit.

