### PR TITLE
Groups: constrain featured image aspect ratio on pages to 16/9

### DIFF
--- a/public_html/wp-content/themes/groups-site/templates/page.html
+++ b/public_html/wp-content/themes/groups-site/templates/page.html
@@ -14,7 +14,7 @@
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","contentSize":"1160px","justifyContent":"center"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
-		<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}},"border":{"radius":"4px"}}} /-->
+		<!-- wp:post-featured-image {"aspectRatio":"16/9","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}},"border":{"radius":"4px"}}} /-->
 
 		<!-- wp:post-content /-->
 


### PR DESCRIPTION
Fixes #2034.

### Description
On pages such as About, tall featured images rendered without an aspect ratio, causing them to render at full height and dominate the viewport.

This update sets `"aspectRatio": "16/9"` on the `core/post-featured-image` block in `page.html`, bringing it in line with the group site's `front-page.html`, `single.html`, and `single-event.html` templates.