### PR TITLE
Groups: Add undo/redo history stack and shortcut support in description editor

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor-history.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor-history.js
@@ -1,0 +1,201 @@
+/**
+ * History manager for the event description block editor.
+ *
+ * Implements an undo/redo stack that distinguishes between transient
+ * keystrokes (onInput) and committed block changes (onChange).
+ *
+ * @package WordCamp\Groups\Frontend
+ */
+
+export const MAX_HISTORY_LENGTH = 50;
+
+/**
+ * Deep clone an arbitrary value (objects, arrays, primitives).
+ *
+ * @param {*} value The value to deep clone.
+ * @return {*} Cloned value.
+ */
+function deepClone( value ) {
+	if ( null === value || typeof value !== 'object' ) {
+		return value;
+	}
+	if ( Array.isArray( value ) ) {
+		return value.map( deepClone );
+	}
+	const copy = {};
+	for ( const key of Object.keys( value ) ) {
+		copy[ key ] = deepClone( value[ key ] );
+	}
+	return copy;
+}
+
+/**
+ * Deep clone an array of blocks while preserving clientIds and attributes.
+ *
+ * @param {Array} blockList Array of block objects to clone.
+ * @return {Array} Cloned array of block objects.
+ */
+export function cloneBlocks( blockList ) {
+	return blockList.map( ( block ) => ( {
+		...block,
+		attributes: deepClone( block.attributes ),
+		innerBlocks: cloneBlocks( block.innerBlocks || [] ),
+	} ) );
+}
+
+/**
+ * Initialize a new history manager state.
+ *
+ * @param {Array} initialBlocks Initial blocks array.
+ * @return {Object} Initialized history manager object.
+ */
+export function createHistoryManager( initialBlocks ) {
+	return {
+		past: [],
+		future: [],
+		present: initialBlocks,
+		lastCommitted: initialBlocks,
+		lastCommittedSerialized: null,
+	};
+}
+
+/**
+ * Record a transient input event (e.g. typing) without committing to past history.
+ *
+ * @param {Object} history   History manager object.
+ * @param {Array}  newBlocks Updated blocks array.
+ */
+export function recordInput( history, newBlocks ) {
+	history.present = newBlocks;
+}
+
+/**
+ * Record a committed change event, saving the previous state into past history.
+ *
+ * @param {Object}   history     History manager object.
+ * @param {Array}    newBlocks   Updated blocks array.
+ * @param {Function} serializeFn Function that serializes a block array to a string.
+ * @param {number}   maxHistory  Maximum number of history entries to retain.
+ */
+export function recordChange( history, newBlocks, serializeFn, maxHistory = MAX_HISTORY_LENGTH ) {
+	const newSerialized = serializeFn( newBlocks );
+	const lastCommittedSerialized =
+		history.lastCommittedSerialized ?? serializeFn( history.lastCommitted );
+
+	if ( newSerialized !== lastCommittedSerialized ) {
+		history.past.push( cloneBlocks( history.lastCommitted ) );
+		if ( history.past.length > maxHistory ) {
+			history.past.shift();
+		}
+		history.future = [];
+		history.lastCommitted = newBlocks;
+		history.lastCommittedSerialized = newSerialized;
+	}
+
+	history.present = newBlocks;
+}
+
+/**
+ * Step back to the previous state in history.
+ *
+ * @param {Object}   history     History manager object.
+ * @param {Function} serializeFn Function that serializes a block array to a string.
+ * @return {Array|null} Restored blocks array, or null if nothing to undo.
+ */
+export function stepUndo( history, serializeFn ) {
+	const lastCommittedSerialized =
+		history.lastCommittedSerialized ?? serializeFn( history.lastCommitted );
+
+	// If there is an uncommitted transient typing burst, undo back to last committed state.
+	if ( history.present !== history.lastCommitted ) {
+		const presentSerialized = serializeFn( history.present );
+		if ( presentSerialized !== lastCommittedSerialized ) {
+			history.future.push( cloneBlocks( history.present ) );
+			const target = cloneBlocks( history.lastCommitted );
+			history.present = target;
+			return target;
+		}
+	}
+
+	if ( history.past.length === 0 ) {
+		return null;
+	}
+
+	const previous = history.past.pop();
+	history.future.push( cloneBlocks( history.lastCommitted ) );
+	history.lastCommitted = previous;
+	history.lastCommittedSerialized = null;
+	history.present = previous;
+	return previous;
+}
+
+/**
+ * Step forward to the next state in redo history.
+ *
+ * @param {Object} history    History manager object.
+ * @param {number} maxHistory Maximum number of history entries to retain.
+ * @return {Array|null} Restored blocks array, or null if nothing to redo.
+ */
+export function stepRedo( history, maxHistory = MAX_HISTORY_LENGTH ) {
+	if ( history.future.length === 0 ) {
+		return null;
+	}
+
+	const next = history.future.pop();
+	history.past.push( cloneBlocks( history.lastCommitted ) );
+	if ( history.past.length > maxHistory ) {
+		history.past.shift();
+	}
+	history.lastCommitted = next;
+	history.lastCommittedSerialized = null;
+	history.present = next;
+	return next;
+}
+
+/**
+ * Handle keyboard events for undo/redo shortcuts.
+ *
+ * @param {KeyboardEvent|Object} event          Keyboard event object.
+ * @param {Object}                actions        Actions containing undo and redo callbacks.
+ * @param {Function}              actions.onUndo Callback for undo.
+ * @param {Function}              actions.onRedo Callback for redo.
+ * @param {boolean}               isApple        Whether the current platform is Apple OS.
+ * @return {boolean} True if the event was handled as an undo/redo shortcut.
+ */
+export function handleEditorKeyDown( event, { onUndo, onRedo }, isApple = false ) {
+	if ( event.defaultPrevented ) {
+		return false;
+	}
+
+	const hasPrimaryModifier = isApple ? event.metaKey : event.ctrlKey;
+	const hasSecondaryModifier = isApple ? event.ctrlKey : event.metaKey;
+
+	if ( ! hasPrimaryModifier || hasSecondaryModifier || event.altKey ) {
+		return false;
+	}
+
+	const key = event.key ? event.key.toLowerCase() : '';
+	const isZ = key === 'z' || event.code === 'KeyZ' || event.keyCode === 90;
+	const isY = key === 'y' || event.code === 'KeyY' || event.keyCode === 89;
+
+	if ( isZ && ! event.shiftKey ) {
+		if ( typeof event.preventDefault === 'function' ) {
+			event.preventDefault();
+		}
+		onUndo();
+		return true;
+	}
+
+	if (
+		( isZ && event.shiftKey ) ||
+		( ! isApple && isY && ! event.shiftKey )
+	) {
+		if ( typeof event.preventDefault === 'function' ) {
+			event.preventDefault();
+		}
+		onRedo();
+		return true;
+	}
+
+	return false;
+}

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/components/event-form/description-editor.js
@@ -8,7 +8,13 @@
 /**
  * WordPress dependencies.
  */
