### PR TITLE
Groups: Allow clearing events search to restore full list

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/gatherpress-groups-tweaks.php
@@ -226,7 +226,8 @@ add_action( 'init', __NAMESPACE__ . '\register_event_speakers_meta' );
 /**
  * Rewrite the search block form action on the events archive to submit
  * to the archive URL instead of the default search URL, so search results
- * stay scoped to events.
+ * stay scoped to events. Also remove the required attribute and handle clearing
+ * the search field to restore the full list of upcoming events.
  */
 add_filter(
 	'render_block_core/search',
@@ -242,6 +243,17 @@ add_filter(
 			$content
 		);
 
+		// Remove required attribute safely and mark the events search form for the clear script.
+		$processor = new \WP_HTML_Tag_Processor( $content );
+		while ( $processor->next_tag() ) {
+			if ( 'FORM' === $processor->get_tag() ) {
+				$processor->set_attribute( 'data-events-search-form', '1' );
+			} elseif ( 'INPUT' === $processor->get_tag() ) {
+				$processor->remove_attribute( 'required' );
+			}
+		}
+		$content = $processor->get_updated_html();
+
 		// Add hidden field to default to "all" time when searching.
 		$content = str_replace(
 			'</form>',
@@ -254,17 +266,41 @@ add_filter(
 );
 
 /**
+ * Normalize the event time filter ('upcoming', 'past', 'all').
+ *
+ * An empty search query should not force the "all" time view. Reverts to "upcoming"
+ * when search query is empty and time is "all".
+ *
+ * @param string      $time   The event time filter slug.
+ * @param string|null $search The search query string. If null, reads from $_GET['s'].
+ * @return string Normalized time filter.
+ */
+function normalize_event_time_filter( string $time, ?string $search = null ): string {
+	if ( null === $search ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only view state.
+		$search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : null;
+	}
+
+	if ( null !== $search && '' === trim( $search ) && 'all' === $time ) {
+		return 'upcoming';
+	}
+
+	return $time;
+}
+
+/**
  * Register query filter options for event archive filtering.
  */
 add_filter(
 	'wporg_query_filter_options_event_time',
 	static function (): array {
 		$current = isset( $_GET['event_time'] ) ? sanitize_text_field( wp_unslash( $_GET['event_time'] ) ) : 'upcoming';
+		$current = normalize_event_time_filter( $current );
 
 		$options = array(
 			'upcoming' => __( 'Upcoming', 'wporg-groups-frontend' ),
 			'past'     => __( 'Past', 'wporg-groups-frontend' ),
-			'all'      => __( 'All events', 'wporg-groups-frontend' ),
+			'all'      => __( 'All', 'wporg-groups-frontend' ),
 		);
 
 		if ( ! isset( $options[ $current ] ) ) {
@@ -274,7 +310,6 @@ add_filter(
 		$selected = array( $current );
 		$label    = __( 'Time', 'wporg-groups-frontend' );
 		if ( 'upcoming' !== $current ) {
-
 			// Single-select filters hide the wporg count badge, so carry the
 			// applied choice in the toggle text itself.
 			$label = sprintf(
@@ -347,6 +382,11 @@ add_filter(
 		}
 
 		$time_filter = isset( $_GET['event_time'] ) ? sanitize_text_field( wp_unslash( $_GET['event_time'] ) ) : 'upcoming';
+
+		// An empty search query should not force the "all" time view.
+		if ( isset( $_GET['s'] ) && '' === trim( (string) $_GET['s'] ) && 'all' === $time_filter ) {
+			$time_filter = 'upcoming';
+		}
 
 		if ( 'past' === $time_filter ) {
 			$query_vars['gatherpress_event_query'] = 'past';

--- a/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-gatherpress-groups-tweaks.php
@@ -2,6 +2,8 @@
 
 namespace WordCamp\Groups\Tests;
 
+use function WordCamp\Groups\GatherPress_Tweaks\normalize_event_time_filter;
+
 defined( 'WPINC' ) || die();
 
 require_once dirname( __DIR__, 2 ) . '/wporg-groups-frontend/tests/class-groups-testcase.php';
@@ -212,5 +214,103 @@ class Test_Groups_GatherPress_Tweaks extends Groups_TestCase {
 		$this->assertFalse( $post_type_object->public );
 		$this->assertFalse( $post_type_object->publicly_queryable );
 		$this->assertFalse( $post_type_object->has_archive );
+	}
+
+	/**
+	 * Search block on the events archive rewrites form action, removes required,
+	 * adds the event_time hidden input, and marks the form for events search clear.
+	 */
+	public function test_search_block_removes_required_and_handles_clearing() {
+		global $wp_query;
+
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.NamingConventions.ValidHookName.UseUnderscores
+		$original_query                 = $wp_query;
+		$wp_query                       = new \WP_Query();
+		$wp_query->is_post_type_archive = true;
+		$wp_query->set( 'post_type', 'gatherpress_event' );
+
+		$input_html = '<form role="search" method="get" action="https://example.org">'
+			. '<input type="search" name="s" required />'
+			. '</form>';
+
+		$output = apply_filters( 'render_block_core/search', $input_html );
+
+		$archive_url = get_post_type_archive_link( 'gatherpress_event' );
+		$this->assertStringContainsString( 'action="' . esc_url( $archive_url ) . '"', $output );
+		$this->assertStringContainsString( 'data-events-search-form="1"', $output );
+		$this->assertStringNotContainsString( 'required', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="event_time" value="all" />', $output );
+		$this->assertStringNotContainsString( '<script', $output );
+
+		$processor = new \WP_HTML_Tag_Processor( $output );
+		$this->assertTrue( $processor->next_tag( 'form' ) );
+		$this->assertSame( '1', $processor->get_attribute( 'data-events-search-form' ) );
+		$this->assertTrue( $processor->next_tag( 'input' ) );
+		$this->assertNull( $processor->get_attribute( 'required' ) );
+
+		$wp_query = $original_query;
+		// phpcs:enable
+	}
+
+	/**
+	 * Search block on other pages remains untouched.
+	 */
+	public function test_search_block_untouched_outside_event_archive() {
+		global $wp_query;
+
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.NamingConventions.ValidHookName.UseUnderscores
+		$original_query                 = $wp_query;
+		$wp_query                       = new \WP_Query();
+		$wp_query->is_post_type_archive = false;
+
+		$input_html = '<form role="search" method="get" action="https://example.org">'
+			. '<input type="search" name="s" required />'
+			. '</form>';
+
+		$output = apply_filters( 'render_block_core/search', $input_html );
+
+		$this->assertSame( $input_html, $output );
+
+		$wp_query = $original_query;
+		// phpcs:enable
+	}
+
+	/**
+	 * Empty search query parameter reverts the default all-time view back to upcoming.
+	 */
+	public function test_event_time_filter_reverts_to_upcoming_on_empty_search() {
+		$_GET['s'] = '';
+		$filter    = $this->get_event_time_filter( 'all' );
+		unset( $_GET['s'] );
+
+		$this->assertSame( 'Time', $filter['label'] );
+		$this->assertSame( array( 'upcoming' ), $filter['selected'] );
+	}
+
+	/**
+	 * Normalizing event time filter reverts 'all' to 'upcoming' on empty search query.
+	 */
+	public function test_normalize_event_time_filter() {
+		// When search query is empty string or whitespace and time is 'all'.
+		$this->assertSame( 'upcoming', normalize_event_time_filter( 'all', '' ) );
+		$this->assertSame( 'upcoming', normalize_event_time_filter( 'all', '   ' ) );
+
+		// When search query has text, 'all' is preserved.
+		$this->assertSame( 'all', normalize_event_time_filter( 'all', 'wordcamp' ) );
+
+		// When search is not set (null), 'all' is preserved.
+		unset( $_GET['s'] );
+		$this->assertSame( 'all', normalize_event_time_filter( 'all' ) );
+
+		// When reading from $_GET['s'].
+		$_GET['s'] = '';
+		$this->assertSame( 'upcoming', normalize_event_time_filter( 'all' ) );
+		$_GET['s'] = 'community';
+		$this->assertSame( 'all', normalize_event_time_filter( 'all' ) );
+		unset( $_GET['s'] );
+
+		// When time is not 'all', it is preserved.
+		$this->assertSame( 'past', normalize_event_time_filter( 'past', '' ) );
+		$this->assertSame( 'upcoming', normalize_event_time_filter( 'upcoming', '' ) );
 	}
 }

--- a/public_html/wp-content/themes/groups-site/assets/js/events-search.js
+++ b/public_html/wp-content/themes/groups-site/assets/js/events-search.js
@@ -1,0 +1,31 @@
+/**
+ * Handles clearing the events search input on the archive page to restore the full list of upcoming events.
+ */
+( function() {
+	function init() {
+		const forms = document.querySelectorAll( '.wp-block-search[data-events-search-form]' );
+		forms.forEach( function( form ) {
+			const input = form.querySelector( 'input[type="search"], input[name="s"]' );
+			if ( ! input ) {
+				return;
+			}
+			input.addEventListener( 'search', function() {
+				if ( ! this.value ) {
+					location.href = form.action;
+				}
+			} );
+			form.addEventListener( 'submit', function( e ) {
+				if ( ! input.value.trim() ) {
+					e.preventDefault();
+					location.href = form.action;
+				}
+			} );
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+}() );

--- a/public_html/wp-content/themes/groups-site/functions.php
+++ b/public_html/wp-content/themes/groups-site/functions.php
@@ -47,7 +47,18 @@ function enqueue_assets() {
 		array( 'groups-site-custom' ),
 		filemtime( get_theme_file_path( 'assets/css/responsive.css' ) )
 	);
+
+	if ( is_post_type_archive( 'gatherpress_event' ) ) {
+		wp_enqueue_script(
+			'groups-site-events-search',
+			get_theme_file_uri( 'assets/js/events-search.js' ),
+			array(),
+			filemtime( get_theme_file_path( 'assets/js/events-search.js' ) ),
+			true
+		);
+	}
 }
+
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_assets' );
 
@@ -168,6 +179,11 @@ function event_archive_body_classes( array $classes ): array {
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only view state.
 	$time = isset( $_GET['event_time'] ) ? sanitize_key( wp_unslash( $_GET['event_time'] ) ) : 'upcoming';
+	if ( function_exists( '\WordCamp\Groups\GatherPress_Tweaks\normalize_event_time_filter' ) ) {
+		$time = \WordCamp\Groups\GatherPress_Tweaks\normalize_event_time_filter( $time );
+	} elseif ( isset( $_GET['s'] ) && '' === trim( sanitize_text_field( wp_unslash( $_GET['s'] ) ) ) && 'all' === $time ) {
+		$time = 'upcoming';
+	}
 	if ( ! in_array( $time, array( 'upcoming', 'past', 'all' ), true ) ) {
 		$time = 'upcoming';
 	}

--- a/public_html/wp-content/themes/groups-site/patterns/archive-events-empty.php
+++ b/public_html/wp-content/themes/groups-site/patterns/archive-events-empty.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Archive — events empty state
+ * Title: Archive - events empty state
  * Slug: groups-site/archive-events-empty
  * Categories: groups-site
  * Inserter: no
@@ -20,6 +20,11 @@ defined( 'ABSPATH' ) || exit;
 // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only view state.
 $search_term = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 $time_filter = isset( $_GET['event_time'] ) ? sanitize_key( wp_unslash( $_GET['event_time'] ) ) : 'upcoming';
+if ( function_exists( '\WordCamp\Groups\GatherPress_Tweaks\normalize_event_time_filter' ) ) {
+	$time_filter = \WordCamp\Groups\GatherPress_Tweaks\normalize_event_time_filter( $time_filter, $search_term );
+} elseif ( '' === $search_term && 'all' === $time_filter ) {
+	$time_filter = 'upcoming';
+}
 // phpcs:enable
 
 $archive_url = get_post_type_archive_link( 'gatherpress_event' );


### PR DESCRIPTION
Fixes #2024

### Changes
- Removes `required` attribute from the search input on the events archive (`gatherpress-groups-tweaks.php`), preventing the browser from blocking submission when the input is emptied.
- Automatically resets and navigates to the events archive link when the browser's native clear button `(x)` is clicked or an empty search form is submitted.
- Reverts the forced `event_time=all` search default back to `upcoming` if an empty search query is submitted, restoring the full default list of upcoming events.
- Adds test cases for the search block filter and empty search parameter behavior.