### PR TITLE
Groups: Restrict allowed blocks in event description editor

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/constants.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/constants.js
@@ -1,0 +1,18 @@
+/**
+ * Allowed core blocks for the event description prose.
+ * Kept in sync with DESCRIPTION_BLOCK_NAMES in inc/defaults.php.
+ */
+export const ALLOWED_BLOCK_TYPES = [
+	'core/paragraph',
+	'core/heading',
+	'core/list',
+	'core/list-item',
+	'core/image',
+	'core/quote',
+	'core/separator',
+	'core/code',
+	'core/preformatted',
+	'core/group',
+	'core/columns',
+	'core/column',
+];

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor.js
@@ -21,6 +21,9 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { createBlock, parse, serialize } from '@wordpress/blocks';
+import { ALLOWED_BLOCK_TYPES } from './constants';
+
+export { ALLOWED_BLOCK_TYPES };
 
 let coreBlocksRegistered = false;
 
@@ -32,14 +35,14 @@ export function ensureCoreBlocksRegistered() {
 		registerCoreBlocks();
 	} catch ( e ) {
 		// `registerCoreBlocks` complains if called twice, but in some
-		// page contexts the editor isn't loaded yet — swallow.
+		// page contexts the editor isn't loaded yet - swallow.
 	}
 	coreBlocksRegistered = true;
 }
 
 // `BlockEditorProvider` gives its subtree an isolated `core/block-editor`
 // registry, so this dispatch only reaches it from a component rendered
-// *inside* the provider — a sibling effect would select a block in the
+// *inside* the provider - a sibling effect would select a block in the
 // wrong (default) store and `BlockToolbar` would never see it.
 function SelectFirstBlockOnMount( { clientId } ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
@@ -47,7 +50,7 @@ function SelectFirstBlockOnMount( { clientId } ) {
 	useEffect( () => {
 		if ( clientId ) {
 			// `null` (instead of the default `0`) selects the block
-			// without also moving real DOM focus into it — see
+			// without also moving real DOM focus into it - see
 			// `useFocusFirstElement` in `@wordpress/block-editor`. We
 			// only need the toolbar to appear, not to steal focus from
 			// the modal on open.
@@ -69,7 +72,7 @@ function SelectFirstBlockOnMount( { clientId } ) {
  *     values back into the editor (no `value` prop, no `useEffect` on
  *     value, no setState ping-pong).
  *   - When the parent needs the serialised markup at submit time it
- *     calls `getValueRef.current()` — the editor exposes an imperative
+ *     calls `getValueRef.current()` - the editor exposes an imperative
  *     getter via the supplied ref instead of pushing every keystroke
  *     up the tree.
  *
@@ -86,10 +89,12 @@ function SelectFirstBlockOnMount( { clientId } ) {
 export default function DescriptionEditor( { initialValue, getValueRef, onDirty, classPrefix } ) {
 	// A description with no supported blocks (empty string, or markup
 	// that doesn't parse into anything) yields `[]`, leaving no block to
-	// select and the toolbar permanently empty — fall back to an empty
+	// select and the toolbar permanently empty - fall back to an empty
 	// paragraph so there's always a first block.
 	const [ blocks, setBlocks ] = useState( () => {
-		const parsed = parse( initialValue || '' );
+		const parsed = parse( initialValue || '' ).filter( ( block ) =>
+			ALLOWED_BLOCK_TYPES.includes( block.name )
+		);
 		return parsed.length ? parsed : [ createBlock( 'core/paragraph' ) ];
 	} );
 
@@ -115,6 +120,7 @@ export default function DescriptionEditor( { initialValue, getValueRef, onDirty,
 				onChange: handleChange,
 				settings: {
 					hasFixedToolbar: true,
+					allowedBlockTypes: ALLOWED_BLOCK_TYPES,
 				},
 			},
 			h( SelectFirstBlockOnMount, { clientId: blocks[ 0 ]?.clientId } ),

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/description-editor.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/description-editor.test.js
@@ -1,0 +1,35 @@
+import { ALLOWED_BLOCK_TYPES } from '../src/components/event-form/constants';
+
+describe( 'DescriptionEditor ALLOWED_BLOCK_TYPES', () => {
+	test( 'includes only the allowed description blocks', () => {
+		expect( ALLOWED_BLOCK_TYPES ).toEqual( [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/list-item',
+			'core/image',
+			'core/quote',
+			'core/separator',
+			'core/code',
+			'core/preformatted',
+			'core/group',
+			'core/columns',
+			'core/column',
+		] );
+	} );
+
+	test( 'disallows unsupported blocks that cannot round-trip', () => {
+		const disallowed = [
+			'core/pullquote',
+			'core/gallery',
+			'core/cover',
+			'core/audio',
+			'core/video',
+			'core/table',
+		];
+
+		disallowed.forEach( ( blockName ) => {
+			expect( ALLOWED_BLOCK_TYPES ).not.toContain( blockName );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #2042

### Changes
- Restricts `allowedBlockTypes` in the event description `BlockEditorProvider` settings to only the blocks supported by `DESCRIPTION_BLOCK_NAMES` (`core/paragraph`, `core/heading`, `core/list`, `core/list-item`, `core/image`, `core/quote`, `core/separator`, `core/code`, `core/preformatted`, `core/group`, `core/columns`, `core/column`).
- Filters parsed initial blocks on mount to drop unsupported blocks before rendering.
- Adds test coverage in `tests-js/description-editor.test.js`.