### PR TITLE
Groups: show event format (in person, online, hybrid) on event cards

### DIFF
--- a/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-cards.php
+++ b/public_html/wp-content/mu-plugins/groups/tests/test-groups-site-event-cards.php
@@ -263,6 +263,125 @@ class Test_Groups_Site_Event_Cards extends Groups_TestCase {
 	}
 
 	/**
+	 * Create a published event post and return its post ID.
+	 *
+	 * @param string $title The event title.
+	 * @return int The event post ID.
+	 */
+	private function create_event_post( string $title ): int {
+		return self::factory()->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_content' => 'An evening of talks, demos and questions about the web.',
+			)
+		);
+	}
+
+	/**
+	 * Assign event venue terms (online sentinel and/or physical venue term).
+	 *
+	 * @param int  $event_id   Event post ID.
+	 * @param bool $is_online  Whether event has the online-event term.
+	 * @param bool $with_venue Whether event has a physical venue term.
+	 */
+	private function set_event_format_terms( int $event_id, bool $is_online, bool $with_venue ): void {
+		if ( ! taxonomy_exists( '_gatherpress_venue' ) ) {
+			register_taxonomy( '_gatherpress_venue', 'gatherpress_event' );
+		}
+
+		$term_ids = array();
+
+		if ( $with_venue ) {
+			$venue_term = term_exists( '_test-venue', '_gatherpress_venue' );
+			if ( ! $venue_term ) {
+				$venue_term = wp_insert_term( 'Test Venue', '_gatherpress_venue', array( 'slug' => '_test-venue' ) );
+			}
+			$term_ids[] = is_array( $venue_term ) ? (int) $venue_term['term_id'] : (int) $venue_term;
+		}
+
+		if ( $is_online ) {
+			$online_term = term_exists( 'online-event', '_gatherpress_venue' );
+			if ( ! $online_term ) {
+				$online_term = wp_insert_term( 'Online event', '_gatherpress_venue', array( 'slug' => 'online-event' ) );
+			}
+			$term_ids[] = is_array( $online_term ) ? (int) $online_term['term_id'] : (int) $online_term;
+		}
+
+		wp_set_object_terms( $event_id, $term_ids, '_gatherpress_venue', false );
+	}
+
+	/**
+	 * Test that get_event_format() returns 'in-person' by default and for physical venue events.
+	 */
+	public function test_event_format_helper_returns_in_person_by_default() {
+		$event_without_terms = $this->create_event_post( 'Default Event' );
+		$this->assertSame( 'in-person', \WordCamp\Groups\Site\get_event_format( $event_without_terms ) );
+
+		$event_with_venue = $this->create_event_post( 'In Person Venue Event' );
+		$this->set_event_format_terms( $event_with_venue, false, true );
+		$this->assertSame( 'in-person', \WordCamp\Groups\Site\get_event_format( $event_with_venue ) );
+	}
+
+	/**
+	 * Test that get_event_format() returns 'online' for online-only events.
+	 */
+	public function test_event_format_helper_returns_online_for_online_only_event() {
+		$event_online = $this->create_event_post( 'Online Only Event' );
+		$this->set_event_format_terms( $event_online, true, false );
+		$this->assertSame( 'online', \WordCamp\Groups\Site\get_event_format( $event_online ) );
+	}
+
+	/**
+	 * Test that get_event_format() returns 'hybrid' for events with both online and physical venue terms.
+	 */
+	public function test_event_format_helper_returns_hybrid_for_event_with_online_and_venue_terms() {
+		$event_hybrid = $this->create_event_post( 'Hybrid Event' );
+		$this->set_event_format_terms( $event_hybrid, true, true );
+		$this->assertSame( 'hybrid', \WordCamp\Groups\Site\get_event_format( $event_hybrid ) );
+	}
+
+	/**
+	 * Test that event cards in the grid render the format badge correctly for in-person events.
+	 */
+	public function test_card_renders_event_format_badge_in_person() {
+		$this->create_event_post( 'In Person Card Event' );
+
+		$output = do_blocks( self::GRID );
+
+		$this->assertStringContainsString( 'is-format-in-person', $output );
+		$this->assertStringContainsString( 'In person', $output );
+	}
+
+	/**
+	 * Test that event cards in the grid render the format badge correctly for online events.
+	 */
+	public function test_card_renders_event_format_badge_online() {
+		$event_id = $this->create_event_post( 'Online Card Event' );
+		$this->set_event_format_terms( $event_id, true, false );
+
+		$output = do_blocks( self::GRID );
+
+		$this->assertStringContainsString( 'is-format-online', $output );
+		$this->assertStringContainsString( 'Online', $output );
+	}
+
+	/**
+	 * Test that event cards in the grid render the format badge correctly for hybrid events.
+	 */
+	public function test_card_renders_event_format_badge_hybrid() {
+		$event_id = $this->create_event_post( 'Hybrid Card Event' );
+		$this->set_event_format_terms( $event_id, true, true );
+
+		$output = do_blocks( self::GRID );
+
+		$this->assertStringContainsString( 'is-format-hybrid', $output );
+		$this->assertStringContainsString( 'Hybrid', $output );
+	}
+
+
+	/**
 	 * Find the first block of a given name in a parsed block tree.
 	 *
 	 * @param array  $blocks Parsed blocks to walk.

--- a/public_html/wp-content/themes/groups-site/assets/css/custom.css
+++ b/public_html/wp-content/themes/groups-site/assets/css/custom.css
@@ -606,10 +606,57 @@ body.error404 .site-content-container h1 {
 }
 
 /*
- * Past events (the `?event_time=past` view — class set in `functions.php`)
+ * Event card format badge (in person, online, hybrid).
+ *
+ * Shows the attendance format at a glance so members do not have to open each
+ * card to discover whether an event is in person, virtual, or both (#2031).
+ */
+
+.groups-site-event-format {
+	margin: 0;
+	line-height: 1.4;
+}
+
+.groups-site-event-format__badge {
+	display: inline-block;
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--extra-small);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	padding: 2px 8px;
+	border-radius: 2px;
+	line-height: 1.4;
+}
+
+.groups-site-event-format.is-format-online .groups-site-event-format__badge {
+	background-color: var(--wp--preset--color--blueberry-4);
+	color: var(--wp--preset--color--blueberry-1);
+}
+
+.groups-site-event-format.is-format-hybrid .groups-site-event-format__badge {
+	background-color: var(--wp--preset--color--light-grey-2);
+	color: var(--wp--preset--color--charcoal-1);
+	border: 1px solid var(--wp--preset--color--light-grey-1);
+}
+
+.groups-site-event-format.is-format-in-person .groups-site-event-format__badge {
+	background-color: var(--wp--preset--color--light-grey-2);
+	color: var(--wp--preset--color--charcoal-4);
+}
+
+.groups-site-events-view-past .gatherpress-event-query .groups-site-event-format.is-format-online .groups-site-event-format__badge {
+	background-color: var(--wp--preset--color--light-grey-2);
+	color: var(--wp--preset--color--charcoal-4);
+}
+
+
+/*
+ * Past events (the `?event_time=past` view - class set in `functions.php`)
  * drop the blue "coming up" date treatment and mute their photography a
  * touch. Same grid, but the page no longer dresses history as future.
  */
