### PR TITLE
Groups: Close RSVP modal on saving and show confirmation feedback

### DIFF
--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/render.php
@@ -157,6 +157,8 @@ $context = array(
 	'modalOpen'         => false,
 	'rsvpLoading'       => false,
 	'rsvpNotice'        => '',
+	'rsvpNoticeSuccess' => false,
+	'rsvpNoticeError'   => false,
 	'questionsError'    => '',
 	'labels'            => $rsvp_labels,
 );
@@ -267,6 +269,9 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		aria-live="polite"
 		aria-atomic="true"
 		data-wp-text="context.rsvpNotice"
+		data-wp-class--screen-reader-text="!context.rsvpNotice"
+		data-wp-class--is-success="context.rsvpNoticeSuccess"
+		data-wp-class--is-error="context.rsvpNoticeError"
 	></p>
 
 	<div
@@ -340,6 +345,11 @@ $wrapper_attributes = get_block_wrapper_attributes(
 									id="<?php echo esc_attr( $error_id ); ?>"
 									data-wp-text="context.questionsError"
 								></p>
+							</fieldset>
+						<?php endif; ?>
+
+						<div class="wporg-event-rsvp__modal-buttons">
+							<?php if ( $questions ) : ?>
 								<button
 									type="button"
 									class="wporg-event-rsvp__save-answers wp-element-button<?php echo $is_attending ? '' : ' is-hidden'; ?>"
@@ -350,26 +360,26 @@ $wrapper_attributes = get_block_wrapper_attributes(
 								>
 									<?php esc_html_e( 'Save answers', 'wporg-groups-frontend' ); ?>
 								</button>
-							</fieldset>
-						<?php endif; ?>
+							<?php endif; ?>
 
-						<button
-							type="button"
-							class="wporg-event-rsvp__modal-rsvp-btn wp-element-button<?php echo $is_attending ? ' is-attending' : ''; ?>"
-							data-wp-on--click="actions.toggleRsvp"
-							data-wp-text="state.modalRsvpLabel"
-							data-wp-class--is-attending="state.isAttending"
-							data-wp-bind--disabled="context.rsvpLoading"
-							data-wp-bind--aria-busy="context.rsvpLoading"
-						>
-							<?php
-							if ( $is_attending ) {
-								echo esc_html( $cancel_rsvp );
-							} else {
-								esc_html_e( 'Attend', 'wporg-groups-frontend' );
-							}
-							?>
-						</button>
+							<button
+								type="button"
+								class="wporg-event-rsvp__modal-rsvp-btn wp-element-button<?php echo $is_attending ? ' is-attending' : ''; ?>"
+								data-wp-on--click="actions.toggleRsvp"
+								data-wp-text="state.modalRsvpLabel"
+								data-wp-class--is-attending="state.isAttending"
+								data-wp-bind--disabled="context.rsvpLoading"
+								data-wp-bind--aria-busy="context.rsvpLoading"
+							>
+								<?php
+								if ( $is_attending ) {
+									echo esc_html( $cancel_rsvp );
+								} else {
+									esc_html_e( 'Attend', 'wporg-groups-frontend' );
+								}
+								?>
+							</button>
+						</div>
 					<?php else : ?>
 						<p class="wporg-event-rsvp__modal-status">
 							<?php

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/style.css
@@ -125,6 +125,43 @@
 /* A past event's button is `disabled`, so the theme's disabled treatment
    already greys it out — the class is left as a styling hook only. */
 
+/* === RSVP status notice === */
+.wporg-event-rsvp__notice:not(.screen-reader-text) {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--wp--preset--spacing--10, 10px);
+	margin-top: 12px;
+	padding: 10px 16px;
+	border: 1px solid #d9d9d9;
+	border-radius: 2px;
+	font-size: var(--wp--preset--font-size--small, 14px);
+	line-height: 1.5;
+}
+
+.wporg-event-rsvp__notice.is-success {
+	border-color: #007a2f;
+	background: var(--wp--preset--color--acid-green-3, #e2ffed);
+	color: var(--wp--preset--color--charcoal-0, #1a1919);
+}
+
+.wporg-event-rsvp__notice.is-success::before {
+	content: "\2713";
+	font-weight: 600;
+	line-height: 1.5;
+}
+
+.wporg-event-rsvp__notice.is-error {
+	border-color: #b32d0f;
+	background: var(--wp--preset--color--pomegranate-3, #fbeae5);
+	color: var(--wp--preset--color--charcoal-0, #1a1919);
+}
+
+.wporg-event-rsvp__notice.is-error::before {
+	content: "!";
+	font-weight: 600;
+	line-height: 1.5;
+}
+
 /* === Full-screen modal === */
 .wporg-event-rsvp__modal {
 	display: none;
@@ -221,28 +258,6 @@
 	display: none;
 }
 
-/* Compact button size — matches the comment composer's submit. */
-.wporg-event-rsvp__save-answers {
-	align-self: flex-start;
-	padding: 10px 20px;
-	font-size: var(--wp--preset--font-size--small, 14px);
-	font-weight: 600;
-	line-height: 1.3;
-	border: 1px solid transparent;
-	border-radius: 2px;
-}
-
-.wporg-event-rsvp__save-answers:disabled {
-	background: var(--wp--preset--color--light-grey-2, #f6f6f6);
-	border-color: var(--wp--preset--color--light-grey-1, #d9d9d9);
-	color: var(--wp--preset--color--charcoal-4, #656a71);
-	cursor: not-allowed;
-}
-
-.wporg-event-rsvp__save-answers.is-hidden {
-	display: none;
-}
-
 .wporg-event-rsvp__question {
 	display: flex;
 	flex-direction: column;
@@ -287,9 +302,46 @@
 	color: var(--wp--preset--color--blueberry-1);
 }
 
+.wporg-event-rsvp__modal-buttons {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.wporg-event-rsvp__questions ~ .wporg-event-rsvp__modal-buttons {
+	width: 100%;
+	margin-top: 4px;
+}
+
+/* Compact button size - matches the comment composer's submit. */
+.wporg-event-rsvp__save-answers {
+	padding: 8px 16px;
+	font-size: var(--wp--preset--font-size--small, 14px);
+	font-weight: 600;
+	line-height: 1.4;
+	border: 1px solid transparent;
+	border-radius: 2px;
+}
+
+.wporg-event-rsvp__save-answers:disabled {
+	background: var(--wp--preset--color--light-grey-2, #f6f6f6);
+	border-color: var(--wp--preset--color--light-grey-1, #d9d9d9);
+	color: var(--wp--preset--color--charcoal-4, #656a71);
+	cursor: not-allowed;
+}
+
+.wporg-event-rsvp__save-answers.is-hidden {
+	display: none;
+}
+
 .wporg-event-rsvp__modal-rsvp-btn {
 	white-space: nowrap;
 	flex-shrink: 0;
+	padding: 8px 16px;
+	font-size: var(--wp--preset--font-size--small, 14px);
+	font-weight: 600;
+	line-height: 1.4;
 }
 
 .wporg-event-rsvp__modal-rsvp-btn.is-attending {
@@ -384,5 +436,15 @@
 		max-width: none;
 		max-height: none;
 		height: 100%;
+	}
+
+	.wporg-event-rsvp__modal-buttons {
+		width: 100%;
+	}
+
+	.wporg-event-rsvp__modal-buttons button {
+		flex: 1 1 auto;
+		text-align: center;
+		justify-content: center;
 	}
 }

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/src/blocks/event-rsvp/view.js
@@ -303,6 +303,8 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 	}
 
 	ctx.rsvpNotice = '';
+	ctx.rsvpNoticeSuccess = false;
+	ctx.rsvpNoticeError = false;
 	ctx.questionsError = '';
 
 	// Join group first if not a member.
@@ -323,6 +325,10 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		} catch {
 			ctx.rsvpLoading = false;
 			ctx.rsvpNotice = labelFromContext( ctx, 'rsvpError' );
+			ctx.rsvpNoticeError = true;
+			if ( ctx.modalOpen ) {
+				ctx.questionsError = ctx.rsvpNotice;
+			}
 			return;
 		}
 	}
@@ -338,6 +344,7 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		const message = labelFromContext( ctx, 'missingAnswers' );
 		ctx.questionsError = message;
 		ctx.rsvpNotice = message;
+		ctx.rsvpNoticeError = true;
 		openRsvpModal( ctx, actionElement );
 		flagMissingAnswers( block, missingInputs );
 		return;
@@ -364,6 +371,8 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		ctx.rsvpNotice = statusChanged
 			? getRsvpSuccessNotice( ctx, data.status )
 			: labelFromContext( ctx, 'answersSaved' );
+		ctx.rsvpNoticeSuccess = true;
+		ctx.rsvpNoticeError = false;
 
 		// Organizers see the answers inline in the attendee list, which the
 		// client-side refresh can't rebuild — reload so their view stays
@@ -374,18 +383,22 @@ async function submitRsvp( ctx, actionElement, newStatus ) {
 		}
 
 		refreshAttendees( ctx, actionElement );
+		closeRsvpModal( ctx );
 	} catch ( error ) {
 		ctx.currentUserStatus = oldStatus;
 		ctx.attendingCount = oldCount;
 
 		// Our own validation failures carry a message the attendee can act on
-		// ("Please answer: Dietary requirements"). Anything else — a network
-		// blip, a 500 — gets the generic retry wording.
+		// ("Please answer: Dietary requirements"). Anything else - a network
+		// blip, a 500 - gets the generic retry wording.
 		const ours = error?.code?.startsWith?.( 'wporg_groups_' ) && error.message;
 		ctx.rsvpNotice = ours ? error.message : labelFromContext( ctx, 'rsvpError' );
+		ctx.rsvpNoticeError = true;
 		if ( ours ) {
 			ctx.questionsError = error.message;
 			openRsvpModal( ctx, actionElement );
+		} else if ( ctx.modalOpen ) {
+			ctx.questionsError = ctx.rsvpNotice;
 		}
 	} finally {
 		ctx.rsvpLoading = false;

--- a/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
+++ b/public_html/wp-content/mu-plugins/wporg-groups-frontend/tests-js/event-rsvp.test.js
@@ -39,6 +39,8 @@ function createContext() {
 		modalOpen: false,
 		rsvpLoading: false,
 		rsvpNotice: '',
+		rsvpNoticeSuccess: false,
+		rsvpNoticeError: false,
 	};
 }
 
@@ -462,6 +464,8 @@ describe( 'event RSVP custom registration questions', () => {
 			answers: { company: 'Automattic', diet: 'Vegetarian' },
 		} );
 		expect( mockContext.currentUserStatus ).toBe( 'attending' );
+		expect( mockContext.rsvpNoticeSuccess ).toBe( true );
+		expect( mockContext.modalOpen ).toBe( false );
 	} );
 
 	test( 'sends blank optional answers so the server can tell cleared from absent', async () => {
@@ -480,10 +484,11 @@ describe( 'event RSVP custom registration questions', () => {
 		} );
 	} );
 
-	test( 'saves edited answers without changing attendance', async () => {
+	test( 'saves edited answers without changing attendance and closes modal', async () => {
 		const { actions } = loadStore();
 		const { diet, rsvp } = renderModalWithQuestions();
 		mockElement = rsvp;
+		mockContext.modalOpen = true;
 		mockContext.currentUserStatus = 'attending';
 		mockContext.attendingCount = 1;
 		mockContext.labels.answersSaved = 'Your answers have been saved.';
@@ -497,6 +502,8 @@ describe( 'event RSVP custom registration questions', () => {
 		expect( mockContext.currentUserStatus ).toBe( 'attending' );
 		expect( mockContext.attendingCount ).toBe( 1 );
 		expect( mockContext.rsvpNotice ).toBe( 'Your answers have been saved.' );
+		expect( mockContext.rsvpNoticeSuccess ).toBe( true );
+		expect( mockContext.modalOpen ).toBe( false );
 	} );
 
 	test( 'surfaces the server validation message instead of the generic error', async () => {


### PR DESCRIPTION
Fixes #2025

### Changes
- Closes the RSVP modal automatically upon successfully updating attendance status or saving answers to registration questions.
- Displays visible, styled confirmation and error status notices to sighted users on the RSVP block (`.wporg-event-rsvp__notice`) using Interactivity API class toggling, while preserving live region announcements for assistive technologies.
- Re-aligns and groups modal footer actions in a dedicated `.wporg-event-rsvp__modal-buttons` container, ensuring consistent button heights, gap spacing, and clean responsive wrapping on mobile screens.
- Adds test assertions covering modal dismissal and confirmation state on RSVP and question answer updates.