### PR TITLE
Coming Soon: Let organizers pick which page's contact form is shown

### DIFF
--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-customizer.php
@@ -128,6 +128,27 @@ class WCCSP_Customizer {
 		);
 
 		$wp_customize->add_setting(
+			'wccsp_settings[contact_form_page_id]',
+			array(
+				'default'           => 0,
+				'type'              => 'option',
+				'capability'        => $GLOBALS['WCCSP_Settings']::REQUIRED_CAPABILITY,
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		$wp_customize->add_control(
+			'wccsp_settings[contact_form_page_id]',
+			array(
+				'label'       => __( 'Contact Form Page', 'wordcamporg' ),
+				'description' => __( 'The page whose contact form is shown on the Coming Soon page. When no page is selected, the form on the oldest page that has one is used.', 'wordcamporg' ),
+				'section'     => 'wccsp_live_preview',
+				'type'        => 'dropdown-pages',
+				'capability'  => $GLOBALS['WCCSP_Settings']::REQUIRED_CAPABILITY,
+			)
+		);
+
+		$wp_customize->add_setting(
 			'wccsp_settings[introduction]',
 			array(
 				'default'           => '',

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-settings.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wccsp-settings.php
@@ -36,6 +36,7 @@ class WCCSP_Settings {
 			'enabled'                    => 'off',        // So that sites created before the plugin was deployed won't display the home page when the plugin is activated.
 			'body_background_color'      => '#0073AA',
 			'image_id'                   => 0,
+			'contact_form_page_id'       => 0,
 			'background_id'              => 0,
 			'container_background_color' => '#FFFFFF', // Deprecated.
 			'text_color'                 => '#000000', // Deprecated.

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/classes/wordcamp-coming-soon-page.php
@@ -316,11 +316,9 @@ class WordCamp_Coming_Soon_Page {
 	/**
 	 * Loop through all pages and renders first contact-us form or contact-us block.
 	 *
-	 * We can't just create an arbitrary shortcode because of https://github.com/Automattic/jetpack/issues/102. Instead we have to use a form that's tied to a page.
-	 * This is somewhat fragile, though. It should work in most cases because the first $page that contains [contact-form] will be the one we automatically create
-	 * when the site is created, but if the organizers delete that and then add multiple forms, the wrong form could be displayed. The alternative approaches also
-	 * have problems, though, and #102 should be fixed relatively soon, so hopefully this will be good enough until it can be refactored.
-	 * todo Refactor this once #102-jetpack is fixed.
+	 * Jetpack contact forms are tied to a post/page context, so the Coming Soon page renders a form that lives on an existing page.
+	 * That constraint came from https://github.com/Automattic/jetpack/issues/102, which was closed in 2025 without changing it for shortcode forms.
+	 * Organizers can select which page's form is shown, and the oldest page with a form remains the fallback when there is no usable selection.
 	 *
 	 * @return string|false
 	 */
@@ -334,6 +332,23 @@ class WordCamp_Coming_Soon_Page {
 			'orderby'        => 'date',
 			'order'          => 'ASC',
 		) );
+
+		/*
+		 * The organizer can pick which page's form is shown. A valid published selection
+		 * is only moved to the front of the scan below, so the oldest-page fallback still
+		 * applies when the selection is missing, unpublished, or has no form.
+		 */
+		$settings  = $GLOBALS['WCCSP_Settings']->get_settings();
+		$chosen_id = absint( $settings['contact_form_page_id'] );
+
+		if ( $chosen_id ) {
+			// Not get_post( 0 ), which would return the global post instead.
+			$chosen_page = get_post( $chosen_id );
+
+			if ( $chosen_page instanceof WP_Post && 'page' === $chosen_page->post_type && 'publish' === $chosen_page->post_status ) {
+				array_unshift( $all_pages, $chosen_page );
+			}
+		}
 
 		foreach ( $all_pages as $page ) {
 

--- a/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-contact-form-selection.php
+++ b/public_html/wp-content/plugins/wordcamp-coming-soon-page/tests/test-contact-form-selection.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace WordCamp\Coming_Soon_Page\Tests;
+
+use WordCamp_Coming_Soon_Page;
+use WP_UnitTestCase;
+use WP_UnitTest_Factory;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group coming-soon-page
+ *
+ * @covers WordCamp_Coming_Soon_Page::get_contact_form_shortcode
+ */
+class Test_Contact_Form_Selection extends WP_UnitTestCase {
+	/**
+	 * @var WordCamp_Coming_Soon_Page
+	 */
+	protected static $coming_soon;
+
+	/**
+	 * @var int Older page with a contact form.
+	 */
+	protected static $older_page_id;
+
+	/**
+	 * @var int Newer page with a contact form.
+	 */
+	protected static $newer_page_id;
+
+	/**
+	 * @var int Page without any form.
+	 */
+	protected static $formless_page_id;
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$coming_soon = new WordCamp_Coming_Soon_Page();
+
+		self::$older_page_id = $factory->post->create( array(
+			'post_type'    => 'page',
+			'post_date'    => '2026-01-01 10:00:00',
+			'post_content' => '[contact-form][/contact-form]',
+		) );
+
+		self::$newer_page_id = $factory->post->create( array(
+			'post_type'    => 'page',
+			'post_date'    => '2026-02-01 10:00:00',
+			'post_content' => '[contact-form][/contact-form]',
+		) );
+
+		self::$formless_page_id = $factory->post->create( array(
+			'post_type'    => 'page',
+			'post_date'    => '2026-03-01 10:00:00',
+			'post_content' => 'No form here.',
+		) );
+	}
+
+	/**
+	 * Registers a stand-in for Jetpack's contact-form shortcode that reports
+	 * which page it was rendered on, so the tests do not depend on Jetpack.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$form_stub = function () {
+			return 'FORM_FROM_PAGE_' . get_the_ID();
+		};
+
+		add_shortcode( 'contact-form', $form_stub );
+	}
+
+	/**
+	 * Cleans the shortcode and the plugin settings between tests.
+	 */
+	public function tear_down(): void {
+		remove_shortcode( 'contact-form' );
+		delete_option( 'wccsp_settings' );
+		unset( $GLOBALS['post'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Without a selection, the form on the oldest page wins.
+	 */
+	public function test_default_uses_the_oldest_page_with_a_form(): void {
+		$rendered = self::$coming_soon->get_contact_form_shortcode();
+
+		$this->assertSame( 'FORM_FROM_PAGE_' . self::$older_page_id, $rendered );
+	}
+
+	/**
+	 * A selected page's form wins over the oldest one.
+	 */
+	public function test_selected_page_wins(): void {
+		update_option( 'wccsp_settings', array( 'contact_form_page_id' => self::$newer_page_id ) );
+
+		$rendered = self::$coming_soon->get_contact_form_shortcode();
+
+		$this->assertSame( 'FORM_FROM_PAGE_' . self::$newer_page_id, $rendered );
+	}
+
+	/**
+	 * A selected page without a form falls back to the oldest page's form.
+	 */
+	public function test_selected_page_without_a_form_falls_back(): void {
+		update_option( 'wccsp_settings', array( 'contact_form_page_id' => self::$formless_page_id ) );
+
+		$rendered = self::$coming_soon->get_contact_form_shortcode();
+
+		$this->assertSame( 'FORM_FROM_PAGE_' . self::$older_page_id, $rendered );
+	}
+
+	/**
+	 * With no selection saved, a published global post must not leak in through
+	 * get_post( 0 ) and steal the selection.
+	 */
+	public function test_no_selection_ignores_the_global_post(): void {
+		update_option( 'wccsp_settings', array( 'contact_form_page_id' => 0 ) );
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Deliberately recreates the global post that exists during a real page render.
+		$GLOBALS['post'] = get_post( self::$newer_page_id );
+
+		$rendered = self::$coming_soon->get_contact_form_shortcode();
+
+		$this->assertSame( 'FORM_FROM_PAGE_' . self::$older_page_id, $rendered );
+	}
+
+	/**
+	 * A selection pointing at a trashed page falls back to the oldest page's form.
+	 */
+	public function test_trashed_selected_page_falls_back(): void {
+		$trashed_id = self::factory()->post->create( array(
+			'post_type'    => 'page',
+			'post_date'    => '2026-04-01 10:00:00',
+			'post_content' => '[contact-form][/contact-form]',
+		) );
+		wp_trash_post( $trashed_id );
+
+		update_option( 'wccsp_settings', array( 'contact_form_page_id' => $trashed_id ) );
+
+		$rendered = self::$coming_soon->get_contact_form_shortcode();
+
+		$this->assertSame( 'FORM_FROM_PAGE_' . self::$older_page_id, $rendered );
+	}
+}


### PR DESCRIPTION
Fixes #648

The Coming Soon page picks a contact form by scanning all pages and rendering the first form it finds. Today the oldest page with a form wins, so organizers cannot choose, and an unexpected page's form can show up.

This adds a Contact Form Page dropdown to the Coming Soon section in the Customizer. The selected page is checked first, and the oldest page scan stays as the fallback when nothing is selected, the page was deleted or unpublished, or the selected page has no form. Shortcode and block-based forms both work because the selection just becomes the first candidate for the existing scan loop.

Also updates the stale method comment that pointed at Jetpack issue 102 as fixable soon; it was closed in 2025 without changing the shortcode limitation.

Testing: new tests/test-contact-form-selection.php covers default oldest wins, selected page wins, formless selection falls back, trashed selection falls back, and no selection ignoring the global post through get_post( 0 ). Full plugin suite green locally, 18 tests, 24 assertions.