+
 
 .groups-site-events-view-past .gatherpress-event-query .wp-block-gatherpress-event-date.has-blueberry-1-color {
 	color: var(--wp--preset--color--charcoal-4) !important;

--- a/public_html/wp-content/themes/groups-site/functions.php
+++ b/public_html/wp-content/themes/groups-site/functions.php
@@ -149,6 +149,10 @@ function prime_event_card_thumbnails( $query ) {
 	}
 
 	update_post_thumbnail_cache( $query );
+
+	if ( ! empty( $query->posts ) ) {
+		update_object_term_cache( wp_list_pluck( $query->posts, 'ID' ), 'gatherpress_event' );
+	}
 }
 add_action( 'loop_start', __NAMESPACE__ . '\prime_event_card_thumbnails' );
 
@@ -503,3 +507,138 @@ function compact_comment_reply_link_args( $args ) {
 	return $args;
 }
 add_filter( 'comment_reply_link_args', __NAMESPACE__ . '\compact_comment_reply_link_args' );
+
+/**
+ * Determine the event format: 'hybrid', 'online', or 'in-person'.
+ *
+ * GatherPress assigns the `online-event` sentinel term to `_gatherpress_venue`
+ * for online and hybrid events. A hybrid event has both `online-event` and
+ * a physical venue term; an online event has only `online-event`; and an
+ * in-person event has no `online-event` term.
+ *
+ * @param int $event_id Event post ID.
+ * @return string 'hybrid', 'online', or 'in-person'.
+ */
+function get_event_format( int $event_id ): string {
+	$terms = get_the_terms( $event_id, '_gatherpress_venue' );
+
+	$has_online   = false;
+	$has_physical = false;
+
+	if ( is_array( $terms ) && ! empty( $terms ) ) {
+		foreach ( $terms as $term ) {
+			if ( 'online-event' === $term->slug ) {
+				$has_online = true;
+			} else {
+				$has_physical = true;
+			}
+		}
+	}
+
+	if ( ! $has_online ) {
+		$online_link = get_post_meta( $event_id, 'gatherpress_online_event_link', true );
+		if ( ! empty( $online_link ) ) {
+			$has_online = true;
+		}
+	}
+
+	if ( $has_online && $has_physical ) {
+		return 'hybrid';
+	}
+
+	if ( $has_online ) {
+		return 'online';
+	}
+
+	return 'in-person';
+}
+
+/**
+ * Retrieve human-readable label for an event format.
+ *
+ * @param string $format Event format slug ('hybrid', 'online', or 'in-person').
+ * @return string Localized label.
+ */
+function get_event_format_label( string $format ): string {
+	switch ( $format ) {
+		case 'hybrid':
+			return __( 'Hybrid', 'groups-site' );
+		case 'online':
+			return __( 'Online', 'groups-site' );
+		case 'in-person':
+		default:
+			return __( 'In person', 'groups-site' );
+	}
+}
+
+/**
+ * Render callback for the `groups-site/event-format` block.
+ *
+ * @param array          $attributes Block attributes.
+ * @param string         $content    Block inner content.
+ * @param \WP_Block|null $block      Block instance.
+ * @return string Rendered HTML.
+ */
+function render_event_format_block( array $attributes, string $content = '', ?\WP_Block $block = null ): string {
+	$post_id = ( $block instanceof \WP_Block && isset( $block->context['postId'] ) )
+		? (int) $block->context['postId']
+		: (int) get_the_ID();
+	if ( ! $post_id ) {
+		return '';
+	}
+
+	$post_type = ( $block instanceof \WP_Block && isset( $block->context['postType'] ) )
+		? (string) $block->context['postType']
+		: (string) get_post_type( $post_id );
+	if ( 'gatherpress_event' !== $post_type ) {
+		return '';
+	}
+
+	$format = get_event_format( (int) $post_id );
+	$label  = get_event_format_label( $format );
+
+	$wrapper_classes = array(
+		'wp-block-groups-site-event-format',
+		'groups-site-event-format',
+		'is-format-' . sanitize_html_class( $format ),
+	);
+
+	if ( ! empty( $attributes['className'] ) ) {
+		$wrapper_classes[] = $attributes['className'];
+	}
+
+	return sprintf(
+		'<div class="%1$s"><span class="groups-site-event-format__badge">%2$s</span></div>',
+		esc_attr( implode( ' ', $wrapper_classes ) ),
+		esc_html( $label )
+	);
+}
+
+/**
+ * Register the event-format block for event card grids.
+ */
+function register_event_format_block(): void {
+	if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'groups-site/event-format' ) ) {
+		return;
+	}
+
+	register_block_type(
+		'groups-site/event-format',
+		array(
+			'api_version'     => 3,
+			'title'           => __( 'Event Format', 'groups-site' ),
+			'category'        => 'groups-site',
+			'description'     => __( 'Displays the event format (in person, online, or hybrid).', 'groups-site' ),
+			'uses_context'    => array( 'postId', 'postType' ),
+			'supports'        => array(
+				'html' => false,
+			),
+			'render_callback' => __NAMESPACE__ . '\render_event_format_block',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_event_format_block' );
+
+if ( did_action( 'init' ) ) {
+	register_event_format_block();
+}

--- a/public_html/wp-content/themes/groups-site/patterns/event-card.php
+++ b/public_html/wp-content/themes/groups-site/patterns/event-card.php
@@ -5,7 +5,7 @@
  * Categories: groups-site
  * Inserter: no
  *
- * The single event card used inside `gatherpress-event-query` query loops —
+ * The single event card used inside `gatherpress-event-query` query loops -
  * the front page's "Upcoming events" section and the events archive both
  * reference this pattern from their `wp:post-template`, so the card is
  * defined once. Card-level polish (equal heights, bottom-pinned meta,
@@ -30,6 +30,7 @@ defined( 'ABSPATH' ) || exit;
 		<!-- wp:group {"className":"groups-site-card-meta","style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group groups-site-card-meta">
 			<!-- wp:gatherpress/rsvp-count {"fontSize":"small","textColor":"charcoal-4","style":{"typography":{"fontWeight":"600"}}} /-->
+			<!-- wp:groups-site/event-format /-->
 			<!-- wp:gatherpress/venue -->
 				<!-- wp:post-title {"level":4,"fontSize":"small","fontFamily":"inter","textColor":"charcoal-4","style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"fontWeight":"400","lineHeight":"1.55"}}} /-->
 			<!-- /wp:gatherpress/venue -->


### PR DESCRIPTION
### Summary of Changes
- Registered dynamic block `groups-site/event-format` in `groups-site` theme with `postId` and `postType` context.
- Added `get_event_format()` and `get_event_format_label()` helpers to determine event modality (`in-person`, `online`, or `hybrid`) based on `_gatherpress_venue` shadow terms and online link metadata.
- Updated `patterns/event-card.php` to render `wp:groups-site/event-format` inside `.groups-site-card-meta` adjacent to the RSVP count and venue details.
- Added clean badge styling for `.groups-site-event-format` in `custom.css` with dedicated variants for `is-format-online`, `is-format-hybrid`, and `is-format-in-person`.
- Added unit tests in `Test_Groups_Site_Event_Cards` verifying format helper resolution and card markup rendering for in-person, online, and hybrid events.

Fixes #2031