### PR TITLE
Groups: Make online event link optional for online events

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/rest.php
@@ -1044,13 +1044,6 @@ function persist_event( int $event_id, WP_REST_Request $request ) {
 	if ( $fields['time_start'] === $fields['time_end'] ) {
 		return new WP_Error( 'wporg_groups_bad_time_range', 'End time must be after start time.', array( 'status' => 400 ) );
 	}
-	if ( $fields['is_online'] && '' === $fields['online_event_link'] ) {
-		return new WP_Error(
-			'wporg_groups_missing_online_event_link',
-			'Online event link is required for online events.',
-			array( 'status' => 400 )
-		);
-	}
 
 	$post_args = array(
 		'post_type'    => Event::POST_TYPE,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/event-form.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/event-form.js
@@ -332,7 +332,6 @@ function EventForm(
 						value={ form.online_event_link }
 						onChange={ ( value ) => updateField( 'online_event_link', value ) }
 						placeholder="https://"
-						required
 						__nextHasNoMarginBottom
 					/>
 				) }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-rest.php
@@ -834,4 +834,26 @@ class Test_Groups_REST extends Groups_TestCase {
 
 		$this->assertTrue( $recurrence['locked'] );
 	}
+
+	/**
+	 * An online event can be created without an online event link.
+	 */
+	public function test_create_online_event_without_link(): void {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$params = array_merge(
+			$this->base_event_params(),
+			array(
+				'is_online'         => true,
+				'online_event_link' => '',
+			)
+		);
+
+		$response = create_event( $this->event_request( $params ) );
+
+		$this->assertNotWPError( $response );
+		$event_id = $response->get_data()['id'];
+		$this->assertSame( '', (string) get_post_meta( $event_id, 'gatherpress_online_event_link', true ) );
+	}
 }


### PR DESCRIPTION
Fixes #2029

### Changes
- Removes `required` validation in REST API (`inc/rest.php`) when creating or updating an online event with an empty online event link.
- Removes `required` attribute on the `online_event_link` text field in the event form component (`event-form.js`).
- Adds a unit test in `tests/test-rest.php` verifying that online events can be created without a link.