-import { createElement as h, useState, useEffect } from '@wordpress/element';
+import {
+	createElement as h,
+	useState,
+	useEffect,
+	useRef,
+	useCallback,
+} from '@wordpress/element';
 import {
 	BlockEditorProvider,
 	BlockList,
@@ -22,7 +28,22 @@ import { useDispatch } from '@wordpress/data';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { registerCoreFormatTypes } from '@wordpress/format-library';
 import { createBlock, parse, serialize } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { isAppleOS } from '@wordpress/keycodes';
+import {
+	ShortcutProvider,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
 import { ALLOWED_BLOCK_TYPES } from './constants';
+import {
+	MAX_HISTORY_LENGTH,
+	createHistoryManager,
+	recordInput,
+	recordChange,
+	stepUndo,
+	stepRedo,
+	handleEditorKeyDown,
+} from './description-editor-history';
 
 export { ALLOWED_BLOCK_TYPES };
 
@@ -81,6 +102,7 @@ function SelectFirstBlockOnMount( { clientId } ) {
  *     calls `getValueRef.current()` - the editor exposes an imperative
  *     getter via the supplied ref instead of pushing every keystroke
  *     up the tree.
+ *   - Maintains an undo/redo stack for block edits and keyboard shortcuts.
  *
  * This avoids the feedback loop that was causing per-keystroke lag and
  * breaking the slash inserter (parent re-renders were tearing down the
@@ -104,25 +126,117 @@ export default function DescriptionEditor( { initialValue, getValueRef, onDirty,
 		return parsed.length ? parsed : [ createBlock( 'core/paragraph' ) ];
 	} );
 
-	if ( getValueRef ) {
-		getValueRef.current = () => serialize( blocks );
+	const historyRef = useRef( null );
+	if ( ! historyRef.current ) {
+		historyRef.current = createHistoryManager( blocks );
 	}
 
-	const handleChange = ( newBlocks ) => {
-		setBlocks( newBlocks );
-		if ( onDirty ) {
-			onDirty();
+	const keyboardShortcutsDispatch = useDispatch( keyboardShortcutsStore );
+
+	useEffect( () => {
+		if ( keyboardShortcutsDispatch?.registerShortcut ) {
+			keyboardShortcutsDispatch.registerShortcut( {
+				name: 'wporg-groups/description-undo',
+				category: 'global',
+				description: __( 'Undo the last change.', 'wporg-groups-frontend' ),
+				keyCombination: {
+					modifier: 'primary',
+					character: 'z',
+				},
+			} );
+			keyboardShortcutsDispatch.registerShortcut( {
+				name: 'wporg-groups/description-redo',
+				category: 'global',
+				description: __( 'Redo the last undone change.', 'wporg-groups-frontend' ),
+				keyCombination: {
+					modifier: 'primaryShift',
+					character: 'z',
+				},
+				aliases: [
+					{
+						modifier: 'primary',
+						character: 'y',
+					},
+				],
+			} );
 		}
-	};
+
+		return () => {
+			if ( keyboardShortcutsDispatch?.unregisterShortcut ) {
+				keyboardShortcutsDispatch.unregisterShortcut( 'wporg-groups/description-undo' );
+				keyboardShortcutsDispatch.unregisterShortcut( 'wporg-groups/description-redo' );
+			}
+		};
+	}, [ keyboardShortcutsDispatch ] );
+
+	if ( getValueRef ) {
+		getValueRef.current = () => serialize( historyRef.current.present );
+	}
+
+	const handleInput = useCallback(
+		( newBlocks ) => {
+			recordInput( historyRef.current, newBlocks );
+			setBlocks( newBlocks );
+			if ( onDirty ) {
+				onDirty();
+			}
+		},
+		[ onDirty ]
+	);
+
+	const handleChange = useCallback(
+		( newBlocks ) => {
+			recordChange( historyRef.current, newBlocks, serialize, MAX_HISTORY_LENGTH );
+			setBlocks( newBlocks );
+			if ( onDirty ) {
+				onDirty();
+			}
+		},
+		[ onDirty ]
+	);
+
+	const undo = useCallback( () => {
+		const target = stepUndo( historyRef.current, serialize );
+		if ( target ) {
+			setBlocks( target );
+			if ( onDirty ) {
+				onDirty();
+			}
+		}
+	}, [ onDirty ] );
+
+	const redo = useCallback( () => {
+		const target = stepRedo( historyRef.current, MAX_HISTORY_LENGTH );
+		if ( target ) {
+			setBlocks( target );
+			if ( onDirty ) {
+				onDirty();
+			}
+		}
+	}, [ onDirty ] );
+
+	const handleKeyDown = useCallback(
+		( event ) => {
+			handleEditorKeyDown(
+				event,
+				{ onUndo: undo, onRedo: redo },
+				isAppleOS()
+			);
+		},
+		[ undo, redo ]
+	);
 
 	return h(
-		'div',
-		{ className: `${ classPrefix }__editor` },
+		ShortcutProvider,
+		{
+			className: `${ classPrefix }__editor`,
+			onKeyDown: handleKeyDown,
+		},
 		h(
 			BlockEditorProvider,
 			{
 				value: blocks,
-				onInput: handleChange,
+				onInput: handleInput,
 				onChange: handleChange,
 				settings: {
 					hasFixedToolbar: true,

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/description-editor-history.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/description-editor-history.test.js
@@ -1,0 +1,349 @@
+import {
+	cloneBlocks,
+	createHistoryManager,
+	recordInput,
+	recordChange,
+	stepUndo,
+	stepRedo,
+	handleEditorKeyDown,
+} from '../src/components/event-form/description-editor-history';
+
+describe( 'DescriptionEditor history manager', () => {
+	function makeBlock( content, clientId = 'cid-1' ) {
+		return {
+			clientId,
+			name: 'core/paragraph',
+			isValid: true,
+			attributes: { content },
+			innerBlocks: [],
+		};
+	}
+
+	const serialize = ( blocks ) => JSON.stringify( blocks );
+
+	test( 'initializes with empty past/future and set present/lastCommitted', () => {
+		const initial = [ makeBlock( 'Initial' ) ];
+		const history = createHistoryManager( initial );
+
+		expect( history.past ).toEqual( [] );
+		expect( history.future ).toEqual( [] );
+		expect( history.present ).toBe( initial );
+		expect( history.lastCommitted ).toBe( initial );
+	} );
+
+	test( 'cloneBlocks deep clones blocks preserving attributes and clientIds', () => {
+		const original = [
+			{
+				...makeBlock( 'Hello' ),
+				attributes: {
+					content: 'Hello',
+					metadata: { nested: { value: 42 }, list: [ 1, 2, 3 ] },
+				},
+			},
+		];
+		const cloned = cloneBlocks( original );
+
+		expect( cloned ).toEqual( original );
+		expect( cloned ).not.toBe( original );
+		expect( cloned[ 0 ] ).not.toBe( original[ 0 ] );
+		expect( cloned[ 0 ].attributes ).not.toBe( original[ 0 ].attributes );
+		expect( cloned[ 0 ].attributes.metadata ).not.toBe( original[ 0 ].attributes.metadata );
+		expect( cloned[ 0 ].attributes.metadata.nested ).not.toBe( original[ 0 ].attributes.metadata.nested );
+		expect( cloned[ 0 ].attributes.metadata.list ).not.toBe( original[ 0 ].attributes.metadata.list );
+		expect( cloned[ 0 ].clientId ).toBe( original[ 0 ].clientId );
+	} );
+
+	test( 'recordInput updates present without modifying past', () => {
+		const initial = [ makeBlock( 'Hello' ) ];
+		const history = createHistoryManager( initial );
+		const updated = [ makeBlock( 'Hello World' ) ];
+
+		recordInput( history, updated );
+
+		expect( history.present ).toBe( updated );
+		expect( history.lastCommitted ).toBe( initial );
+		expect( history.past ).toEqual( [] );
+	} );
+
+	test( 'recordChange saves previous committed state to past and clears future', () => {
+		const initial = [ makeBlock( 'Step 1' ) ];
+		const history = createHistoryManager( initial );
+		history.future = [ [ makeBlock( 'Future' ) ] ];
+
+		const step2 = [ makeBlock( 'Step 2' ) ];
+		recordChange( history, step2, serialize );
+
+		expect( history.past.length ).toBe( 1 );
+		expect( history.past[ 0 ][ 0 ].attributes.content ).toBe( 'Step 1' );
+		expect( history.lastCommitted ).toBe( step2 );
+		expect( history.present ).toBe( step2 );
+		expect( history.future ).toEqual( [] );
+	} );
+
+	test( 'recordChange does not duplicate past entry when content is identical', () => {
+		const initial = [ makeBlock( 'Same' ) ];
+		const history = createHistoryManager( initial );
+
+		const clone = [ makeBlock( 'Same' ) ];
+		recordChange( history, clone, serialize );
+
+		expect( history.past ).toEqual( [] );
+	} );
+
+	test( 'recordChange caps history at maxHistory', () => {
+		const history = createHistoryManager( [ makeBlock( '0' ) ] );
+
+		for ( let i = 1; i <= 5; i++ ) {
+			recordChange( history, [ makeBlock( String( i ) ) ], serialize, 3 );
+		}
+
+		expect( history.past.length ).toBe( 3 );
+		expect( history.past.map( ( b ) => b[ 0 ].attributes.content ) ).toEqual( [ '2', '3', '4' ] );
+		expect( history.lastCommitted[ 0 ].attributes.content ).toBe( '5' );
+	} );
+
+	test( 'stepUndo reverts uncommitted typing burst to lastCommitted and pushes to future', () => {
+		const committed = [ makeBlock( 'Committed' ) ];
+		const history = createHistoryManager( committed );
+
+		const typing = [ makeBlock( 'Committed typing...' ) ];
+		recordInput( history, typing );
+
+		const restored = stepUndo( history, serialize );
+
+		expect( restored[ 0 ].attributes.content ).toBe( 'Committed' );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'Committed' );
+		expect( history.future.length ).toBe( 1 );
+		expect( history.future[ 0 ][ 0 ].attributes.content ).toBe( 'Committed typing...' );
+	} );
+
+	test( 'stepUndo steps through multiple committed states', () => {
+		const history = createHistoryManager( [ makeBlock( 'A' ) ] );
+		recordChange( history, [ makeBlock( 'B' ) ], serialize );
+		recordChange( history, [ makeBlock( 'C' ) ], serialize );
+
+		const undo1 = stepUndo( history, serialize );
+		expect( undo1[ 0 ].attributes.content ).toBe( 'B' );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'B' );
+		expect( history.lastCommitted[ 0 ].attributes.content ).toBe( 'B' );
+
+		const undo2 = stepUndo( history, serialize );
+		expect( undo2[ 0 ].attributes.content ).toBe( 'A' );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'A' );
+		expect( history.lastCommitted[ 0 ].attributes.content ).toBe( 'A' );
+
+		const undo3 = stepUndo( history, serialize );
+		expect( undo3 ).toBeNull();
+	} );
+
+	test( 'stepRedo steps forward into future stack', () => {
+		const history = createHistoryManager( [ makeBlock( 'A' ) ] );
+		recordChange( history, [ makeBlock( 'B' ) ], serialize );
+
+		stepUndo( history, serialize );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'A' );
+
+		const redo1 = stepRedo( history );
+		expect( redo1[ 0 ].attributes.content ).toBe( 'B' );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'B' );
+		expect( history.lastCommitted[ 0 ].attributes.content ).toBe( 'B' );
+
+		const redo2 = stepRedo( history );
+		expect( redo2 ).toBeNull();
+	} );
+
+	test( 'new edit after undo clears redo future stack', () => {
+		const history = createHistoryManager( [ makeBlock( 'A' ) ] );
+		recordChange( history, [ makeBlock( 'B' ) ], serialize );
+		stepUndo( history, serialize );
+
+		expect( history.future.length ).toBe( 1 );
+
+		recordChange( history, [ makeBlock( 'C' ) ], serialize );
+		expect( history.future ).toEqual( [] );
+		expect( stepRedo( history ) ).toBeNull();
+	} );
+} );
+
+describe( 'handleEditorKeyDown keyboard shortcuts', () => {
+	function createEvent( overrides = {} ) {
+		return {
+			key: '',
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+			defaultPrevented: false,
+			preventDefault: jest.fn(),
+			...overrides,
+		};
+	}
+
+	test( 'triggers onUndo on Mac when Cmd+Z is pressed', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'z', metaKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, true );
+
+		expect( handled ).toBe( true );
+		expect( onUndo ).toHaveBeenCalledTimes( 1 );
+		expect( onRedo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'triggers onRedo on Mac when Shift+Cmd+Z is pressed (uppercase Z)', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'Z', metaKey: true, shiftKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, true );
+
+		expect( handled ).toBe( true );
+		expect( onRedo ).toHaveBeenCalledTimes( 1 );
+		expect( onUndo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'triggers onRedo on Mac when Cmd+Shift+Z is pressed (lowercase z)', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'z', metaKey: true, shiftKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, true );
+
+		expect( handled ).toBe( true );
+		expect( onRedo ).toHaveBeenCalledTimes( 1 );
+		expect( onUndo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does not trigger onRedo on Mac when Cmd+Y is pressed (reserved by browser)', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'y', metaKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, true );
+
+		expect( handled ).toBe( false );
+		expect( onRedo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).not.toHaveBeenCalled();
+	} );
+
+	test( 'triggers onUndo on Windows/Linux when Ctrl+Z is pressed', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'z', ctrlKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, false );
+
+		expect( handled ).toBe( true );
+		expect( onUndo ).toHaveBeenCalledTimes( 1 );
+		expect( onRedo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'triggers onRedo on Windows/Linux when Shift+Ctrl+Z is pressed', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'Z', ctrlKey: true, shiftKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, false );
+
+		expect( handled ).toBe( true );
+		expect( onRedo ).toHaveBeenCalledTimes( 1 );
+		expect( onUndo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'triggers onRedo on Windows/Linux when Ctrl+Y is pressed', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'y', ctrlKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, false );
+
+		expect( handled ).toBe( true );
+		expect( onRedo ).toHaveBeenCalledTimes( 1 );
+		expect( onUndo ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'ignores keystrokes with alt/option modifier pressed', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'z', metaKey: true, altKey: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, true );
+
+		expect( handled ).toBe( false );
+		expect( onUndo ).not.toHaveBeenCalled();
+		expect( onRedo ).not.toHaveBeenCalled();
+	} );
+
+	test( 'ignores events where default is already prevented', () => {
+		const onUndo = jest.fn();
+		const onRedo = jest.fn();
+		const event = createEvent( { key: 'z', metaKey: true, defaultPrevented: true } );
+
+		const handled = handleEditorKeyDown( event, { onUndo, onRedo }, true );
+
+		expect( handled ).toBe( false );
+		expect( onUndo ).not.toHaveBeenCalled();
+	} );
+
+	test( 'full keystroke-driven undo and redo cycle restores editor blocks', () => {
+		function makeBlock( content ) {
+			return {
+				clientId: 'cid-1',
+				name: 'core/paragraph',
+				isValid: true,
+				attributes: { content },
+				innerBlocks: [],
+			};
+		}
+		const serialize = ( blocks ) => JSON.stringify( blocks );
+
+		const initial = [ makeBlock( '' ) ];
+		const history = createHistoryManager( initial );
+
+		// Simulate typing 'GAMMA'
+		const typing = [ makeBlock( 'GAMMA' ) ];
+		recordInput( history, typing );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'GAMMA' );
+
+		const actions = {
+			onUndo: () => {
+				const target = stepUndo( history, serialize );
+				if ( target ) {
+					history.present = target;
+				}
+			},
+			onRedo: () => {
+				const target = stepRedo( history );
+				if ( target ) {
+					history.present = target;
+				}
+			},
+		};
+
+		// 1. Press Cmd+Z (undo) - text clears to initial empty block
+		const undoEvent = createEvent( { key: 'z', metaKey: true } );
+		handleEditorKeyDown( undoEvent, actions, true );
+		expect( history.present[ 0 ].attributes.content ).toBe( '' );
+		expect( undoEvent.preventDefault ).toHaveBeenCalled();
+
+		// 2. Press Shift+Cmd+Z (redo) - text restores back to 'GAMMA'
+		const redoEvent = createEvent( { key: 'Z', metaKey: true, shiftKey: true } );
+		handleEditorKeyDown( redoEvent, actions, true );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'GAMMA' );
+		expect( redoEvent.preventDefault ).toHaveBeenCalled();
+
+		// 3. Repeated undo and redo cycle
+		handleEditorKeyDown( createEvent( { key: 'z', metaKey: true } ), actions, true );
+		expect( history.present[ 0 ].attributes.content ).toBe( '' );
+
+		handleEditorKeyDown( createEvent( { key: 'z', metaKey: true, shiftKey: true } ), actions, true );
+		expect( history.present[ 0 ].attributes.content ).toBe( 'GAMMA' );
+	} );
+} );


### PR DESCRIPTION
### Description
This PR resolves #2018 by adding undo and redo support to the event description block editor.

Previously, `DescriptionEditor` mounted a bare `BlockEditorProvider` with no `ShortcutProvider` and no undo/redo stack, so pressing `Cmd/Ctrl+Z` had no effect.

Changes in this PR:
- Wrap `BlockEditorProvider` in `ShortcutProvider` from `@wordpress/keyboard-shortcuts` and register `core/editor/undo` and `core/editor/redo`.
- Implement a dedicated history manager (`description-editor-history.js`) that distinguishes between transient keystrokes (`onInput`) and committed block changes (`onChange`), maintaining `past` and `future` stacks.
- Handle keyboard shortcuts (`Cmd/Ctrl+Z` for undo, `Cmd/Ctrl+Shift+Z` / `Ctrl+Y` for redo), reverting uncommitted typing bursts or stepping through committed states.
- Deep clone block snapshots to avoid state mutation.
- Add unit tests covering undo/redo history management (`description-editor-history.test.js`).

Fixes #2018