### PR TITLE
Groups: Enable inline formatting in description editor

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/modal.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/inc/modal.php
@@ -39,6 +39,7 @@ function enqueue_supplementary_assets(): void {
 	wp_enqueue_media();
 	wp_enqueue_style( 'wp-components' );
 	wp_enqueue_style( 'wp-block-editor' );
+	wp_enqueue_style( 'wp-format-library' );
 }
 
 /**

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { registerCoreFormatTypes } from '@wordpress/format-library';
 import { createBlock, parse, serialize } from '@wordpress/blocks';
 
 let coreBlocksRegistered = false;
@@ -32,7 +33,12 @@ export function ensureCoreBlocksRegistered() {
 		registerCoreBlocks();
 	} catch ( e ) {
 		// `registerCoreBlocks` complains if called twice, but in some
-		// page contexts the editor isn't loaded yet — swallow.
+		// page contexts the editor isn't loaded yet - swallow.
+	}
+	try {
+		registerCoreFormatTypes();
+	} catch ( e ) {
+		// `registerCoreFormatTypes` may throw if called twice - swallow.
 	}
 	coreBlocksRegistered = true;
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests/test-event-manage-block.php
@@ -124,4 +124,18 @@ class Test_Event_Manage_Block extends Groups_TestCase {
 
 		$this->assertSame( '', trim( (string) $output ) );
 	}
+
+	/**
+	 * Supplementary assets for the modal include wp-format-library styles.
+	 */
+	public function test_supplementary_assets_enqueue_format_library() {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		\WordCamp\Groups\Frontend\Modal\enqueue_supplementary_assets();
+
+		$this->assertTrue( wp_style_is( 'wp-format-library', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'wp-block-editor', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
+	}
 }


### PR DESCRIPTION
Fixes #2017

### Changes
- Imports and calls `registerCoreFormatTypes` from `@wordpress/format-library` in `description-editor.js`, registering inline format types (bold, italic, link, etc.) in the event description editor toolbar.
- Enqueues `wp-format-library` stylesheet alongside `wp-components` and `wp-block-editor` in `enqueue_supplementary_assets()` in `inc/modal.php`.
- Adds test coverage in `tests/test-event-manage-block.php`.